### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# EditorConfig is awesome:
+http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+# Trim trailing whitespace
+[*]
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{asm,inc}]
+indent_size = 8
+
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+[CMakeLists.txt]
+indent_size = 2
+
+[*.cmd]
+indent_size = 2


### PR DESCRIPTION
EditorConfig allow all developers use same space/tab settings for all files if they install EditorConfig plugin

Similar to that PR https://github.com/dotnet/corefx/pull/56