### PR TITLE
Enable ETW_EBP_FRAMED flag on System V systems.

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -1713,7 +1713,14 @@ UNATIVE_OFFSET      emitter::emitInsSizeSV(size_t code, int var, int dsp)
 #endif
                 {
                     // Dev10 804810 - failing this assert can lead to bad codegen and runtime crashes
+#ifdef UNIX_AMD64_ABI
+                    LclVarDsc*  varDsc = emitComp->lvaTable + var;
+                    bool isRegPassedArg = varDsc->lvIsParam && varDsc->lvIsRegArg;
+                    // Register passed args could have a stack offset of 0.
+                    noway_assert((int)offs < 0 || isRegPassedArg);
+#else // !UNIX_AMD64_ABI
                     noway_assert((int)offs < 0);
+#endif // !UNIX_AMD64_ABI
                 }
  
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -667,12 +667,11 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define FEATURE_EH_FUNCLETS      1
   #define FEATURE_EH_CALLFINALLY_THUNKS 1  // Generate call-to-finally code in "thunks" in the enclosing EH region, protected by "cloned finally" clauses.
   #define FEATURE_STACK_FP_X87     0 
-#ifndef UNIX_AMD64_ABI
+#ifdef    UNIX_AMD64_ABI
+  #define ETW_EBP_FRAMED           1       // if 1 we cannot use EBP as a scratch register and must create EBP based frames for most methods
+#else // !UNIX_AMD64_ABI
   #define ETW_EBP_FRAMED           0       // if 1 we cannot use EBP as a scratch register and must create EBP based frames for most methods
-#else // UNIX_AMD64_ABI
-  // TODO-Amd64-Unis: Enable Frame Pointer chaining for most methods when uniwinding and the rest is implemented. Set the following to 1.
-  #define ETW_EBP_FRAMED           0       // if 1 we cannot use EBP as a scratch register and must create EBP based frames for most methods
-#endif // UNIX_AMD64_ABI
+#endif // !UNIX_AMD64_ABI
   #define FEATURE_FP_REGALLOC      0       // Enabled if RegAlloc is used to enregister Floating Point LclVars  
   #define CSE_CONSTS               1       // Enable if we want to CSE constants
 
@@ -695,26 +694,26 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define STACK_ALIGN              16      // stack alignment requirement
   #define STACK_ALIGN_SHIFT        3       // Shift-right amount to convert stack size in bytes to size in pointer sized words
 
-#ifndef UNIX_AMD64_ABI
-#if !ETW_EBP_FRAMED
-  #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ESI|RBM_EDI|RBM_EBP|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
-#else // ETW_EBP_FRAMED
-  #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ESI|RBM_EDI|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
-#endif // ETW_EBP_FRAMED
-  #define RBM_INT_CALLEE_TRASH    (RBM_EAX|RBM_ECX|RBM_EDX|RBM_R8|RBM_R9|RBM_R10|RBM_R11)
-  #define RBM_FLT_CALLEE_SAVED    (RBM_XMM6|RBM_XMM7|RBM_XMM8|RBM_XMM9|RBM_XMM10|RBM_XMM11|RBM_XMM12|RBM_XMM13|RBM_XMM14|RBM_XMM15)
-  #define RBM_FLT_CALLEE_TRASH    (RBM_XMM0|RBM_XMM1|RBM_XMM2|RBM_XMM3|RBM_XMM4|RBM_XMM5)
-#else // UNIX_AMD64_ABI
-#if !ETW_EBP_FRAMED
-  #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_EBP|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
-#else // ETW_EBP_FRAMED
+#ifdef UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
   #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
-#endif // ETW_EBP_FRAMED
+#else // !ETW_EBP_FRAMED
+  #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_EBP|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
+#endif // !ETW_EBP_FRAMED
   #define RBM_INT_CALLEE_TRASH    (RBM_EAX|RBM_RDI|RBM_RSI|RBM_EDX|RBM_ECX|RBM_R8|RBM_R9|RBM_R10|RBM_R11)
   #define RBM_FLT_CALLEE_SAVED    (0)
   #define RBM_FLT_CALLEE_TRASH    (RBM_XMM0|RBM_XMM1|RBM_XMM2|RBM_XMM3|RBM_XMM4|RBM_XMM5|RBM_XMM6|RBM_XMM7| \
                                    RBM_XMM8|RBM_XMM9|RBM_XMM10|RBM_XMM11|RBM_XMM12|RBM_XMM13|RBM_XMM14|RBM_XMM15)
