### PR TITLE
Reimplement CPalThread::Get/SetLastError in terms of errno

### DIFF
--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -33,6 +33,7 @@ Abstract:
 #include "threadsusp.hpp"
 #include "tls.hpp"
 #include "synchobjects.hpp"
+#include <errno.h>
 
 namespace CorUnix
 {
@@ -283,7 +284,6 @@ namespace CorUnix
         friend CPalThread *InternalGetCurrentThread();
 #endif
         
-        DWORD m_dwLastError;
         DWORD m_dwExitCode;
         BOOL m_fExitCodeSet;
         CRITICAL_SECTION m_csLock;
@@ -392,7 +392,6 @@ namespace CorUnix
 #ifdef _DEBUG
             m_dwGuard(0),
 #endif
-            m_dwLastError(0),
             m_dwExitCode(STILL_ACTIVE),
             m_fExitCodeSet(FALSE),
             m_fLockInitialized(FALSE),
@@ -500,7 +499,7 @@ namespace CorUnix
             DWORD dwLastError
             )
         {
-            m_dwLastError = dwLastError;    
+            errno = dwLastError;    
         };
 
         DWORD
@@ -508,7 +507,7 @@ namespace CorUnix
             void
             )
         {
-            return m_dwLastError;
+            return errno;
         };
 
         void


### PR DESCRIPTION
GetLastError in the PAL isn't checking errno, and is instead using its own m_dwLastError.  As such, it doesn't properly handle arbitrary P/Inovkes, and all of our P/Invokes to libc are resulting in garbage GetLastWin32Error values, which throws off all of the error handling paths.

This commit just reimplements CPalThread::GetLastError and CPalThread::SetLastError to use errno (defined by POSIX.1c to be per-thread) as the backing store rather than using the m_dwLastError field, which I've removed.