### PR TITLE
[OSX] Resolve all compiler warnings in the PAL

### DIFF
--- a/src/pal/src/exception/machmessage.cpp
+++ b/src/pal/src/exception/machmessage.cpp
@@ -26,8 +26,6 @@ Abstract:
 
 #if HAVE_MACH_EXCEPTIONS
 
-SET_DEFAULT_DEBUG_CHANNEL(EXCEPT);
-
 // The vast majority of Mach calls we make in this module are critical: we cannot recover from failures of
 // these methods (principally because we're handling hardware exceptions in the context of a single dedicated
 // handler thread). The following macro encapsulates checking the return code from Mach methods (we always


### PR DESCRIPTION
Remove the OSX specific implementations of GetVersion*, they relied on
deprecated functionality, and aren't really needed anywas.  Unified the
behaviour with the rest of the PAL variants.
Removed the DEBUG channel from machmessage.cpp.  It was unused.