### PR TITLE
Fix Windows x64 corerun.exe to run anycpu 32-bit preferred exe

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -372,26 +372,19 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
     wchar_t appNiPath[MAX_PATH * 2] = W("");
     wchar_t managedAssemblyFullName[MAX_PATH] = W("");
 
-    HMODULE managedExeModule = nullptr;
-
-    // Have the OS loader discover the location of the managed exe
-    managedExeModule = ::LoadLibraryExW(programPath, NULL, 0);
+    wchar_t* filePart = NULL;
     
-    if (!managedExeModule) {
-        log << W("Failed to load: ") << programPath << Logger::endl;
+    if (!::GetFullPathName(programPath, MAX_PATH, appPath, &filePart)) {
+        log << W("Failed to get full path: ") << programPath << Logger::endl;
         log << W("Error code: ") << GetLastError() << Logger::endl;
         return false;
     } 
 
-    // If the module was successfully loaded, get the path to where it was found.
-    ::GetModuleFileNameW(managedExeModule, managedAssemblyFullName, MAX_PATH);
-    
-    log << W("Loaded: ") << managedAssemblyFullName << Logger::endl;
+    wcscpy_s(managedAssemblyFullName, appPath);
 
-    wchar_t* filePart = NULL;
-    
-    ::GetFullPathName(managedAssemblyFullName, MAX_PATH, appPath, &filePart);
     *(filePart) = W('\0');
+
+    log << W("Loading: ") << managedAssemblyFullName << Logger::endl;
 
     wcscpy_s(appNiPath, appPath);
     wcscat_s(appNiPath, MAX_PATH * 2, W(";"));

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -399,31 +399,20 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
     wchar_t appNiPath[MAX_PATH * 2] = W("");
     wchar_t managedAssemblyFullName[MAX_PATH] = W("");
     wchar_t appLocalWinmetadata[MAX_PATH] = W("");
-
-    HMODULE managedExeModule = nullptr;
-
-    wchar_t fullExePath[MAX_PATH];
-    ::GetFullPathName(exeName, MAX_PATH, fullExePath, NULL); // Bizarrely, loading a relative path is failing on Phone OS
-
-    // Have the OS loader discover the location of the managed exe
-    managedExeModule = ::LoadLibraryExW(fullExePath, NULL, 0);
     
-    if (!managedExeModule) {
-        log << W("Failed to load: ") << fullExePath << Logger::endl;
+    wchar_t* filePart = NULL;
+    
+    if (!::GetFullPathName(exeName, MAX_PATH, appPath, &filePart)) {
+        log << W("Failed to get full path: ") << exeName << Logger::endl;
         log << W("Error code: ") << GetLastError() << Logger::endl;
         return false;
     } 
 
-    // If the module was successfully loaded, get the path to where it was found.
-    ::GetModuleFileNameW(managedExeModule, managedAssemblyFullName, MAX_PATH);
-    
-    log << W("Loaded: ") << managedAssemblyFullName << Logger::endl;
+    wcscpy_s(managedAssemblyFullName, appPath);
 
-    wchar_t* filePart = NULL;
-    
-    ::GetFullPathName(managedAssemblyFullName, MAX_PATH, appPath, &filePart);
     *(filePart) = W('\0');
 
+    log << W("Loading: ") << managedAssemblyFullName << Logger::endl;
    
     wcscpy_s(appLocalWinmetadata, appPath);
     wcscat(appLocalWinmetadata, W("\\WinMetadata"));


### PR DESCRIPTION
The bug was caused by call to LoadLibrary in Windows corerun and coreconsole hosts that refused to load 32-bit preferred exe.

I have removed the problematic call to LoadLibrary. The purpose of this call was to normalize the exe path. The exe path is already normalized and so this call was unnecessary.

Fixes #92