### PR TITLE
Fix long-standing String.GetHashCode x64 early halt bug

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -857,11 +857,11 @@ namespace System {
                     int hash1 = 5381;
 #endif
                     int hash2 = hash1;
+                    int len = this.Length;
 
 #if WIN32
                     // 32 bit machines.
                     int* pint = (int *)src;
-                    int len = this.Length;
                     while (len > 2)
                     {
                         hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
@@ -875,15 +875,17 @@ namespace System {
                         hash1 = ((hash1 << 5) + hash1 + (hash1 >> 27)) ^ pint[0];
                     }
 #else
-                    int     c;
+                    int c;
                     char *s = src;
-                    while ((c = s[0]) != 0) {
+                    while (len > 0) {
+                        c = s[0];
                         hash1 = ((hash1 << 5) + hash1) ^ c;
-                        c = s[1];
-                        if (c == 0)
+                        if (len == 1)
                             break;
+                        c = s[1];
                         hash2 = ((hash2 << 5) + hash2) ^ c;
                         s += 2;
+                        len -= 2;
                     }
 #endif
 #if DEBUG


### PR DESCRIPTION
As documented in connect bug 519104, ```String.GetHashCode``` ignores any characters in the string beyond the first null character in x64 runtime. This means that if someone embeds a NULL character in a string, the hash-code will only be computed up to that character. This is wrong in that CLR ```String``` instances are Length specified and embedded NULL character **are** significant and characters after it **are** important to the hash-code.

NOTE:

1. The return value in 32-bit builds DOES take all characters into account, so the strings that have a nice distribution in x32 builds might generate horrific collisions in x64 builds.
1. While as an implementation detail the String buffer is always followed by a NULL character, this is merely to ease the interop issues and has NOTHING to do with how strings should be handled in pure CLR.
1. Changing the hash-code in a new build is NOT a breaking change, just look at the comment in line 892-896.