### PR TITLE
Fix links to Linux build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 |   |Linux|Windows|
 |:-:|:-:|:-:|
-|Debug|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_linux_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_windows_linux_debug/)|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_windows_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_windows_debug/)|
-|Release|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_linux_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_windows_linux_release/)|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_windows_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_windows_release/)|
+|Debug|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_linux_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_linux_debug/)|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_windows_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_windows_debug/)|
+|Release|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_linux_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_linux_release/)|[![Build status](http://dotnet-ci.cloudapp.net/job/zzztest_windows_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/zzztest_windows_release/)|
 
 The coreclr repo contains the complete runtime implementation (called "CoreCLR") for [.NET Core](http://github.com/dotnet/core). It includes RyuJIT, the .NET GC, native interop and many other components. It builds and runs on Windows. You can 'watch' the repo to see Linux and Mac support being added over the next few months.
 


### PR DESCRIPTION
Remove an extraneous `windows_` from the badge link.
