### PR TITLE
Build unixmscorlib without CMake

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -64,6 +64,9 @@ if not exist "%__BinDir%" md "%__BinDir%"
 if not exist "%__IntermediatesDir%" md "%__IntermediatesDir%"
 if not exist "%__LogsDir%" md "%__LogsDir%"
 
+:: CMake isn't a requirement when building unixmscorlib
+if defined __UnixMscorlibOnly goto CheckVS
+
 :CheckPrereqs
 :: Check prerequisites
 echo Checking pre-requisites...


### PR DESCRIPTION
The Linux build instructions don't list CMake as a pre-requisite for
building mscorlib yet build.cmd errors out if it is not present on the
machine.  CMake isn't actually necessary for this particular build so
instead of requiring users to install CMake when not needed I added code
to skip the CMake detection logic in this case.