### PR TITLE
Make assertion failures to break into debugger

### DIFF
--- a/src/inc/winwrap.h
+++ b/src/inc/winwrap.h
@@ -992,11 +992,9 @@ inline int LateboundMessageBoxW(HWND hWnd,
     DbgWPrintf(W("********\n"));
     DbgWPrintf(W("\n"));
 
-    // If a debugger is attached breakpoint as well.
-    if (IsDebuggerPresent())
-        DebugBreak();
-
-    return IDCANCEL;
+    // Indicate to the caller that message box was not actually displayed
+    SetLastError(ERROR_NOT_SUPPORTED);
+    return 0;
 }
 
 inline int LateboundMessageBoxA(HWND hWnd,

--- a/src/utilcode/debug.cpp
+++ b/src/utilcode/debug.cpp
@@ -482,28 +482,25 @@ int _DbgBreakCheck(
 
     switch(ret)
     {
-        // For abort, just quit the app.
-        case IDABORT:
-          TerminateProcess(GetCurrentProcess(), 1);
-//        WszFatalAppExit(0, W("Shutting down"));
+    // For abort, just quit the app.
+    case IDABORT:
+        TerminateProcess(GetCurrentProcess(), 1);
         break;
 
-        // Tell caller to break at the correct loction.
-        case IDRETRY:
-
-            if (IsDebuggerPresent())
-            {
-                SetErrorMode(0);
-            }
-            else
-            {
-                LaunchJITDebugger();
-            }
-
+    // Tell caller to break at the correct loction.
+    case IDRETRY:
+        if (IsDebuggerPresent())
+        {
+            SetErrorMode(0);
+        }
+        else
+        {
+            LaunchJITDebugger();
+        }
         return (true);
 
-        // If we want to ignore the assert, find out if this is forever.
-        case IDIGNORE:
+    // If we want to ignore the assert, find out if this is forever.
+    case IDIGNORE:
         if (formattedMessages) 
         {
             if (UtilMessageBoxCatastrophicNonLocalized(
@@ -531,6 +528,10 @@ int _DbgBreakCheck(
         psData->iLine = iLine;
         strcpy(psData->rcFile, szFile);
         break;
+
+    case 0:
+        // The message box was not displayed. Tell caller to break.
+        return true;
     }
 
     return (false);


### PR DESCRIPTION
On Unix, assertion failures just printed a message and program kept going. They were easy to miss. This change makes them to execute DebugBreak that breaks into debugger.