### PR TITLE
Fixed error message when running tests\buildtest.cmd

### DIFF
--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -21,7 +21,7 @@ if not defined __BuildArch set __BuildArch=x64
 if not defined __BuildType set __BuildType=debug
 if not defined __TestWorkingDir set __TestWorkingDir=%__ProjectFilesDir%\..\binaries\tests\%__BuildArch%\%__BuildType%
 
-if not defined __LogsDir  set  __LogsDir=%__ProjectFilesDir%..\binaries\Logs 
+if not defined __LogsDir  set  __LogsDir=%__ProjectFilesDir%..\binaries\Logs
 
 set __TestBuildLog=%__LogsDir%\Tests_%__BuildArch%__%__BuildType%.log
 set __XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildArch%__%__BuildType%.log


### PR DESCRIPTION
This PR fixed a small error in buildtest.cmd, which causes it to show "The system cannot find the path specified" when ran.
It's due to a trailing space in the definition of __LogsDir in the script.