### PR TITLE
Fix rebuild issue with development package

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <!-- Generate Microsoft.Dotnet.CoreCLR nuget package and associated development package -->
-  <Target Name="BuildNuGetPackages" AfterTargets="Build" Condition="'$(BuildNugetPackage)' != 'false'">
+  <Target Name="BuildNuGetPackages" AfterTargets="MovePDB" Condition="'$(BuildNugetPackage)' != 'false'">
     <MakeDir Directories="$(PackagesBinDir)" Condition="!Exists('$(PackagesBinDir)')" />
     <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(PackagesBinDir)" />
     <Exec Command="$(NuGetToolPath) pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" />

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
@@ -33,7 +33,7 @@
     <file src="..\PDB\mscorrc.debug.pdb" target="bin\mscorrc.debug.pdb" />
     <file src="..\PDB\corerun.pdb" target="bin\corerun.pdb" />
     <file src="..\PDB\sos.pdb" target="bin\sos.pdb" />
-    <file src="..\mscorlib.pdb" target="bin\mscorlib.pdb" />
+    <file src="..\PDB\mscorlib.pdb" target="bin\mscorlib.pdb" />
     <file src="..\inc\cor.h" target="inc\cor.h" />
     <file src="..\inc\corerror.h" target="inc\corerror.h" />
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />


### PR DESCRIPTION
If the development package is deleted and then a rebuild is attempted we fail because mscorlib is not where we think it should be.  We should be looking for mscorlib.pdb in the PDBs dir and also building the packages after the PDBs are moved.