### PR TITLE
Random fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ __BuildArch=x64
 # Use uname to determine what the OS is.  
 if [ $(uname -o | grep -i Linux) ]; then
     __BuildOS=linux
-elif [ $(uname -o | grep -i Darwin) ]; then
+elif [ $(uname -s | grep -i Darwin) ]; then
     __BuildOS=mac
 else
     echo "Unsupported OS detected, assuming linux"

--- a/src/pal/tests/palsuite/runpaltests.sh
+++ b/src/pal/tests/palsuite/runpaltests.sh
@@ -70,7 +70,6 @@ do
 
   # Create path to a test executable to run
   TEST_COMMAND="$PAL_TEST_BUILD/$TEST_NAME"
-  echo Running $TEST_COMMAND
   $TEST_COMMAND
 
   # Get exit code of the test process.

--- a/src/pal/tests/palsuite/runpaltests.sh
+++ b/src/pal/tests/palsuite/runpaltests.sh
@@ -70,6 +70,7 @@ do
 
   # Create path to a test executable to run
   TEST_COMMAND="$PAL_TEST_BUILD/$TEST_NAME"
+  echo -n .
   $TEST_COMMAND
 
   # Get exit code of the test process.
@@ -80,7 +81,8 @@ do
     NUMBER_OF_PASSED_TESTS=$(($NUMBER_OF_PASSED_TESTS + 1))
   else
     FAILED_TEST="$TEST_NAME. Exit code: $TEST_EXIT_CODE"
-    echo FAILED: $FAILED_TEST
+    echo
+	echo FAILED: $FAILED_TEST
     echo
 
     # Store the name of the failed test in the list of failed tests.

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.c
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.c
@@ -51,7 +51,7 @@ int __cdecl main( int argc, char **argv )
      */
 
     RunTest(TRUE);
-    if ((ThreadWaitDelta - InterruptTime) > AcceptableDelta)
+    if (abs(ThreadWaitDelta - InterruptTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and get interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 
@@ -64,7 +64,7 @@ int __cdecl main( int argc, char **argv )
      * it, if it is not in an alertable state.
      */
     RunTest(FALSE);
-    if ((ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
+    if (abs(ThreadWaitDelta - ChildThreadWaitTime) > AcceptableDelta)
     {
         Fail("Expected thread to wait for %d ms (and not be interrupted).\n"
             "Thread waited for %d ms! (Acceptable delta: %d)\n", 


### PR DESCRIPTION
* Use uname -s on mac
* Don't print "Running ..." for pal tests (will still print failures).  Cuts down on noise in output.