### PR TITLE
Small fixes to enable AltJit support on UNIX.

### DIFF
--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -266,7 +266,7 @@ int ExecuteManagedAssembly(
     std::string tpaList;
     AddFilesFromDirectoryToTpaList(clrFilesAbsolutePath, tpaList);
     
-    void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW);
+    void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (coreclrLib != nullptr)
     {
         ExecuteAssemblyFunction executeAssembly = (ExecuteAssemblyFunction)dlsym(coreclrLib, "ExecuteAssembly");

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -762,6 +762,8 @@ void PAL_CallRunHandler()
     _ASSERT(FALSE);
 }
 
+extern "C"
+PALAPI
 struct _Unwind_Exception *PAL_TryExcept(
     PFN_PAL_BODY pfnBody,
     PFN_PAL_EXCEPTION_FILTER pfnFilter,

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -1300,7 +1300,7 @@ static void LoadAndInitializeJIT(LPCWSTR pwzJitName, OUT HINSTANCE* phJit, OUT I
     extern HINSTANCE g_hThisInst;
     if (WszGetModuleFileName(g_hThisInst, CoreClrFolder, MAX_PATH))
     {
-        WCHAR *filePtr = wcsrchr(CoreClrFolder, W('\\'));
+        WCHAR *filePtr = wcsrchr(CoreClrFolder, DIRECTORY_SEPARATOR_CHAR_W);
         if (filePtr)
         {
             filePtr[1] = W('\0');


### PR DESCRIPTION
- Load libcoreclr.so with the RTLD_GLOBAL flag set in unixxorerun s.t.
  its exports are available for subsequently loaded libraries.
- Demangle PAL_TryExcept
- Replace a non-portable path separator character with the corresponding
  portable definition from the PAL.