### PR TITLE
Add information to build.cmd regarding what version of VS 2013 is required

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -86,13 +86,13 @@ goto :eof
 :CheckVS
 :: Check presence of VS
 if defined VS120COMNTOOLS goto CheckVSExistence
-echo Installation of VS 2013 is a pre-requisite to build this repository.
+echo Installation of VS 2013 Professional or higher is a pre-requisite to build this repository.
 goto :eof
 
 :CheckVSExistence
 :: Does VS 2013 really exist?
 if exist "%VS120COMNTOOLS%\..\IDE\devenv.exe" goto CheckMSBuild
-echo Installation of VS 2013 is a pre-requisite to build this repository.
+echo Installation of VS 2013 Professional or higher is a pre-requisite to build this repository.
 goto :eof
 
 :CheckMSBuild    
@@ -119,9 +119,12 @@ call "%VS120COMNTOOLS%\..\..\VC\vcvarsall.bat" x86_amd64
 
 if exist "%VSINSTALLDIR%DIA SDK" goto GenVSSolution
 echo Error: DIA SDK is missing at "%VSINSTALLDIR%DIA SDK". ^
-This is due to bug in VS Intaller. It does not install DIA SDK at "%VSINSTALLDIR%" but rather ^
+This is due to a bug in the VS Intaller. It does not install DIA SDK at "%VSINSTALLDIR%" but rather ^
 at VS install location of previous version. Workaround is to copy DIA SDK folder from VS install location ^
 of previous version to "%VSINSTALLDIR%" and then resume build.
+:: DIA SDK not included in Express editions
+echo Please note that the Express edition of VS 2013 does not include the DIA SDK. ^
+In this case, you will need to upgrade to VS 2013 Professional or higher.
 goto :eof
 
 :GenVSSolution


### PR DESCRIPTION
Express editions are not capable of compiling due to lacking the DIA SDK. Also corrected some minor grammar mistakes regarding DIA SDK information.