### PR TITLE
Make git ignore intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ bld/
 [Oo]bj/
 msbuild.log
 binaries
+intermediates
 
 # Roslyn stuff
 *.sln.ide


### PR DESCRIPTION
That folder contains intermediate artifacts of build process. After each build git shows several hounded untracked .txt files.