### PR TITLE
Move shebang to top of shell scripts

### DIFF
--- a/src/pal/tests/palsuite/runpaltests.sh
+++ b/src/pal/tests/palsuite/runpaltests.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 #
 # This script executes PAL tests from the specified build location.
 #
-#!/bin/bash
 
 if [ $# -lt 1 -o $# -gt 3 ]
 then

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 #
 # This file invokes cmake and generates the build system for gcc.
 #
-#!/bin/bash
 
 if [ $# -lt 1 -o $# -gt 2 ]
 then

--- a/src/pal/tools/setup-compiler-clang.sh
+++ b/src/pal/tools/setup-compiler-clang.sh
@@ -1,8 +1,7 @@
+#!/bin/bash
 #
 # This file sets the environment to be used for building with clang.
 #
-
-#!/bin/bash
 
 export CC=/usr/bin/clang
 export CXX=/usr/bin/clang++


### PR DESCRIPTION
This line should be at the top of the file, not after
comments. Otherwise the correct shell is not picked in some cases
(like when you the scripts file via sudo).