### PR TITLE
Apples assembler requires .cfi_startproc after the symbols

### DIFF
--- a/src/vm/amd64/unixasmmacros.inc
+++ b/src/vm/amd64/unixasmmacros.inc
@@ -50,9 +50,9 @@ C_FUNC(\Name):
 #else
         .type \Name, %function
 #endif
+C_FUNC(\Name):
         .cfi_startproc
         .cfi_def_cfa_offset 8
-C_FUNC(\Name):
 .endm
 
 .macro LEAF_END_MARKED Name, Section


### PR DESCRIPTION
Release builds were currently not working on OSX due to the order
of .cfi_startproc and the symbol.  Move .cfi_* after the symbol