-#endif // UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ESI|RBM_EDI|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
+#else // ETW_EBP_FRAMED
+  #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ESI|RBM_EDI|RBM_EBP|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
+#endif // ETW_EBP_FRAMED
+  #define RBM_INT_CALLEE_TRASH    (RBM_EAX|RBM_ECX|RBM_EDX|RBM_R8|RBM_R9|RBM_R10|RBM_R11)
+  #define RBM_FLT_CALLEE_SAVED    (RBM_XMM6|RBM_XMM7|RBM_XMM8|RBM_XMM9|RBM_XMM10|RBM_XMM11|RBM_XMM12|RBM_XMM13|RBM_XMM14|RBM_XMM15)
+  #define RBM_FLT_CALLEE_TRASH    (RBM_XMM0|RBM_XMM1|RBM_XMM2|RBM_XMM3|RBM_XMM4|RBM_XMM5)
+#endif // !UNIX_AMD64_ABI
   
   #define REG_FLT_CALLEE_SAVED_FIRST   REG_XMM6
   #define REG_FLT_CALLEE_SAVED_LAST    REG_XMM15
@@ -725,74 +724,135 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define RBM_CALLEE_TRASH_NOGC   RBM_CALLEE_TRASH
 
   #define RBM_ALLINT              (RBM_INT_CALLEE_SAVED | RBM_INT_CALLEE_TRASH)
-#ifndef UNIX_AMD64_ABI
-  #define RBM_LOWINT              (RBM_EAX|RBM_ECX|RBM_EBX|RBM_EBP|RBM_ESI|RBM_EDI)
-#else // UNIX_AMD64_ABI
+#ifdef UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define RBM_LOWINT              (RBM_EAX|RBM_RDI|RBM_RSI|RBM_EDX|RBM_ECX|RBM_EBX)
+#else // !ETW_EBP_FRAMED
   #define RBM_LOWINT              (RBM_EAX|RBM_RDI|RBM_RSI|RBM_EDX|RBM_ECX|RBM_EBX|RBM_EBP)
-#endif // UNIX_AMD64_ABI
+#endif // !ETW_EBP_FRAMED
+#else // !UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define RBM_LOWINT              (RBM_EAX|RBM_ECX|RBM_EBX|RBM_ESI|RBM_EDI)
+#else // !ETW_EBP_FRAMED
+  #define RBM_LOWINT              (RBM_EAX|RBM_ECX|RBM_EBX|RBM_EBP|RBM_ESI|RBM_EDI)
+#endif // !ETW_EBP_FRAMED
+#endif // !UNIX_AMD64_ABI
 
 #if 0
-  #define REG_VAR_ORDER            REG_EAX,REG_EDX,REG_ECX,REG_ESI,REG_EDI,REG_EBX,REG_EBP, \
-                                   REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13 
+#if ETW_EBP_FRAMED
+#define REG_VAR_ORDER            REG_EAX,REG_EDX,REG_ECX,REG_ESI,REG_EDI,REG_EBX, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+#else // !ETW_EBP_FRAMED
+#define REG_VAR_ORDER            REG_EAX,REG_EDX,REG_ECX,REG_ESI,REG_EDI,REG_EBX,REG_EBP, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+#endif // !ETW_EBP_FRAMED
+
 #else
   // TEMPORARY ORDER TO AVOID CALLEE-SAVES
   // TODO-CQ: Review this and set appropriately
