### PR TITLE
Fix register usage in ResolveWorkerChainLookupAsmStub

### DIFF
--- a/src/vm/amd64/virtualcallstubamd64.S
+++ b/src/vm/amd64/virtualcallstubamd64.S
@@ -47,7 +47,7 @@ NESTED_END ResolveWorkerAsmStub, _TEXT
 LEAF_ENTRY ResolveWorkerChainLookupAsmStub, _TEXT
 // This will perform a quick chained lookup of the entry if the initial cache lookup fails
 // On Input:  
-//   rsi       contains our type     (MethodTable)
+//   rdx       contains our type     (MethodTable)
 //   r10       contains our contract (DispatchToken)
 //   r11       contains the address of the indirection (and the flags in the low two bits)
 // [rsp+0x00]  contains the pointer to the ResolveCacheElem
@@ -64,25 +64,25 @@ MainLoop_RWCLAS:
         test    rax,rax          // test if we hit a terminating NULL
         jz      Fail_RWCLAS
 
-        cmp    rsi, [rax+00h]    // compare our MT with the one in the ResolveCacheElem
+        cmp    rdx, [rax+00h]    // compare our MT with the one in the ResolveCacheElem
         jne    MainLoop_RWCLAS
         cmp    r10, [rax+08h]    // compare our DispatchToken with one in the ResolveCacheElem
         jne    MainLoop_RWCLAS
 Success_RWCLAS:        
-        PREPARE_EXTERNAL_VAR CHAIN_SUCCESS_COUNTER, rsi
-        sub    qword ptr [rsi],1 // decrement success counter 
+        PREPARE_EXTERNAL_VAR CHAIN_SUCCESS_COUNTER, rdx
+        sub    qword ptr [rdx],1 // decrement success counter 
         jl     Promote_RWCLAS
         mov    rax, [rax+10h]    // get the ImplTarget
-        pop    rsi
+        pop    rdx
         jmp    rax
         
 Promote_RWCLAS:                  // Move this entry to head postion of the chain
         // be quick to reset the counter so we don't get a bunch of contending threads
-        mov    qword ptr [rsi], INITIAL_SUCCESS_COUNT
+        mov    qword ptr [rdx], INITIAL_SUCCESS_COUNT
         or     r11, PROMOTE_CHAIN_FLAG
         mov    r10, rax          // We pass the ResolveCacheElem to ResolveWorkerAsmStub instead of the DispatchToken 
 Fail_RWCLAS:           
-        pop    rsi               // Restore the original saved rdx value
+        pop    rdx               // Restore the original saved rdx value
         push   r10               // pass the DispatchToken or ResolveCacheElem to promote to ResolveWorkerAsmStub
         
         jmp    C_FUNC(ResolveWorkerAsmStub)


### PR DESCRIPTION
This stub has 100% custom calling convention. It gets the argument in rdx even on Unix.