### PR TITLE
Update usage text to show correct arguments.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 usage()
 {
     echo "Usage: $0 [BuildArch] [BuildType] [clean]"
-    echo "BuildType can be: Debug, Release"
-    echo "BuildArch can be: Amd64"
+    echo "BuildArch can be: amd64"
+    echo "BuildType can be: debug, release"
     echo "clean - optional argument to force a clean build."
 
     exit 1


### PR DESCRIPTION
The usage text printed the arguments with a capital letter,
whilst the script looked for the same arguments but without
the leading capital letter.

Also reordered the argument help list so it is in the same
order as the script accepts them.