### PR TITLE
Add unhandled exception stack trace print

### DIFF
--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -790,7 +790,11 @@ UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
 
         if (uControlPc == 0)
         {
-            _ASSERTE(!"Thread::VirtualUnwindToFirstManagedCallFrame: PAL_VirtualUnwind reached end of the stack");
+            // This displays the managed stack in case the unwind has walked out of the stack and
+            // a managed exception was being unwound.
+            DefaultCatchHandler(NULL /*pExceptionInfo*/, NULL /*Throwable*/, TRUE /*useLastThrownObject*/,
+                                TRUE /*isTerminating*/, FALSE /*isThreadBaseFIlter*/, FALSE /*sendAppDomainEvents*/);
+
             EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
         }
 


### PR DESCRIPTION
This change adds printing of unhandled managed exception stack trace to
console before exiting.