### PR TITLE
Remove .so extension from libcoreclr in mscorlib P/Invokes

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -697,9 +697,9 @@ namespace Microsoft.Win32 {
         internal const String USER32   = "user32.dll";
         internal const String OLE32    = "ole32.dll";
 #else //FEATURE_PAL
-        internal const String KERNEL32 = "libcoreclr.so";
-        internal const String USER32   = "libcoreclr.so";
-        internal const String OLE32    = "libcoreclr.so";
+        internal const String KERNEL32 = "libcoreclr";
+        internal const String USER32   = "libcoreclr";
+        internal const String OLE32    = "libcoreclr";
 #endif //FEATURE_PAL         
         internal const String ADVAPI32 = "advapi32.dll";
         internal const String OLEAUT32 = "oleaut32.dll";


### PR DESCRIPTION
Let the runtime apply the right extension based on the target platform.