### PR TITLE
Remove Unix specific hack in Encoding.GetEncoding

### DIFF
--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -413,11 +413,6 @@ namespace System.Text
 #endif
         public static Encoding GetEncoding(int codepage)
         {
-// TODO: Remove the PLATFOM_UNIX specific code in favor of there regular path.  Right the regular path causes exceptions to be thrown
-//       which hangs the runtime on Unix.
-#if PLATFORM_UNIX            
-            return UTF8;
-#else
             Encoding result = EncodingProvider.GetEncodingFromProvider(codepage);
             if (result != null)
                 return result;
@@ -552,7 +547,6 @@ namespace System.Text
 
             }
             return result;
-#endif
         }
 
         [Pure]


### PR DESCRIPTION
During Hello World bring-up for Unix, we ran into a crash which at the
time I thought was incorrectly due to some missing support in
globalization leading to a first chance exception being thrown.

Instead the problem was that due to a JIT bug, a hashtable that the
Encodings code tried to construct was getting bad data passed to the
constructor which caused an exception to try to be thrown.  The change
I provided caused the hashtable codepath to not be taken and hence
masked the issue.

Now that the JIT bug is fixed, we can remove this workaround. I
verified that HelloWorld still runs on Unix with these changes.