### PR TITLE
Fix warnings generated when building with Clang on Linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 msbuild.log
+binaries
 
 # Roslyn stuff
 *.sln.ide
@@ -254,3 +255,7 @@ TestWrappers_x64_release
 Vagrantfile
 .vagrant
 
+# CMake files
+CMakeFiles/
+cmake_install.cmake
+CMakeCache.txt

--- a/src/inc/debugreturn.h
+++ b/src/inc/debugreturn.h
@@ -65,6 +65,7 @@
 class __SafeToReturn {
 public:
     static int safe_to_return() {return 0;};
+    static int used() {return 0;};
 };
 
 class __YouCannotUseAReturnStatementHere {
@@ -76,9 +77,10 @@ private:
     //
     static int safe_to_return() {return 0;};
 public:
-    // Some compilers warn if all member functions in a class are private.
-    // Rather than disable the warning, we'll work around it here.
-    static void dont_call_this() { _ASSERTE(!"Don't call this!"); }
+    // Some compilers warn if all member functions in a class are private
+    // or if a typedef is unused. Rather than disable the warning, we'll work
+    // around it here.
+    static int used() {return 0;};
 };
 
 typedef __SafeToReturn __ReturnOK;
@@ -93,15 +95,15 @@ typedef __SafeToReturn __ReturnOK;
 //
 #define return if (0 && __ReturnOK::safe_to_return()) { } else return
 
-#define DEBUG_ASSURE_NO_RETURN_BEGIN(arg) { typedef __YouCannotUseAReturnStatementHere __ReturnOK; 
-#define DEBUG_ASSURE_NO_RETURN_END(arg)   }
+#define DEBUG_ASSURE_NO_RETURN_BEGIN(arg) { typedef __YouCannotUseAReturnStatementHere __ReturnOK; if (0 && __ReturnOK::used()) { } else {
+#define DEBUG_ASSURE_NO_RETURN_END(arg)   } }
 
 // rotor_pal.h defaulted these to empty macros; this file redefines them
 #undef DEBUG_OK_TO_RETURN_BEGIN
 #undef DEBUG_OK_TO_RETURN_END
 
-#define DEBUG_OK_TO_RETURN_BEGIN(arg) { typedef __SafeToReturn __ReturnOK; 
-#define DEBUG_OK_TO_RETURN_END(arg) }
+#define DEBUG_OK_TO_RETURN_BEGIN(arg) { typedef __SafeToReturn __ReturnOK; if (0 && __ReturnOK::used()) { } else {
+#define DEBUG_OK_TO_RETURN_END(arg) } }
 
 #else // !_DEBUG
 

--- a/src/inc/staticcontract.h
+++ b/src/inc/staticcontract.h
@@ -244,6 +244,10 @@ namespace StaticContract
             STATIC_CONTRACT_GC_NOTRIGGER;
             STATIC_CONTRACT_SO_TOLERANT;
         }
+
+        static void used()
+        {
+        }
     };
 
     struct ScanThrowMarkerTerminal
@@ -252,6 +256,10 @@ namespace StaticContract
         {
             METHOD_CANNOT_BE_FOLDED_DEBUG;
         }
+
+        static void used()
+        {
+        }
     };
 
     struct ScanThrowMarkerIgnore
@@ -259,6 +267,10 @@ namespace StaticContract
         __declspec(noinline) ScanThrowMarkerIgnore()
         {
             METHOD_CANNOT_BE_FOLDED_DEBUG;
+        }
+
+        static void used()
+        {
         }
     };
 }
@@ -270,13 +282,13 @@ typedef StaticContract::ScanThrowMarkerStandard ScanThrowMarker;
 #define SCAN_THROW_MARKER do { ScanThrowMarker __throw_marker; } while (0)
 
 #define SCAN_IGNORE_THROW_MARKER                                    \
-    typedef StaticContract::ScanThrowMarkerIgnore ScanThrowMarker
+    typedef StaticContract::ScanThrowMarkerIgnore ScanThrowMarker; if (0) ScanThrowMarker::used();
 
 // Terminal exceptions are asynchronous and cannot be included in THROWS contract
 // analysis. As such, this uses typedef to reassign the ScanThrowMarker to a
 // non-annotating struct so that SCAN does not see the block as throwing.
 #define STATIC_CONTRACT_THROWS_TERMINAL                             \
-    typedef StaticContract::ScanThrowMarkerTerminal ScanThrowMarker;
+    typedef StaticContract::ScanThrowMarkerTerminal ScanThrowMarker; if (0) ScanThrowMarker::used();
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE) && defined(FEATURE_STACK_PROBE) && !defined(_TARGET_ARM_) // @ARMTODO
 extern void EnsureSOIntolerantOK(const char *szFunction, const char *szFile, int lineNum);

