### PR TITLE
Add support for exceptions crossing native frames

### DIFF
--- a/src/debug/di/amd64/floatconversion.S
+++ b/src/debug/di/amd64/floatconversion.S
@@ -4,7 +4,7 @@
 //
 
 .intel_syntax noprefix
-#include "../../../vm/amd64/unixasmmacros.inc"
+#include <unixasmmacros.inc>
 
 LEAF_ENTRY FPFillR8, _TEXT
             movdqa  xmm0, [rdi]

--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -26,9 +26,11 @@
 
 #if defined(__APPLE__)
 #define C_FUNC(name) _##name
+#define EXTERNAL_C_FUNC(name) C_FUNC(name)
 #define LOCAL_LABEL(name) L##name
 #else
 #define C_FUNC(name) name
+#define EXTERNAL_C_FUNC(name) C_FUNC(name)@plt
 #define LOCAL_LABEL(name) .L##name
 #endif
 
@@ -131,13 +133,16 @@ C_FUNC(\Name\()_End):
 .macro save_xmm128_postrsp Reg, Offset
         __Offset = \Offset
         movdqa  [rsp + __Offset], \Reg
-        .cfi_rel_offset \Reg, __Offset
+        // NOTE: We cannot use ".cfi_rel_offset \Reg, __Offset" here, 
+        // the xmm registers are not supported by the libunwind
 .endm
 
 .macro restore_xmm128 Reg, ofs
         __Offset = \ofs
         movdqa          \Reg, [rsp + __Offset]
-        .cfi_restore \Reg
+        // NOTE: We cannot use ".cfi_restore \Reg" here, 
+        // the xmm registers are not supported by the libunwind
+        
 .endm
 
 .macro POP_CALLEE_SAVED_REGISTERS
@@ -153,6 +158,11 @@ C_FUNC(\Name\()_End):
 
 .macro push_register Reg
         push            \Reg
+        .cfi_adjust_cfa_offset 8
+.endm
+
+.macro push_eflags
+        pushfq
         .cfi_adjust_cfa_offset 8
 .endm
 

--- a/src/pal/src/arch/i386/context2.S
+++ b/src/pal/src/arch/i386/context2.S
@@ -8,15 +8,20 @@
 // and is always apply to the current thread.
 //
 
-#include "macros.inc"
+.intel_syntax noprefix
+#include "unixasmmacros.inc"
 
 #ifdef BIT64
+
+#define CONTEXT_AMD64   0x100000
 
 #define CONTEXT_CONTROL 1 // SegSs, Rsp, SegCs, Rip, and EFlags
 #define CONTEXT_INTEGER 2 // Rax, Rcx, Rdx, Rbx, Rbp, Rsi, Rdi, R8-R15
 #define CONTEXT_SEGMENTS 4 // SegDs, SegEs, SegFs, SegGs
 #define CONTEXT_FLOATING_POINT 8
 #define CONTEXT_DEBUG_REGISTERS 16 // Dr0-Dr3 and Dr6-Dr7
+
+#define CONTEXT_FULL (CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT)
 
 #define CONTEXT_ContextFlags 6*8
 #define CONTEXT_SegCs CONTEXT_ContextFlags+8
@@ -78,66 +83,75 @@
 // Incoming:
 //  RDI: Context*
 //
