### PR TITLE
Make _gtCostEx and _gtCostSz in gentree.h public

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -885,8 +885,9 @@ void                Compiler::compDisplayStaticSizes(FILE* fout)
 #if FEATURE_STACK_FP_X87
     fprintf(fout, "Offset / size of gtFPlvl        = %2u / %2u\n", offsetof(GenTree, gtFPlvl       ), sizeof(gtDummy->gtFPlvl       ));
 #endif // FEATURE_STACK_FP_X87
-    fprintf(fout, "Offset / size of gtCostEx       = %2u / %2u\n", offsetof(GenTree, _gtCostEx     ), sizeof(gtDummy->_gtCostEx     ));
-    fprintf(fout, "Offset / size of gtCostSz       = %2u / %2u\n", offsetof(GenTree, _gtCostSz     ), sizeof(gtDummy->_gtCostSz     ));
+// TODO: The section that report GenTree sizes should be made into a public static member function of the GenTree class (see https://github.com/dotnet/coreclr/pull/493)
+//    fprintf(fout, "Offset / size of gtCostEx       = %2u / %2u\n", offsetof(GenTree, _gtCostEx     ), sizeof(gtDummy->_gtCostEx     ));
+//    fprintf(fout, "Offset / size of gtCostSz       = %2u / %2u\n", offsetof(GenTree, _gtCostSz     ), sizeof(gtDummy->_gtCostSz     ));
     fprintf(fout, "Offset / size of gtFlags        = %2u / %2u\n", offsetof(GenTree, gtFlags       ), sizeof(gtDummy->gtFlags       ));
     fprintf(fout, "Offset / size of gtVNPair       = %2u / %2u\n", offsetof(GenTree, gtVNPair      ), sizeof(gtDummy->gtVNPair      ));
     fprintf(fout, "Offset / size of gtRsvdRegs     = %2u / %2u\n", offsetof(GenTree, gtRsvdRegs    ), sizeof(gtDummy->gtRsvdRegs    ));


### PR DESCRIPTION
If you change line

```
#define MEASURE_NODE_SIZE   0   // Collect stats about GenTree node allocations.
```

in jit.h and set `MEASURE_NODE_SIZE`=1, you will get a build error like this:

```
coreclr\src\jit\compiler.cpp(888): error C2248: 'GenTree::_gtCostEx' : cannot access private member declared in class 'GenTree' [coreclr\binaries\intermediates\Windows_NT.x64.debug\src\jit\ClrJit.vcxproj]
coreclr\src\jit\compiler.cpp(889): error C2248: 'GenTree::_gtCostSz' : cannot access private member declared in class 'GenTree' [coreclr\binaries\intermediates\Windows_NT.x64.debug\src\jit\ClrJit.vcxproj]
```

So, the `_gtCostEx` and `_gtCostSz` variables should be public because of JIT statistics