-#ifndef UNIX_AMD64_ABI
-  #define REG_VAR_ORDER            REG_EAX,REG_EDX,REG_ECX, \
-                                   REG_R8,REG_R9,REG_R10,REG_R11, \
-                                   REG_ESI,REG_EDI,REG_EBX,REG_EBP, \
-                                   REG_R14,REG_R15,REG_R12,REG_R13 
-#else // UNIX_AMD64_ABI
-  #define REG_VAR_ORDER \
-                                   REG_EAX, REG_EDI, REG_ESI, \
-                                   REG_EDX, REG_ECX, REG_R8, REG_R9, \
-                                   REG_R10, REG_R11, REG_EBX, REG_EBP, \
-                                   REG_R14, REG_R15, REG_R12, REG_R13
-#endif // UNIX_AMD64_ABI
+#ifdef UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define                        REG_VAR_ORDER \
+                                 REG_EAX,REG_EDI,REG_ESI, \
+                                 REG_EDX,REG_ECX,REG_R8,REG_R9, \
+                                 REG_R10,REG_R11,REG_EBX, \
+                                 REG_R14,REG_R15,REG_R12,REG_R13
+#else // !ETW_EBP_FRAMED
+  #define                        REG_VAR_ORDER \
+                                 REG_EAX,REG_EDI,REG_ESI, \
+                                 REG_EDX,REG_ECX,REG_R8,REG_R9, \
+                                 REG_R10,REG_R11,REG_EBX,REG_EBP, \
+                                 REG_R14,REG_R15,REG_R12,REG_R13
+#endif // !ETW_EBP_FRAMED
+#else // !UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define REG_VAR_ORDER          REG_EAX,REG_EDX,REG_ECX, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11, \
+                                 REG_ESI,REG_EDI,REG_EBX, \
+                                 REG_R14,REG_R15,REG_R12,REG_R13
+#else // !ETW_EBP_FRAMED
+  #define REG_VAR_ORDER          REG_EAX,REG_EDX,REG_ECX, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11, \
+                                 REG_ESI,REG_EDI,REG_EBX,REG_EBP, \
+                                 REG_R14,REG_R15,REG_R12,REG_R13
+#endif // !ETW_EBP_FRAMED
+#endif // !UNIX_AMD64_ABI
 #endif
 
-  #define REG_VAR_ORDER_FLT        REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3, REG_XMM4, REG_XMM5, REG_XMM6, REG_XMM7, REG_XMM8, REG_XMM9, REG_XMM10, REG_XMM11, REG_XMM12, REG_XMM13, REG_XMM14, REG_XMM15
+  #define REG_VAR_ORDER_FLT      REG_XMM0,REG_XMM1,REG_XMM2,REG_XMM3,REG_XMM4,REG_XMM5,REG_XMM6,REG_XMM7,REG_XMM8,REG_XMM9,REG_XMM10,REG_XMM11,REG_XMM12,REG_XMM13,REG_XMM14,REG_XMM15
 
-  #define MAX_VAR_ORDER_SIZE       15
+#ifdef UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define REG_TMP_ORDER          REG_EAX,REG_EDI,REG_ESI,REG_EDX,REG_ECX,REG_EBX, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+#else // !ETW_EBP_FRAMED
+  #define REG_TMP_ORDER          REG_EAX,REG_EDI,REG_ESI,REG_EDX,REG_ECX,REG_EBX,REG_EBP, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+#endif // !ETW_EBP_FRAMED
+#else // !UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define MAX_VAR_ORDER_SIZE     14
+  #define REG_TMP_ORDER          REG_EAX,REG_EDX,REG_ECX,REG_EBX,REG_ESI,REG_EDI, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+#else // !ETW_EBP_FRAMED
+  #define MAX_VAR_ORDER_SIZE     15
+  #define REG_TMP_ORDER          REG_EAX,REG_EDX,REG_ECX,REG_EBX,REG_ESI,REG_EDI,REG_EBP, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+#endif // !ETW_EBP_FRAMED
+#endif // !UNIX_AMD64_ABI
 
