### PR TITLE
Update docs and links to docs

### DIFF
--- a/Documentation/glossary.md
+++ b/Documentation/glossary.md
@@ -1,3 +1,10 @@
+.NET Core Glossary
+===
+
+This glossary defines terms, both common and more niche, that are important to understand when reading .NET Core documents and source code. They are also often used by .NET Core team members and other contributers when conversing on GitHub (issues, PRs), on twitter and other sites.
+
+As much as possible, we should link to the most authoritative and recent source of information for a term. That approach should be the most helpful for people who want to learn more about a topic.
+
 * COR: [Common Object Runtime](http://www.danielmoth.com/Blog/mscorlibdll.aspx). The name of .NET before it was named .NET.
 * DAC: Data Access Component. An abstraction layer over the internal structures in the runtime.
 * EE: Execution Engine. 

--- a/Documentation/intro-to-clr.md
+++ b/Documentation/intro-to-clr.md
@@ -1,6 +1,6 @@
 Introduction to the Common Language Runtime (CLR)
 ===
-By Vance Morrison (@vancem) - 2007
+By Vance Morrison ([@vancem](https://github.com/vancem)) - 2007
 
 What is the Common Language Runtime (CLR)? To put it succinctly: 
 

--- a/Documentation/mscorlib.md
+++ b/Documentation/mscorlib.md
@@ -1,6 +1,6 @@
 Mscorlib and Calling Into the Runtime
 ===
-Author: Brian Grunkemeyer (@briangru) - 2006
+Author: Brian Grunkemeyer ([@briangru](https://github.com/briangru)) - 2006
 
 # Introduction
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Historically, new devs to the CLR team would be encouraged to read the "Book of 
 - [Book of the Runtime FAQ](https://github.com/dotnet/coreclr/blob/master/Documentation/botr-faq.md)
 - [Introduction to the Common Language Runtime](https://github.com/dotnet/coreclr/blob/master/Documentation/intro-to-clr.md)
 - [Mscorlib and Calling Into the Runtime](https://github.com/dotnet/coreclr/blob/master/Documentation/mscorlib.md)
+- [.NET Core Glossary](https://github.com/dotnet/coreclr/blob/master/Documentation/glossary.md)
 - More coming 
 
 ## How to Engage, Contribute and Provide Feedback

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ The [.NET Core Libraries][corefx] repo contains the base class libraries, which 
 ## Learn about CoreCLR
 Historically, new devs to the CLR team would be encouraged to read the "Book of the Runtime" (BotR) before making substative changes to the product. We have released the meaningful BotR chapters, for the same goal with new contributors.
 
-- [Book of the Runtime FAQ](https://github.com/dotnet/coreclr/blob/master/Documentation/botr-faq.md)
-- [Introduction to the Common Language Runtime](https://github.com/dotnet/coreclr/blob/master/Documentation/intro-to-clr.md)
-- [Mscorlib and Calling Into the Runtime](https://github.com/dotnet/coreclr/blob/master/Documentation/mscorlib.md)
-- [.NET Core Glossary](https://github.com/dotnet/coreclr/blob/master/Documentation/glossary.md)
+- [Book of the Runtime FAQ](Documentation/botr-faq.md)
+- [Introduction to the Common Language Runtime](Documentation/intro-to-clr.md)
+- [Mscorlib and Calling Into the Runtime](Documentation/mscorlib.md)
+- [.NET Core Glossary](Documentation/glossary.md)
 - More coming 
 
 ## How to Engage, Contribute and Provide Feedback


### PR DESCRIPTION
- Add a title and intro to the .NET Core glossary
- Link to the glossary from the readme
- Make all of the docs links repo-relative (no more absolute http links to upstream repo)
- Make author handles links, to their personal repos