### PR TITLE
Fix "pNeeded" increment in GetJitManagerList()

### DIFF
--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -446,7 +446,7 @@ ClrDataAccess::GetJitManagerList(unsigned int count, struct DacpJitManagerInfo m
     {
         *pNeeded = 1;
 #ifdef FEATURE_PREJIT
-        *pNeeded++;
+        (*pNeeded)++;
 #endif
     }
 


### PR DESCRIPTION
"++" has a higher priority than "*".