### PR TITLE
Fix std::out_of_range exception with short filenames (Linux)

### DIFF
--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -190,7 +190,7 @@ void AddFilesFromDirectoryToTpaList(const char* directory, std::string& tpaList)
             std::string filename(entry->d_name);
             
             // Check if the extension matches the one we are looking for
-            size_t extPos = filename.length() - extLength;
+            int extPos = filename.length() - extLength;
             if ((extPos <= 0) || (filename.compare(extPos, extLength, ext) != 0))
             {
                 continue;


### PR DESCRIPTION
An unsigned integer was being used while scanning the CLR path to locate assemblies. If a file existed in the directory with a name shorter than the longest extension being checked for (.ni.dll), then the variable would underflow and cause an exception when used as an index on the filename.

$ touch 123456

$ ./corerun hello.exe 
terminate called after throwing an instance of 'std::out_of_range'
  what():  basic_string::compare: __pos (which is 18446744073709551615) > this->size() (which is 6)
Aborted (core dumped)
