### PR TITLE
FIx Travis CI release failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ env:
         - BUILD_CONFIG=debug
 script:
     - ./build.sh $BUILD_CONFIG
-    - src/pal/tests/palsuite/runpaltests.sh $TRAVIS_BUILD_DIR/binaries/intermediates/mac.x64.debug $TRAVIS_BUILD_DIR/binaries/paltestout
+    - src/pal/tests/palsuite/runpaltests.sh $TRAVIS_BUILD_DIR/binaries/intermediates/mac.x64.$BUILD_CONFIG $TRAVIS_BUILD_DIR/binaries/paltestout

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ env:
         - BUILD_CONFIG=debug
 script:
     - ./build.sh $BUILD_CONFIG
-    - src/pal/tests/palsuite/runpaltests.sh $TRAVIS_BUILD_DIR/binaries/intermediates/mac.x64.$BUILD_CONFIG $TRAVIS_BUILD_DIR/binaries/paltestout


### PR DESCRIPTION
Travis CI release mode failed as the test path was always debug rather
than referencing the build matrix. Apologies for not noticing this sooner, however when I tested this on my repo release builds actually failed earlier and so this got overlooked.

@mmitche 