### PR TITLE
Improve LLDB probing and fix a small bug in umthunkstub.S.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@ cmake_minimum_required(VERSION 2.8.12)
 # Set the project name
 project(CoreCLR)
 
+if(APPLE)
+    # Enable @rpath support for shared libraries.
+    set(MACOSX_RPATH ON)
+    if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+        cmake_policy(SET CMP0042 NEW)
+    endif()
+endif()
+
 set(CLR_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(VM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/vm)
 

--- a/build.sh
+++ b/build.sh
@@ -88,15 +88,22 @@ echo "Commencing CoreCLR Repo build"
 # Obtain the location of the bash script to figure out whether the root of the repo is.
 __ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 __BuildArch=x64
-# Use uname to determine what the OS is.  
-if [ $(uname -o | grep -i Linux) ]; then
-    __BuildOS=linux
-elif [ $(uname -s | grep -i Darwin) ]; then
-    __BuildOS=mac
-else
-    echo "Unsupported OS detected, assuming linux"
-    __BuildOS=linux
-fi
+# Use uname to determine what the OS is.
+OSName=$(uname -s)
+case $OSName in
+    Linux)
+        __BuildOS=linux
+        ;;
+
+    Darwin)
+        __BuildOS=mac
+        ;;
+
+    *)
+        echo "Unsupported OS $OSName detected, configuring as if for Linux"
+        __BuildOS=linux
+        ;;
+esac
 __MSBuildBuildArch=x64
 __BuildType=debug
 __CMakeArgs=DEBUG

--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -1,35 +1,36 @@
 project(sosplugin)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(ENABLE_SOSPLUGIN OFF)
 
-if((NOT $ENV{LLDB_INCLUDE_DIR} STREQUAL "") AND (NOT $ENV{LLDB_LIB_DIR} STREQUAL ""))
-    # The OSx build depends on the environment variables LLDB_INCLUDE_DIR and LLDB_LIB_DIR being set
-    set(LLDB_INCLUDE_DIR "$ENV{LLDB_INCLUDE_DIR}")
-    set(LLDB_LIB_DIR "$ENV{LLDB_LIB_DIR}")
-elseif(CLR_CMAKE_PLATFORM_LINUX)
-    # The Linux build depends on the lldb-3.5-dev package
-    set(LLVM_DIR "/usr/lib/llvm-3.5")
-    set(LLDB_INCLUDE_DIR "${LLVM_DIR}/include")
-    set(LLDB_LIB_DIR "${LLVM_DIR}/lib")
-
-    if (NOT HAVE_LLDB_H)
-        message(STATUS "Looking for include file LLDB.h")
-        if(NOT EXISTS ${LLDB_INCLUDE_DIR}/lldb/API/LLDB.h)
-            unset(HAVE_LLDB_H CACHE)
-            message(FATAL_ERROR "Cannot find LLDB.h. Try installing lldb-3.5-dev (or the appropriate packages for your platform)")
-        else()
-            set(HAVE_LLDB_H 1 CACHE INTERNAL "Have LLDB.h")
-        endif()
-        message(STATUS "Looking for include file LLDB.h - found")
+if(CLR_CMAKE_PLATFORM_UNIX)
+    # Check for LLDB library
+    find_library(LLDB NAMES lldb lldb-3.5 PATHS WITH_LLDB_LIBS)
+    if(LLDB STREQUAL LLDB-NOTFOUND)
+        message(FATAL_ERROR "Cannot find liblldb or liblldb-3.5. Try installing lldb-3.5-dev (or the appropriate package for your platform)")
     endif()
