### PR TITLE
Place binaries and intermediates in folders that include OS

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,6 +4,7 @@ setlocal EnableDelayedExpansion
 :: Set the default arguments for build
 set __BuildArch=x64
 set __BuildType=debug
+set __BuildOS=Windows_NT
 
 :: Set the various build properties here so that CMake and MSBuild can pick them up
 set "__ProjectDir=%~dp0"
@@ -14,7 +15,6 @@ set "__SourceDir=%__ProjectDir%\src"
 set "__PackagesDir=%__ProjectDir%\packages"
 set "__RootBinDir=%__ProjectDir%\binaries"
 set "__LogsDir=%__RootBinDir%\Logs"
-set "__CMakeSlnDir=%__RootBinDir%\CMake"
 set __MSBCleanBuildArgs=
 
 :Arg_Loop
@@ -27,7 +27,7 @@ if /i "%1" == "release"   (set __BuildType=release&shift&goto Arg_Loop)
 
 if /i "%1" == "clean"   (set __CleanBuild=1&shift&goto Arg_Loop)
 
-if /i "%1" == "unixmscorlib" (set __UnixMscorlibOnly=1&shift&goto Arg_Loop)
+if /i "%1" == "unixmscorlib" (set __UnixMscorlibOnly=1&set __BuildOS=Unix&shift&goto Arg_Loop)
 
 echo Invalid commandline argument: %1
 goto Usage
@@ -38,21 +38,18 @@ echo Commencing CoreCLR Repo build
 echo.
 
 :: Set the remaining variables based upon the determined build configuration
-set "__BinDir=%__RootBinDir%\Product\%__BuildArch%\%__BuildType%"
+set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__IntermediatesDir=%__RootBinDir%\intermediates\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__PackagesBinDir=%__BinDir%\.nuget"
 set "__ToolsDir=%__RootBinDir%\tools"
-set "__TestWorkingDir=%__RootBinDir%\tests\%__BuildArch%\%__BuildType%"
-set "__IntermediatesDir=%__RootBinDir%\intermediates\%__BuildArch%\%__BuildType%"
+set "__TestWorkingDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
 
 :: Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"
 set "__CMakeBinDir=%__CMakeBinDir:\=/%"
 
-:: Switch to clean build mode if the binaries output folder does not exist
-if not exist "%__RootBinDir%" set __CleanBuild=1
-
 :: Configure environment if we are doing a clean build.
-if not defined __CleanBuild goto CheckPrereqs
+if not defined __CleanBuild goto MakeDirectories
 echo Doing a clean build
 echo.
 
@@ -60,19 +57,18 @@ echo.
 set __MSBCleanBuildArgs=/t:rebuild
 
 :: Cleanup the binaries drop folder
-if exist "%__BinDir%" rd /s /q "%__BinDir%"
-md "%__BinDir%"
-
-:: Cleanup the CMake folder
-if exist "%__CMakeSlnDir%" rd /s /q "%__CMakeSlnDir%"
-md "%__CMakeSlnDir%"
+if exist "%__RootBinDir%" rd /s /q "%__RootBinDir%"
 
 :: Cleanup the logs folder
 if exist "%__LogsDir%" rd /s /q "%__LogsDir%"
-md "%__LogsDir%"
 
 ::Cleanup intermediates folder
 if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"
+
+:MakeDirectories
+if not exist "%__BinDir%" md "%__BinDir%"
+if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
+if not exist "%__LogsDir%" md "%__LogsDir%"
 
 :CheckPrereqs
 :: Check prerequisites
@@ -113,7 +109,7 @@ if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see h
 setlocal
 if defined __UnixMscorlibOnly goto PerformMScorlibBuild
 
-echo Commencing build of native components for %__BuildArch%/%__BuildType%
+echo Commencing build of native components for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
 
 :: Set the environment for the native build
@@ -132,19 +128,19 @@ goto :eof
 
 :GenVSSolution
 :: Regenerate the VS solution
-pushd "%__CMakeSlnDir%"
+pushd "%__IntermediatesDir%"
 call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%"
 popd
 
 :BuildComponents
-if exist "%__CMakeSlnDir%\install.vcxproj" goto BuildCoreCLR
+if exist "%__IntermediatesDir%\install.vcxproj" goto BuildCoreCLR
 echo Failed to generate native component build project!
 goto :eof
 
 REM Build CoreCLR
 :BuildCoreCLR
