### PR TITLE
Remove duplicate object code from cordbdi

### DIFF
--- a/src/debug/di/CMakeLists.txt
+++ b/src/debug/di/CMakeLists.txt
@@ -17,7 +17,6 @@ set(CORDBDI_SOURCES
   hash.cpp
   module.cpp
   nativepipeline.cpp
-  eventredirectionpipeline.cpp
   platformspecific.cpp
   process.cpp
   rsappdomain.cpp


### PR DESCRIPTION
eventredirectionpipeline.cpp is #included by platformspecific.cpp,
so remove it from the CMakeLists.txt since that causes linker warnings

This fixes #457 