### PR TITLE
Fix serialization bug in NotFiniteNumberException

### DIFF
--- a/src/mscorlib/src/System/NotFiniteNumberException.cs
+++ b/src/mscorlib/src/System/NotFiniteNumberException.cs
@@ -49,7 +49,7 @@ namespace System {
         }
 
         protected NotFiniteNumberException(SerializationInfo info, StreamingContext context) : base(info, context) {
-            _offendingNumber = info.GetInt32("OffendingNumber");
+            _offendingNumber = info.GetDouble("OffendingNumber");
         }
 
         public double OffendingNumber {
@@ -63,7 +63,7 @@ namespace System {
             }
             Contract.EndContractBlock();
             base.GetObjectData(info, context);
-            info.AddValue("OffendingNumber", _offendingNumber, typeof(Int32));
+            info.AddValue("OffendingNumber", _offendingNumber, typeof(double));
         }
     }
 }

--- a/src/mscorlib/src/System/NotFiniteNumberException.cs
+++ b/src/mscorlib/src/System/NotFiniteNumberException.cs
@@ -63,7 +63,7 @@ namespace System {
             }
             Contract.EndContractBlock();
             base.GetObjectData(info, context);
-            info.AddValue("OffendingNumber", _offendingNumber, typeof(double));
+            info.AddValue("OffendingNumber", _offendingNumber, typeof(Double));
         }
     }
 }


### PR DESCRIPTION
This PR fixes the serialization logic for `NotFiniteNumberException`, which erroneously reads/writes an integer when in fact its contained value is a double.