### PR TITLE
Build fixes for clang3.7 and systems without stropt.h.

### DIFF
--- a/src/pal/src/config.h
+++ b/src/pal/src/config.h
@@ -55,9 +55,6 @@ because gcc will complain about %I64d and %S
 /* Define as 1 if you have inttypes.h. */
 #define HAVE_INTTYPES_H 1
 
-/* Define as 1 if you have stropts.h. */
-#define HAVE_STROPTS_H 1
-
 /* Define as 1 if you have sys/vmparam.h. */
 #define HAVE_SYS_VMPARAM_H 0
 

--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -56,9 +56,6 @@ because gcc will complain about %I64d and %S
 /* Define as 1 if you have inttypes.h. */
 #define HAVE_INTTYPES_H 0
 
-/* Define as 1 if you have stropts.h. */
-#define HAVE_STROPTS_H 0
-
 /* Define as 1 if you have sys/vmparam.h. */
 #define HAVE_SYS_VMPARAM_H 0
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -59,9 +59,6 @@ Abstract:
 #else
 #include "pal/fakepoll.h"
 #endif  // HAVE_POLL
-#if HAVE_STROPTS_H
-#include <stropts.h>
-#endif  // HAVE_STROPTS_H
 
 #if defined(__APPLE__)
 #include <sys/sysctl.h>

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -35,9 +35,6 @@ Abstract:
 #else
 #include "pal/fakepoll.h"
 #endif // HAVE_POLL
-#if HAVE_STROPTS_H
-#include <stropts.h>
-#endif  // HAVE_STROPTS_H
 
 namespace CorUnix
 {

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -41,9 +41,6 @@ Abstract:
 
 #include <sys/types.h>
 #include <signal.h>
-#if HAVE_STROPTS_H
-#include <stropts.h>
-#endif  // HAVE_STROPTS_H
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/resource.h>

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -48,9 +48,6 @@ Abstract:
 #include "pal/fakepoll.h"
 #endif  // HAVE_POLL
 #include <limits.h>
-#if HAVE_STROPTS_H
-#include <stropts.h>
-#endif  // HAVE_STROPTS_H
 #if HAVE_SYS_LWP_H
 #include <sys/lwp.h>
 // If we don't have sys/lwp.h but do expect to use _lwp_self, declare it to silence compiler warnings

--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -50,9 +50,6 @@ Revision History:
 #include <stddef.h>
 #include <sys/stat.h>
 #include <limits.h>
-#if HAVE_STROPTS_H
-#include <stropts.h>
-#endif  // HAVE_STROPTS_H
 
 #if defined(_AIX)
 // AIX requires explicit definition of the union semun (see semctl man page)

--- a/src/pal/tools/setup-compiler-clang.sh
+++ b/src/pal/tools/setup-compiler-clang.sh
@@ -3,5 +3,5 @@
 # This file sets the environment to be used for building with clang.
 #
 
-export CC=/usr/bin/clang
-export CXX=/usr/bin/clang++
+export CC=$(which clang)
+export CXX=$(which clang++)

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -150,7 +150,7 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         // **ALSO update the shadow GC heap if that is enabled**
         // Do not perform the work if g_GCShadow is 0
         PREPARE_EXTERNAL_VAR g_GCShadow, rax
-        cmp     [rax], 0
+        cmp     qword ptr [rax], 0
         je      NoShadow_ByRefWriteBarrier
 
         // If we end up outside of the heap don't corrupt random memory

--- a/src/vm/amd64/jithelpers_slow.S
+++ b/src/vm/amd64/jithelpers_slow.S
@@ -17,7 +17,7 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         // **ALSO update the shadow GC heap if that is enabled**
         // Do not perform the work if g_GCShadow is 0
         PREPARE_EXTERNAL_VAR g_GCShadow, rax
-        cmp     [rax], 0
+        cmp     qword ptr [rax], 0
         je      NoShadow
 
         // If we end up outside of the heap don't corrupt random memory


### PR DESCRIPTION
- Fix setup-compiler-clang to detect binaries outside of /usr/bin
- Fix ambiguously-sized cmp instructions when comparing g_GCShadow and 0
- Remove references to stropt.h. None of the defiinitions in this header
  are used by the product, and this header is not present on certain
  systems.