### PR TITLE
Fix Unix asm stubs personality routines

### DIFF
--- a/src/vm/amd64/externalmethodfixupthunk.S
+++ b/src/vm/amd64/externalmethodfixupthunk.S
@@ -11,7 +11,7 @@
 //============================================================================================
 // EXTERN_C VOID __stdcall ExternalMethodFixupStub()
 
-NESTED_ENTRY ExternalMethodFixupStub, _TEXT, ProcessCLRException
+NESTED_ENTRY ExternalMethodFixupStub, _TEXT, NoHandler
 
         PROLOG_WITH_TRANSITION_BLOCK 0, 8, rdx, 0, 0
 
@@ -32,7 +32,7 @@ NESTED_END ExternalMethodFixupStub, _TEXT
 //============================================================================================
 // EXTERN_C VOID __stdcall VirtualMethodFixupStub()
 
-NESTED_ENTRY VirtualMethodFixupStub, _TEXT, ProcessCLRException
+NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
         PROLOG_WITH_TRANSITION_BLOCK 0, 8, rdx, 0, 0
 

--- a/src/vm/amd64/theprestubamd64.S
+++ b/src/vm/amd64/theprestubamd64.S
@@ -7,7 +7,7 @@
 #include "unixasmmacros.inc"
 #include "asmconstants.h"
 
-NESTED_ENTRY ThePreStub, _TEXT, ProcessCLRException
+NESTED_ENTRY ThePreStub, _TEXT, NoHandler
         PROLOG_WITH_TRANSITION_BLOCK 0, 0, 0, 0, 0
 
         //

--- a/src/vm/amd64/umthunkstub.S
+++ b/src/vm/amd64/umthunkstub.S
@@ -11,7 +11,7 @@
 //
 // METHODDESC_REGISTER: UMEntryThunk*
 //
-NESTED_ENTRY TheUMEntryPrestub, _TEXT, UMEntryPrestubUnwindFrameChainHandler
+NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
     PUSH_ARGUMENT_REGISTERS
     // +8 for alignment
     alloc_stack (SIZEOF_MAX_FP_ARG_SPILL + 8)
@@ -33,7 +33,7 @@ NESTED_END TheUMEntryPrestub, _TEXT
 //
 // METHODDESC_REGISTER: UMEntryThunk*
 //
-NESTED_ENTRY UMThunkStub, _TEXT, UMThunkStubUnwindFrameChainHandler
+NESTED_ENTRY UMThunkStub, _TEXT, UnhandledExceptionHandlerUnix
 #define UMThunkStubAMD64_FIXED_STACK_ALLOC_SIZE (SIZEOF_MAX_INT_ARG_SPILL + SIZEOF_MAX_FP_ARG_SPILL + 0x8)
 #define UMThunkStubAMD64_XMM_SAVE_OFFSET 0x0
 #define UMThunkStubAMD64_INT_ARG_OFFSET (SIZEOF_MAX_FP_ARG_SPILL + 0x8)

--- a/src/vm/amd64/virtualcallstubamd64.S
+++ b/src/vm/amd64/virtualcallstubamd64.S
@@ -90,7 +90,7 @@ Fail_RWCLAS:
 LEAF_END ResolveWorkerChainLookupAsmStub, _TEXT
 
 #ifdef FEATURE_PREJIT
-NESTED_ENTRY StubDispatchFixupStub, _TEXT, ProcessCLRException
+NESTED_ENTRY StubDispatchFixupStub, _TEXT, NoHandler
 
         PROLOG_WITH_TRANSITION_BLOCK 0, 0, 0, 0, 0
         


### PR DESCRIPTION
The Unix asm stubs had personality routines that were the windows personality
routines. This was incorrect since the signature of the Unix ones is completely
different. Moreover, some of these personality routines were not necessary
on Unix at all and two of them should dump the stack and terminate the process
instead of the handling that was necessary on Windows.
Finally, I've fixed an issue in the HandleHardwareException that contains
_ASSERTE in case the hardware exception was unhandled. But _ASSERTE contains
a debugger break instruction, which in the absence of the debugger invokes
the HandleHardwareException again. So I've added detection of the
breakpoint.