### PR TITLE
Fix size computation in ZapWriter::WritePad

### DIFF
--- a/src/zap/zapwriter.cpp
+++ b/src/zap/zapwriter.cpp
@@ -384,11 +384,11 @@ void ZapWriter::WritePad(DWORD dwSize, BYTE fill)
     if (dwSize == 0)
         return;
 
-    memset(m_pBuffer, fill, max(WRITE_BUFFER_SIZE, dwSize));
+    memset(m_pBuffer, fill, min(WRITE_BUFFER_SIZE, dwSize));
 
     while (dwSize >= WRITE_BUFFER_SIZE)
     {
-        cbAvailable = max(WRITE_BUFFER_SIZE, dwSize);
+        cbAvailable = min(WRITE_BUFFER_SIZE, dwSize);
         IfFailThrow(m_pStream->Write(m_pBuffer, cbAvailable, NULL));
         dwSize -= cbAvailable;
     }


### PR DESCRIPTION
Bug found via code review. It is not causing any real problems right now because WritePad is always called with small-enough buffer.