### PR TITLE
Fix typo in garbage-collection.md

### DIFF
--- a/Documentation/garbage-collection.md
+++ b/Documentation/garbage-collection.md
@@ -138,7 +138,7 @@ When a GC is triggered, the GC must first determine which generation to collect.
 
 - Fragmentation of a generation – if a generation has high fragmentation, collecting that generation is likely to be productive.
 - If the memory load on the machine is too high, the GC may collect 
-  more aggressively if that’s likely to yield free space. This is improtant to 
+  more aggressively if that’s likely to yield free space. This is important to 
   prevent unnecessary paging (across the machine).
 - If the ephemeral segment is running out of space, the GC may do more aggressive ephemeral collections (meaning doing more gen1’s) to avoid acquiring a new heap segment.
 


### PR DESCRIPTION
Changed "improtant" to "important".

I'm not sure why GitHub thinks theres a second change at line 332. Perhaps it automatically changed some whitespace?