--- a/src/pal/inc/pal_assert.h
+++ b/src/pal/inc/pal_assert.h
@@ -23,21 +23,13 @@ extern "C" {
 // C_ASSERT() can be used to perform many compile-time assertions:
 //            type sizes, field offsets, etc.
 //
-// An assertion failure results in error C2118: negative subscript.
-//  or
-// size of array `__C_ASSERT__' is negative
-//
-
-#define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
+#define C_ASSERT(e) static_assert(e, #e)
 
 //
 // CPP_ASSERT() can be used within a class definition, to perform a
 // compile-time assertion involving private names within the class.
 //
-// MS compiler doesn't allow redefinition of the typedef within a template.
-// gcc doesn't allow redefinition of the typedef within a class, though 
-// it does at file scope.
-#define CPP_ASSERT(n, e) typedef char __C_ASSERT__##n[(e) ? 1 : -1];
+#define CPP_ASSERT(n, e) static_assert(e, #e)
 
 #endif // __cplusplus
 

--- a/src/pal/tests/palsuite/miscellaneous/queryperformancecounter/test1/test1.c
+++ b/src/pal/tests/palsuite/miscellaneous/queryperformancecounter/test1/test1.c
@@ -84,7 +84,7 @@ int __cdecl main(int argc, char *argv[])
          */
         TimeDiff[i] = (DWORD)(((EndTime.QuadPart - StartTime.QuadPart)*1000)/
                              (Freq.QuadPart));
-        TotalTimeDiff += abs(TimeDiff[i] - SleepInterval);
+        TotalTimeDiff += TimeDiff[i] - SleepInterval;
 
     }
 

--- a/src/pal/tests/palsuite/threading/SleepEx/test2/test2.c
+++ b/src/pal/tests/palsuite/threading/SleepEx/test2/test2.c
@@ -57,7 +57,7 @@ int __cdecl main( int argc, char **argv )
     for (i=0;i<Iterations;i++)
     {
 	RunTest(TRUE);
-	dwAvgDelta += abs(ThreadSleepDelta - InterruptTime);
+	dwAvgDelta += ThreadSleepDelta - InterruptTime;
     }
     dwAvgDelta /= Iterations;
 
@@ -76,7 +76,7 @@ int __cdecl main( int argc, char **argv )
     for (i=0;i<Iterations;i++)
     {
 	RunTest(FALSE);
-	dwAvgDelta += abs(ThreadSleepDelta - ChildThreadSleepTime);
+	dwAvgDelta += ThreadSleepDelta - ChildThreadSleepTime;
     }
     dwAvgDelta /= Iterations;
 

--- a/src/pal/tests/palsuite/threading/SuspendThread/test4/test4.c
+++ b/src/pal/tests/palsuite/threading/SuspendThread/test4/test4.c
@@ -19,6 +19,9 @@
 
 #include <palsuite.h>
 
+// Declare sched_yield(), as we cannot include <sched.h> here.
+int sched_yield(void);
+
 #define NUM_MALLOCS 256
 #define MAX_THREADS 64
 int numThreads, numIterations, targetThreadsSelectionAlgo, targetThreadsPos;

