### PR TITLE
Force PAL test lists to have Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -64,3 +64,5 @@
 
 *.in text eol=lf
 *.sh text eol=lf
+src/pal/tests/palsuite/paltestlist.txt text eol=lf
+src/pal/tests/palsuite/paltestlist_to_be_reviewed.txt text eol=lf


### PR DESCRIPTION
A common workflow for some folks on our team is to check out the Git
repository, then share that folder out over to Linux.  In this case,
we need the pal test files to have Unix line endings, even in the case
where core.autocrlf = true, which is the case on Windows.

My hunch is that we would also need this even if we didn't do this,
since otherwise changes to this file will be mirrored back to TFS with
DOS line endings, which would break building the TFS version when
checked out, so it's likely a good idea to do this anyway, even if the
leading factor is a somewhat odd workflow.