-    .globl C_FUNC(CONTEXT_CaptureContext)
-C_FUNC(CONTEXT_CaptureContext):
-    testb $CONTEXT_INTEGER, CONTEXT_ContextFlags(%rdi)
-    je 0f
-    mov %rdi, CONTEXT_Rdi(%rdi)
-    mov %rsi, CONTEXT_Rsi(%rdi)
-    mov %rbx, CONTEXT_Rbx(%rdi)
-    mov %rdx, CONTEXT_Rdx(%rdi)
-    mov %rcx, CONTEXT_Rcx(%rdi)
-    mov %rax, CONTEXT_Rax(%rdi)
-    mov %rbp, CONTEXT_Rbp(%rdi)
-    mov %r8, CONTEXT_R8(%rdi)
-    mov %r9, CONTEXT_R9(%rdi)
-    mov %r10, CONTEXT_R10(%rdi)
-    mov %r11, CONTEXT_R11(%rdi)
-    mov %r12, CONTEXT_R12(%rdi)
-    mov %r13, CONTEXT_R13(%rdi)
-    mov %r14, CONTEXT_R14(%rdi)
-    mov %r15, CONTEXT_R15(%rdi)
-    jmp 1f
+LEAF_ENTRY CONTEXT_CaptureContext, _TEXT
+    test    BYTE PTR [rdi + CONTEXT_ContextFlags], CONTEXT_INTEGER
+    je      0f
+    mov     [rdi + CONTEXT_Rdi], rdi
+    mov     [rdi + CONTEXT_Rsi], rsi
+    mov     [rdi + CONTEXT_Rbx], rbx
+    mov     [rdi + CONTEXT_Rdx], rdx
+    mov     [rdi + CONTEXT_Rcx], rcx
+    mov     [rdi + CONTEXT_Rax], rax
+    mov     [rdi + CONTEXT_Rbp], rbp
+    mov     [rdi + CONTEXT_R8], r8
+    mov     [rdi + CONTEXT_R9], r9
+    mov     [rdi + CONTEXT_R10], r10
+    mov     [rdi + CONTEXT_R11], r11
+    mov     [rdi + CONTEXT_R12], r12
+    mov     [rdi + CONTEXT_R13], r13
+    mov     [rdi + CONTEXT_R14], r14
+    mov     [rdi + CONTEXT_R15], r15   
+    jmp     1f
 0:
     nop
 1:
-    testb $CONTEXT_CONTROL, CONTEXT_ContextFlags(%rdi)
-    je 2f
+    test    BYTE PTR [rdi + CONTEXT_ContextFlags], CONTEXT_CONTROL
+    je      2f
     
     // Return address is @ RSP
-    mov (%rsp), %rdx
-    mov %rdx, CONTEXT_Rip(%rdi)
-    mov %cs, CONTEXT_SegCs(%rdi)
-    pushfq
-    pop %rdx
-    mov %edx, CONTEXT_EFlags(%rdi)
-    lea 8(%rsp), %rdx
-    mov %rdx, CONTEXT_Rsp(%rdi)
-    mov %ss, CONTEXT_SegSs(%rdi)
+    mov     rdx, [rsp]
+    mov     [rdi + CONTEXT_Rip], rdx
+.att_syntax 
+    mov     %cs, CONTEXT_SegCs(%rdi)
+.intel_syntax noprefix
+    push_eflags
+    pop_register rdx
+    mov     [rdi + CONTEXT_EFlags], edx
+    lea     rdx, [rsp + 8]
+    mov     [rdi + CONTEXT_Rsp], rdx
+.att_syntax 
+    mov     %ss, CONTEXT_SegSs(%rdi)
+.intel_syntax noprefix
 2:
     // Need to double check this is producing the right result
     // also that FFSXR (fast save/restore) is not turned on
     // otherwise it omits the xmm registers.
-    testb $CONTEXT_FLOATING_POINT, CONTEXT_ContextFlags(%rdi)
-    je 3f
-    fxsave CONTEXT_FltSave(%rdi)
+    test    BYTE PTR [rdi + CONTEXT_ContextFlags], CONTEXT_FLOATING_POINT
+    je      3f
+    fxsave  [rdi + CONTEXT_FltSave]
 3:
