### PR TITLE
Fixes for building tests alone

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -47,7 +47,7 @@ set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__IntermediatesDir=%__RootBinDir%\intermediates\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__PackagesBinDir=%__BinDir%\.nuget"
 set "__ToolsDir=%__RootBinDir%\tools"
-set "__TestWorkingDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__TestBinDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
 
 :: Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"
@@ -63,12 +63,6 @@ set __MSBCleanBuildArgs=/t:rebuild
 
 :: Cleanup the binaries drop folder
 if exist "%__RootBinDir%" rd /s /q "%__RootBinDir%"
-
-:: Cleanup the logs folder
-if exist "%__LogsDir%" rd /s /q "%__LogsDir%"
-
-::Cleanup intermediates folder
-if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"
 
 :MakeDirectories
 if not exist "%__BinDir%" md "%__BinDir%"
@@ -188,7 +182,7 @@ goto :eof
 echo Repo successfully built.
 echo.
 echo Product binaries are available at !__BinDir!
-echo Test binaries are available at !__TestWorkingDir!
+echo Test binaries are available at !__TestBinDir!
 goto :eof
 
 :Usage

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@ if (WIN32)
     add_definitions(-DWINDOWS=1)
 endif()
 
+# Compile options
+
+if (WIN32)
+    add_compile_options(-wd4820)
+endif()
+
 MACRO(SUBDIRLIST result curdir)
   FILE(GLOB children RELATIVE ${curdir} ${curdir}/*)
   SET(dirlist "")
@@ -29,3 +35,4 @@ MACRO(ADDSUBDIR_REC  curdir)
 ENDMACRO()
 
 ADDSUBDIR_REC(${CMAKE_CURRENT_SOURCE_DIR})
+

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -40,7 +40,7 @@ if not defined __BuildType set __BuildType=debug
 if not defined __BuildOS set __BuildOS=Windows_NT
 if not defined __BinDir    set  __BinDir=%__ProjectFilesDir%..\binaries\Product\%__BuildOS%.%__BuildArch%.%__BuildType%
 if not defined __TestWorkingDir set __TestWorkingDir=%__ProjectFilesDir%..\binaries\tests\%__BuildOS%.%__BuildArch%.%__BuildType%
-if not defined __LogsDir        set  __LogsDir=%__ProjectFilesDir%..\binaries\Logs\
+if not defined __LogsDir        set  __LogsDir=%__ProjectFilesDir%..\binaries\Logs
 
 :: Default global test environmet variables
 if not defined XunitTestBinBase       set  XunitTestBinBase=%__TestWorkingDir%\

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -30,13 +30,14 @@
 <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
     <BaseOutputPathWithConfig>$(ProjectDir)\..\binaries\tests\$(BuildOS).$(Platform).$(Configuration)\</BaseOutputPathWithConfig>
-    <BaseOutputPathWithConfig Condition="'$(__TestWorkingDir)' != ''">$(__TestWorkingDir)\</BaseOutputPathWithConfig>
+    <BaseOutputPathWithConfig Condition="'$(__TestBinDir)' != ''">$(__TestBinDir)\</BaseOutputPathWithConfig>
     <BinDir>$(BaseOutputPathWithConfig)\..</BinDir>
-    <BaseIntermediateOutputPath>$(BinDir)\intermediates\</BaseIntermediateOutputPath>
-    <__CMakeTestSlnDir Condition="'$(__CMakeTestSlnDir)' == ''">$(BaseOutputPathWithConfig)\CMake\</__CMakeTestSlnDir>
+    <BaseIntermediateOutputPath>$(ProjectDir)\..\binaries\tests\intermediates\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(__ManagedTestIntermediatesDir)' != ''">$(__ManagedTestIntermediatesDir)\</BaseIntermediateOutputPath>
+    <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\intermediates\$(BuildOS).$(Platform).$(Configuration)\))</__NativeTestIntermediatesDir>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
     <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))</BuildProjectRelativeDir>
-    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)\$(BuildOS).$(Platform).$(Configuration)\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPathWithConfig)$(BuildProjectRelativeDir)\</OutputPath>
   </PropertyGroup>
 

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -61,10 +61,10 @@
 
   <Target Name="CopyNativeProjectBinaries">
      <ItemGroup>
-        <NativeProjectBinaries Include="$(NativeProjectOutPutFolder)\**\*.*" />
+        <NativeProjectBinaries Include="$(NativeProjectOutputFolder)\**\*.*" />
      </ItemGroup>
 
-     <Error  Text="Then Native Project files are missing in $(NativeProjectOutPutFolder) please run build from the root of the repo at least once"
+     <Error  Text="The native project files are missing in $(NativeProjectOutputFolder) please run build from the root of the repo at least once"
              Condition="'@(NativeProjectBinaries)' == ''" />
 
      <Copy
@@ -93,15 +93,16 @@
           Condition="'@(ProjectReference)' != ''"
           BeforeTargets="Build" >
      <ItemGroup>
-        <NativeProjectOutPutFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(SourceDir),$(__CMakeTestSlnDir)src\))$(Configuration)\"/>
+        <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(SourceDir),$(__NativeTestIntermediatesDir)\src\))$(Configuration)\"/>
      </ItemGroup>
 
-       <Message Text= "Project filese are :$([System.String]::Copy(%(ProjectReference.FileName)).ToUpper()) " />
-       <Message Text= "Project refernce are :%(ProjectReference.Identity)" />
-       <Message Text= "Native Project refernce are :%(NativeProjectReference.Identity)" />
-       <Message Text= "Native Project refernce are :%(NativeProjectReferenceNormalized.Identity)" />
-       <Message Text= "Native Binaries will be copied from :%(NativeProjectOutPutFoldersToCopy.Identity)" />
-   <MSBuild Projects="$(MSBuildProjectFile)" Targets="CopyNativeProjectBinaries" Properties="NativeProjectOutPutFolder=%(NativeProjectOutPutFoldersToCopy.Identity)" Condition="'@(NativeProjectReference)' != ''" />
+    <Message Text= "Project files are :$([System.String]::Copy(%(ProjectReference.FileName)).ToUpper()) " />
+    <Message Text= "Project references are :%(ProjectReference.Identity)" />
+    <Message Text= "Native project references are :%(NativeProjectReference.Identity)" />
+    <Message Text= "Full native project references are :%(NativeProjectReferenceNormalized.Identity)" />
+    <Message Text= "Native binaries will be copied from :%(NativeProjectOutputFoldersToCopy.Identity)" />
+   <MSBuild Projects="$(MSBuildProjectFile)" Targets="CopyNativeProjectBinaries" Properties="NativeProjectOutputFolder=%(NativeProjectOutputFoldersToCopy.Identity)" Condition="'@(NativeProjectReference)' != ''" />
 
   </Target>
 </Project>
+

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -18,7 +18,7 @@
       <TestAssemblies Include="@(AllTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity).XUnitWrapper.dll')" />
     </ItemGroup>
     
-    <Error  Text=" The Wrappers must be compiled and placed at $(TestAssemblyDir) before they can be run, Do a clean Test Run"
+    <Error  Text=" The wrappers must be compiled and placed at $(TestAssemblyDir) before they can be run, Do a clean Test Run"
             Condition="'@(AllTestAssemblies)' == ''" />
     
     <Message Text= "AllTestAssemblies= @(AllTestAssemblies)"/>


### PR DESCRIPTION
This change fixes an issue where tests cannot be built alone as well as cleans up the paths.  The general path cleanup was done so that the path format and variable names generally follow the main build of the coreclr repo.  Some highlights are:

 * Don't use Cmake as a directory name for intermediates, use intermediates instead.
 * Disable 4820 warning (this is about padding) when building tests.  Reduces noise in output significantly
 * Some fixes in typos and casing in the project files and build scripts