### PR TITLE
Disable a few PAL sscanf test cases

### DIFF
--- a/src/pal/tests/palsuite/paltestlist.txt
+++ b/src/pal/tests/palsuite/paltestlist.txt
@@ -150,8 +150,6 @@ c_runtime/sprintf/test8/paltest_sprintf_test8
 c_runtime/sprintf/test9/paltest_sprintf_test9
 c_runtime/sqrt/test1/paltest_sqrt_test1
 c_runtime/sscanf/test1/paltest_sscanf_test1
-c_runtime/sscanf/test10/paltest_sscanf_test10
-c_runtime/sscanf/test11/paltest_sscanf_test11
 c_runtime/sscanf/test12/paltest_sscanf_test12
 c_runtime/sscanf/test13/paltest_sscanf_test13
 c_runtime/sscanf/test14/paltest_sscanf_test14
@@ -164,7 +162,6 @@ c_runtime/sscanf/test5/paltest_sscanf_test5
 c_runtime/sscanf/test6/paltest_sscanf_test6
 c_runtime/sscanf/test7/paltest_sscanf_test7
 c_runtime/sscanf/test8/paltest_sscanf_test8
-c_runtime/sscanf/test9/paltest_sscanf_test9
 c_runtime/strcat/test1/paltest_strcat_test1
 c_runtime/strchr/test1/paltest_strchr_test1
 c_runtime/strcmp/test1/paltest_strcmp_test1

--- a/src/pal/tests/palsuite/paltestlist_to_be_reviewed.txt
+++ b/src/pal/tests/palsuite/paltestlist_to_be_reviewed.txt
@@ -15,7 +15,10 @@ c_runtime/fwprintf/test19/paltest_fwprintf_test19
 c_runtime/fwprintf/test2/paltest_fwprintf_test2
 c_runtime/fwprintf/test7/paltest_fwprintf_test7
 c_runtime/iswprint/test1/paltest_iswprint_test1
+c_runtime/sscanf/test10/paltest_sscanf_test10
+c_runtime/sscanf/test11/paltest_sscanf_test11
 c_runtime/sscanf/test3/paltest_sscanf_test3
+c_runtime/sscanf/test9/paltest_sscanf_test9
 c_runtime/swprintf/test2/paltest_swprintf_test2
 c_runtime/swprintf/test7/paltest_swprintf_test7
 c_runtime/ungetc/test2/paltest_ungetc_test2


### PR DESCRIPTION
These tests need to be temporary disabled untill the issue https://github.com/dotnet/coreclr/issues/161 is fixed. This needs to be done in order to enable running PAL tests in the lab. Currently these test cases fail on Mac and Linux release builds.