-    testb $CONTEXT_DEBUG_REGISTERS, CONTEXT_ContextFlags(%rdi)
-    je 4f
-    mov %dr0, %rdx
-    mov %rdx, CONTEXT_Dr0(%rdi)
-    mov %dr1, %rdx
-    mov %rdx, CONTEXT_Dr1(%rdi)
-    mov %dr2, %rdx
-    mov %rdx, CONTEXT_Dr2(%rdi)
-    mov %dr3, %rdx
-    mov %rdx, CONTEXT_Dr3(%rdi)
-    mov %dr6, %rdx
-    mov %rdx, CONTEXT_Dr6(%rdi)
-    mov %dr7, %rdx
-    mov %rdx, CONTEXT_Dr7(%rdi)
+    test    BYTE PTR [rdi + CONTEXT_ContextFlags], CONTEXT_DEBUG_REGISTERS
+    je      4f
+    mov     rdx, dr0
+    mov     [rdi + CONTEXT_Dr0], rdx
+    mov     rdx, dr1
+    mov     [rdi + CONTEXT_Dr1], rdx
+    mov     rdx, dr2
+    mov     [rdi + CONTEXT_Dr2], rdx
+    mov     rdx, dr3
+    mov     [rdi + CONTEXT_Dr3], rdx
+    mov     rdx, dr6
+    mov     [rdi + CONTEXT_Dr6], rdx
+    mov     rdx, dr7
+    mov     [rdi + CONTEXT_Dr7], rdx
 4:
     ret
+LEAF_END CONTEXT_CaptureContext, _TEXT
+
+LEAF_ENTRY RtlCaptureContext, _TEXT
+    mov     DWORD PTR [rdi + CONTEXT_ContextFlags], (CONTEXT_AMD64 | CONTEXT_FULL | CONTEXT_SEGMENTS)
+    jmp     C_FUNC(CONTEXT_CaptureContext)
+LEAF_END RtlCaptureContext, _TEXT
 
 #else
 

