### PR TITLE
Update assembly helpers to use regular RBP frames

### DIFF
--- a/src/vm/amd64/calldescrworkeramd64.S
+++ b/src/vm/amd64/calldescrworkeramd64.S
@@ -16,7 +16,8 @@
 //      EXTERN_C void FastCallFinalizeWorker(Object *obj, PCODE funcPtr);
 //
 NESTED_ENTRY FastCallFinalizeWorker, _TEXT, CallDescrWorkerUnwindFrameChainHandler
-        alloc_stack     0x28     // alloc callee scratch and align the stack
+        push_nonvol_reg rbp
+        mov     rbp, rsp
         END_PROLOGUE
         
         //
@@ -32,7 +33,7 @@ NESTED_ENTRY FastCallFinalizeWorker, _TEXT, CallDescrWorkerUnwindFrameChainHandl
         xor     rax, rax
         
         // epilog
-        add     rsp, 0x28
+        pop_nonvol_reg rbp
         ret
 
 
@@ -41,10 +42,11 @@ NESTED_END FastCallFinalizeWorker, _TEXT
 //extern "C" void CallDescrWorkerInternal(CallDescrData * pCallDescrData);
 
 NESTED_ENTRY CallDescrWorkerInternal, _TEXT, CallDescrWorkerUnwindFrameChainHandler
-        push_nonvol_reg rbx             // save nonvolatile registers
-        push_nonvol_reg rbp             // 
-        set_frame rbp, 0                // set frame pointer
-        lea     rsp, [rsp - 8]          // ensure proper alignment of the rsp
+        push_nonvol_reg rbp
+        mov     rbp, rsp
+        push_nonvol_reg rbx
+        lea     rsp, [rsp - 8]          // ensure proper alignment of the rsp 
+        set_cfa_register rbp, (4*8)
 
         END_PROLOGUE
 
@@ -114,12 +116,10 @@ LOCAL_LABEL(ReturnsInt):
         mov     [rbx+CallDescrData__returnValue], rax
 
 LOCAL_LABEL(Epilog):
-        lea     rsp, 0[rbp]             // deallocate argument list
-        .cfi_def_cfa_register rsp
-        pop     rbp                     // restore nonvolatile register
-        .cfi_adjust_cfa_offset -8       //
-        pop     rbx                     //
-        .cfi_adjust_cfa_offset -8       //
+        lea     rsp, [rbp - 8]          // deallocate arguments
+        set_cfa_register rsp, (3*8)
+        pop_nonvol_reg rbx
+        pop_nonvol_reg rbp
         ret
 
 LOCAL_LABEL(ReturnsFloat):

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -178,13 +178,17 @@ struct CalleeSavedRegisters {
 #ifndef UNIX_AMD64_ABI
     INT_PTR     rdi;
     INT_PTR     rsi;
-#endif
     INT_PTR     rbx;
     INT_PTR     rbp;
+#endif
     INT_PTR     r12;
     INT_PTR     r13;
     INT_PTR     r14;
     INT_PTR     r15;
+#ifdef UNIX_AMD64_ABI
+    INT_PTR     rbx;
+    INT_PTR     rbp;
+#endif
 };
 
 struct REGDISPLAY;

--- a/src/vm/amd64/umthunkstub.S
+++ b/src/vm/amd64/umthunkstub.S
@@ -55,11 +55,12 @@ NESTED_ENTRY UMThunkStub, _TEXT, UMThunkStubUnwindFrameChainHandler
 // rdx
 // r8
 // r9
-// rbp
 // r12
+// rbp
 // return address                           <-- entry RSP
-        push_nonvol_reg r12
-        push_nonvol_reg rbp                                                                     // stack_args
+        push_nonvol_reg rbp
+        mov             rbp, rsp
+        push_nonvol_reg r12                                                                     // stack_args
         alloc_stack     UMThunkStubAMD64_FIXED_STACK_ALLOC_SIZE
         save_reg_postrsp rdi, (UMThunkStubAMD64_INT_ARG_OFFSET)
         save_reg_postrsp rsi, (UMThunkStubAMD64_INT_ARG_OFFSET + 0x08)
@@ -68,7 +69,7 @@ NESTED_ENTRY UMThunkStub, _TEXT, UMThunkStubUnwindFrameChainHandler
         save_reg_postrsp r8,  (UMThunkStubAMD64_INT_ARG_OFFSET + 0x20)
         save_reg_postrsp r9,  (UMThunkStubAMD64_INT_ARG_OFFSET + 0x28)
         save_reg_postrsp METHODDESC_REGISTER, UMThunkStubAMD64_METHODDESC_OFFSET
-        set_frame       rbp, 0                                                                  // stack_args
+        set_cfa_register rbp, (UMThunkStubAMD64_FIXED_STACK_ALLOC_SIZE + 3*8)
         SAVE_FLOAT_ARGUMENT_REGISTERS UMThunkStubAMD64_XMM_SAVE_OFFSET
         END_PROLOGUE
 
@@ -140,9 +141,10 @@ LOCAL_LABEL(PostCall):
         mov             dword ptr [r12 + OFFSETOF__Thread__m_fPreemptiveGCDisabled], 0
 
         // epilog
