### PR TITLE
Expand the availability of MSILC JIT to all tests 

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -8,6 +8,7 @@ if /i "%1" == "x64"    (set __BuildArch=x64&set __MSBuildBuildArch=x64&shift&got
 if /i "%1" == "debug"    (set __BuildType=debug&shift&goto Arg_Loop)
 if /i "%1" == "release"   (set __BuildType=release&shift&goto Arg_Loop)
 if /i "%1" == "SkipWrapperGeneration" (set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
+if /i "%1" == "EnableMSILC" (set __EnableMSILC=true&shift&goto Arg_Loop)
 
 if /i "%1" == "/?"      (goto Usage)
 
@@ -132,6 +133,7 @@ echo.
 echo BuildArch is x64
 echo BuildType can be: Debug, Release
 echo SkipWrapperGeneration- Optional parameter this will run the same set of tests as the last time it was run
+echo EnableMSILC- Optional parameter this will use MSILC JIT, an alternative JIT for testing
 echo CORE_ROOT The path to the runtime  
 goto :eof
 

--- a/tests/src/JIT/CodeGenBringUpTests/cs_template.proj
+++ b/tests/src/JIT/CodeGenBringUpTests/cs_template.proj
@@ -21,9 +21,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
-  <PropertyGroup>
-    <_CLRTestPreCommands>IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJit=*;IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJitName=MSILCJit.dll</_CLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>

--- a/tests/src/JIT/Directed/Arrays/cs_template.proj
+++ b/tests/src/JIT/Directed/Arrays/cs_template.proj
@@ -21,9 +21,6 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
-  <PropertyGroup>
-    <_CLRTestPreCommands>IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJit=*;IF NOT "%DOMSILCTEST%"=="" set COMPLus_AltJitName=MSILCJit.dll</_CLRTestPreCommands>
-  </PropertyGroup>
   <ItemGroup>
     <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
       <Visible>False</Visible>

--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -9,5 +9,9 @@
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
-
+  <!-- Enable MSILC JIT for testing if specified -->
+  <PropertyGroup>
+    <_CLRTestPreCommands>IF NOT "%__EnableMSILC%"=="" set COMPLus_AltJit=*;IF NOT "%__EnableMSILC%"=="" set COMPLus_AltJitName=MSILCJit.dll</_CLRTestPreCommands>
+  </PropertyGroup>
+ 
 </Project>


### PR DESCRIPTION
1. Add EnableMSILC command line option to runtest.cmd 
2. Expand the availability of MSILC JIT to all tests for future MSILC JIT.
