### PR TITLE
Fix cfi annotation for NDirectImportThunk and JIT_RareDisableHelper

### DIFF
--- a/src/vm/amd64/unixasmhelpers.S
+++ b/src/vm/amd64/unixasmhelpers.S
@@ -101,7 +101,7 @@ NESTED_ENTRY NDirectImportThunk, _TEXT, NoHandler
         // Make sure to preserve r11 as well as it is used to pass the stack argument size from JIT
         //
         PUSH_ARGUMENT_REGISTERS
-        push            r11
+        push_register r11
         
         //
         // Allocate space for XMM parameter registers
@@ -123,12 +123,12 @@ NESTED_ENTRY NDirectImportThunk, _TEXT, NoHandler
         //
         // epilogue, rax contains the native target address
         //
-        add             rsp, 0x80
+        free_stack      0x80
 
         //
         // Restore integer parameter registers and r11
         //
-        pop             r11
+        pop_register r11
         POP_ARGUMENT_REGISTERS
         
     TAILJMP_RAX
@@ -153,9 +153,9 @@ LEAF_END moveOWord, _TEXT
 NESTED_ENTRY JIT_RareDisableHelper, _TEXT, NoHandler
 
     // First integer return register
-    push rax
+    push_register rax
     // Second integer return register
-    push rdx
+    push_register rdx
     alloc_stack         0x28
     END_PROLOGUE
     // First float return register
@@ -167,9 +167,9 @@ NESTED_ENTRY JIT_RareDisableHelper, _TEXT, NoHandler
 
     movdqa              xmm0, [rsp]
     movdqa              xmm1, [rsp+0x10]
-    add                 rsp, 0x28
-    pop                 rdx
-    pop                 rax
+    free_stack          0x28
+    pop_register        rdx
+    pop_register        rax
     ret
 
 NESTED_END JIT_RareDisableHelper, _TEXT

--- a/src/vm/amd64/unixasmmacros.inc
+++ b/src/vm/amd64/unixasmmacros.inc
@@ -173,9 +173,13 @@ C_FUNC(\Name\()_End):
 
 .endm
 
-.macro push_argument_register Reg
+.macro push_register Reg
         push            \Reg
         .cfi_adjust_cfa_offset 8
+.endm
+
+.macro push_argument_register Reg
+        push_register \Reg
 .endm
 
 .macro PUSH_ARGUMENT_REGISTERS
@@ -189,9 +193,13 @@ C_FUNC(\Name\()_End):
 
 .endm
 
-.macro pop_argument_register Reg
+.macro pop_register Reg
         pop            \Reg
         .cfi_adjust_cfa_offset -8
+.endm
+
+.macro pop_argument_register Reg
+        pop_register \Reg
 .endm
 
 .macro POP_ARGUMENT_REGISTERS


### PR DESCRIPTION
The title says all. I've talked to @sergiy-k who fixed it in a slightly different way and since I have fixed one more function in there, we've decided to use my change.