--- a/src/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.c
+++ b/src/pal/tests/palsuite/threading/WaitForMultipleObjectsEx/test2/test2.c
@@ -57,8 +57,8 @@ int __cdecl main( int argc, char **argv )
     // Make sure that the wait returns in time greater than interrupt and less than 
     // wait timeout
     if ( 
-        ((ThreadWaitDelta >= ChildThreadWaitTime) && ( abs( ThreadWaitDelta - ChildThreadWaitTime) > TOLERANCE )) 
-        || (( ThreadWaitDelta < InterruptTime) && ( abs( ThreadWaitDelta - InterruptTime) > TOLERANCE ) )
+        ((ThreadWaitDelta >= ChildThreadWaitTime) && (ThreadWaitDelta - ChildThreadWaitTime) > TOLERANCE) 
+        || (( ThreadWaitDelta < InterruptTime) && (ThreadWaitDelta - InterruptTime) > TOLERANCE)
         )
     {
         Fail("Expected thread to wait for %d ms (and get interrupted).\n"
@@ -75,7 +75,7 @@ int __cdecl main( int argc, char **argv )
     // Make sure that time taken for thread to return from wait is more than interrupt
     // and also not less than the complete child thread wait time
 
-    delta = abs( ThreadWaitDelta - ChildThreadWaitTime);
+    delta = ThreadWaitDelta - ChildThreadWaitTime;
     if( (ThreadWaitDelta < ChildThreadWaitTime) && ( delta > TOLERANCE) ) 
     {
         Fail("Expected thread to wait for %d ms (and not get interrupted).\n"

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.c
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExMutexTest/WFSOExMutexTest.c
@@ -75,7 +75,7 @@ int __cdecl main( int argc, char **argv )
      */
 
     RunTest(TRUE);
-    if (abs(ThreadWaitDelta - InterruptTime) > AcceptableDelta)
+    if ((ThreadWaitDelta - InterruptTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and get interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 
@@ -88,7 +88,7 @@ int __cdecl main( int argc, char **argv )
      * it, if it is not in an alertable state.
      */
     RunTest(FALSE);
-    if (abs(ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
+    if ((ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and not be interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.c
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExSemaphoreTest/WFSOExSemaphoreTest.c
@@ -50,7 +50,7 @@ int __cdecl main( int argc, char **argv )
      */
 
     RunTest(TRUE);
-    if (abs(ThreadWaitDelta - InterruptTime) > AcceptableDelta)
+    if ((ThreadWaitDelta - InterruptTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and get interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 
@@ -63,7 +63,7 @@ int __cdecl main( int argc, char **argv )
      * it, if it is not in an alertable state.
      */
     RunTest(FALSE);
-    if (abs(ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
+    if ((ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and not be interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.c
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.c
@@ -51,7 +51,7 @@ int __cdecl main( int argc, char **argv )
      */
 
     RunTest(TRUE);
-    if (abs(ThreadWaitDelta - InterruptTime) > AcceptableDelta)
+    if ((ThreadWaitDelta - InterruptTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and get interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 
@@ -64,7 +64,7 @@ int __cdecl main( int argc, char **argv )
      * it, if it is not in an alertable state.
      */
     RunTest(FALSE);
-    if (abs(ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
+    if ((ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and not be interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1107,9 +1107,9 @@ class StringObject : public Object
     static SIZE_T GetSize(DWORD stringLength);
 
     DWORD   GetStringLength()                           { LIMITED_METHOD_DAC_CONTRACT; return( m_StringLength );}
-    WCHAR*  GetBuffer()                                 { LIMITED_METHOD_CONTRACT; _ASSERTE(this); return (WCHAR*)( dac_cast<TADDR>(this) + offsetof(StringObject, m_Characters) );  }
-    WCHAR*  GetBuffer(DWORD *pdwSize)                   { LIMITED_METHOD_CONTRACT; _ASSERTE(this && pdwSize); *pdwSize = GetStringLength(); return GetBuffer();  }
-    WCHAR*  GetBufferNullable()                         { LIMITED_METHOD_CONTRACT; return( (this == 0) ? 0 : (WCHAR*)( dac_cast<TADDR>(this) + offsetof(StringObject, m_Characters) ) );  }
+    WCHAR*  GetBuffer()                                 { LIMITED_METHOD_CONTRACT; _ASSERTE(this != nullptr); return (WCHAR*)( dac_cast<TADDR>(this) + offsetof(StringObject, m_Characters) );  }
+    WCHAR*  GetBuffer(DWORD *pdwSize)                   { LIMITED_METHOD_CONTRACT; _ASSERTE((this != nullptr) && pdwSize); *pdwSize = GetStringLength(); return GetBuffer();  }
+    WCHAR*  GetBufferNullable()                         { LIMITED_METHOD_CONTRACT; return( (this == nullptr) ? nullptr : (WCHAR*)( dac_cast<TADDR>(this) + offsetof(StringObject, m_Characters) ) );  }
 
     DWORD GetHighCharState() {
         WRAPPER_NO_CONTRACT;

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -3577,7 +3577,7 @@ Thread::~Thread()
 #endif
 
 #ifdef _DEBUG
-    if (m_pFiberInfo) {
+    if (m_pFiberInfo != NULL) {
         delete [] (DWORD_PTR*)m_pFiberInfo[0];
     }
 #endif


### PR DESCRIPTION
There were three classes of warnings that needed to be fixed:
1) Warnings for unused typedefs
2) Warnings for pointer to boolean conversions that were always true
3) Warnings for taking the absolute value of unsigned values

(1) accounted for the majority of the warnings. All of these warnings
originated from macro definitions debugreturn.h, staticcontract.h,
or pal_assert.h. In the first two cases, typedefs were used as
compile-time checks to ensure certain invariants inside of method or
function bodies. These cases were addressed by using an empty member
of the typedef under an "if (0)" guard. In the third case, typedefs
were used for compile-time assertions that may appear in any location
in a source file; these have been updated to use C++11's static_assert.

(2) and (3) were much more straightforward: the former was addressed by
explicitly comparing the source pointer against NULL and the latter by
removing the offending calls to abs().

This change also contains a small update to .gitignore to ignore the
binaries directory and CMake artifacts created by build.sh.