-#ifndef UNIX_AMD64_ABI
-  #define REG_TMP_ORDER            REG_EAX,REG_EDX,REG_ECX,REG_EBX,REG_ESI,REG_EDI,REG_EBP, \
-                                   REG_R8, REG_R9, REG_R10, REG_R11, REG_R14, REG_R15, REG_R12, REG_R13
-#else // UNIX_AMD64_ABI
-  #define REG_TMP_ORDER            REG_EAX,REG_EDI,REG_ESI,REG_EDX,REG_ECX,REG_EBX,REG_EBP, \
-                                   REG_R8, REG_R9, REG_R10, REG_R11, REG_R14, REG_R15, REG_R12, REG_R13
-#endif // UNIX_AMD64_ABI
-
-  #define REG_TMP_ORDER_COUNT      15
-#ifndef UNIX_AMD64_ABI
-  #define REG_PREDICT_ORDER        REG_EAX,REG_EDX,REG_ECX,REG_EBX,REG_ESI,REG_EDI,REG_EBP, \
-                                   REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
-
-  #define CNT_CALLEE_SAVED         (8)
-  #define CNT_CALLEE_TRASH         (7)
-  #define CNT_CALLEE_ENREG         (CNT_CALLEE_SAVED)
-
-  #define CNT_CALLEE_SAVED_FLOAT   (10)
-  #define CNT_CALLEE_TRASH_FLOAT   (6)
-
-  #define REG_CALLEE_SAVED_ORDER   REG_EBX,REG_ESI,REG_EDI,REG_EBP,REG_R12,REG_R13,REG_R14,REG_R15
-  #define RBM_CALLEE_SAVED_ORDER   RBM_EBX,RBM_ESI,RBM_EDI,RBM_EBP,RBM_R12,RBM_R13,RBM_R14,RBM_R15
-  #define CALLEE_SAVED_REG_MAXSZ   (CNT_CALLEE_SAVED*REGSIZE_BYTES) // RBX, RSI, RDI, RBP, R12, R13, R14, R15
-#else // UNIX_AMD64_ABI
-  #define REG_PREDICT_ORDER        REG_EAX, REG_EDI, REG_ESI, REG_EDX, REG_ECX, REG_EBX, REG_EBP, \
-                                   REG_R8, REG_R9, REG_R10, REG_R11, REG_R14, REG_R15, REG_R12, REG_R13
-
-  #define CNT_CALLEE_SAVED         (6)
+#ifdef UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define REG_PREDICT_ORDER      REG_EAX,REG_EDI,REG_ESI,REG_EDX,REG_ECX,REG_EBX, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+  #define CNT_CALLEE_SAVED       (5)
+#else // ETW_EBP_FRAMED
+  #define REG_PREDICT_ORDER      REG_EAX,REG_EDI,REG_ESI,REG_EDX,REG_ECX,REG_EBX,REG_EBP, \
+                                 REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+  #define CNT_CALLEE_SAVED       (6)
+#endif // ETW_EBP_FRAMED
   #define CNT_CALLEE_TRASH         (9)
   #define CNT_CALLEE_ENREG         (CNT_CALLEE_SAVED)
 
   #define CNT_CALLEE_SAVED_FLOAT   (0)
   #define CNT_CALLEE_TRASH_FLOAT   (16)
 
+#if ETW_EBP_FRAMED
+  #define REG_CALLEE_SAVED_ORDER   REG_EBX,REG_R12,REG_R13,REG_R14,REG_R15
+  #define RBM_CALLEE_SAVED_ORDER   RBM_EBX,RBM_R12,RBM_R13,RBM_R14,RBM_R15
+#else // !ETW_EBP_FRAMED
   #define REG_CALLEE_SAVED_ORDER   REG_EBX,REG_EBP,REG_R12,REG_R13,REG_R14,REG_R15
   #define RBM_CALLEE_SAVED_ORDER   RBM_EBX,RBM_EBP,RBM_R12,RBM_R13,RBM_R14,RBM_R15
+#endif // !ETW_EBP_FRAMED
   #define CALLEE_SAVED_REG_MAXSZ   (CNT_CALLEE_SAVED*REGSIZE_BYTES) // RBX, RBP, R12, R13, R14, R15
-#endif // UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
+#if ETW_EBP_FRAMED
+  #define REG_TMP_ORDER_COUNT      14
+  #define REG_PREDICT_ORDER        REG_EAX,REG_EDX,REG_ECX,REG_EBX,REG_ESI,REG_EDI, \
+                                   REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+  #define CNT_CALLEE_SAVED         (7)
+#else // ETW_EBP_FRAMED
+  #define REG_TMP_ORDER_COUNT      15
+  #define REG_PREDICT_ORDER        REG_EAX,REG_EDX,REG_ECX,REG_EBX,REG_ESI,REG_EDI,REG_EBP, \
+                                   REG_R8,REG_R9,REG_R10,REG_R11,REG_R14,REG_R15,REG_R12,REG_R13
+  #define CNT_CALLEE_SAVED         (8)
+#endif // ETW_EBP_FRAMED
+
+  #define CNT_CALLEE_TRASH         (7)
+  #define CNT_CALLEE_ENREG         (CNT_CALLEE_SAVED)
+
+  #define CNT_CALLEE_SAVED_FLOAT   (10)
+  #define CNT_CALLEE_TRASH_FLOAT   (6)
+
+#if ETW_EBP_FRAMED
+  #define REG_CALLEE_SAVED_ORDER   REG_EBX,REG_ESI,REG_EDI,REG_R12,REG_R13,REG_R14,REG_R15
+  #define RBM_CALLEE_SAVED_ORDER   RBM_EBX,RBM_ESI,RBM_EDI,RBM_R12,RBM_R13,RBM_R14,RBM_R15
+#else // !ETW_EBP_FRAMED
+  #define REG_CALLEE_SAVED_ORDER   REG_EBX,REG_ESI,REG_EDI,REG_EBP,REG_R12,REG_R13,REG_R14,REG_R15
+  #define RBM_CALLEE_SAVED_ORDER   RBM_EBX,RBM_ESI,RBM_EDI,RBM_EBP,RBM_R12,RBM_R13,RBM_R14,RBM_R15
+#endif // !ETW_EBP_FRAMED
+  #define CALLEE_SAVED_REG_MAXSZ   (CNT_CALLEE_SAVED*REGSIZE_BYTES) // RBX, RSI, RDI, RBP, R12, R13, R14, R15
+#endif // !UNIX_AMD64_ABI
 
   #define CALLEE_SAVED_FLOAT_MAXSZ (CNT_CALLEE_SAVED_FLOAT*16)
 
