### PR TITLE
Set the mach exception default to MachException_SuppressDebugging

### DIFF
--- a/src/pal/src/exception/machexception.cpp
+++ b/src/pal/src/exception/machexception.cpp
@@ -123,7 +123,7 @@ enum MachExceptionMode
     MachException_SuppressManaged   = 4,
 
     // Default value to use if environment variable not set.
-    MachException_Default           = 0,
+    MachException_Default           = 2,
 };
 
 static exception_mask_t GetExceptionMask()


### PR DESCRIPTION
There is no managed debugger, so lets at least make the native one work for now.