-set "__CoreCLRBuildLog=%__LogsDir%\CoreCLR_%__BuildArch%__%__BuildType%.log"
-%_msbuildexe% "%__CMakeSlnDir%\install.vcxproj" %__MSBCleanBuildArgs% /nologo /maxcpucount /nodeReuse:false /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% /fileloggerparameters:Verbosity=diag;LogFile="%__CoreCLRBuildLog%"
+set "__CoreCLRBuildLog=%__LogsDir%\CoreCLR_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
+%_msbuildexe% "%__IntermediatesDir%\install.vcxproj" %__MSBCleanBuildArgs% /nologo /maxcpucount /nodeReuse:false /p:Configuration=%__BuildType% /p:Platform=%__BuildArch% /fileloggerparameters:Verbosity=diag;LogFile="%__CoreCLRBuildLog%"
 IF NOT ERRORLEVEL 1 goto PerformMScorlibBuild
 echo Native component build failed. Refer !__CoreCLRBuildLog! for details.
 goto :eof
@@ -157,14 +153,14 @@ REM setlocal to prepare for vsdevcmd.bat
 setlocal
 set __AdditionalMSBuildArgs=
 
-if defined __UnixMscorlibOnly set __AdditionalMSBuildArgs=/p:OS=Unix /p:BuildNugetPackage=false
+if defined __UnixMscorlibOnly set __AdditionalMSBuildArgs=/p:BuildNugetPackage=false
 
 :: Set the environment for the managed build
 call "%VS120COMNTOOLS%\VsDevCmd.bat"
-echo Commencing build of mscorlib for %__BuildArch%/%__BuildType%
+echo Commencing build of mscorlib for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
-set "__MScorlibBuildLog=%__LogsDir%\MScorlib_%__BuildArch%__%__BuildType%.log"
-%_msbuildexe% "%__ProjectFilesDir%\build.proj" %__MSBCleanBuildArgs% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%__MScorlibBuildLog%" %__AdditionalMSBuildArgs%
+set "__MScorlibBuildLog=%__LogsDir%\MScorlib_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
+%_msbuildexe% "%__ProjectFilesDir%\build.proj" %__MSBCleanBuildArgs% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=diag;LogFile="%__MScorlibBuildLog%" /p:OS=%__BuildOS% %__AdditionalMSBuildArgs%
 IF NOT ERRORLEVEL 1 (
   if defined __UnixMscorlibOnly goto :eof
   goto PerformTestBuild
@@ -175,7 +171,7 @@ goto :eof
 
 :PerformTestBuild
 echo.
-echo Commencing build of tests for %__BuildArch%/%__BuildType%
+echo Commencing build of tests for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
 call tests\buildtest.cmd
 IF NOT ERRORLEVEL 1 goto SuccessfulBuild

--- a/build.sh
+++ b/build.sh
@@ -10,41 +10,22 @@ usage()
     exit 1
 }
 
+setup_dirs()
+{
+    echo Setting up directories for build
+    
+    mkdir -p "$__RootBinDir"
+    mkdir -p "$__BinDir"
+    mkdir -p "$__LogsDir"
+    mkdir -p "$__IntermediatesDir"
+}
+
 # Performs "clean build" type actions (deleting and remaking directories)
 
 clean()
 {
-    echo Doing a clean build
-
-    # make projects would need a rebuild
-    MakeCleanArgs=clean
-
-    # Cleanup the binaries drop folder
-    if [ -d "$__BinDir" ]; then 
-        rm -r "$__BinDir"
-    fi
-    
-    mkdir -p "$__BinDir"
-
-    # Cleanup the CMake folder
-    if [ -d "$__CMakeSlnDir" ]; then
-         rm -r "$__CMakeSlnDir"
-    fi
-    mkdir -p "$__CMakeSlnDir"
-
-    # Cleanup the logs folder
-    if [ -d "$__LogsDir" ]; then
-        rm -r "$__LogsDir"
-    fi
-    
-    mkdir -p "$__LogsDir"
-
-    # Cleanup intermediates folder
-    if [ -d "$__IntermediatesDir" ]; then
-        rm -r "$__IntermediatesDir"
-    fi
-
-    mkdir -p "$__IntermediatesDir"
+    echo Cleaning binaries directory
+    rm -rf "$__RootBinDir"
 }
 
 # Check the system to ensure the right pre-reqs are in place
