### PR TITLE
SemaphoreSlim performance improvement

### DIFF
--- a/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
@@ -781,13 +781,11 @@ namespace System.Threading
 
                 // Signal to any synchronous waiters
                 int waitCount = m_waitCount;
-                if (currentCount == 1 || waitCount == 1)
+
+                int waitersToNotify = Math.Min(releaseCount, waitCount);
+                for (int i = 0; i < waitersToNotify; i++)
                 {
                     Monitor.Pulse(m_lockObj);
-                }
-                else if (waitCount > 1)
-                {
-                    Monitor.PulseAll(m_lockObj);
                 }
 
                 // Now signal to any asynchronous waiters, if there are any.  While we've already

--- a/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
@@ -350,9 +350,7 @@ namespace System.Threading
                 //       This additional amount of spinwaiting in addition
                 //       to Monitor.Enter()’s spinwaiting has shown measurable perf gains in test scenarios.
                 //
-                // If there's too many waiters then we got nothing from spinwaiting
-
-
+                
                 // Getting the id for current thread
                 int myEntryId = 0;
                 try { }
@@ -361,7 +359,8 @@ namespace System.Threading
                     myEntryId = Interlocked.Increment(ref m_enteringWaiterNumber);
                     enteringWaiterNumberUpdated = true;
                 }
-
+                
+                // If there's too many waiters then we got nothing from spinwaiting
                 if (m_waitCount <= PlatformHelper.ProcessorCount)
                 {
                     SpinWait spin = new SpinWait();


### PR DESCRIPTION
This tweak improves performance for the case when the number of working threads more than the number of CPU cores.

The original code uses SpinWait before calling Monitor.Enter(), but the spinning condition is not perfect. To reduce the number of unnecessary waiting on the Monitor it would be good to wait while other threads finished their work inside critical section. The idea of this tweak is to arrange threads on SpinWait so that they do not enter critical section concurrently.


Measurement taken on i7-4770k (8 cores: 4 physical + 4HT).

SemaphoreSlim tests (source code of the test can be found [here](https://gist.github.com/ikopylov/3ba679adaaeb416d19a4#file-semaphoreslimperftest-cs)).
Old:
```
<# of threads calling Release>, <# of threads calling Wait>: <Average execution time>
1, 1:   1585ms
8, 8:   2367ms
1, 8:   3727ms
1, 16: 97430ms
8, 1:   1522ms
16, 1:  1515ms
```

New:
```
1, 1:   1488ms
8, 8:   2402ms
1, 8:   3556ms
1, 16:  6649ms
8, 1:   1546ms
16, 1:  1489ms
```

For the '**1, 16**' case the boost is obvious. For other cases the difference is comparable to the measurement error.



BlockingCollection uses SemaphoreSlim under cover so I decided to test it too (source code of the test can be found [here](https://gist.github.com/ikopylov/3ba679adaaeb416d19a4#file-blockingcollectionperftest-cs)).
Old:
```
<# of threads adding elements>, <# of threads taking elements>: <Average execution time>
1, 1:    2106ms
4, 4:    2111ms
8, 8:    2683ms
16, 1:  24670ms
1, 16:  22661ms
16, 16:  3147ms
```

New:
```
1, 1:    2126ms
4, 4:    1888ms
8, 8:    2176ms
16, 1:   2997ms
1, 16:   3577ms
16, 16:  2138ms
```

Again you can see the measurable boost when the number of threads more than the number of cores.
