### PR TITLE
Parallelize Linux build by adding "-j `nproc`" to make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ build_coreclr()
     # Build CoreCLR
     
     echo Executing make $__UnprocessedBuildArgs
-    make $__UnprocessedBuildArgs
+    make -j `nproc` $__UnprocessedBuildArgs
     if [ $? != 0 ]; then
         echo Failed to build coreclr components.
         exit 1


### PR DESCRIPTION
This just adds `-j `nproc`` when invoking make.

`nproc` returns the number of cores on a Linux machine. It's part of coreutils, so almost any Linux install should have it.

`-j <num>` tells make to run _num_ tasks in parallel.
