### PR TITLE
Fix unwinding past main on OSX

### DIFF
--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -148,7 +148,7 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
 #endif
 
     st = unw_step(&cursor);
-    if (st < 0)
+    if (st <= 0)
     {
         return FALSE;
     }

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -782,22 +782,14 @@ UINT_PTR Thread::VirtualUnwindToFirstManagedCallFrame(T_CONTEXT* pContext)
         BOOL success = PAL_VirtualUnwind(pContext, NULL);
         if (!success)
         {
-            _ASSERTE(!"Thread::VirtualUnwindToFirstManagedCallFrame: PAL_VirtualUnwind failed");
-            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
-        }
-
-        uControlPc = GetIP(pContext);
-
-        if (uControlPc == 0)
-        {
             // This displays the managed stack in case the unwind has walked out of the stack and
             // a managed exception was being unwound.
             DefaultCatchHandler(NULL /*pExceptionInfo*/, NULL /*Throwable*/, TRUE /*useLastThrownObject*/,
                                 TRUE /*isTerminating*/, FALSE /*isThreadBaseFIlter*/, FALSE /*sendAppDomainEvents*/);
-
             EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
         }
 
+        uControlPc = GetIP(pContext);
 #endif // !FEATURE_PAL
     }
 


### PR DESCRIPTION
unw_step is defined to return 0 when it hits the bottom.
The current code assumes a non-osx-libunwind specific behavior
of a null $pc coming back from the cursor.  The correct behavior
is to return when the step fails, and dump the exception to
the console.

Currently any test that throws through main ends up in an infinite loop on OSX.