### PR TITLE
If there is a file in the working directory that is shorter than any of ...

### DIFF
--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -193,6 +193,10 @@ void AddFilesFromDirectoryToTpaList(const char* directory, std::string& tpaList)
 
             std::string filename(entry->d_name);
             
+            // If the file is shorter than the 
+            if (extLength > filename.length())
+              continue;
+
             // Check if the extension matches the one we are looking for
             size_t extPos = filename.length() - extLength;
             if ((extPos <= 0) || (filename.compare(extPos, extLength, ext) != 0))


### PR DESCRIPTION
...the extLengths, it can underflow