### PR TITLE
Make it easier for people to find ECMA info

### DIFF
--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -18,7 +18,7 @@ Book of the Runtime
 ==================
 
 - [CLR Coding Guide](clr-code-guide.md)
-- [.NET Standards](dotnet-standards.md)
+- [.NET Standards (ECMA)](dotnet-standards.md)
 
 Decoder Rings
 =============


### PR DESCRIPTION
- Change link text to make it clear what kind of standards we have.
- Didn't change the title of the standards doc. It didn't seem like that was necessary. There are also more than ECMA standards discussed there.