### PR TITLE
correct clean path for 'build unixmscorlib clean'

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -23,6 +23,7 @@
 
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)\Product\$(BuildArch)\$(BuildType)\</BinDir>
+    <BinDir Condition="'$(OS)'=='unix'">$(RootBinDir)\intermediates\$(BuildArch)\$(BuildType)\</BinDir>
 
     <!-- We dont append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.


### PR DESCRIPTION
Fix incorrect BinDir When building mscorlib.dll with 'build unixmscorlib clean'.
Set BinDir from 'binaries\Product\x64\debug' to 'binaries\intermediates\amd64\Debug'.