### PR TITLE
Flush sampled allocations to event stream at runtime shutdown

### DIFF
--- a/src/inc/eventtrace.h
+++ b/src/inc/eventtrace.h
@@ -151,6 +151,7 @@ namespace ETW
         static void OnKeywordsChanged();
         static void Cleanup();
         static VOID DeleteTypeHashNoLock(AllLoggedTypes **ppAllLoggedTypes);
+        static VOID FlushObjectAllocationEvents();
 
     private:
         static BOOL ShouldLogType(TypeHandle th);

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1899,6 +1899,14 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
             }
         }
 
+#ifdef FEATURE_EVENT_TRACE
+        // Flush managed object allocation logging data.
+        // We do this after finalization is complete and returning threads have been trapped, so that
+        // no there will be no more managed allocations and no more GCs which will manipulate the
+        // allocation sampling data structures.
+        ETW::TypeSystemLog::FlushObjectAllocationEvents();
+#endif // FEATURE_EVENT_TRACE
+
 #ifdef FEATURE_PREJIT
         // If we're doing basic block profiling, we need to write the log files to disk.
 


### PR DESCRIPTION
The GC sampled object allocation feature is used to log managed allocations for performance analysis.  The main benefit of this feature is that it does smart sampling so that we don't have to emit one event per allocation, which has a significant performance penalty.

This pull request fixes a bug where allocations that have not yet been logged to the event stream are lost when the runtime shuts down.  Instead, with this change, we walk the allocation sampling data structures at shutdown and log any allocations that have not yet been written.