### PR TITLE
Fix build inside badly named directory

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -57,7 +57,7 @@
   <Target Name="BuildNuGetPackages" AfterTargets="Build" Condition="'$(BuildNugetPackage)' != 'false'">
     <MakeDir Directories="$(PackagesBinDir)" Condition="!Exists('$(PackagesBinDir)')" />
     <Copy SourceFiles="$(NuSpecPathSrc)" DestinationFiles="$(NuSpecPathBin)" />
-    <Exec Command="$(NuGetToolPath) pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -OutputDirectory &quot;$(PackagesBinDir)&quot;" />
+    <Exec Command="$(NuGetToolPath) pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
 Nuget fails with message "Cannot create a package that has no dependencies nor content." if path contains directory with name that begins with dot. Fixes #68

It's safe change since explicit file list is used.