### PR TITLE
AcquireNoThrow(): return type must be HRESULT

### DIFF
--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -5555,7 +5555,7 @@ public:
     {
     }
 
-    BOOL AcquireNoThrow()
+    HRESULT AcquireNoThrow()
     {
         WRAPPER_NO_CONTRACT;
 


### PR DESCRIPTION
But all users of this function take result like "HRESULT".