### PR TITLE
Remove PAL_printf_arg_remover

### DIFF
--- a/src/pal/src/cruntime/printf.cpp
+++ b/src/pal/src/cruntime/printf.cpp
@@ -124,42 +124,6 @@ BOOL Internal_AddPaddingA(LPSTR *Out, INT Count, LPSTR In,
 }
 
 
-/*******************************************************************************
-Function:
-  PAL_printf_arg_remover
-
-Parameters:
-  ap
-    - pointer to the va_list from which to remove arguments
-  Precision
-    - the precision of the current format option
-  Type
-    - the type of the argument for the current format option
-  Prefix
-    - the prefix for the current format option
-*******************************************************************************/
-void PAL_printf_arg_remover(va_list *ap, INT Precision, INT Type, INT Prefix)
-{
-    /* remove arg and precision if needed */
-    if (PRECISION_STAR == Precision ||
-        PRECISION_INVALID == Precision)
-    {
-        (void)va_arg(*ap, LONG);
-    }
-    if (Type == PFF_TYPE_FLOAT)
-    {
-        (void)va_arg(*ap, double);
-    }
-    else if (Type == PFF_TYPE_INT && Prefix == PFF_PREFIX_LONGLONG)
-    {  
-        (void)va_arg(*ap, INT64);
-    }
-    else
-    {
-        (void)va_arg(*ap, LONG);
-    }
-}
-
 /*++
 Function:
   PAL_printf

--- a/src/pal/src/cruntime/printfcpp.cpp
+++ b/src/pal/src/cruntime/printfcpp.cpp
@@ -1377,7 +1377,10 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                 }
                 else
                 {
-                    TempInt = NativeVsnprintf(pthrCurrent, TempSprintfStr, TEMP_COUNT, TempBuff, ap);
+                    va_list apcopy;
+
+                    va_copy(apcopy, ap);
+                    TempInt = NativeVsnprintf(pthrCurrent, TempSprintfStr, TEMP_COUNT, TempBuff, apcopy);
 
                     if (TempInt < 0 || static_cast<size_t>(TempInt) >= TEMP_COUNT)
                     {
@@ -1391,10 +1394,13 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                         }
                         
                         TempSprintfStr = TempSprintfStrPtr;
-                        NativeVsnprintf(pthrCurrent, TempSprintfStr, TempInt, TempBuff, ap);
+                        va_end(apcopy);
+                        va_copy(apcopy, ap);
+                        NativeVsnprintf(pthrCurrent, TempSprintfStr, TempInt, TempBuff, apcopy);
                     }
                     
-                    PAL_printf_arg_remover((va_list *)&ap, Precision, Type, Prefix);
+                    va_copy(ap, apcopy);
+                    va_end(apcopy);
                 }
 
                 mbtowcResult = MultiByteToWideChar(CP_ACP, 0,
@@ -1706,7 +1712,6 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                 else
                 {
                      TempInt = NativeVsnprintf(pthrCurrent, BufferPtr, TempCount, TempBuff, ap);
-                     PAL_printf_arg_remover((va_list *)&ap, Precision, Type, Prefix);
                 }
 
                 if (TempInt < 0 || static_cast<size_t>(TempInt) >= TempCount) /* buffer not long enough */
@@ -1969,7 +1974,6 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                 else
                 {
                     TempInt = NativeVsnprintf(pthrCurrent, (LPSTR) BufferPtr, TempCount, TempBuff, ap);
-                    PAL_printf_arg_remover((va_list *)&ap, Precision, Type, Prefix);
                 }
 
                 if (TempInt == 0)
@@ -2305,7 +2309,6 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 else
                 {
                     TempInt = NativeVfprintf(pthrCurrent, stream->bsdFilePtr, TempBuff, ap);
-                    PAL_printf_arg_remover((va_list *)&ap, Precision, Type, Prefix);
                 }
 
                 if (-1 == TempInt)

--- a/src/pal/src/cruntime/silent_printf.cpp
+++ b/src/pal/src/cruntime/silent_printf.cpp
@@ -209,7 +209,6 @@ INT Silent_PAL_vsnprintf(LPSTR Buffer, INT Count, LPCSTR Format, va_list ap)
                     }                                     
 
                      TempInt = PAL__vsnprintf(BufferPtr, TempCount, TempBuff, ap);
-                     PAL_printf_arg_remover((va_list *)&ap, Precision, Type, Prefix);
                 }
 
                 if (TempInt < 0 || static_cast<size_t>(TempInt) >= TempCount) /* buffer not long enough */
@@ -407,7 +406,6 @@ int Silent_PAL_vfprintf(PAL_FILE *stream, const char *format, va_list ap)
                 else
                 {
                     TempInt = PAL_vfprintf(stream, TempBuff, ap);
-                    PAL_printf_arg_remover((va_list *)&ap, Precision, Type, Prefix);
                 }
 
                 if (-1 != TempInt)

--- a/src/pal/src/include/pal/cruntime.h
+++ b/src/pal/src/include/pal/cruntime.h
@@ -104,22 +104,6 @@ Parameters:
 *******************************************************************************/
 BOOL Internal_AddPaddingA(LPSTR *Out, INT Count, LPSTR In, INT Padding, INT Flags);
 
-/*******************************************************************************
-Function:
-  PAL_printf_arg_remover
-
-Parameters:
-  ap
-    - pointer to the va_list from which to remove arguments
-  Precision
-    - the precision of the current format option
-  Type
-    - the type of the argument for the current format option
-  Prefix
-    - the prefix for the current format option
-*******************************************************************************/
-void PAL_printf_arg_remover(va_list *ap, INT Precision, INT Type, INT Prefix);
-
 /*++
 Function:
   Silent_PAL_vsnprintf


### PR DESCRIPTION
The current code seems to assume that va_lists need manual advancing.
This is against the standard, and actually breaks many things rather badly on OSX.
Remove it, and favor va_copy as needed.  Fixes all PAL tests in debug and release mode on OS X