### PR TITLE
Call TryGetValue in overload of ConcurrentDictionary.GetOrAdd to avoid acquiring lock

### DIFF
--- a/src/mscorlib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/mscorlib/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -1064,6 +1064,10 @@ namespace System.Collections.Concurrent
             if (key == null) throw new ArgumentNullException("key");
 
             TValue resultingValue;
+            if (TryGetValue(key, out resultingValue))
+            {
+                return resultingValue;
+            }
             TryAddInternal(key, value, false, true, out resultingValue);
             return resultingValue;
         }


### PR DESCRIPTION
There are two overloads of ConcurrentDictionary.GetOrAdd. One accepts a
factory method to generate the value if the key is not found, and calls
TryGetValue for the existence check which is a lock-free operation.

The other overload, however, does not call TryGetValue - it simply calls
straight through to TryAddInternal, which will obtain a bucket lock *before it
does the existence check*. This violates the documented claim of
ConcurrentDictionary of lock-free reads. This commit simply adds the same
TryGetValue check, making the two overloads consistent.