-        lea             rsp, [rbp + UMThunkStubAMD64_FIXED_STACK_ALLOC_SIZE]
-        pop_nonvol_reg  rbp                                                                             // stack_args
+        lea             rsp, [rbp - 8]         // deallocate arguments
+        set_cfa_register rsp, (3*8)
         pop_nonvol_reg  r12
+        pop_nonvol_reg  rbp
         ret
 
 

--- a/src/vm/amd64/unixasmmacros.inc
+++ b/src/vm/amd64/unixasmmacros.inc
@@ -112,28 +112,15 @@ C_FUNC(\Name\()_End):
         .cfi_adjust_cfa_offset -\Size
 .endm
 
-.macro set_frame Reg, Offset
-        lea     \Reg, \Offset[rsp]
+.macro set_cfa_register Reg, Offset
         .cfi_def_cfa_register \Reg
-.endm
-
-.macro restore_frame Reg, Offset
-        lea     rsp, \Offset[\Reg]
-        .cfi_def_cfa_register rsp
+        .cfi_def_cfa_offset \Offset
 .endm
 
 .macro save_reg_postrsp Reg, Offset
-
-        .ifdef ___FRAME_REG_SET
-        .error "save_reg_postrsp cannot be used after set_frame"
-        .endif
-
         __Offset = \Offset
         mov     qword ptr [rsp + __Offset], \Reg
         .cfi_rel_offset \Reg, __Offset
-
-        ___STACK_ADJUSTMENT_FORBIDDEN = 1
-
 .endm
 
 .macro restore_reg Reg, Offset
@@ -143,17 +130,9 @@ C_FUNC(\Name\()_End):
 .endm
 
 .macro save_xmm128_postrsp Reg, Offset
-
-        .ifdef ___FRAME_REG_SET
-        .error "save_reg_postrsp cannot be used after set_frame"
-        .endif
-
         __Offset = \Offset
         movdqa  [rsp + __Offset], \Reg
         .cfi_rel_offset \Reg, __Offset
-
-        ___STACK_ADJUSTMENT_FORBIDDEN = 1
-
 .endm
 
 .macro restore_xmm128 Reg, ofs
@@ -164,12 +143,12 @@ C_FUNC(\Name\()_End):
 
 .macro POP_CALLEE_SAVED_REGISTERS
 
-        pop_nonvol_reg rbx
-        pop_nonvol_reg rbp
         pop_nonvol_reg r12
         pop_nonvol_reg r13
         pop_nonvol_reg r14
         pop_nonvol_reg r15
+        pop_nonvol_reg rbx
+        pop_nonvol_reg rbp
 
 .endm
 
@@ -244,12 +223,12 @@ C_FUNC(\Name\()_End):
 // (stack parameters)
 // ...
 // return address
+// CalleeSavedRegisters::rbp
+// CalleeSavedRegisters::rbx
 // CalleeSavedRegisters::r15
 // CalleeSavedRegisters::r14
 // CalleeSavedRegisters::r13
 // CalleeSavedRegisters::r12
-// CalleeSavedRegisters::rbp
-// CalleeSavedRegisters::rbx
 // ArgumentRegisters::r9
 // ArgumentRegisters::r8
 // ArgumentRegisters::rcx
@@ -288,37 +267,39 @@ C_FUNC(\Name\()_End):
         // PUSH_CALLEE_SAVED_REGISTERS expanded here
 
         .if \stackAllocOnEntry < 8
-        push_nonvol_reg r15
+        push_nonvol_reg rbp
+        mov rbp, rsp
         .endif
 
         .if \stackAllocOnEntry < 2*8
-        push_nonvol_reg r14
+        push_nonvol_reg rbx
         .endif
 
         .if \stackAllocOnEntry < 3*8
-        push_nonvol_reg r13
+        push_nonvol_reg r15
         .endif
 
+        push_nonvol_reg r14
+        push_nonvol_reg r13
         push_nonvol_reg r12
-        push_nonvol_reg rbp
-        push_nonvol_reg rbx
 
         // ArgumentRegisters
         PUSH_ARGUMENT_REGISTERS
 
         .if \stackAllocOnEntry >= 3*8
         mov \stackAllocSpill3, [rsp + 0x48]
-        save_reg_postrsp    r13, 0x48
+        save_reg_postrsp    r15, 0x48
         .endif
 
         .if \stackAllocOnEntry >= 2*8
         mov \stackAllocSpill2, [rsp + 0x50]
-        save_reg_postrsp    r14, 0x50
+        save_reg_postrsp    rbx, 0x50
         .endif
 
         .if \stackAllocOnEntry >= 8
         mov \stackAllocSpill1, [rsp + 0x58]
-        save_reg_postrsp    r15, 0x58
+        save_reg_postrsp    rbp, 0x58
+        lea rbp, [rsp + 0x58]
         .endif
 
         alloc_stack     __PWTB_StackAlloc


### PR DESCRIPTION
This should help with stack unwinding in some cases. #366 to get the JIT fixed as well.