### PR TITLE
Hook up initial JIT tests for MSILC JIT

### DIFF
--- a/tests/src/JIT/CodeGenBringUpTests/cs_template.proj
+++ b/tests/src/JIT/CodeGenBringUpTests/cs_template.proj
@@ -21,6 +21,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
+  <PropertyGroup>
+    <_CLRTestPreCommands>IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJit=*;IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJitName=MSILCJit.dll</_CLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>

--- a/tests/src/JIT/Directed/Arrays/cs_template.proj
+++ b/tests/src/JIT/Directed/Arrays/cs_template.proj
@@ -21,6 +21,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
+  <PropertyGroup>
+    <_CLRTestPreCommands>IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJit=*;IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJitName=MSILCJit.dll</_CLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>


### PR DESCRIPTION
Hook up initial JIT tests for MSILC JIT. If environment variable DOMSILCTEST is set, use MSILC JIT. Otherwise, it does nothing.