@@ -65,8 +46,8 @@ build_coreclr()
 {
     # All set to commence the build
     
-    echo "Commencing build of native components for $__BuildArch/$__BuildType"
-    cd "$__CMakeSlnDir"
+    echo "Commencing build of native components for $__BuildOS.$__BuildArch.$__BuildType"
+    cd "$__IntermediatesDir"
     
     # Regenerate the CMake solution
     echo "Invoking cmake with arguments: \"$__ProjectRoot\" $__CMakeArgs"
@@ -74,7 +55,7 @@ build_coreclr()
     
     # Check that the makefiles were created.
     
-    if [ ! -f "$__CMakeSlnDir/Makefile" ]; then
+    if [ ! -f "$__IntermediatesDir/Makefile" ]; then
         echo "Failed to generate native component build project!"
         exit 1
     fi
@@ -106,7 +87,16 @@ echo "Commencing CoreCLR Repo build"
 
 # Obtain the location of the bash script to figure out whether the root of the repo is.
 __ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-__BuildArch=amd64
+__BuildArch=x64
+# Use uname to determine what the OS is.  
+if [ $(uname -o | grep -i Linux) ]; then
+    __BuildOS=linux
+elif [ $(uname -o | grep -i Darwin) ]; then
+    __BuildOS=mac
+else
+    echo "Unsupported OS detected, assuming linux"
+    __BuildOS=linux
+fi
 __MSBuildBuildArch=x64
 __BuildType=debug
 __CMakeArgs=DEBUG
@@ -117,7 +107,6 @@ __SourceDir="$__ProjectDir/src"
 __PackagesDir="$__ProjectDir/packages"
 __RootBinDir="$__ProjectDir/binaries"
 __LogsDir="$__RootBinDir/Logs"
-__CMakeSlnDir="$__RootBinDir/CMake"
 __UnprocessedBuildArgs=
 __MSBCleanBuildArgs=
 __CleanBuild=false
@@ -131,7 +120,7 @@ for i in "$@"
         exit 1
         ;;
         amd64)
-        __BuildArch=amd64
+        __BuildArch=x64
         __MSBuildBuildArch=x64
         ;;
         debug)
@@ -150,25 +139,24 @@ for i in "$@"
 done
 
 # Set the remaining variables based upon the determined build configuration
-__BinDir="$__RootBinDir/Product/$__BuildArch/$__BuildType"
+__BinDir="$__RootBinDir/Product/$__BuildOS.$__BuildArch.$__BuildType"
 __PackagesBinDir="$__BinDir/.nuget"
 __ToolsDir="$__RootBinDir/tools"
-__TestWorkingDir="$__RootBinDir/tests/$__BuildArch/$__BuildType"
-__IntermediatesDir="$__RootBinDir/intermediates/$__BuildArch/$__BuildType"
+__TestWorkingDir="$__RootBinDir/tests/$__BuildOS.$__BuildArch.$__BuildType"
+__IntermediatesDir="$__RootBinDir/intermediates/$__BuildOS.$__BuildArch.$__BuildType"
 
 # Specify path to be set for CMAKE_INSTALL_PREFIX.
 # This is where all built CoreClr libraries will copied to.
 export __CMakeBinDir="$__BinDir"
 
-# Switch to clean build mode if the binaries output folder does not exist
-if [ ! -d "$__RootBinDir" ]; then
-    __CleanBuild=1
-fi
-
 # Configure environment if we are doing a clean build.
 if [ $__CleanBuild == 1 ]; then
     clean
 fi
+
+# Make the directories necessary for build if they don't exist
+
+setup_dirs
 
 # Check prereqs.
 

--- a/dir.props
+++ b/dir.props
@@ -1,13 +1,18 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Common properties -->
   <PropertyGroup>
-    <BuildArch Condition="'$(__BuildArch)'==''">amd64</BuildArch>
-    <BuildArch Condition="'$(__BuildArch)' == 'x64'">amd64</BuildArch>
+    <!-- Set basic properties and normalize -->
+    
+    <BuildArch>$(__BuildArch)</BuildArch>
+    <BuildArch Condition="'$(__BuildArch)'==''">x64</BuildArch>
+    <BuildArch Condition="'$(__BuildArch)' == 'amd64'">x64</BuildArch>
 
     <BuildType Condition="'$(__BuildType)'==''">Debug</BuildType>
     <BuildType Condition="'$(__BuildType)' == 'debug'">Debug</BuildType>
     <BuildType Condition="'$(__BuildType)' == 'release'">Release</BuildType>
