### PR TITLE
Throw FileNotFoundException in AssemblyLoadContext for unresolved Assemb...

### DIFF
--- a/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
+++ b/src/mscorlib/src/System/Runtime/Loader/AssemblyLoadContext.cs
@@ -177,7 +177,7 @@ namespace System.Runtime.Loader
             Assembly assembly = Load(assemblyName);
             if (assembly == null)
             {
-                throw new FileLoadException(Environment.GetResourceString("IO.FileLoad"), requestedSimpleName);
+                throw new FileNotFoundException(Environment.GetResourceString("IO.FileLoad"), requestedSimpleName);
             }
             
             // Get the name of the loaded assembly


### PR DESCRIPTION
...lyName

FileLoadException thrown internally by AssemblyLoadContext for unresolved AssemblyName was escaping from Type.GetType(..., throwOnError:false).

The fix is to throw FileNotFoundException instead that is one of the specific types specifically filtered out for throwOnError:false.