### PR TITLE
Use # of processors + 1 available to OS scheduler on Linux when building

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -81,7 +81,7 @@ build_coreclr()
     # Get the number of processors available to the scheduler
     # Other techniques such as `nproc` only get the number of
     # processors available to a single process.
-    NumProc=$(getconf _NPROCESSORS_ONLN)
+    NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
     
     # Build CoreCLR
     

--- a/build.sh
+++ b/build.sh
@@ -77,11 +77,17 @@ build_coreclr()
         echo Failed to generate native component build project!
         exit 1
     fi
+
+    # Get the number of processors available to the scheduler
+    # Other techniques such as `nproc` only get the number of
+    # processors available to a single process.
+    NumProc=$(getconf _NPROCESSORS_ONLN)
     
     # Build CoreCLR
     
-    echo Executing make $__UnprocessedBuildArgs
-    make install -j `nproc` $__UnprocessedBuildArgs
+    echo Executing make install -j $NumProc $__UnprocessedBuildArgs
+
+    make install -j $NumProc $__UnprocessedBuildArgs
     if [ $? != 0 ]; then
         echo Failed to build coreclr components.
         exit 1


### PR DESCRIPTION
`getconf _NPROCESSORS_ONLN` provides the number of cores available to
the OS scheduler, while `nproc` provides the number of cores available
to `nproc` itself. We want to use the former value since make spawns
new processes instead of running compilation tasks in the same process.
(FWIW, the two values are usually the same, but `getconf` gets us the
value that we actually want.)

Additionally, `getconf` is available on Mac OSX while `nproc` is not.

I also fixed the printout of the `make` command that's actually
executed when we build.

Also, thank you to Sedat Dilek for reporting this via email.