### PR TITLE
Fix the build on OSX.  std::string is used without <string>

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/debugclient.cpp
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.cpp
@@ -6,6 +6,7 @@
 #include "sosplugin.h"
 #include <string.h>
 #include <dbgtargetcontext.h>
+#include <string>
 
 DebugClient::DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject) :
     m_debugger(debugger),


### PR DESCRIPTION
LLDB build is currently broken on OSX.