-
+    
+    <BuildOS>$(__BuildOS)</BuildOS>
+    <BuildOS Condition="'$(__BuildOS)' == ''">Windows_NT</BuildOS>
 
     <ProjectDir>$(__ProjectDir)\</ProjectDir>
     <ProjectDir Condition="'$(__ProjectDir)'==''">$(MSBuildThisFileDirectory)\</ProjectDir>
@@ -22,9 +27,9 @@
     <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)\binaries\</RootBinDir>
 
     <BinDir>$(__BinDir)\</BinDir>
-    <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)\Product\$(BuildArch)\$(BuildType)\</BinDir>
+    <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)\Product\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
-    <!-- We dont append back slash because this path is used by nuget.exe as output directory and it
+    <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.
     -->
     <PackagesBinDir>$(__PackagesBinDir)</PackagesBinDir>
@@ -34,7 +39,7 @@
     <ToolsDir Condition="'$(__ToolsDir)'==''">$(RootBinDir)\tools\</ToolsDir>
 
     <TestWorkingDir>$(__TestWorkingDir)\</TestWorkingDir>
-    <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)\tests\$(BuildArch)\$(BuildType)\</TestWorkingDir>
+    <TestWorkingDir Condition="'$(__TestWorkingDir)'==''">$(RootBinDir)\tests\$(BuildOS).$(BuildArch).$(BuildType)\</TestWorkingDir>
   </PropertyGroup>
 
   <!-- Setup Nuget properties -->

--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -10,6 +10,9 @@
     <AvailablePlatforms>amd64,x86,arm,arm64</AvailablePlatforms>
     <Configuration Condition=" '$(Configuration)' == '' ">$(BuildType)</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">$(BuildArch)</Platform>
+    <!-- The CLR properties use amd64 as their platform string, we want to keep in sync with those, so set Platform appropriately,
+         though still use the 'x64' output path (see use of BuildArch below) -->
+    <Platform Condition=" '$(Platform)' == 'x64' ">amd64</Platform>
     <ProjectGuid>{3DA06C3A-2E7B-4CB7-80ED-9B12916013F9}</ProjectGuid>
 
     <OutputType>Library</OutputType>
@@ -102,7 +105,8 @@
   <!-- Output paths -->
   <PropertyGroup>
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)intermediates</BaseIntermediateOutputPath>
-    <OutputPath Condition="'$(OutputPath)' == ''">$(BaseIntermediateOutputPath)\$(Platform)\$(Configuration)</OutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(Configuration)</IntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(Configuration)</OutputPath>
     <FinalOutputPath Condition="'$(FinalOutputPath)' == ''">$(BinDir)</FinalOutputPath>
   </PropertyGroup>
   
@@ -110,7 +114,7 @@
   <PropertyGroup>
     <ClrProduct>core_clr</ClrProduct>
     <BuildForCoreSystem>true</BuildForCoreSystem>
-
+    
     <!-- These are needed by BCLRewriter -->
     <_BuildType Condition="'$(Configuration)' == 'Debug'">chk</_BuildType>
     <_BuildType Condition="'$(Configuration)' == 'Release'">ret</_BuildType>

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -19,12 +19,13 @@ goto Usage
 
 if not defined __BuildArch set __BuildArch=x64
 if not defined __BuildType set __BuildType=debug
-if not defined __TestWorkingDir set "__TestWorkingDir=%__ProjectFilesDir%\..\binaries\tests\%__BuildArch%\%__BuildType%"
+if not defined __BuildOS set __BuildOS=Windows_NT
+if not defined __TestWorkingDir set "__TestWorkingDir=%__ProjectFilesDir%\..\binaries\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
 
 if not defined __LogsDir  set  "__LogsDir=%__ProjectFilesDir%..\binaries\Logs"
 
-set "__TestBuildLog=%__LogsDir%\Tests_%__BuildArch%__%__BuildType%.log"
-set "__XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildArch%__%__BuildType%.log"
+set "__TestBuildLog=%__LogsDir%\Tests_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
+set "__XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
 
 :: Switch to clean build mode if the binaries output folder does not exist
 if not exist "%__TestWorkingDir%" set __CleanBuild=1

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -37,8 +37,9 @@ if not defined VSINSTALLDIR echo Error: runtest.cmd should be run from a Visual 
 
 if not defined __BuildArch set __BuildArch=x64
 if not defined __BuildType set __BuildType=debug
