### PR TITLE
Fix undefined symbols "_DBG_CheckStackAlignment" in release build on osx

### DIFF
--- a/src/pal/src/arch/i386/context.S
+++ b/src/pal/src/arch/i386/context.S
@@ -1,4 +1,4 @@
-#if defined(_DEBUG)
+#if defined(__APPLE__)
     .text
     .globl _DBG_CheckStackAlignment
 


### PR DESCRIPTION
Either remove "#if defined(_DEBUG)/#endif" or replace with "\__APPLE_\__" can fix it. But for readability, "\_\_APPLE\_\_" is a better choice.
Fixes #121