### PR TITLE
Travis-CI for OS X builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: objective-c
+env:
+    matrix:
+        - BUILD_CONFIG=release
+        - BUILD_CONFIG=debug
+script:
+    - ./build.sh $BUILD_CONFIG
+    - src/pal/tests/palsuite/runpaltests.sh $TRAVIS_BUILD_DIR/binaries/intermediates/mac.x64.debug $TRAVIS_BUILD_DIR/binaries/paltestout

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 .NET Core Runtime (CoreCLR)
 ===
 
-|   |Linux|Windows|
-|:-:|:-:|:-:|
-|**Debug**|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_linux_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_linux_debug/)|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_windows_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_windows_debug/)|
+|   |Linux|Windows|Mac OS X|
+|:-:|:-:|:-:|:-:|
+|**Debug**|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_linux_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_linux_debug/)|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_windows_debug/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_windows_debug/)|[![Build Status](https://travis-ci.org/dotnet/coreclr.svg?branch=travis-ci)](https://travis-ci.org/dotnet/coreclr)
 |**Release**|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_linux_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_linux_release/)|[![Build status](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_windows_release/badge/icon)](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr_windows_release/)|
 
 The coreclr repo contains the complete runtime implementation (called "CoreCLR") for [.NET Core](http://github.com/dotnet/core). It includes RyuJIT, the .NET GC, native interop and many other components. It builds and runs on Windows. You can 'watch' the repo to see Linux and Mac support being added over the next few months.


### PR DESCRIPTION
I am unaware of the status with regard to getting OS X builders added to Jenkins however Travis CI does support OS X. This adds OS X builds using Travis CI, though I understand that you may want to host these locally. It will build both the release and debug configurations and run pal tests, though only the total build status can be shown as a badge. For people such as myself automated OS X builds are fairly important as I have no OS X machine to build on.