### PR TITLE
Do not hardcode path to bash into the shell scripts.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage()
 {

--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file invokes cmake and generates the build system for gcc.
 #

--- a/src/pal/tools/setup-compiler-clang.sh
+++ b/src/pal/tools/setup-compiler-clang.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file sets the environment to be used for building with clang.
 #

--- a/src/pal/tools/setup-ubuntuvm.sh
+++ b/src/pal/tools/setup-ubuntuvm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo Installing basic Ubuntu \(VM\) XPlat environment
 


### PR DESCRIPTION
bash is not in /bin/ on every system. Use /usr/bin/env to find bash, no
matter under which path.

This change makes the build scripts more portable and eventually allows building on more systems.