### PR TITLE
Implement CreateSemaphoreExA/W via CreateSemaphoreA/W

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1492,6 +1492,17 @@ CreateSemaphoreA(
 PALIMPORT
 HANDLE
 PALAPI
+CreateSemaphoreExA(
+         IN LPSECURITY_ATTRIBUTES lpSemaphoreAttributes,
+         IN LONG lInitialCount,
+         IN LONG lMaximumCount,
+         IN LPCSTR lpName,
+         IN /*_Reserved_*/  DWORD dwFlags,
+         IN DWORD dwDesiredAccess);
+
+PALIMPORT
+HANDLE
+PALAPI
 CreateSemaphoreW(
          IN LPSECURITY_ATTRIBUTES lpSemaphoreAttributes,
          IN LONG lInitialCount,

--- a/src/pal/src/synchobj/semaphore.cpp
+++ b/src/pal/src/synchobj/semaphore.cpp
@@ -61,7 +61,7 @@ Function:
 CreateSemaphoreExA
 
 Note:
-lpSemaphoreAttributes currentely ignored:
+lpSemaphoreAttributes currently ignored:
 -- Win32 object security not supported
 -- handles to semaphore objects are not inheritable
 
@@ -75,11 +75,20 @@ CreateSemaphoreExA(
         IN LPSECURITY_ATTRIBUTES lpSemaphoreAttributes,
         IN LONG lInitialCount,
         IN LONG lMaximumCount,
-        IN LPCSTR lpName)
+        IN LPCSTR lpName,
+        IN /*_Reserved_*/  DWORD dwFlags,
+        IN DWORD dwDesiredAccess)
 {
-    // TODO: Implement this!
-    ERROR("Needs Implementation!!!");
-    return NULL;
+    // dwFlags is reserved and unused, and dwDesiredAccess is currently
+    // only ever used as SEMAPHORE_ALL_ACCESS.  The other parameters
+    // all map to CreateSemaphoreA.
+    _ASSERTE(SEMAPHORE_ALL_ACCESS == dwDesiredAccess);
+
+    return CreateSemaphoreA(
+        lpSemaphoreAttributes,
+        lInitialCount,
+        lMaximumCount,
+        lpName);
 }
 
 /*++
@@ -87,7 +96,7 @@ Function:
   CreateSemaphoreA
 
 Note:
-  lpSemaphoreAttributes currentely ignored:
+  lpSemaphoreAttributes currently ignored:
   -- Win32 object security not supported
   -- handles to semaphore objects are not inheritable
 
@@ -190,9 +199,16 @@ CreateSemaphoreExW(
         IN /*_Reserved_*/  DWORD dwFlags,
         IN DWORD dwDesiredAccess)
 {
-    // TODO: Implement this!
-    ERROR("Needs Implementation!!!");
-    return NULL;
+    // dwFlags is reserved and unused, and dwDesiredAccess is currently
+    // only ever used as SEMAPHORE_ALL_ACCESS.  The other parameters
+    // all map to CreateSemaphoreW.
+    _ASSERTE(SEMAPHORE_ALL_ACCESS == dwDesiredAccess);
+
+    return CreateSemaphoreW(
+        lpSemaphoreAttributes,
+        lInitialCount,
+        lMaximumCount,
+        lpName);
 }
 
 /*++


### PR DESCRIPTION
Any managed code that touches the ThreadPool is currently crashing when the ThreadPool tries to initialize.  This is due to it creating a semaphore via CreateSemaphoreEx in the pal, and those functions not being implemented.

To help make forward progress, this commit just implements those functions simply by delegating to their non-Ex counterparts, ignoring the additional arguments that come with the Ex versions.  With this change, ThreadPool.QueueUserWorkItem, Task.Run, etc. are able to successfully schedule work and have it executed.

I've left the "TODO: Implement this!" comments in place, under the assumption that these implementations are shortish-term workarounds.