### PR TITLE
Introduce FC_TypedByRef for passing TypedReferences as FCall arguments

### DIFF
--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -2469,7 +2469,7 @@ FCIMPL2(LPVOID,COMInterlocked::ExchangeObject, LPVOID*location, LPVOID value)
 }
 FCIMPLEND
 
-FCIMPL2_VV(void,COMInterlocked::ExchangeGeneric, TypedByRef location, TypedByRef value)
+FCIMPL2_VV(void,COMInterlocked::ExchangeGeneric, FC_TypedByRef location, FC_TypedByRef value)
 {
     FCALL_CONTRACT;
 
@@ -2487,7 +2487,7 @@ FCIMPL2_VV(void,COMInterlocked::ExchangeGeneric, TypedByRef location, TypedByRef
 }
 FCIMPLEND
 
-FCIMPL3_VVI(void,COMInterlocked::CompareExchangeGeneric, TypedByRef location, TypedByRef value, LPVOID comparand)
+FCIMPL3_VVI(void,COMInterlocked::CompareExchangeGeneric, FC_TypedByRef location, FC_TypedByRef value, LPVOID comparand)
 {
     FCALL_CONTRACT;
 

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -230,8 +230,8 @@ public:
         static FCDECL3(LPVOID, CompareExchangeObject, LPVOID* location, LPVOID value, LPVOID comparand);
         static FCDECL2(INT32, ExchangeAdd32, INT32 *location, INT32 value);
         static FCDECL2_IV(INT64, ExchangeAdd64, INT64 *location, INT64 value);
-        static FCDECL2_VV(void, ExchangeGeneric, TypedByRef location, TypedByRef value);
-        static FCDECL3_VVI(void, CompareExchangeGeneric, TypedByRef location, TypedByRef value, LPVOID comparand);
+        static FCDECL2_VV(void, ExchangeGeneric, FC_TypedByRef location, FC_TypedByRef value);
+        static FCDECL3_VVI(void, CompareExchangeGeneric, FC_TypedByRef location, FC_TypedByRef value, LPVOID comparand);
 };
 
 class ManagedLoggingHelper {

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -1315,6 +1315,14 @@ typedef UINT16 FC_UINT16_RET;
 #endif
 
 
+// FC_TypedByRef should be used for TypedReferences in FCall signatures
+#ifdef UNIX_AMD64_ABI
+// Explicitly pass the TypedReferences by reference 
+// UNIXTODO: Remove once the proper managed calling convention for struct is in place
+#define FC_TypedByRef   TypedByRef&
+#else
+#define FC_TypedByRef   TypedByRef
+#endif
 
 
 // The fcall entrypoints has to be at unique addresses. Use this helper macro to make 

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -3678,8 +3678,8 @@ class SafeBuffer : SafeHandle
   public:
     static FCDECL1(UINT, SizeOfType, ReflectClassBaseObject* typeUNSAFE);
     static FCDECL1(UINT, AlignedSizeOfType, ReflectClassBaseObject* typeUNSAFE);
-    static FCDECL3(void, PtrToStructure, BYTE* ptr, TypedByRef structure, UINT32 sizeofT);
-    static FCDECL3(void, StructureToPtr, TypedByRef structure, BYTE* ptr, UINT32 sizeofT);
+    static FCDECL3(void, PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UINT32 sizeofT);
+    static FCDECL3(void, StructureToPtr, FC_TypedByRef structure, BYTE* ptr, UINT32 sizeofT);
 };
 
 #ifdef USE_CHECKED_OBJECTREFS

--- a/src/vm/safehandle.cpp
+++ b/src/vm/safehandle.cpp
@@ -484,7 +484,7 @@ FCIMPL1(UINT, SafeBuffer::AlignedSizeOfType, ReflectClassBaseObject* typeUNSAFE)
 }
 FCIMPLEND
 
-FCIMPL3(void, SafeBuffer::PtrToStructure, BYTE* ptr, TypedByRef structure, UINT32 sizeofT)
+FCIMPL3(void, SafeBuffer::PtrToStructure, BYTE* ptr, FC_TypedByRef structure, UINT32 sizeofT)
 {
 	FCALL_CONTRACT;
 
@@ -495,7 +495,7 @@ FCIMPL3(void, SafeBuffer::PtrToStructure, BYTE* ptr, TypedByRef structure, UINT3
 }
 FCIMPLEND
 
-FCIMPL3(void, SafeBuffer::StructureToPtr, TypedByRef structure, BYTE* ptr, UINT32 sizeofT)
+FCIMPL3(void, SafeBuffer::StructureToPtr, FC_TypedByRef structure, BYTE* ptr, UINT32 sizeofT)
 {
 	FCALL_CONTRACT;
 


### PR DESCRIPTION
FC_TypedByRef is defined as TypedByRef& for now to workaround the mismatch between managed and native struct calling convention.

This change makes Interlocked.Exchange<T> work on Linux.