### PR TITLE
Change MRES to use DateTime.UtcNow instead of Now

### DIFF
--- a/src/mscorlib/src/System/Threading/ManualResetEventSlim.cs
+++ b/src/mscorlib/src/System/Threading/ManualResetEventSlim.cs
@@ -373,7 +373,7 @@ namespace System.Threading
             }
 
 #if DEBUG
-            m_lastSetTime = DateTime.Now.Ticks;
+            m_lastSetTime = DateTime.UtcNow.Ticks;
 #endif
         }
 
@@ -404,7 +404,7 @@ namespace System.Threading
             IsSet = false;
 
 #if DEBUG
-            m_lastResetTime = DateTime.Now.Ticks;
+            m_lastResetTime = DateTime.UtcNow.Ticks;
 #endif
         }
 


### PR DESCRIPTION
In debug builds, ManualResetEventSlim is storing the last time that Set and Reset are called, using DateTime.Now.  This in turn requires time zone information, which is currently not implemented on Unix, causing any usage of ManualResetEventSlim.Set/Reset in a debug build to throw a NotImplementedException.

This change just switches the usage to be DateTime.UtcNow instead of DateTime.Now to avoid the need for time zone information.  (I was tempted to remove these debug-only fields entirely, but in case someone's actually using them during debugging, doesn't seem particularly harmful to leave them.)