### PR TITLE
Return null for GetLocalTzFile

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -1947,7 +1947,7 @@ namespace System {
         [SecurityCritical]
         internal static Byte[] GetLocalTzFile() {
             // UNIXTODO
-            throw new NotImplementedException();
+            return null;
         }
 
         //


### PR DESCRIPTION
Throwing an exception from GetLocalTzFile causes DateTime.Now to throw
an exception and the runtime to tear down.  While we are bringing up
the globalization stack on Unix, we can just return null instead of
throwing.  This will cause us to use a zero UTC offset, so the local
times will not actually match the local clock, but we will be able to
get further along.