+
+    # Check for LLDB headers
+    find_path(LLDB_H "lldb/API/LLDB.h" PATHS WITH_LLDB_INCLUDES)
+    if(LLDB_H STREQUAL LLDB_H-NOTFOUND)
+        find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/lib/llvm-3.5/include")
+        if(LLDB_H STREQUAL LLDB_H-NOTFOUND)
+            message(FATAL_ERROR "Cannot find LLDB.h. Try installing lldb-3.5-dev (or the appropriate package for your platform)")
+        endif()
+    endif()
+
+    # Add the parent's parent's directory to the include path
+    get_filename_component(LLDB_H LLDB_H DIRECTORY)
+    get_filename_component(LLDB_H LLDB_H DIRECTORY)
+    include_directories(LLDB_H)
+
+    set(ENABLE_SOSPLUGIN ON)
 endif()
 
-if((NOT ${LLDB_INCLUDE_DIR} STREQUAL "") AND (NOT ${LLDB_LIB_DIR} STREQUAL ""))
+if(ENABLE_SOSPLUGIN)
     add_compile_options(-Wno-delete-non-virtual-dtor)
 
     include_directories(inc)
-    include_directories("${LLDB_INCLUDE_DIR}")
-
     set(SOURCES
         sosplugin.cpp
         soscommand.cpp
@@ -39,14 +40,9 @@ if((NOT ${LLDB_INCLUDE_DIR} STREQUAL "") AND (NOT ${LLDB_LIB_DIR} STREQUAL ""))
     add_library(sosplugin SHARED ${SOURCES})
     add_dependencies(sosplugin sos)
 
-    if(CLR_CMAKE_PLATFORM_LINUX)
-        link_directories("${LLDB_LIB_DIR}")
-    endif(CLR_CMAKE_PLATFORM_LINUX)
-
-    if(CLR_CMAKE_PLATFORM_DARWIN)
-        find_library(LLDB LLDB PATHS ${LLDB_LIB_DIR})
+    if (CLR_CMAKE_PLATFORM_UNIX)
         target_link_libraries(sosplugin ${LLDB})
-    endif(CLR_CMAKE_PLATFORM_DARWIN)
+    endif()
 
     # add the install targets
     install (TARGETS sosplugin DESTINATION .)

--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -3,22 +3,25 @@ project(sosplugin)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(ENABLE_SOSPLUGIN OFF)
 
+set(WITH_LLDB_LIBS "" CACHE PATH "Path to LLDB libraries")
+set(WITH_LLDB_INCLUDES "" CACHE PATH "Path to LLDB headers")
+
 if(CLR_CMAKE_PLATFORM_UNIX)
     # Check for LLDB library
-    find_library(LLDB NAMES lldb lldb-3.5 PATHS WITH_LLDB_LIBS)
+    find_library(LLDB NAMES lldb lldb-3.5 PATHS "${WITH_LLDB_LIBS}")
     if(LLDB STREQUAL LLDB-NOTFOUND)
-        message(FATAL_ERROR "Cannot find liblldb or liblldb-3.5. Try installing lldb-3.5-dev (or the appropriate package for your platform)")
+        message(FATAL_ERROR "Cannot find lldb or lldb-3.5. Try installing lldb-3.5-dev (or the appropriate package for your platform)")
     endif()
 
     # Check for LLDB headers
-    find_path(LLDB_H "lldb/API/LLDB.h" PATHS WITH_LLDB_INCLUDES)
+    find_path(LLDB_H "lldb/API/LLDB.h" PATHS "${WITH_LLDB_INCLUDES}")
     if(LLDB_H STREQUAL LLDB_H-NOTFOUND)
         find_path(LLDB_H "lldb/API/LLDB.h" PATHS "/usr/lib/llvm-3.5/include")
         if(LLDB_H STREQUAL LLDB_H-NOTFOUND)
             message(FATAL_ERROR "Cannot find LLDB.h. Try installing lldb-3.5-dev (or the appropriate package for your platform)")
         endif()
     endif()
-    include_directories(LLDB_H)
+    include_directories("${LLDB_H}")
 
     set(ENABLE_SOSPLUGIN ON)
 endif()

--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -18,10 +18,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
             message(FATAL_ERROR "Cannot find LLDB.h. Try installing lldb-3.5-dev (or the appropriate package for your platform)")
         endif()
     endif()
-
-    # Add the parent's parent's directory to the include path
-    get_filename_component(LLDB_H LLDB_H DIRECTORY)
-    get_filename_component(LLDB_H LLDB_H DIRECTORY)
     include_directories(LLDB_H)
 
     set(ENABLE_SOSPLUGIN ON)

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -65,6 +65,14 @@ if [ $OS = "Linux" ]; then
   [[ $? -eq 0 ]] || { echo "Unable to locate llvm-objdump"; exit 1; }
 fi
 
+cmake_extra_defines=
+if [[ -n "$LLDB_LIB_DIR" ]]; then
+    cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_LIBS=$LLDB_LIB_DIR"
+fi
+if [[ -n "$LLDB_INCLUDE_DIR" ]]; then
+    cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_INCLUDES=$LLDB_INCLUDE_DIR"
+fi
+
 cmake "-DCMAKE_USER_MAKE_RULES_OVERRIDE=$1/src/pal/tools/clang-compiler-override.txt" \
   "-DCMAKE_AR=$llvm_ar" \
   "-DCMAKE_LINKER=$llvm_link" \
@@ -72,5 +80,6 @@ cmake "-DCMAKE_USER_MAKE_RULES_OVERRIDE=$1/src/pal/tools/clang-compiler-override
   "-DCMAKE_OBJDUMP=$llvm_objdump" \
   "-DCMAKE_RANLIB=$llvm_ranlib" \
   "-DCMAKE_BUILD_TYPE=$buildtype" \
+  "$cmake_extra_defines" \
   "$1"
 

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -73,13 +73,13 @@ if [[ -n "$LLDB_INCLUDE_DIR" ]]; then
     cmake_extra_defines="$cmake_extra_defines -DWITH_LLDB_INCLUDES=$LLDB_INCLUDE_DIR"
 fi
 
-cmake "-DCMAKE_USER_MAKE_RULES_OVERRIDE=$1/src/pal/tools/clang-compiler-override.txt" \
+cmake \
+  "-DCMAKE_USER_MAKE_RULES_OVERRIDE=$1/src/pal/tools/clang-compiler-override.txt" \
   "-DCMAKE_AR=$llvm_ar" \
   "-DCMAKE_LINKER=$llvm_link" \
   "-DCMAKE_NM=$llvm_nm" \
   "-DCMAKE_OBJDUMP=$llvm_objdump" \
   "-DCMAKE_RANLIB=$llvm_ranlib" \
   "-DCMAKE_BUILD_TYPE=$buildtype" \
-  "$cmake_extra_defines" \
+  $cmake_extra_defines \
   "$1"
-

--- a/src/vm/amd64/umthunkstub.S
+++ b/src/vm/amd64/umthunkstub.S
@@ -92,7 +92,7 @@ LOCAL_LABEL(HaveThread):
         // catch returning thread here if a GC is in progress
         //
         PREPARE_EXTERNAL_VAR g_TrapReturningThreads, rax
-        cmp                  [rax], 0
+        cmp                  dword ptr [rax], 0
         jnz                  LOCAL_LABEL(DoTrapReturningThreadsTHROW)
 
 LOCAL_LABEL(InCooperativeMode):


### PR DESCRIPTION
- Replace the LLDB_{INCLUDE,LIB}_DIR environment variables with
  WITH_LLDB_{INCLUDES,LIBS} variables in lldbplugin/CMakeLists.txt. These
  variables are instead picked up in gen-buildsys-clang.sh.
- Look for a typical lldb installation as well as the Ubuntu-specific
  lldb-3.5 installationin the usual location as well as the Ubuntu-specific
  location for lldb-3.5.
- Unify the probing logic for Linux and OS X.
- In addition to ensuring the presence of LLDB.h, ensure that liblldb is
  present.
- Fix an ambiguously-sized comparison in umthunkstub.S.