### PR TITLE
Implement JIT_MemSet and JIT_MemCpy for clang

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -326,6 +326,7 @@ set(VM_SOURCES_WKS_AMD64_ASM
 
 else()
 set(VM_SOURCES_WKS_AMD64_ASM
+    ${AMD64_SOURCES_DIR}/crthelpers.S
     ${AMD64_SOURCES_DIR}/jithelpers_fastwritebarriers.S
     ${AMD64_SOURCES_DIR}/jithelpers_slow.S
     ${AMD64_SOURCES_DIR}/jithelpers_fast.S

--- a/src/vm/amd64/crthelpers.S
+++ b/src/vm/amd64/crthelpers.S
@@ -1,0 +1,43 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Geoff Norton. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
+#include "asmconstants.h"
+
+// JIT_MemSet/JIT_MemCpy
+//
+// It is IMPORANT that the exception handling code is able to find these guys
+// on the stack, but on non-windows platforms we can just defer to the platform
+// implementation.
+// 
+
+LEAF_ENTRY JIT_MemSet, _TEXT
+        test rdx, rdx
+        jz   Exit_MemSet
+
+        cmp  byte ptr [rdi], 0
+
+        jmp  C_FUNC(memset)
+
+Exit_MemSet:
+        ret
+
+LEAF_END JIT_MemSet, _TEXT
+
+LEAF_ENTRY JIT_MemCpy, _TEXT
+        test rdx, rdx
+        jz   Exit_MemCpy
+
+        cmp  byte ptr [rdi], 0
+        cmp  byte ptr [rsi], 0
+
+        jmp  C_FUNC(memcpy)
+
+Exit_MemCpy:
+        ret
+
+LEAF_END JIT_MemCpy, _TEXT

--- a/src/vm/amd64/crthelpers.S
+++ b/src/vm/amd64/crthelpers.S
@@ -1,7 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
 // Copyright (c) Geoff Norton. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 .intel_syntax noprefix
@@ -13,7 +13,7 @@
 // It is IMPORANT that the exception handling code is able to find these guys
 // on the stack, but on non-windows platforms we can just defer to the platform
 // implementation.
-// 
+//
 
 LEAF_ENTRY JIT_MemSet, _TEXT
         test rdx, rdx
@@ -21,7 +21,7 @@ LEAF_ENTRY JIT_MemSet, _TEXT
 
         cmp  byte ptr [rdi], 0
 
-        jmp  C_FUNC(memset)
+        jmp  C_PLTFUNC(memset)
 
 Exit_MemSet:
         ret
@@ -35,7 +35,7 @@ LEAF_ENTRY JIT_MemCpy, _TEXT
         cmp  byte ptr [rdi], 0
         cmp  byte ptr [rsi], 0
 
-        jmp  C_FUNC(memcpy)
+        jmp  C_PLTFUNC(memset)
 
 Exit_MemCpy:
         ret

--- a/src/vm/amd64/crthelpers.S
+++ b/src/vm/amd64/crthelpers.S
@@ -26,7 +26,7 @@ LEAF_ENTRY JIT_MemSet, _TEXT
 Exit_MemSet:
         ret
 
-LEAF_END JIT_MemSet, _TEXT
+LEAF_END_MARKED JIT_MemSet, _TEXT
 
 LEAF_ENTRY JIT_MemCpy, _TEXT
         test rdx, rdx
@@ -40,4 +40,4 @@ LEAF_ENTRY JIT_MemCpy, _TEXT
 Exit_MemCpy:
         ret
 
-LEAF_END JIT_MemCpy, _TEXT
+LEAF_END_MARKED JIT_MemCpy, _TEXT

--- a/src/vm/amd64/unixasmmacros.inc
+++ b/src/vm/amd64/unixasmmacros.inc
@@ -1,15 +1,15 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 #define INVALIDGCVALUE -0x33333333 // 0CCCCCCCDh - the assembler considers it to be a signed integer constant
 
-.macro NOP_3_BYTE 
+.macro NOP_3_BYTE
         nop dword ptr [rax]
 .endm
 
-.macro NOP_2_BYTE 
+.macro NOP_2_BYTE
         xchg ax, ax
 .endm
 
@@ -28,6 +28,12 @@
 #define C_FUNC(name) _##name
 #else
 #define C_FUNC(name) name
+#endif
+
+#if defined(__APPLE__)
+#define C_PLTFUNC(name) _##name
+#else
+#define C_PLTFUNC(name) name@PLT
 #endif
 
 .macro PATCH_LABEL Name
@@ -126,7 +132,7 @@ C_FUNC(\Name\()_End):
 //       this one gives an "unknown directive" error
 //
 //        .savexmm128 \Reg, \Offset
-    
+
         ___STACK_ADJUSTMENT_FORBIDDEN = 1
 
 .endm
@@ -134,7 +140,7 @@ C_FUNC(\Name\()_End):
 .macro restore_xmm128 Reg, ofs
         __Offset = \ofs
         movdqa          \Reg, [rsp + __Offset]
-.endm 
+.endm
 
 .macro POP_CALLEE_SAVED_REGISTERS
 
@@ -205,7 +211,7 @@ C_FUNC(\Name\()_End):
 // CalleeSavedRegisters::r13
 // CalleeSavedRegisters::r12
 // CalleeSavedRegisters::rbp
-// CalleeSavedRegisters::rbx 
+// CalleeSavedRegisters::rbx
 // ArgumentRegisters::r9
 // ArgumentRegisters::r8
 // ArgumentRegisters::rcx
@@ -258,7 +264,7 @@ C_FUNC(\Name\()_End):
         push_nonvol_reg r12
         push_nonvol_reg rbp
         push_nonvol_reg rbx
-        
+
         // ArgumentRegisters
         PUSH_ARGUMENT_REGISTERS
 
@@ -279,12 +285,12 @@ C_FUNC(\Name\()_End):
 
         alloc_stack     __PWTB_StackAlloc
         SAVE_FLOAT_ARGUMENT_REGISTERS __PWTB_FloatArgumentRegisters
-        
+
         END_PROLOGUE
 
 .endm
 
-.macro EPILOG_WITH_TRANSITION_BLOCK_TAILCALL 
+.macro EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
 
         RESTORE_FLOAT_ARGUMENT_REGISTERS __PWTB_FloatArgumentRegisters
         lea rsp,        [rsp + __PWTB_StackAlloc]

--- a/src/vm/amd64/unixstubs.cpp
+++ b/src/vm/amd64/unixstubs.cpp
@@ -117,24 +117,6 @@ extern "C"
         return eax;
     }
     
-    void STDCALL JIT_MemCpy(void *dest, const void *src, SIZE_T count)
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void STDCALL JIT_MemCpy_End()
-    {
-    }
-
-    void STDCALL JIT_MemSet(void *dest, int c, SIZE_T count)
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void STDCALL JIT_MemSet_End()
-    {
-    }
-
     void STDCALL JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR ProfilerHandle)
     {
     }


### PR DESCRIPTION
The windows build has a hand written version of these functions, but
modern systems should have an equivalent performant version of this.
We do need to wrap them to get the trap for a null reference exception,
but after that we can tail call directly.