### PR TITLE
Add check and instruction to build.cmd to run from normal prompt

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -19,7 +19,7 @@ set __MSBCleanBuildArgs=
 
 :: Ensure we are not already running in a development prompt
 if "%VisualStudioVersion%" == "" goto Arg_Loop
-echo Please make sure to run %0 from a normal prompt (not from a development prompt!) 
+echo Please make sure to run %0 from a normal prompt (not from a VS Developer Command Prompt!) 
 goto :eof
 
 :Arg_Loop

--- a/build.cmd
+++ b/build.cmd
@@ -17,6 +17,11 @@ set "__RootBinDir=%__ProjectDir%\binaries"
 set "__LogsDir=%__RootBinDir%\Logs"
 set __MSBCleanBuildArgs=
 
+:: Ensure we are not already running in a development prompt
+if "%VisualStudioVersion%" == "" goto Arg_Loop
+echo Please make sure to run %0 from a normal prompt (not from a development prompt!) 
+goto :eof
+
 :Arg_Loop
 if "%1" == "" goto ArgsDone
 if /i "%1" == "/?" goto Usage


### PR DESCRIPTION
This should fix issue #113 
Tested with both normal and development prompt.