--- a/src/pal/src/arch/i386/macros.inc
+++ b/src/pal/src/arch/i386/macros.inc
@@ -1,6 +1,0 @@
-#if defined(__APPLE__)
-#define C_FUNC(name) _##name
-#else
-#define C_FUNC(name) name
-#endif
-

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -520,15 +520,6 @@ SetThreadContext(
 
 VOID 
 PALAPI 
-RtlCaptureContext(
-  OUT PCONTEXT ContextRecord
-)
-{
-    ASSERT("UNIXTODO: Implement this");
-}
-
-VOID 
-PALAPI 
 RtlRestoreContext(
   IN PCONTEXT ContextRecord,
   IN PEXCEPTION_RECORD ExceptionRecord

--- a/src/vm/amd64/unixasmhelpers.S
+++ b/src/vm/amd64/unixasmhelpers.S
@@ -190,3 +190,41 @@ NullObject:
         jmp     C_FUNC(JIT_InternalThrow)
                                                                                       
 LEAF_END SinglecastDelegateInvokeStub, _TEXT
+
+//////////////////////////////////////////////////////////////////////////
+//
+// This function initiates unwinding of native frames during the unwinding of a managed 
+// exception. The managed exception can be propagated over several managed / native ranges 
+// until it is finally handled by a managed handler or leaves the stack unhandled and
+// aborts the current process.
+// It creates a stack frame right below the target frame, restores all callee saved registers
+// from the passed in context and finally sets the RSP to that frame and sets the return
+// address to the target frame's RIP.
+//
+// EXTERN_C void StartUnwindingNativeFrames(CONTEXT* context);
+LEAF_ENTRY StartUnwindingNativeFrames, _TEXT
+        // Save the RBP to the stack so that the unwind can work at the instruction after
+        // loading the RBP from the context, but before loading the RSP from the context.
+        push_nonvol_reg rbp
+        mov     r12, [rdi + OFFSETOF__CONTEXT__R12]
+        mov     r13, [rdi + OFFSETOF__CONTEXT__R13]
+        mov     r14, [rdi + OFFSETOF__CONTEXT__R14]
+        mov     r15, [rdi + OFFSETOF__CONTEXT__R15]
+        mov     rbx, [rdi + OFFSETOF__CONTEXT__Rbx]
+        mov     rbp, [rdi + OFFSETOF__CONTEXT__Rbp]
+        mov     rsp, [rdi + OFFSETOF__CONTEXT__Rsp]
+        // The RSP was set to the target frame's value, so the current function's
+        // CFA is now right at the RSP.
+        .cfi_def_cfa_offset 0
+
+        // Indicate that now that we have moved the RSP to the target address, 
+        // the RBP is no longer saved in the current stack frame. 
+        .cfi_restore rbp
+
+        mov     rax, [rdi + OFFSETOF__CONTEXT__Rip]
+
+        // Store return address to the stack
+        push_register rax
+        call    EXTERNAL_C_FUNC(__cxa_rethrow)
+LEAF_END StartUnwindingNativeFrames, _TEXT
+

--- a/src/vm/exstatecommon.h
+++ b/src/vm/exstatecommon.h
@@ -337,6 +337,14 @@ public:
     void SetIsRethrown()   { LIMITED_METHOD_CONTRACT; AssertIfReadOnly(); m_flags |= Ex_IsRethrown; }
     void ResetIsRethrown() { LIMITED_METHOD_CONTRACT; AssertIfReadOnly(); m_flags &= ~Ex_IsRethrown; }
 
+#ifdef FEATURE_PAL
+    BOOL IsInterleavedHandling()      { LIMITED_METHOD_CONTRACT; return m_flags & Ex_IsInterleavedHandling; }
+    void SetIsInterleavedHandling()   { LIMITED_METHOD_CONTRACT; AssertIfReadOnly(); m_flags |= Ex_IsInterleavedHandling; }
+    void ResetIsInterleavedHandling() { LIMITED_METHOD_CONTRACT; AssertIfReadOnly(); m_flags &= ~Ex_IsInterleavedHandling; }
+#else // FEATURE_PAL
+    BOOL IsInterleavedHandling() { return FALSE; }
+#endif //  FEATURE_PAL
+
     BOOL UnwindHasStarted()      { LIMITED_METHOD_CONTRACT; return m_flags & Ex_UnwindHasStarted; }
     void SetUnwindHasStarted()   { LIMITED_METHOD_CONTRACT; AssertIfReadOnly(); m_flags |= Ex_UnwindHasStarted; }
     void ResetUnwindHasStarted() { LIMITED_METHOD_CONTRACT; AssertIfReadOnly(); m_flags &= ~Ex_UnwindHasStarted; }
@@ -415,8 +423,9 @@ private:
 
         Ex_WasThrownByUs                = 0x00002000,
 
-        Ex_GotWatsonBucketInfo          = 0x00004000
+        Ex_GotWatsonBucketInfo          = 0x00004000,
 
+        Ex_IsInterleavedHandling        = 0x00008000
 
 #if defined(WIN64EXCEPTIONS) && defined(_DEBUG)
     ,

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -779,7 +779,13 @@ UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
 #ifndef FEATURE_PAL
         uControlPc = VirtualUnwindCallFrame(pContext);
 #else // !FEATURE_PAL
-        PAL_VirtualUnwind(pContext, NULL);
+        BOOL success = PAL_VirtualUnwind(pContext, NULL);
+        if (!success)
+        {
+            _ASSERTE(!"Thread::VirtualUnwindToFirstManagedCallFrame: PAL_VirtualUnwind failed");
+            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
+        }
+
         uControlPc = GetIP(pContext);
 #endif // !FEATURE_PAL
     }


### PR DESCRIPTION
This change adds support for unwinding exceptions that cross native frames.
These are for example exceptions thrown / rethrown from catch blocks.
The exceptions are unwound in an interleaved manner in this case. First,
all managed frames upto the first native frame are unwound (both the first
and second pass), then the native frames are unwound by standard c++ exception
handling, then the next block of managed frames is unwound etc.
The change also implements RtlCaptureContext and changes the managed exception
handling to use it instead of the GetThreadContext. The difference is that the
RtlCaptureContext gets context of the caller while the GetThreadContext gets
a context somewhere deep in the PAL and so unwinding from such a context to the
first managed frame would be walking old stack frames that can already be corrupted.
I have also moved the unixasmmacros.inc to the src/pal/inc folder so that it can be 
used by PAL asm code too.