### PR TITLE
Add custom entry point support.

### DIFF
--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -42,6 +42,9 @@ typedef HRESULT (*ExecuteAssemblyFunction)(
                     int argc,
                     LPCSTR* argv,
                     LPCSTR managedAssemblyPath,
+                    LPCSTR entryPointAssemblyName,
+                    LPCSTR entryPointTypeName,
+                    LPCSTR entryPointMethodsName,
                     DWORD* exitCode);
 
 // Display the command line options
@@ -315,6 +318,9 @@ int ExecuteManagedAssembly(
                             managedAssemblyArgc,
                             managedAssemblyArgv,
                             managedAssemblyAbsolutePath,
+                            NULL,
+                            NULL,
+                            NULL,
                             (DWORD*)&exitCode);
 
             if (!SUCCEEDED(st))


### PR DESCRIPTION
Hosts like ASP.net don't want to call ExecuteAssembly, because their
entry point is library, not a managed exe.  However, forcing cross
platform hosts to actually call CreateAppDomainWithManager and
CreateDelegate themselves requires a bunch of tedious code, since these
hosts don't have access to mscoree.h and the PAL.

This change adds the ability to specificy an assembly, type and method
which can be used as a custom entrypoint.  The signiture of the managed
entry point needs to be `static int E(int, char**)`.