### PR TITLE
Implement hardware exception handling

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -5941,6 +5941,13 @@ public:
     }
 };
 
+typedef VOID (PALAPI *PHARDWARE_EXCEPTION_HANDLER)(PAL_SEHException* ex);
+
+PALIMPORT
+VOID
+PALAPI
+PAL_SetHardwareExceptionHandler(IN PHARDWARE_EXCEPTION_HANDLER handler);
+
 #endif // __cplusplus
 
 // Start of a try block for exceptions raised by RaiseException

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -129,6 +129,15 @@ void SEHCleanup (void)
 #endif
 }
 
+PHARDWARE_EXCEPTION_HANDLER g_hardwareExceptionHandler = NULL;
+
+VOID
+PALAPI 
+PAL_SetHardwareExceptionHandler(PHARDWARE_EXCEPTION_HANDLER handler)
+{
+    g_hardwareExceptionHandler = handler;
+}
+
 #ifdef FEATURE_PAL_SXS
 BOOL
 PALAPI

--- a/src/pal/src/include/pal/seh.hpp
+++ b/src/pal/src/include/pal/seh.hpp
@@ -25,6 +25,8 @@ Abstract:
 #include "pal/palinternal.h"
 #include "pal/corunix.hpp"
 
+extern PHARDWARE_EXCEPTION_HANDLER g_hardwareExceptionHandler;
+
 // Uncomment this define to turn off the signal handling thread.
 // #define DO_NOT_USE_SIGNAL_HANDLING_THREAD
 

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7233,8 +7233,9 @@ EXTERN_C void JIT_WriteBarrier_Debug_End();
 EXTERN_C void FCallMemcpy_End();
 #endif
 
-static
-bool IsIPExcluded(UINT_PTR uControlPc)
+// Check if the passed in instruction pointer is in one of the
+// JIT helper functions.
+bool IsIPInMarkedJitHelper(UINT_PTR uControlPc)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -7292,7 +7293,7 @@ AdjustContextForWriteBarrier(
     CONTEXT             tempContext;
     CONTEXT*            pExceptionContext = pContext;
 
-    BOOL fExcluded = IsIPExcluded((UINT_PTR)f_IP);
+    BOOL fExcluded = IsIPInMarkedJitHelper((UINT_PTR)f_IP);
 
     if (fExcluded)
     {

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -24,6 +24,7 @@ class Thread;
 #include "interoputil.h"
 
 BOOL IsExceptionFromManagedCode(const EXCEPTION_RECORD * pExceptionRecord);
+bool IsIPInMarkedJitHelper(UINT_PTR uControlPc);
 
 #if defined(_TARGET_AMD64_) && defined(FEATURE_HIJACK)
 


### PR DESCRIPTION
This change implements handling of hardware exceptions that happened in the
managed code or in one of the JIT helpers. The coreclr registers a callback
with PAL. This callback is invoked by PAL whenever a hardware exception happens.
coreclr code then dispatches that exception using the DispatchManagedException.