### PR TITLE
Make GC work without context pointers on OSX

### DIFF
--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -545,6 +545,13 @@ private:
                         PREGDISPLAY     pRD
                         );
 
+#ifdef FEATURE_PAL
+    OBJECTREF* GetCapturedRegister(
+                        int             regNum,
+                        PREGDISPLAY     pRD
+                        );
+#endif // FEATURE_PAL
+
     OBJECTREF* GetStackSlot(
                         INT32           spOffset,
                         GcStackSlotBase spBase,

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -91,7 +91,8 @@ static void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
 static void GetContextPointer(unw_cursor_t *cursor, unw_context_t *unwContext, int reg, PDWORD64 *contextPointer)
 {
 #if defined(__APPLE__)
-    //OSXTODO
+    // Returning NULL indicates that we don't have context pointers available
+    *contextPointer = NULL;
 #else
     unw_save_loc_t saveLoc;
     unw_get_save_loc(cursor, reg, &saveLoc);

--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -232,12 +232,30 @@ void HelperMethodFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pCurrentContext->Rdi = *m_MachState.m_pRdi;
     pRD->pCurrentContext->Rsi = *m_MachState.m_pRsi;
 #endif
-    pRD->pCurrentContext->Rbx = *m_MachState.m_pRbx;
-    pRD->pCurrentContext->Rbp = *m_MachState.m_pRbp;
-    pRD->pCurrentContext->R12 = *m_MachState.m_pR12;
-    pRD->pCurrentContext->R13 = *m_MachState.m_pR13;
-    pRD->pCurrentContext->R14 = *m_MachState.m_pR14;
-    pRD->pCurrentContext->R15 = *m_MachState.m_pR15;
+    if (m_MachState.m_pRbx != NULL) 
+    {
+        pRD->pCurrentContext->Rbx = *m_MachState.m_pRbx;
+    }
+    if (m_MachState.m_pRbp != NULL)
+    {
+        pRD->pCurrentContext->Rbp = *m_MachState.m_pRbp;
+    }
+    if (m_MachState.m_pR12 != NULL)
+    {
+        pRD->pCurrentContext->R12 = *m_MachState.m_pR12;
+    }
+    if (m_MachState.m_pR13 != NULL)
+    {
+        pRD->pCurrentContext->R13 = *m_MachState.m_pR13;
+    }
+    if (m_MachState.m_pR14 != NULL)
+    {
+        pRD->pCurrentContext->R14 = *m_MachState.m_pR14;
+    }
+    if (m_MachState.m_pR15 != NULL)
+    {
+        pRD->pCurrentContext->R15 = *m_MachState.m_pR15;
+    }
 #ifndef UNIX_AMD64_ABI
     pRD->pCurrentContextPointers->Rdi = m_MachState.m_pRdi;
     pRD->pCurrentContextPointers->Rsi = m_MachState.m_pRsi;

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -1450,6 +1450,24 @@ OBJECTREF* GcInfoDecoder::GetRegisterSlot(
     return (OBJECTREF*)*(ppRax + regNum);
 }
 
+#ifdef FEATURE_PAL
+OBJECTREF* GcInfoDecoder::GetCapturedRegister(
+    int             regNum,
+    PREGDISPLAY     pRD
+    )
+{
+    _ASSERTE(regNum >= 0 && regNum <= 16);
+    _ASSERTE(regNum != 4);  // rsp
+
+    // The fields of CONTEXT are in the same order as
+    // the processor encoding numbers.
+
+    ULONGLONG *pRax;
+    pRax = &pRD->pCurrentContext->Rax;
+
+    return (OBJECTREF*)(pRax + regNum);
+}
+#endif // FEATURE_PAL
 
 bool GcInfoDecoder::IsScratchRegister(int regNum,  PREGDISPLAY pRD)
 {
@@ -1506,6 +1524,28 @@ void GcInfoDecoder::ReportRegisterToGC(  // AMD64
     LOG((LF_GCROOTS, LL_INFO1000, "Reporting " FMT_REG, regNum ));
 
     OBJECTREF* pObjRef = GetRegisterSlot( regNum, pRD );
+
+#ifdef FEATURE_PAL
+    // On PAL, we don't always have the context pointers available due to
+    // a limitation of an unwinding library. In such case, the context
+    // pointers for some nonvolatile registers are NULL.
+    // In such case, we let the pObjRef point to the captured register
+    // value in the context and pin the object itself.
+    if (pObjRef == NULL)
+    {
+        // Report a pinned object to GC only in the promotion phase when the
+        // GC is scanning roots. 
+        GCCONTEXT* pGCCtx = (GCCONTEXT*)(hCallBack);
+        if (!pGCCtx->sc->promotion)
+        {
+            return;
+        }
+        
+        pObjRef = GetCapturedRegister(regNum, pRD);
+
+        gcFlags |= GC_CALL_PINNED;
+    }
+#endif // FEATURE_PAL
 
 #ifdef _DEBUG
     if(IsScratchRegister(regNum, pRD))


### PR DESCRIPTION
On OSX, the libunwind doesn't have support for getting context pointers.
This change modifies the way GC handles object pointers in registers
so that when the context pointer cannot be obtained, the object is
pinned so that GC doesn't move it and thus doesn't need to update
the object reference in the register value stored on the stack.