@@ -808,13 +868,13 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define RBM_TMP_0                RBM_EAX
 
   //  This is the second register in REG_TMP_ORDER
-#ifndef UNIX_AMD64_ABI
-  #define REG_TMP_1                REG_EDX
-  #define RBM_TMP_1                RBM_EDX
-#else // UNIX_AMD64_ABI
+#ifdef UNIX_AMD64_ABI
   #define REG_TMP_1                REG_EDI
   #define RBM_TMP_1                RBM_EDI
-#endif // UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
+  #define REG_TMP_1                REG_EDX
+  #define RBM_TMP_1                RBM_EDX
+#endif // !UNIX_AMD64_ABI
   #define REG_PAIR_TMP             REG_PAIR_EAXEDX
   #define RBM_PAIR_TMP             (RBM_EAX|RBM_EDX)
   #define REG_PAIR_TMP_LO          REG_EAX
@@ -834,13 +894,13 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define RBM_SCRATCH              RBM_EAX
 
 // Where is the exception object on entry to the handler block?
-#ifndef UNIX_AMD64_ABI
-  #define REG_EXCEPTION_OBJECT     REG_EDX
-  #define RBM_EXCEPTION_OBJECT     RBM_EDX
-#else
+#ifdef UNIX_AMD64_ABI
   #define REG_EXCEPTION_OBJECT     REG_ESI
   #define RBM_EXCEPTION_OBJECT     RBM_ESI
-#endif // UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
+  #define REG_EXCEPTION_OBJECT     REG_EDX
+  #define RBM_EXCEPTION_OBJECT     RBM_EDX
+#endif // !UNIX_AMD64_ABI
 
   #define REG_JUMP_THUNK_PARAM     REG_EAX
   #define RBM_JUMP_THUNK_PARAM     RBM_EAX
@@ -924,28 +984,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 
   #define FIRST_ARG_STACK_OFFS     (REGSIZE_BYTES)   // return address
 
-#ifndef UNIX_AMD64_ABI
-  #define MAX_REG_ARG              4
-  #define MAX_FLOAT_REG_ARG        4
-  #define REG_ARG_FIRST            REG_ECX
-  #define REG_ARG_LAST             REG_R9
-  #define INIT_ARG_STACK_SLOT      4                  // 4 outgoing reserved stack slots
-
-  #define REG_ARG_0                REG_ECX
-  #define REG_ARG_1                REG_EDX
-  #define REG_ARG_2                REG_R8
-  #define REG_ARG_3                REG_R9
-
-  SELECTANY const regNumber intArgRegs [] = {REG_ECX, REG_EDX, REG_R8, REG_R9};
-  SELECTANY const regMaskTP intArgMasks[] = {RBM_ECX, RBM_EDX, RBM_R8, RBM_R9};
-  SELECTANY const regNumber fltArgRegs [] = {REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3};
-  SELECTANY const regMaskTP fltArgMasks[] = {RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3};
-
-  #define RBM_ARG_0                RBM_ECX
-  #define RBM_ARG_1                RBM_EDX
-  #define RBM_ARG_2                RBM_R8
-  #define RBM_ARG_3                RBM_R9
-#else // UNIX_AMD64_ABI
+#ifdef UNIX_AMD64_ABI
   #define MAX_REG_ARG              6
   #define MAX_FLOAT_REG_ARG        8
   #define REG_ARG_FIRST            REG_EDI
@@ -970,7 +1009,28 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define RBM_ARG_3                RBM_ECX
   #define RBM_ARG_4                RBM_R8
   #define RBM_ARG_5                RBM_R9
