### PR TITLE
Fix mscorlib warnings.

### DIFF
--- a/src/mscorlib/Common/PinnableBufferCache.cs
+++ b/src/mscorlib/Common/PinnableBufferCache.cs
@@ -45,7 +45,9 @@ namespace System
         /// This is only used in mscorlib.
         /// </summary>
 #if (ENABLE || MINBUFFERS)
+#pragma warning disable 618
         [EnvironmentPermission(SecurityAction.Assert, Unrestricted = true)]
+#pragma warning restore 618
         [System.Security.SecuritySafeCritical]
 #endif
         internal PinnableBufferCache(string cacheName, Func<object> factory)


### PR DESCRIPTION
PinnableBufferCache uses some of the declaritive CAS attributes which
don't mean anything on CoreCLR. We had disabled this warning
internally, but this copy of the file is specific to open source and
we didn't disable it in this file.

This simply ports the change to disable this warning to mscorlib's
copy of the file.