-if not defined __BinDir    set  __BinDir=%__ProjectFilesDir%..\binaries\Product\%__BuildArch%\%__BuildType%
-if not defined __TestWorkingDir set __TestWorkingDir=%__ProjectFilesDir%..\binaries\tests\%__BuildArch%\%__BuildType%
+if not defined __BuildOS set __BuildOS=Windows_NT
+if not defined __BinDir    set  __BinDir=%__ProjectFilesDir%..\binaries\Product\%__BuildOS%.%__BuildArch%.%__BuildType%
+if not defined __TestWorkingDir set __TestWorkingDir=%__ProjectFilesDir%..\binaries\tests\%__BuildOS%.%__BuildArch%.%__BuildType%
 if not defined __LogsDir        set  __LogsDir=%__ProjectFilesDir%..\binaries\Logs\
 
 :: Default global test environmet variables
@@ -58,10 +59,10 @@ if defined __EnableAltJit          (if not exist %Core_Root%\%Alt_Jit_Name%.dll 
 if not exist %__LogsDir%           md  %__LogsDir%
 
 :SkipDefaultCoreRootSetup
-set __XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildArch%__%__BuildType%.log
-set __TestRunBuildLog=%__LogsDir%\TestRunResults_%__BuildArch%__%__BuildType%.log
-set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildArch%_%__BuildType%.html
-set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildArch%_%__BuildType%.xml
+set __XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildOS%__%__BuildArch%__%__BuildType%.log
+set __TestRunBuildLog=%__LogsDir%\TestRunResults_%__BuildOS%__%__BuildArch%__%__BuildType%.log
+set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%_%__BuildType%.html
+set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%_%__BuildType%.xml
 
 echo "Core_Root that will be used is : %Core_Root%"
 echo "Starting The Test Run .. "

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -5,8 +5,10 @@
   <PropertyGroup>
     <__BuildArch Condition="'$(__BuildArch)' == ''">x64</__BuildArch>
     <__BuildType Condition="'$(__BuildType)' == ''">Debug</__BuildType>
+	<__BuildOS Condition="'$(__BuildOS)' == ''">Windows_NT</__BuildOS>
     <BuildArch>$(__BuildArch)</BuildArch>
     <BuildType>$(__BuildType)</BuildType>
+	<BuildOS>$(__BuildOS)</BuildOS>
     <Configuration Condition="'$(Configuration)' ==''">$(BuildType)</Configuration>
     <Platform Condition="'$(Platform)'==''">$(BuildArch)</Platform>
   </PropertyGroup>
@@ -27,13 +29,13 @@
 
 <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
-    <BaseOutputPathWithConfig>$(ProjectDir)\..\binaries\tests\$(Platform)\$(Configuration)\</BaseOutputPathWithConfig>
+    <BaseOutputPathWithConfig>$(ProjectDir)\..\binaries\tests\$(BuildOS).$(Platform).$(Configuration)\</BaseOutputPathWithConfig>
     <BaseOutputPathWithConfig Condition="'$(__TestWorkingDir)' != ''">$(__TestWorkingDir)\</BaseOutputPathWithConfig>
-    <BinDir>$(BaseOutputPathWithConfig)\..\..\</BinDir>
-    <BaseIntermediateOutputPath>$(BinDir)\obj\</BaseIntermediateOutputPath>
+    <BinDir>$(BaseOutputPathWithConfig)\..\..\..\</BinDir>
+    <BaseIntermediateOutputPath>$(BinDir)\intermediates\</BaseIntermediateOutputPath>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
     <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))</BuildProjectRelativeDir>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)\$(Configuration)\$(Platform)\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)\$(BuildOS).$(Platform).$(Configuration)\</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPathWithConfig)$(BuildProjectRelativeDir)\</OutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
Rework the output paths so that the OS may appear in them.  This then follows the same form as corefx.  This solves a number of problems:
    1) When building unix mscorlib after the regular build, we would use the wrong intermediates for incremental.
    2) When testing windows after building unix mscorlib we'd use the wrong outputs and fail.

This change removes our cmake directory and moves cmake generated files into intermediates (under OS/arch paths)
The reason is that the intermediates go under here when actually doing the build, and on unix based systems, we need to generate the cmake files for different builds into different directories for the purpose of preserving incremental builds.

Change clean behavior

Clean should simply delete the root binary.  We also should not make assumptions about
whether necessary directories are available when we begin to build and should create them every time if
necessary.

Create directories as needed.