### PR TITLE
Delete host authentication enforcement

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -424,17 +424,6 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         return false;
     }
 
-    log << W("Authenticating ICLRRuntimeHost2") << Logger::endl;
-
-    // Authenticate with either
-    //  CORECLR_HOST_AUTHENTICATION_KEY  or
-    //  CORECLR_HOST_AUTHENTICATION_KEY_NONGEN  
-    hr = host->Authenticate(CORECLR_HOST_AUTHENTICATION_KEY); 
-    if (FAILED(hr)) {
-        log << W("Failed authenticate. ") << hr << Logger::endl;
-        return false;
-    }
-
     log << W("Starting ICLRRuntimeHost2") << Logger::endl;
 
     hr = host->Start();

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -462,17 +462,6 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         return false;
     }
 
-    log << W("Authenticating ICLRRuntimeHost2") << Logger::endl;
-
-    // Authenticate with either
-    //  CORECLR_HOST_AUTHENTICATION_KEY  or
-    //  CORECLR_HOST_AUTHENTICATION_KEY_NONGEN  
-    hr = host->Authenticate(CORECLR_HOST_AUTHENTICATION_KEY); 
-    if (FAILED(hr)) {
-        log << W("Failed authenticate. ") << hr << Logger::endl;
-        return false;
-    }
-
     log << W("Starting ICLRRuntimeHost2") << Logger::endl;
 
     hr = host->Start();

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -135,9 +135,6 @@ HRESULT ExecuteAssembly(
                                 STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN));
     IfFailRet(hr);
 
-    hr = host->Authenticate(CORECLR_HOST_AUTHENTICATION_KEY);
-    IfFailRet(hr);
-
     hr = host->Start();
     IfFailRet(hr);
     

--- a/src/inc/MSCOREE.IDL
+++ b/src/inc/MSCOREE.IDL
@@ -1980,11 +1980,8 @@ interface ICLRRuntimeHost : IUnknown
 };
 
 #ifdef FEATURE_CORECLR
-// This is the key that the host needs to pass to us in the call to ICLRRuntmeHost2::Authenticate.
-// This key is generated using the CalcFileTime utility under ndp\clr\src\coreclr\CalcFileTime.
-// See comments of CorHost2::Authenticate for details.
 
-// This key corresponds to 28th August 2006
+// Keys for ICLRRuntmeHost2::Authenticate. No longer required.
 cpp_quote("#define CORECLR_HOST_AUTHENTICATION_KEY 0x1C6CA6F94025800LL")
 cpp_quote("#define CORECLR_HOST_AUTHENTICATION_KEY_NONGEN 0x1C6CA6F94025801LL")
 
@@ -2018,8 +2015,7 @@ interface ICLRRuntimeHost2 : ICLRRuntimeHost
                                  [in] LPCWSTR wszMethodName,
                                  [out] INT_PTR* fnPtr);
 
-    // Authenticates a host based upon a key value. See CorHost2::Authenticate comments
-    // for details.
+    // Authenticates a host based upon a key value. No longer required.
     HRESULT Authenticate([in] ULONGLONG authKey);
 
     // Ensures CLR-set Mac (Mach) EH port is registered.


### PR DESCRIPTION
Host authentication has been left over from Silverlight. It is no longer relevant.