### PR TITLE
Improve Enum.TryParse performance. Fixes #70

### DIFF
--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -388,28 +388,24 @@ namespace System
 
             if (Char.IsDigit(value[0]) || value[0] == '-' || value[0] == '+')
             {
-                Type underlyingType = GetUnderlyingType(enumType);
-                Object temp;
+                bool parseSuccess = TryParseEnumValue(enumType, value, ref result);
 
-                try
+                if (parseSuccess)
                 {
-                    temp = Convert.ChangeType(value, underlyingType, CultureInfo.InvariantCulture);
-                    parseResult.parsedEnum = ToObject(enumType, temp);
-                    return true;
-                }
-                catch (FormatException)
-                { // We need to Parse this as a String instead. There are cases
-                  // when you tlbimp enums that can have values of the form "3D".
-                  // Don't fix this code.
-                }
-                catch (Exception ex)
-                {
-                    if (parseResult.canThrow)
-                        throw;
-                    else
+                    try
                     {
-                        parseResult.SetFailure(ex);
-                        return false;
+                        parseResult.parsedEnum = ToObject(enumType, result);
+                        return true;
+                    }
+                    catch (Exception ex)
+                    {
+                        if (parseResult.canThrow)
+                            throw;
+                        else
+                        {
+                            parseResult.SetFailure(ex);
+                            return false;
+                        }
                     }
                 }
             }
@@ -472,6 +468,105 @@ namespace System
                     return false;
                 }
             }
+        }
+
+        private static bool TryParseEnumValue(Type enumType, String value, ref ulong result)
+        {
+            // No need to check for bool here since we don't want it to be parsed by value
+            switch (Type.GetTypeCode(enumType))
+            {
+                case TypeCode.Char:
+                {
+                    char temp;
+                    if (Char.TryParse(value, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.Byte:
+                {
+                    byte temp;
+                    if (Byte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.SByte:
+                {
+                    sbyte temp;
+                    if (SByte.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.Int16:
+                {
+                    short temp;
+                    if (Int16.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.UInt16:
+                {
+                    ushort temp;
+                    if (UInt16.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.Int32:
+                {
+                    int temp;
+                    if (Int32.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.UInt32:
+                {
+                    uint temp;
+                    if (UInt32.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.Int64:
+                {
+                    long temp;
+                    if (Int64.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+                case TypeCode.UInt64:
+                {
+                    ulong temp;
+                    if (UInt64.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out temp))
+                    {
+                        result = (ulong)temp;
+                        return true;
+                    }
+                    return false;
+                }
+            }
+            return false;
         }
 
         [System.Runtime.InteropServices.ComVisible(true)]

--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -388,7 +388,7 @@ namespace System
 
             if (Char.IsDigit(value[0]) || value[0] == '-' || value[0] == '+')
             {
-                bool parseSuccess = TryParseEnumValue(enumType, value, ref result);
+                bool parseSuccess = TryParseEnumValue(enumType, value, ref result, ref parseResult);
 
                 if (parseSuccess)
                 {
@@ -407,6 +407,10 @@ namespace System
                             return false;
                         }
                     }
+                }
+                else if (parseResult.m_failure != ParseFailureKind.None)
+                {
+                    return false;
                 }
             }
 
@@ -470,11 +474,13 @@ namespace System
             }
         }
 
-        private static bool TryParseEnumValue(Type enumType, String value, ref ulong result)
+        private static bool TryParseEnumValue(Type enumType, String value, ref ulong result, ref EnumResult parseResult)
         {
-            // No need to check for bool here since we don't want it to be parsed by value
             switch (Type.GetTypeCode(enumType))
             {
+                case TypeCode.Boolean:
+                    return false;
+
                 case TypeCode.Char:
                 {
                     char temp;
@@ -565,8 +571,13 @@ namespace System
                     }
                     return false;
                 }
+                default:
+                {
+                    // This is needed for backwards compatibility
+                    parseResult.SetFailure(ParseFailureKind.Argument, "Arg_MustBeEnumBaseTypeOrEnum", null);
+                    return false;
+                }
             }
-            return false;
         }
 
         [System.Runtime.InteropServices.ComVisible(true)]


### PR DESCRIPTION
The idea here is that enum value is always integer, so it will surely fit into long if it's signed or into ulong if it's unsigned.  Furthermore, string-to-enum code uses ulong to store both signed and unsigned results anyway, so there is no real need to make any difference between signed/unsigned other than handling negative numbers or cast to intermediate results.

Performance figures:
Since I was unable to run MeasureIt on CoreClr, not was I able to find System.dll to get Stopwatch this results was taken using DateTime.Now and are fairly approximate, but difference is so big that it is hard to make mistake here.

Measurements taken on i5-4670K CPU at 4.2GHz, Win 8.1,  release build
Old:
```
Good run: 218ms
Bad run: 13657ms
Big numbers run: 10955ms
Small numbers run: 295ms
All letters run: 125ms
```
New:
```
Good run: 215ms
Bad run: 187ms
Big numbers run: 252ms
Small numbers run: 218ms
All letters run: 123ms
```

In worst case improvement are over 70 times, plus there is noticeable speedup of parsing numbers as such (something near 25% since we now do less operations)

Code I used to test this can be viewed as gist: https://gist.github.com/Alexx999/84640c2c31e4f5806cd1

Issues/Open questions:

I found one edge case with undefined behavior - more precisely, when you do supply value that overflows enum's backing data type. This case is not covered by tests in CoreFx, it is present in my test as "Case 13".
For example, imagine following code:
``` C#
enum SmallEnum : byte
{}
bool result = Enum.TryParse(ulong.MaxValue.ToString(), out smallEnum);
```
In this case you'll get false with old code (and new code will parse it fine).

I believe this is inconsistent with how enums work in general - you can do this:
``` C#
ulong bigValue = ulong.MaxValue;
SmallEnum smallEnum = (SmallEnum)bigValue;
```
and it will not fail. Even more than that - this behavior actually *is* covered by tests, as can be seen here:
https://github.com/dotnet/corefx/blob/master/src/System.Runtime/tests/System/Enum.cs#L290

So is it okay to have such behavior changes or it must be changed to perfectly mimic old behavior?

Fixes #70