### PR TITLE
Implement ExternalMethodFixupStub, VirtualMethodFixupStub and StubDispatchFixupStub for UNIX

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -326,14 +326,15 @@ set(VM_SOURCES_WKS_AMD64_ASM
 
 else()
 set(VM_SOURCES_WKS_AMD64_ASM
+    ${AMD64_SOURCES_DIR}/calldescrworkeramd64.S
     ${AMD64_SOURCES_DIR}/crthelpers.S
+    ${AMD64_SOURCES_DIR}/externalmethodfixupthunk.S
+    ${AMD64_SOURCES_DIR}/getstate.S
+    ${AMD64_SOURCES_DIR}/jithelpers_fast.S
     ${AMD64_SOURCES_DIR}/jithelpers_fastwritebarriers.S
     ${AMD64_SOURCES_DIR}/jithelpers_slow.S
-    ${AMD64_SOURCES_DIR}/jithelpers_fast.S
-    ${AMD64_SOURCES_DIR}/getstate.S
-    ${AMD64_SOURCES_DIR}/calldescrworkeramd64.S
-    ${AMD64_SOURCES_DIR}/unixasmhelpers.S
     ${AMD64_SOURCES_DIR}/theprestubamd64.S
+    ${AMD64_SOURCES_DIR}/unixasmhelpers.S
     ${AMD64_SOURCES_DIR}/umthunkstub.S
     ${AMD64_SOURCES_DIR}/virtualcallstubamd64.S
 )

--- a/src/vm/amd64/externalmethodfixupthunk.S
+++ b/src/vm/amd64/externalmethodfixupthunk.S
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Geoff Norton. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+;
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
+#include "asmconstants.h"
+
+//============================================================================================
+// EXTERN_C VOID __stdcall ExternalMethodFixupStub()
+
+NESTED_ENTRY ExternalMethodFixupStub, _TEXT, ProcessCLRException
+
+        PROLOG_WITH_TRANSITION_BLOCK 0, 8, rdx, 0, 0
+
+        lea             rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
+        sub             rsi, 5                              // pThunk
+        mov             rdx, 0                              // sectionIndex
+        mov             rcx, 0                              // pModule
+
+        call            C_FUNC(ExternalMethodFixupWorker)
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+PATCH_LABEL ExternalMethodFixupPatchLabel
+        TAILJMP_RAX
+
+NESTED_END ExternalMethodFixupStub, _TEXT
+
+
+//============================================================================================
+// EXTERN_C VOID __stdcall VirtualMethodFixupStub()
+
+NESTED_ENTRY VirtualMethodFixupStub, _TEXT, ProcessCLRException
+
+        PROLOG_WITH_TRANSITION_BLOCK 0, 8, rdx, 0, 0
+
+        lea             rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
+        sub             rsi, 5                              // pThunk
+        call            C_FUNC(VirtualMethodFixupWorker)
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+PATCH_LABEL VirtualMethodFixupPatchLabel
+        TAILJMP_RAX
+
+NESTED_END VirtualMethodFixupStub, _TEXT

--- a/src/vm/amd64/unixstubs.cpp
+++ b/src/vm/amd64/unixstubs.cpp
@@ -12,16 +12,6 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
-    void ExternalMethodFixupPatchLabel()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void ExternalMethodFixupStub()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-    
     void GenericPInvokeCalliHelper()
     {
         PORTABILITY_ASSERT("Implement for PAL");
@@ -48,16 +38,6 @@ extern "C"
     }
     
     void VarargPInvokeStub_RetBuffArg()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void VirtualMethodFixupPatchLabel()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
-    void VirtualMethodFixupStub()
     {
         PORTABILITY_ASSERT("Implement for PAL");
     }
@@ -96,16 +76,4 @@ extern "C"
     void STDCALL JIT_ProfilerEnterLeaveTailcallStub(UINT_PTR ProfilerHandle)
     {
     }
-
-#ifdef FEATURE_PREJIT
-    void StubDispatchFixupStub()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-#endif    
-
-    void StubDispatchFixupPatchLabel()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }    
 };

--- a/src/vm/amd64/virtualcallstubamd64.S
+++ b/src/vm/amd64/virtualcallstubamd64.S
@@ -88,3 +88,23 @@ Fail_RWCLAS:
         jmp    C_FUNC(ResolveWorkerAsmStub)
         
 LEAF_END ResolveWorkerChainLookupAsmStub, _TEXT
+
+#ifdef FEATURE_PREJIT
+NESTED_ENTRY StubDispatchFixupStub, _TEXT, ProcessCLRException
+
+        PROLOG_WITH_TRANSITION_BLOCK 0, 0, 0, 0, 0
+        
+        lea             rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
+        mov             rsi, r11                            // indirection cell address
+
+        mov             rdx,0                               // sectionIndex
+        mov             rcx,0                               // pModule
+
+        call            C_FUNC(StubDispatchFixupWorker)
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+PATCH_LABEL StubDispatchFixupPatchLabel
+        TAILJMP_RAX
+
+NESTED_END StubDispatchFixupStub, _TEXT
+#endif


### PR DESCRIPTION
Pretty self explanatory.

We still need to figure out the PROLOG_WITH_TRANSITION_BLOCK macro issue, but I've kept this consistent with the other usages for now.

Fixes https://github.com/dotnet/coreclr/issues/345#issuecomment-76125349