### PR TITLE
Add development package to build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,10 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_subdirectory(src/coreclr/hosts/unixcorerun)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
+# Add this subdir. We install the headers for the jit.
+
+add_subdirectory(src/pal/prebuilt/inc)
+
 # Set to 1 if you want to clear the CMAKE initial compiler flags and set all the flags explicitly
 # or to 0 if the CMake generated flags should be used
 

--- a/build.proj
+++ b/build.proj
@@ -44,19 +44,20 @@
   </Target>
 
   <!-- Setup Nuget properties -->
-  <PropertyGroup>
-    <NuSpecPathSrc>$(PackagesDir)Microsoft.DotNet.CoreCLR.nuspec</NuSpecPathSrc>
-    <NuSpecPathBin>$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.nuspec</NuSpecPathBin>
-  </PropertyGroup>
-
   <ItemGroup>
-    <NuSpecs Include="$(NuSpecPathBin)" />
+    <NuSpecSrcs Include="$(PackagesDir)Microsoft.DotNet.CoreCLR.nuspec" />
+    <NuSpecSrcs Include="$(PackagesDir)Microsoft.DotNet.CoreCLR.Development.nuspec" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Backslash appended, see note in dir.props about the PackagesBinDir property -->
+    <NuSpecs Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.nuspec" />
+    <NuSpecs Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.Development.nuspec" />
   </ItemGroup>
 
-  <!-- Generate Microsoft.Dotnet.CoreCLR nuget package -->
+  <!-- Generate Microsoft.Dotnet.CoreCLR nuget package and associated development package -->
   <Target Name="BuildNuGetPackages" AfterTargets="Build" Condition="'$(BuildNugetPackage)' != 'false'">
     <MakeDir Directories="$(PackagesBinDir)" Condition="!Exists('$(PackagesBinDir)')" />
-    <Copy SourceFiles="$(NuSpecPathSrc)" DestinationFiles="$(NuSpecPathBin)" />
+    <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(PackagesBinDir)" />
     <Exec Command="$(NuGetToolPath) pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" />
   </Target>
 

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.CoreCLR.Development</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft DotNet CoreCLR Runtime For Component Development</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides the CoreCLR runtime binaries with debug information and interface headers</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="..\clretwrc.dll" target="bin\clretwrc.dll" />
+    <file src="..\coreclr.dll" target="bin\coreclr.dll" />
+    <file src="..\mscordaccore.dll" target="bin\mscordaccore.dll" />
+    <file src="..\mscordbi.dll" target="bin\mscordbi.dll" />
+    <file src="..\mscorrc.dll" target="bin\mscorrc.dll" />
+    <file src="..\mscorrc.debug.dll" target="bin\mscorrc.debug.dll" />
+    <file src="..\corerun.exe" target="bin\corerun.exe" />
+    <file src="..\mscorlib.dll" target="bin\mscorlib.dll" />
+    <file src="..\PDB\clretwrc.pdb" target="bin\clretwrc.pdb" />
+    <file src="..\PDB\coreclr.pdb" target="bin\coreclr.pdb" />
+    <file src="..\PDB\corerun.pdb" target="bin\corerun.pdb" />
+    <file src="..\PDB\mscordaccore.pdb" target="bin\mscordaccore.pdb" />
+    <file src="..\PDB\mscordbi.pdb" target="bin\mscordbi.pdb" />
+    <file src="..\PDB\mscorrc.pdb" target="bin\mscorrc.pdb" />
+    <file src="..\PDB\mscorrc.debug.pdb" target="bin\mscorrc.debug.pdb" />
+    <file src="..\PDB\corerun.pdb" target="bin\corerun.pdb" />
+    <file src="..\mscorlib.pdb" target="bin\mscorlib.pdb" />
+    <file src="..\inc\cor.h" target="inc\cor.h" />
+    <file src="..\inc\corerror.h" target="inc\corerror.h" />
+    <file src="..\inc\corhdr.h" target="inc\corhdr.h" />
+    <file src="..\inc\corinfo.h" target="inc\corinfo.h" />
+    <file src="..\inc\corjit.h" target="inc\corjit.h" />
+  </files>
+</package>

--- a/src/dlls/clretwrc/CMakeLists.txt
+++ b/src/dlls/clretwrc/CMakeLists.txt
@@ -18,7 +18,6 @@ add_custom_command(
 
 # add the install targets
 install (TARGETS clretwrc DESTINATION .)
-
 if(WIN32)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/clretwrc.pdb DESTINATION PDB)
 endif(WIN32)

--- a/src/dlls/mscorrc/full/CMakeLists.txt
+++ b/src/dlls/mscorrc/full/CMakeLists.txt
@@ -6,7 +6,6 @@ add_definitions(-DFX_VER_INTERNALNAME_STR=mscorrc.debug.dll)
 
 # add the install targets
 install (TARGETS mscorrc.debug DESTINATION .)
-
 if(WIN32)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscorrc.debug.pdb DESTINATION PDB)
 endif(WIN32)

--- a/src/dlls/mscorrc/small/CMakeLists.txt
+++ b/src/dlls/mscorrc/small/CMakeLists.txt
@@ -6,7 +6,6 @@ add_definitions(-DFX_VER_INTERNALNAME_STR=mscorrc.dll)
 
 # add the install targets
 install (TARGETS mscorrc DESTINATION .)
-
 if(WIN32)
 install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscorrc.pdb DESTINATION PDB)
 endif(WIN32)

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -60,3 +60,7 @@ endif(WIN32)
 
 # Compile *_i.c to lib
 add_library(corguids ${CORGUIDS_SOURCES})
+
+# Binplace the inc files for packaging later.
+
+install (FILES cor.h corhdr.h corinfo.h corjit.h DESTINATION inc)

--- a/src/pal/prebuilt/inc/CMakeLists.txt
+++ b/src/pal/prebuilt/inc/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 2.8.12.2)
+
+project(COREPAL)
+
+install (FILES corerror.h DESTINATION inc)
+


### PR DESCRIPTION
(Note once the other PDB changes go in I'll rebase this onto master to remove some of the noisy diffs from that change)

Adds a "development" package to the build.  This builds a nuget package that contains the PDBs as well as headers that can be used for development of other components.
