### PR TITLE
Remove non ASCII characters from source files

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -12006,7 +12006,7 @@ DECLARE_API(Watch)
     {
         if(nArg != 1)
         {
-             ExtOut("Must provide an old and new name. Usage: !watch –rename <old_name> <new_name>.\n");
+             ExtOut("Must provide an old and new name. Usage: !watch -rename <old_name> <new_name>.\n");
              return S_FALSE;
         }
         WCHAR pOldName[MAX_EXPRESSION];

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -2092,10 +2092,10 @@ TypeHandle DacDbiInterfaceImpl::TypeDataWalk::ReadLoadedTypeHandle(TypeHandleRea
 //                             pArrayTypeInfo along with arrayElementTypeArg to FindLoadedArrayType
 //                             to get the type handle for this particular array type.
 //                             Note:
-//                             On entry, we know that pArrayTypeInfo is the same as m_pCurrentData – 1,
+//                             On entry, we know that pArrayTypeInfo is the same as m_pCurrentData - 1,
 //                             but by the time we need to use it, this is no longer true. Because
-//                             we can’t predict how many nodes will be consumed by the call to 
-//                             ReadLoadedTypeArg, we can’t compute this value from the member fields
+//                             we can't predict how many nodes will be consumed by the call to 
+//                             ReadLoadedTypeArg, we can't compute this value from the member fields
 //                             of TypeDataWalk and therefore pass it as a parameter.                   
 //            retrieveWhich -  determines whether we can return the type handle for 
 //                             a canonical type or only for an exact type
@@ -2133,10 +2133,10 @@ TypeHandle DacDbiInterfaceImpl::TypeDataWalk::ArrayTypeArg(DebuggerIPCE_TypeArgD
 //                             pPtrOrByRefTypeInfo along with referentTypeArg to FindLoadedPointerOrByrefType
 //                             to get the type handle for this particular pointer or byref type.
 //                             Note:
-//                             On entry, we know that pPtrOrByRefTypeInfo is the same as m_pCurrentData – 1,
+//                             On entry, we know that pPtrOrByRefTypeInfo is the same as m_pCurrentData - 1,
 //                             but by the time we need to use it, this is no longer true. Because
-//                             we can’t predict how many nodes will be consumed by the call to 
-//                             ReadLoadedTypeArg, we can’t compute this value from the member fields
+//                             we can't predict how many nodes will be consumed by the call to 
+//                             ReadLoadedTypeArg, we can't compute this value from the member fields
 //                             of TypeDataWalk and therefore pass it as a parameter.                   
 //            retrieveWhich - determines whether we can return the type handle for 
 //                            a canonical type or only for an exact type
@@ -3213,8 +3213,8 @@ TypeHandle DacDbiInterfaceImpl::ExpandedTypeInfoToTypeHandle(DebuggerIPCE_Expand
 // Notes: 
 // The address is  constant and could be cached.
 // 
-// If this is a context-static, the function uses the thread’s current context.  
-// [This is important because it means that you can’t lookup a context static 
+// If this is a context-static, the function uses the thread's current context.  
+// [This is important because it means that you can't lookup a context static 
 // unless you have a thread in that context. If anybody actually cared about contexts, 
 // we might have to revise this in the future] 
 // 

--- a/src/debug/daccess/dacdbiimplstackwalk.cpp
+++ b/src/debug/daccess/dacdbiimplstackwalk.cpp
@@ -1003,7 +1003,7 @@ ULONG32 DacDbiInterfaceImpl::GetStackParameterSize(EECodeInfo * pCodeInfo)
 //
 //    There are only two transition cases where we can reliably adjust for the callee stack parameter size:
 //    1) when the debugger calls SetContext() with the CONTEXT of the first managed stack frame in a 
-//       managed stack chain (i.e. SetContext() with M2’s CONTEXT)
+//       managed stack chain (i.e. SetContext() with M2's CONTEXT)
 //      - the M2U transition is protected by an explicit frame (aka Frame-chain frame)
 //    2) when the debugger calls GetContext() on the first native stack frame in a native stack chain 
 //       (i.e. GetContext() at U0)

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -861,7 +861,7 @@ NativeImageDumper::DumpNativeImage()
     {
         if (m_decoder.IsStrongNameSigned())
         {
-            DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn’t maintain a clean separation of address spaces (target and host are the same.");
+            DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn't maintain a clean separation of address spaces (target and host are the same.");
             data = reinterpret_cast<void*>(dac_cast<TADDR>(m_decoder.GetStrongNameSignature(&size)));
 
             IF_OPT(COR_INFO)
@@ -893,7 +893,7 @@ NativeImageDumper::DumpNativeImage()
     else
         DisplayWriteElementString( "imageType", "Mixed image", COR_INFO);
 
-    DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn’t maintain a clean separation of address spaces (target and host are the same.");
+    DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn't maintain a clean separation of address spaces (target and host are the same.");
     data = reinterpret_cast<void*>(dac_cast<TADDR>(m_decoder.GetMetadata(&size)));
     OpenMetadata();
     IF_OPT(METADATA)
@@ -919,7 +919,7 @@ NativeImageDumper::DumpNativeImage()
 
     if (m_decoder.HasNativeHeader())
     {
-        DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn’t maintain a clean separation of address spaces (target and host are the same.");
+        DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn't maintain a clean separation of address spaces (target and host are the same.");
         data = reinterpret_cast<void*>(dac_cast<TADDR>(m_decoder.GetNativeManifestMetadata(&size)));
 
         IF_OPT(METADATA)
@@ -1419,7 +1419,7 @@ void NativeImageDumper::OpenMetadata()
 {
     COUNT_T size;
 
-    DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn’t maintain a clean separation of address spaces (target and host are the same.");
+    DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn't maintain a clean separation of address spaces (target and host are the same.");
     const void *data = reinterpret_cast<void*>(dac_cast<TADDR>(m_decoder.GetMetadata(&size)));
 
     ReleaseHolder<IMetaDataDispenserEx> pDispenser;
@@ -1445,7 +1445,7 @@ void NativeImageDumper::OpenMetadata()
 
     if (m_decoder.HasNativeHeader())
     {
-        DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn’t maintain a clean separation of address spaces (target and host are the same.");
+        DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn't maintain a clean separation of address spaces (target and host are the same.");
         data = reinterpret_cast<void*>(dac_cast<TADDR>(m_decoder.GetNativeManifestMetadata(&size)));
 
         IfFailThrow(pDispenser->OpenScopeOnMemory(data, size, ofRead, 
@@ -2749,7 +2749,7 @@ NativeImageDumper::Dependency *NativeImageDumper::OpenDependency(int index)
             const void * data;
             COUNT_T size;
 
-            DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn’t maintain a clean separation of address spaces (target and host are the same.");
+            DACCOP_IGNORE(CastBetweenAddressSpaces,"nidump is in-proc and doesn't maintain a clean separation of address spaces (target and host are the same.");
             data = reinterpret_cast<void*>(dac_cast<TADDR>(decoder.GetMetadata(&size)));
 
             dependency.pMetadataStartTarget = TO_TADDR(data);

--- a/src/debug/inc/dacdbiinterface.h
+++ b/src/debug/inc/dacdbiinterface.h
@@ -2259,7 +2259,7 @@ public:
     // Notes:
     //     This will produce a VMPTR_OBJECTHANDLE regardless of whether handle is 
     //     valid.     
-    //     Ideally we’d be using only strongly-typed variables on the RS, and then this would be unnecessary 
+    //     Ideally we'd be using only strongly-typed variables on the RS, and then this would be unnecessary 
     virtual
     VMPTR_OBJECTHANDLE GetVmObjectHandle(CORDB_ADDRESS handleAddress) = 0;
 

--- a/src/inc/MSCOREE.IDL
+++ b/src/inc/MSCOREE.IDL
@@ -339,9 +339,9 @@ typedef enum
     RUNTIME_INFO_REQUEST_IA64           = 0x002, // requesting a CLR for ia64
     RUNTIME_INFO_REQUEST_AMD64          = 0x004, // requesting a CLR for amd64
     RUNTIME_INFO_REQUEST_X86            = 0x008, // requesting a CLR for x86
-    RUNTIME_INFO_DONT_RETURN_DIRECTORY  = 0x010, // don’t return directory information
-    RUNTIME_INFO_DONT_RETURN_VERSION    = 0x020, // don’t return version information
-    RUNTIME_INFO_DONT_SHOW_ERROR_DIALOG = 0x040, // don’t pop up an error dialog on failure
+    RUNTIME_INFO_DONT_RETURN_DIRECTORY  = 0x010, // don't return directory information
+    RUNTIME_INFO_DONT_RETURN_VERSION    = 0x020, // don't return version information
+    RUNTIME_INFO_DONT_SHOW_ERROR_DIALOG = 0x040, // don't pop up an error dialog on failure
     RUNTIME_INFO_IGNORE_ERROR_MODE      = 0x1000,// ignore SEM_FAILCRITICALERRORS 
                                                  // (by default the error dialog is not shown if  SEM_FAILCRITICALERRORS is set)
     // Reserved values here - see mscoreepriv.h

--- a/src/inc/cordebug.idl
+++ b/src/inc/cordebug.idl
@@ -637,12 +637,12 @@ interface ICorDebugSymbolProvider2 : IUnknown
      *    If the high bit is set, the following N entries are sorted by RVA in ascending order.
      *
      *  - N 8 byte wide entries, each entry consisting of 2 4-byte entries:
-     *    1st 4 byte entry - RVA:    the dictionary’s RVA
+     *    1st 4 byte entry - RVA:    the dictionary's RVA
      *    2nd 4 byte entry - Offset: an offset relative to the start of the heap.
      *
      *  - Heap
      *
-     * The heap’s size can be computed be a stream reader by subtracting the directory size + 4.
+     * The heap's size can be computed be a stream reader by subtracting the directory size + 4.
      *
      * The format for each instantiation info in heap is as follows:
      *  - Length of this instantiation info (in bytes, not including this length information) in compressed ECMA metadata format.
@@ -743,7 +743,7 @@ interface ICorDebugDataTarget2 : IUnknown
 
     /*
      * CreateVirtualUnwinder:
-     * Create a new stack unwinder that starts unwinding from initialContext (which isn’t
+     * Create a new stack unwinder that starts unwinding from initialContext (which isn't
      * necessarily the leaf of a thread).
      * Any failing HRESULT received by mscordbi is considered fatal and will cause ICorDebug
      * APIs to return CORDBG_E_DATA_TARGET_ERROR.
@@ -2377,8 +2377,8 @@ interface ICorDebugAssembly3 : IUnknown
 
     /*
      * Gets an enumeration for all the assemblies contained within this assembly
-     * If the assembly isn’t a container, the result is S_FALSE and the enumeration
-     * will be empty. Symbols are needed to compute this result; if they aren’t 
+     * If the assembly isn't a container, the result is S_FALSE and the enumeration
+     * will be empty. Symbols are needed to compute this result; if they aren't 
      * present an error will be returned and no enumeration provided.
      */
     HRESULT EnumerateContainedAssemblies(ICorDebugAssemblyEnum **ppAssemblies);
@@ -2919,7 +2919,7 @@ interface ICorDebugProcess3 : IUnknown
      *  Notifications are disabled by default and the debugger must opt-into
      *  any notification types it knows of and wishes to handle.
      *  Since ICorDebugClass is scoped by appdomains, the debugger needs to 
-     *  call this API for every appdomain in the process if it’s interested in 
+     *  call this API for every appdomain in the process if it's interested in 
      *  receiving the notification across the entire process. 
      */
 
@@ -2987,7 +2987,7 @@ typedef enum CorDebugStateChange
 {
     PROCESS_RUNNING = 0x0000001, // The process reached a new memory state via 
                                  // forward execution.    
-    FLUSH_ALL       = 0x0000002, // The process’ memory might be arbitrarily 
+    FLUSH_ALL       = 0x0000002, // The process' memory might be arbitrarily 
                                  // different than it was before.
 } CorDebugStateChange;
 
@@ -3075,7 +3075,7 @@ interface ICorDebugProcess6 : IUnknown
     // sub-modules or virtual modules. Both container modules and sub-modules are 
     // represented with the ICorDebugModule interface, however the behavior of the 
     // interface is slightly different in each case, as described below.
-    // In addition there may still be modules loaded that weren’t merged during build. 
+    // In addition there may still be modules loaded that weren't merged during build. 
     // These modules, called regular modules, are neither container modules nor
     // sub-modules. 
     //
@@ -3117,19 +3117,19 @@ interface ICorDebugProcess6 : IUnknown
     //
     // Enabling Virtual Module Splitting has the following effects elsewhere in the API:
     // ICorDebugFunction.GetModule
-    //     Disabled – Returns the container module this function was merged into
+    //     Disabled - Returns the container module this function was merged into
     //     Enabled - Returns the sub-module this function was originally defined in
     // ICorDebugClass.GetModule
-    //     Disabled – Returns the container module this class was merged into
-    //     Enabled – Returns the sub-module this class was originally defined in
+    //     Disabled - Returns the container module this class was merged into
+    //     Enabled - Returns the sub-module this class was originally defined in
     // ICorDebugModuleDebugEvent.GetModule
-    //     Enabled OR Disabled – Returns the container module that was loaded.
+    //     Enabled OR Disabled - Returns the container module that was loaded.
     //                           Sub-modules are not given load events regardless of this
     //                           setting.
     // ICorDebugAppDomain.EnumerateAssemblies
-    //     Disabled – Returns a list of container assemblies + regular assemblies
+    //     Disabled - Returns a list of container assemblies + regular assemblies
     //                (no sub-assemblies are shown)
-    //     Enabled – Returns the list of sub-assemblies + regular assemblies
+    //     Enabled - Returns the list of sub-assemblies + regular assemblies
     //                (no container assemblies are shown). 
     //                Note: If any container assembly is missing symbols, none of its
     //                sub-assemblies will be enumerated. If any regular assembly is

--- a/src/inc/corprof.idl
+++ b/src/inc/corprof.idl
@@ -771,11 +771,11 @@ interface ICorProfilerCallback : IUnknown
      *
      * NOTE: Shutdown will only fire where the managed application that is being
      * profiled was started running managed code (i.e., the initial frame on the
-     * process’ stack is managed).  If the application being profiled started
-     * life as unmanaged code, which later ‘jumped into’ managed code (thereby
+     * process' stack is managed).  If the application being profiled started
+     * life as unmanaged code, which later 'jumped into' managed code (thereby
      * creating an instance of the CLR), then Shutdown will not fire.  In these
      * cases, the profiler should include a DllMain routine in their library that
-     * uses Win32’s DLL_PROCESS_DETACH call to free any resources and perform tidy-up
+     * uses Win32's DLL_PROCESS_DETACH call to free any resources and perform tidy-up
      * processing of its data (flush traces to disk, etc)
      *
      * NOTE: The profiler must in general cope with unexpected shutdowns, such as

--- a/src/inc/eventtrace.h
+++ b/src/inc/eventtrace.h
@@ -267,7 +267,7 @@ namespace ETW
             struct {
                 ULONGLONG SegmentSize; 
                 ULONGLONG LargeObjectSegmentSize; 
-                BOOL ServerGC; // TRUE means it’s server GC; FALSE means it’s workstation.
+                BOOL ServerGC; // TRUE means it's server GC; FALSE means it's workstation.
             } GCSettings;
 
             struct {

--- a/src/inc/metahost.idl
+++ b/src/inc/metahost.idl
@@ -391,7 +391,7 @@ CLR_DEBUGGING_PROCESS_FLAGS;
  ** This interface allows the debugger to provide modules which are needed for       **
  ** debugging a particular CLR such as mscordbi and mscordacwks. The module handles  **
  ** need to remain valid until a call to ICLRDebugging::CanUnloadNow indicates they  **
- ** may be freed, at which point it is the caller’s responsibility to free the       **
+ ** may be freed, at which point it is the caller's responsibility to free the       **
  ** handles.                                                                         **
  **************************************************************************************/
 [

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -881,7 +881,7 @@ unsigned Compiler::optCreateAssertion(GenTreePtr op1, GenTreePtr op2,
             //
             // TODO-CQ: Check for Sealed class and change kind to O1K_EXACT_TYPE
             //          And consider the special cases, like CORINFO_FLG_SHAREDINST or CORINFO_FLG_VARIANCE
-            //          where a class can be sealed, but they don’t behave as exact types because casts to 
+            //          where a class can be sealed, but they don't behave as exact types because casts to 
             //          non-base types sometimes still succeed.  
             //
             assertion->op1.kind         = O1K_SUBTYPE;

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -8025,7 +8025,7 @@ void                CodeGen::genFnProlog()
             signed int hiOffs = loOffs + TARGET_POINTER_SIZE;
 
             // If there is a frame pointer used, due to frame pointer chaining it will point to the stored value of the previous
-            // frame pointer. Thus, stkOffs can’t be zero.
+            // frame pointer. Thus, stkOffs can't be zero.
             // However, on amd64 there is no requirement to chain frame pointers.
 #if !defined(_TARGET_AMD64_)
             noway_assert(!isFramePointerUsed() || loOffs != 0);

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -2597,7 +2597,7 @@ void                emitter::emitIns_R_R_I(instruction ins,
         assert(insOptsNone(opt));
 
         // On ARM, the immediate shift count of LSL and ROR must be between 1 and 31. For LSR and ASR, it is between
-        // 1 and 32, though we don’t ever use 32. Although x86 allows an immediate shift count of 8-bits in instruction
+        // 1 and 32, though we don't ever use 32. Although x86 allows an immediate shift count of 8-bits in instruction
         // encoding, the CPU looks at only the lower 5 bits. As per ECMA, specifying a shift count to the IL SHR, SHL, or SHL.UN
         // instruction that is greater than or equal to the width of the type will yield an undefined value. We choose that
         // undefined value in this case to match x86 behavior, by only using the lower 5 bits of the constant shift count.

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2969,16 +2969,16 @@ void Lowering::LowerInd(GenTreePtr* pTree)
 //    expressions that have side-effects.
 //    We then transform the tree into:
 //                      <offset is null - no accumulated offset for the first index>
-//                   /--*  <arrObj>
-//                   +--*  <index0>
-//                /--*  ArrIndex[i, ]
+//                   /--*  <arrObj>
+//                   +--*  <index0>
+//                /--*  ArrIndex[i, ]
 //                +--*  <arrObj>
-//             /--|  arrOffs[i, ]
+//             /--|  arrOffs[i, ]
 //             |  +--*  <arrObj>
 //             |  +--*  <index1>
-//             +--*  ArrIndex[*,j]
+//             +--*  ArrIndex[*,j]
 //             +--*  <arrObj>
-//          /--|  arrOffs[*,j]
+//          /--|  arrOffs[*,j]
 //          +--*  lclVar NewTemp
 //       /--*  lea (scale = element size, offset = offset of first element)
 //

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -10900,7 +10900,7 @@ ASG_OP:
 // optimization.  This code is previously from UTC where it notes it was taken from
 // _The_PowerPC_Compiler_Writer's_Guide_, pages 57-58.
 // The paper it is based on is "Division by invariant integers using multiplication"
-// by Torbjörn Granlund and Peter L. Montgomery in PLDI 94
+// by Torbjorn Granlund and Peter L. Montgomery in PLDI 94
 
 template <typename T>
 T GetSignedMagicNumberForDivide(T denom, int *shift /*out*/)

--- a/src/jit/simd.cpp
+++ b/src/jit/simd.cpp
@@ -1670,7 +1670,7 @@ GenTreePtr Compiler::createAddressNodeForSIMDInit(GenTreePtr tree, unsigned simd
             // e.g. s.x x is a field, and s is a struct, then we should set the s's lvUsedInSIMDIntrinsic as true.
             // so that s won't be promoted.
             // Notice that if we have a case like s1.s2.x. s1 s2 are struct, and x is a field, then it is possible that s1 can be promoted, so that s2 can be promoted.
-            // The reason for that is if we don't allow s1 to be promoted, then this will affect the other optimizations which are depend on s1’s struct promotion.
+            // The reason for that is if we don't allow s1 to be promoted, then this will affect the other optimizations which are depend on s1's struct promotion.
             // TODO-CQ:
             //  In future, we should optimize this case so that if there is a nested field like s1.s2.x and s1.s2.x's address is used for 
             //  initializing the vector, then s1 can be promoted but s2 can't. 

--- a/src/pal/tests/palsuite/composite/object_management/semaphore/shared/main.c
+++ b/src/pal/tests/palsuite/composite/object_management/semaphore/shared/main.c
@@ -123,11 +123,11 @@ int GetParameters( int argc, char **argv)
     }
 
 /*
-"While the new PAL does support named semaphore it’s unclear 
+"While the new PAL does support named semaphore it's unclear 
 if we should change the Windows PAL, since we share that w/ Rotor 
 and they are still using the old PAL. For the time being it may 
 make the most sense to just skip the named semaphore test on Windows 
-– from an object management perspective it doesn’t really gain 
+- from an object management perspective it doesn't really gain 
 us anything over what we already have."
 */
 #ifdef PLATFORM_UNIX

--- a/src/utilcode/loaderheap.cpp
+++ b/src/utilcode/loaderheap.cpp
@@ -1741,7 +1741,7 @@ void *UnlockedLoaderHeap::UnlockedAllocMemForCode_NoThrow(size_t dwHeaderSize, s
     // which address will be handed out which in turn we don't know because we don't
     // know whether the allocation will fit within the current reserved range.
     //
-    // Thus, we'll request as much heap growth as is needed for the worst case (we request an extra dwCodeAlignment – 1 bytes)
+    // Thus, we'll request as much heap growth as is needed for the worst case (we request an extra dwCodeAlignment - 1 bytes)
 
     S_SIZE_T cbAllocSize = S_SIZE_T(dwHeaderSize) + S_SIZE_T(dwCodeSize) + S_SIZE_T(dwCodeAlignment - 1);
     if( cbAllocSize.IsOverflow() )

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -3305,7 +3305,7 @@ void FileLockHolder::Acquire(LPCWSTR lockName, HANDLE hInterrupt, BOOL* pInterru
         // Logically we should only expect ERROR_SHARING_VIOLATION, but Windows can also return
         // ERROR_ACCESS_DENIED for underlying NtStatus DELETE_PENDING.  That happens when another process
         // (gacutil.exe or indexer) have the file opened.  Unfortunately there is no public API that would
-        // allow us to detect this NtStatus and distinguish it from ‘real’ access denied (candidates are
+        // allow us to detect this NtStatus and distinguish it from 'real' access denied (candidates are
         // RtlGetLastNtStatus that is not documented on MSDN and NtCreateFile that is internal and can change
         // at any time), so we retry on access denied, but only for a limited number of times.
         if (dwErr == ERROR_SHARING_VIOLATION ||

--- a/src/utilcode/utilmessagebox.cpp
+++ b/src/utilcode/utilmessagebox.cpp
@@ -253,7 +253,7 @@ int MessageBoxImpl(
 
     if (activatedActivationContext) {
         DeactivateActCtx(0, cookie);
-        ReleaseActCtx(hActCtx);  // perf isn’t important so we won’t bother caching the actctx
+        ReleaseActCtx(hActCtx);  // perf isn't important so we won't bother caching the actctx
     }
  
     return result;

--- a/src/vm/assembly.hpp
+++ b/src/vm/assembly.hpp
@@ -898,7 +898,7 @@ public:
     // Checks to see if an assembly has friend access to a particular member.
     //
     // Arguments:
-    //    pAccessingAssembly – the assembly requesting friend access
+    //    pAccessingAssembly - the assembly requesting friend access
     //    pMember            - the member that is attempting to be accessed
     //
     // Return Value:

--- a/src/vm/callhelpers.h
+++ b/src/vm/callhelpers.h
@@ -568,7 +568,7 @@ enum DispatchCallSimpleFlags
 // such as END_DOMAIN_TRANSITION or EX_CATCH. Catching exceptions in the managed code is properly instrumented and
 // does not need this notification.
 //
-// The notification is what enables both the managed ‘unhandled exception’ dialog and the ‘user unhandled’ dialog when 
+// The notification is what enables both the managed 'unhandled exception' dialog and the 'user unhandled' dialog when 
 // JMC is turned on. Many things that VS puts up the unhandled exception dialog for are actually cases where the native
 // exception was caught, for example catching exceptions at the thread base. JMC requires further accuracy - in that case
 // VS is checking to see if an exception escaped particular ranges of managed code frames.

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -10736,7 +10736,7 @@ void Module::PlaceMethod(DataImage *image, MethodDesc *pMD, DWORD profilingFlags
        }
 #endif // FEATURE_COMINTEROP
 
-        // Stubs-as-IL have writeable signatures sometimes, so can’t place them
+        // Stubs-as-IL have writeable signatures sometimes, so can't place them
         // into read-only section. We should not get here for stubs-as-il anyway,
         // but we will filter them out just to be sure.
         if (pMD->HasStoredSig() && !pMD->IsILStub())

--- a/src/vm/clrex.cpp
+++ b/src/vm/clrex.cpp
@@ -2477,7 +2477,7 @@ ObjrefException::ObjrefException(OBJECTREF throwable)
 // --------------------------------------------------------------------------------------------------------------------------------------
 // ObjrefException and CLRLastThrownObjectException are never set as inner exception for an internal CLR exception.
 // As a result, if we invoke DomainBoundClone against an exception, it will never reach these implementations.
-// If someone does set them as inner, it will trigger contract violation – which is valid and should be fixed by whoever
+// If someone does set them as inner, it will trigger contract violation - which is valid and should be fixed by whoever
 // set them as inner since Exception::DomainBoundClone is implemented in utilcode that has to work outside the context of CLR and thus,
 // should never trigger GC. This is also why GC_TRIGGERS is not supported in utilcode (refer to its definition in contracts.h).
 // --------------------------------------------------------------------------------------------------------------------------------------

--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -6364,7 +6364,7 @@ BOOL ClassLoader::CheckAccessMember(                // TRUE if access is allowed
 //
 // The second part:
 //
-//              For verifiable code (see §8.8), there is an additional
+//              For verifiable code (see Section 8.8), there is an additional
 //              requirement that can require a runtime check: the reference
 //              shall be made through an item whose exact type supports
 //              the exact type of the referent. That is, the item whose

--- a/src/vm/eehash.inl
+++ b/src/vm/eehash.inl
@@ -80,7 +80,7 @@ void EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::ClearHashTable()
     
     // Transition to COOP mode. This is need because EEHashTable is lock free and it can be read 
     // from multiple threads without taking locks. On rehash, you want to get rid of the old copy 
-    // of table. You can only get rid of it once nobody is using it. That’s a problem because 
+    // of table. You can only get rid of it once nobody is using it. That's a problem because 
     // there is no lock to tell when the last reader stopped using the old copy of the table.
     // The solution to this problem is to access the table in cooperative mode, and to get rid of 
     // the old copy of the table when we are suspended for GC. When we are suspended for GC, 
@@ -126,7 +126,7 @@ void EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::EmptyHashTable()
     
     // Transition to COOP mode. This is need because EEHashTable is lock free and it can be read 
     // from multiple threads without taking locks. On rehash, you want to get rid of the old copy 
-    // of table. You can only get rid of it once nobody is using it. That’s a problem because 
+    // of table. You can only get rid of it once nobody is using it. That's a problem because 
     // there is no lock to tell when the last reader stopped using the old copy of the table.
     // The solution to this problem is to access the table in cooperative mode, and to get rid of 
     // the old copy of the table when we are suspended for GC. When we are suspended for GC, 
@@ -237,7 +237,7 @@ void EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::InsertValue(KeyType p
     
     // Transition to COOP mode. This is need because EEHashTable is lock free and it can be read 
     // from multiple threads without taking locks. On rehash, you want to get rid of the old copy 
-    // of table. You can only get rid of it once nobody is using it. That’s a problem because 
+    // of table. You can only get rid of it once nobody is using it. That's a problem because 
     // there is no lock to tell when the last reader stopped using the old copy of the table.
     // The solution to this problem is to access the table in cooperative mode, and to get rid of 
     // the old copy of the table when we are suspended for GC. When we are suspended for GC, 
@@ -291,7 +291,7 @@ void EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::InsertKeyAsValue(KeyT
     
     // Transition to COOP mode. This is need because EEHashTable is lock free and it can be read 
     // from multiple threads without taking locks. On rehash, you want to get rid of the old copy 
-    // of table. You can only get rid of it once nobody is using it. That’s a problem because 
+    // of table. You can only get rid of it once nobody is using it. That's a problem because 
     // there is no lock to tell when the last reader stopped using the old copy of the table.
     // The solution to this problem is to access the table in cooperative mode, and to get rid of 
     // the old copy of the table when we are suspended for GC. When we are suspended for GC, 
@@ -543,7 +543,7 @@ EEHashEntry_t *EEHashTableBase<KeyType, Helper, bDefaultCopyIsDeep>::FindItem(Ke
 
     // Transition to COOP mode. This is need because EEHashTable is lock free and it can be read 
     // from multiple threads without taking locks. On rehash, you want to get rid of the old copy 
-    // of table. You can only get rid of it once nobody is using it. That’s a problem because 
+    // of table. You can only get rid of it once nobody is using it. That's a problem because 
     // there is no lock to tell when the last reader stopped using the old copy of the table.
     // The solution to this problem is to access the table in cooperative mode, and to get rid of 
     // the old copy of the table when we are suspended for GC. When we are suspended for GC, 

--- a/src/vm/eetoprofinterfaceimpl.h
+++ b/src/vm/eetoprofinterfaceimpl.h
@@ -655,7 +655,7 @@ private:
 
     // ELT3 no long keeps track of FunctionID of current managed method.  Therefore, a hash table of bookkeeping 
     // the mapping from FunctionID to clientID is needed to build up ELT2 on top of ELT3.  When ELT2 (slow-path 
-    // or fast-path) is registered by the profiler and the profiler’s IDFunctionMapper requests to hook up the 
+    // or fast-path) is registered by the profiler and the profiler's IDFunctionMapper requests to hook up the 
     // function being loading, the clientID returned by FunctionIDMapper will be saved as the value to be looked 
     // up by the corresponding FunctionID in the hash table.  FunctionIDs can be recycled after an app domain
     // that contains the function bodies is unloaded so this hash table needs to replace the existing FunctionID 

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -2205,8 +2205,8 @@ public:
     // node. Edges are reported in bulk, separately from Nodes, but it is expected that
     // the consumer read the Node and Edge streams together. One takes the first node
     // from the Node stream, and then reads EdgeCount entries in the Edge stream, telling
-    // you all of that Node’s targets. Then, one takes the next node in the Node stream,
-    // and reads the next entries in the Edge stream (using this Node’s EdgeCount to
+    // you all of that Node's targets. Then, one takes the next node in the Node stream,
+    // and reads the next entries in the Edge stream (using this Node's EdgeCount to
     // determine how many) to find all of its targets. This continues on until the Node
     // and Edge streams have been fully read.
     // 

--- a/src/vm/generics.h
+++ b/src/vm/generics.h
@@ -26,7 +26,7 @@ class DictionaryEntryLayout;
 // Generics helper functions
 namespace Generics
 {
-    // Part of the recursive inheritance graph as defined by ECMA part.II §9.2.
+    // Part of the recursive inheritance graph as defined by ECMA part.II Section 9.2.
     // 
     // code:MethodTable.DoFullyLoad and code:TypeDesc.DoFullyLoad declare local variable of
     // this type and initialize it with:

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -309,8 +309,8 @@ static bool shouldEnterCall(PTR_BYTE ip) {
 
 /***************************************************************/
 // A fundamental requirement of managed code is that we need to be able to enumerate all GC references on the
-// stack at GC time. To do this we need to be able to ‘crawl’ the stack. We know how to do this in JIT
-// compiled code (it generates additional information like the frame size etc), but we don’t know how to do
+// stack at GC time. To do this we need to be able to 'crawl' the stack. We know how to do this in JIT
+// compiled code (it generates additional information like the frame size etc), but we don't know how to do
 // this for unmanaged code. For PINVOKE calls, we leave a pointer to the transition boundary between managed
 // and unmanaged code and we simply ignore the lower part of the stack. However setting up this transition is
 // a bit expensive (1-2 dozen instructions), and while that is acceptable for PINVOKE, it is not acceptable
@@ -319,15 +319,15 @@ static bool shouldEnterCall(PTR_BYTE ip) {
 // To get around this, for transitions into the runtime (which we call FCALLS), we DEFER setting up the
 // boundary variables (what we call the transition frame), until we actually need it (we will do an operation
 // that might cause a GC). This allow us to handle the common case (where we might find the thing in a cache,
-// or be service the ‘new’ from a allocation quantum), and only pay the cost of setting up the transition
+// or be service the 'new' from a allocation quantum), and only pay the cost of setting up the transition
 // frame when it will actually be used.
 //
 // The problem is that in order to set up a transition frame we need to be able to find ALL REGISTERS AT THE
 // TIME THE TRANSITION TO UNMANAGED CODE WAS MADE (because we might need to update them if they have GC
 // references). Because we have executed ordinary C++ code (which might spill the registers to the stack at
-// any time), we have a problem. LazyMachState is our ‘solution’ to this problem. We take advantage of the
+// any time), we have a problem. LazyMachState is our 'solution' to this problem. We take advantage of the
 // fact that the C++ code MUST RESTORE the register before returning. Thus we simulate the execution from the
-// current location to the return and ‘watch’ where the registers got restored from. This is what
+// current location to the return and 'watch' where the registers got restored from. This is what
 // unwindLazyState does (determine what the registers would be IF you had never executed and unmanaged C++
 // code).
 // 

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -4044,7 +4044,7 @@ BOOL MethodNeedsReverseComStub(MethodDesc *pMD)
             {
                 //
                 // However, we do need CCWs for internal interfaces that define protected members of inheritable classes
-                // (for example, Windows.UI.Xaml.Application implements both IApplication, which we don’t need 
+                // (for example, Windows.UI.Xaml.Application implements both IApplication, which we don't need 
                 // a CCW for and IApplicationOverrides, which we do need).
                 //
                 if (!pMT->GetWriteableData()->IsOverridingInterface())

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -3047,7 +3047,7 @@ void MethodDesc::Save(DataImage *image)
                 // Store signatures that doesn't need restore into a read only section.
                 DataImage::ItemKind sigItemKind = DataImage::ITEM_STORED_METHOD_SIG_READONLY;
                 // Place the signatures for stubs-as-il into hot/cold or writeable section
-                // here since Module::Arrange won’t place them for us.
+                // here since Module::Arrange won't place them for us.
                 if (IsILStub())
                 {
                     PTR_DynamicMethodDesc pDynamicMD = AsDynamicMethodDesc();

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -4720,7 +4720,7 @@ void MethodTable::DoFullyLoad(Generics::RecursionGraph * const pVisited,  const 
         else if (level == CLASS_DEPENDENCIES_LOADED && HasInstantiation())
         {
             // This is a typical instantiation of a generic type. When attaining CLASS_DEPENDENCIES_LOADED, the
-            // recursive inheritance graph (ECMA part.II §9.2) will be constructed and checked for "expanding
+            // recursive inheritance graph (ECMA part.II Section 9.2) will be constructed and checked for "expanding
             // cycles" to detect infinite recursion, e.g. A<T> : B<A<A<T>>>.
             // 
             // The dependencies loaded by this method (parent type, implemented interfaces, generic arguments)

--- a/src/vm/mlinfo.cpp
+++ b/src/vm/mlinfo.cpp
@@ -2904,7 +2904,7 @@ MarshalInfo::MarshalInfo(Module* pModule,
 lExit:
 #ifdef FEATURE_COMINTEROP
 #ifdef FEATURE_CORECLR
-//Field scenario is not blocked here because we don’t want to block loading structs that 
+//Field scenario is not blocked here because we don't want to block loading structs that 
 //have the types which we are blocking, but never pass it to Interop.
 
     if (AppX::IsAppXProcess() && ms != MarshalInfo::MARSHAL_SCENARIO_FIELD)

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1939,7 +1939,7 @@ public:
         /* 0x0c0 */ STRINGREF sPositiveInfinity        ; // + Infinity
         /* 0x0c8 */ STRINGREF sNegativeInfinity        ; // - Infinity
         /* 0x0d0 */ STRINGREF sPercent                 ; // Percent (%) symbol
-        /* 0x0d8 */ STRINGREF sPerMille                ; // PerMille (‰) symbol
+        /* 0x0d8 */ STRINGREF sPerMille                ; // PerMille (U+2030) symbol
         /* 0x0e0 */ STRINGREF sCurrency                ; // (user can override) local monetary symbol
         /* 0x0e8 */ STRINGREF sIntlMonetarySymbol      ; // international monetary symbol (RegionInfo)
         /* 0x0f0 */ STRINGREF sEnglishCurrency         ; // English name for this currency

--- a/src/vm/profattach.h
+++ b/src/vm/profattach.h
@@ -122,13 +122,13 @@ public:
     // customize its response for the format expected by the trigger.
     VersionBlock    m_triggerVersion;
 
-    // The GUID of the profiler’s COM object to load
+    // The GUID of the profiler's COM object to load
     CLSID           m_clsidProfiler;
 
-    // The path to the profiler’s COM object to load
+    // The path to the profiler's COM object to load
     WCHAR           m_wszProfilerPath[MAX_PATH];
 
-    // Client data is custom data that the profiler’s
+    // Client data is custom data that the profiler's
     // trigger-process wishes to copy into this process.
     // Profiler authors will typically use this as a way to
     // communicate to the profiler DLL what options the profiler

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -86,12 +86,12 @@
 //             startup). This will also allow the SetEnterLeaveFunctionHooks(2) info
 //             functions to be called outside of Initialize(). If a profiler later
 //             attaches and calls these functions, then the slow-path wrapper will call
-//             into the profiler’s ELT hooks.
+//             into the profiler's ELT hooks.
 //    * COMPLUS_TestOnlyEnableObjectAllocatedHook:
 //         * If nonzero, then on startup the runtime will act as if a profiler was loaded
 //             on startup and requested ObjectAllocated callback (even if no profiler is loaded
 //             on startup). If a profiler later attaches and calls these functions, then the 
-//             ObjectAllocated notifications will call into the profiler’s ObjectAllocated callback.
+//             ObjectAllocated notifications will call into the profiler's ObjectAllocated callback.
 //    * COMPLUS_TestOnlyEnableICorProfilerInfo:
 //         * If nonzero, then attaching profilers allows to call ICorProfilerInfo inteface, 
 //             which would otherwise be disallowed for attaching profilers
@@ -5395,7 +5395,7 @@ HRESULT ProfToEEInterfaceImpl::GetClassFromTokenAndTypeArgs(ModuleID moduleID,
         if (GetThreadNULLOk() == NULL)
         {
             // Type system will try to validate as part of its contract if the current 
-            // AppDomain returned by GetAppDomain can load types in specified module’s 
+            // AppDomain returned by GetAppDomain can load types in specified module's 
             // assembly.   On a non-EE thread it results in an AV in a check build 
             // since the type system tries to dereference NULL returned by GetAppDomain.  
             // More importantly, loading a type on a non-EE thread is not allowed.

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -1900,11 +1900,11 @@ void QCALLTYPE RuntimeTypeHandle::GetTypeByName(LPCWSTR pwzClassName, BOOL bThro
         OBJECTREF keepAlive = NULL;
 
         // BEGIN_QCALL/END_QCALL define try/catch scopes for potential exceptions thrown when bThrowOnError is enabled.
-        // Originally, in case of an exception the GCFrame was removed from the Thread’s Frame chain in the catch block, in UnwindAndContinueRethrowHelperInsideCatch.
+        // Originally, in case of an exception the GCFrame was removed from the Thread's Frame chain in the catch block, in UnwindAndContinueRethrowHelperInsideCatch.
         // However, the catch block declared some local variables that overlapped the location of the now out of scope GCFrame and OBJECTREF, therefore corrupting
         // those values. Having the GCX_COOP/GCX_PREEMP switching GC modes, allowed a situation where in case of an exception, the thread would wait for a GC to complete
-        // while still having the GCFrame in the Thread’s Frame chain, but with a corrupt OBJECTREF due to stack location reuse in the catch block.
-        // The solution is to force the removal of GCFrame (and the Frames above) from the Thread’s Frame chain before entering the catch block, at the time of 
+        // while still having the GCFrame in the Thread's Frame chain, but with a corrupt OBJECTREF due to stack location reuse in the catch block.
+        // The solution is to force the removal of GCFrame (and the Frames above) from the Thread's Frame chain before entering the catch block, at the time of 
         // FrameWithCookieHolder's destruction.
         GCPROTECT_HOLDER(keepAlive);
 

--- a/src/vm/securitytransparentassembly.cpp
+++ b/src/vm/securitytransparentassembly.cpp
@@ -643,7 +643,7 @@ bool SecurityTransparent::SecurityCalloutQuickCheck(MethodDesc *pCallerMD)
     CONTRACTL_END;
 
     // In coreclr, we modified the logic in the callout to also do some transparency method access checks
-    // These checks need to happen regardless of trust level and we shouldn’t be bailing out early 
+    // These checks need to happen regardless of trust level and we shouldn't be bailing out early 
     // just because we happen to be in Full Trust
 #ifndef FEATURE_CORECLR
     // See if we need to process this callout for real, or if we can bail out early before setting up a HMF,

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -1968,7 +1968,7 @@ ProcessFuncletsForGCReporting:
                                     
                                     if (!m_fDidFuncletReportGCReferences)
                                     {
-                                        // we have reached the parent frame of the funclet which didn’t report roots since it was already unwound.
+                                        // we have reached the parent frame of the funclet which didn't report roots since it was already unwound.
                                         // check if the parent frame of the funclet is also handling an exception. if it is, then we will need to
                                         // report roots for it since the catch handler may use references inside it.
                                     


### PR DESCRIPTION
Our native files were more or less encoded in Windows-1252, which
causes problems when we try to compile them on machines where the
current codepage can't represent everything that Windows-1252
can. With this conversion I just moved characters to their ASCII
counterparts (e.g. no smart quotes, the section marker glyph is now
"Section"). There were two places where I couldn't do the straight
forward thing, in object.h we wanted to insert the Per Mille symbol in
a comment so instead I just spelled out the Unicode codepoint. In
morph.cpp, there was a comment pointing to a paper by Torbjörn
Granlund (note the diaeresis above the second o).  In this case,
unfortuntely I had to just drop the diaeresis.  However, searching for
"Torbjorn Granlund" will lead you to the right person.

Fixes #49