### PR TITLE
Fix unwinding through assembly helpers

### DIFF
--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -94,6 +94,15 @@ C_FUNC(\Name\()_End):
 
 .macro NESTED_END Name, Section
         LEAF_END \Name, \Section
+#if defined(__APPLE__)
+        .section __LD,__compact_unwind,regular,debug
+        .quad C_FUNC(\Name)
+        .set C_FUNC(\Name\()_Size), C_FUNC(\Name\()_End) - C_FUNC(\Name)
+        .long C_FUNC(\Name\()_Size)
+        .long 0x04000000 # DWARF
+        .quad 0
+        .quad 0
+#endif
 .endm
 
 .macro END_PROLOGUE


### PR DESCRIPTION
NESTED_ENTRY/NESTED_END assembly helpers are currently using cfi ops
that are not supported by Apple's compact unwind format.  Additionally
the apple linker appears to be doing the wrong thing, and mapping functions
like CallDescrWorkerInternal to an invalid compatc unwind encoding.  This
patch manually emits the __compact_unwind section manually for the affected
functions, and points the unwinder to parse the DWARF instead of using the
compact table.