### PR TITLE
Redirect mscorlib's ole32.dll P/Invokes to libcoreclr

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -695,12 +695,13 @@ namespace Microsoft.Win32 {
 #if !FEATURE_PAL
         internal const String KERNEL32 = "kernel32.dll";
         internal const String USER32   = "user32.dll";
+        internal const String OLE32    = "ole32.dll";
 #else //FEATURE_PAL
         internal const String KERNEL32 = "libcoreclr.so";
         internal const String USER32   = "libcoreclr.so";
+        internal const String OLE32    = "libcoreclr.so";
 #endif //FEATURE_PAL         
         internal const String ADVAPI32 = "advapi32.dll";
-        internal const String OLE32    = "ole32.dll";
         internal const String OLEAUT32 = "oleaut32.dll";
         internal const String SHELL32  = "shell32.dll";
         internal const String SHIM     = "mscoree.dll";


### PR DESCRIPTION
When FEATURE_PAL is defined, mscorlib P/Invokes to kernel32 and user32 are being redirected to libcoreclr.so (at least for now as a bring-up mechanism).  However, P/Invokes to ole32.dll aren't being redirected (CoCreateGuid, CoTaskMemAlloc, etc.) even though all of the ones that are used exist in the PAL.  This causes failures on Linux any time Guid.NewGuid is called, any time the StubHelpers string marshalers are used, etc.

This commit just adds ole32.dll to the set of libraries for which mscorlib redirects its P/Invokes to libcoreclr.