-#endif // UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
+  #define MAX_REG_ARG              4
+  #define MAX_FLOAT_REG_ARG        4
+  #define REG_ARG_FIRST            REG_ECX
+  #define REG_ARG_LAST             REG_R9
+  #define INIT_ARG_STACK_SLOT      4                  // 4 outgoing reserved stack slots
+
+  #define REG_ARG_0                REG_ECX
+  #define REG_ARG_1                REG_EDX
+  #define REG_ARG_2                REG_R8
+  #define REG_ARG_3                REG_R9
+
+  SELECTANY const regNumber intArgRegs[] = { REG_ECX, REG_EDX, REG_R8, REG_R9 };
+  SELECTANY const regMaskTP intArgMasks[] = { RBM_ECX, RBM_EDX, RBM_R8, RBM_R9 };
+  SELECTANY const regNumber fltArgRegs[] = { REG_XMM0, REG_XMM1, REG_XMM2, REG_XMM3 };
+  SELECTANY const regMaskTP fltArgMasks[] = { RBM_XMM0, RBM_XMM1, RBM_XMM2, RBM_XMM3 };
+
+  #define RBM_ARG_0                RBM_ECX
+  #define RBM_ARG_1                RBM_EDX
+  #define RBM_ARG_2                RBM_R8
+  #define RBM_ARG_3                RBM_R9
+#endif // !UNIX_AMD64_ABI
 
   #define REG_FLTARG_0             REG_XMM0
   #define REG_FLTARG_1             REG_XMM1
@@ -982,10 +1042,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define RBM_FLTARG_2             RBM_XMM2
   #define RBM_FLTARG_3             RBM_XMM3
 
-#ifndef UNIX_AMD64_ABI
-  #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3)
-  #define RBM_FLTARG_REGS         (RBM_FLTARG_0|RBM_FLTARG_1|RBM_FLTARG_2|RBM_FLTARG_3)
-#else // UNIX_AMD64_ABI
+#ifdef UNIX_AMD64_ABI
   #define REG_FLTARG_4             REG_XMM4
   #define REG_FLTARG_5             REG_XMM5
   #define REG_FLTARG_6             REG_XMM6
@@ -998,7 +1055,10 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 
   #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3|RBM_ARG_4|RBM_ARG_5)
   #define RBM_FLTARG_REGS         (RBM_FLTARG_0|RBM_FLTARG_1|RBM_FLTARG_2|RBM_FLTARG_3|RBM_FLTARG_4|RBM_FLTARG_5|RBM_FLTARG_6|RBM_FLTARG_7)
-#endif // UNIX_AMD64_ABI
+#else // !UNIX_AMD64_ABI
+  #define RBM_ARG_REGS            (RBM_ARG_0|RBM_ARG_1|RBM_ARG_2|RBM_ARG_3)
+  #define RBM_FLTARG_REGS         (RBM_FLTARG_0|RBM_FLTARG_1|RBM_FLTARG_2|RBM_FLTARG_3)
+#endif // !UNIX_AMD64_ABI
 
   // The registers trashed by profiler enter/leave/tailcall hook
   // See vm\amd64\amshelpers.asm for more details.

--- a/src/jit/unwindamd64.cpp
+++ b/src/jit/unwindamd64.cpp
@@ -121,7 +121,15 @@ void Compiler::unwindPush(regNumber reg)
     unsigned int cbProlog = unwindGetCurrentOffset(func);
     noway_assert((BYTE)cbProlog == cbProlog);
     code->CodeOffset = (BYTE)cbProlog;
-    if (RBM_CALLEE_SAVED & genRegMask(reg))
+    if ((RBM_CALLEE_SAVED & genRegMask(reg))
+#if ETW_EBP_FRAMED
+        // In case of ETW_EBP_FRAMED defined the REG_FPBASE (RBP)
+        // is excluded from the callee-save register list.
+        // Make sure the register gets PUSH unwind info in this case,
+        // since it is pushed as a frame register.
+        || (reg == REG_FPBASE)
+#endif // ETW_EBP_FRAMED
+        )
     {
         code->UnwindOp = UWOP_PUSH_NONVOL;
         code->OpInfo = (BYTE)reg;


### PR DESCRIPTION
Enable the ETW_EBP_FRAMED flag on System V systems to allow for using
frame pointer (RBP) for mostly all functions.
The change includes:
1. Removing RBP from all the lists of registers that the RA uses to assign
to tmps/vars/etc.
2. Enable generation of unwind info for pushing of REG_FPBASE even if not included in callee-save list
of registers.
3 Fixed a conservative assert - for System V systems stack offset for reg
passed argument can be 0 or even positive.