### PR TITLE
Workaround for DECIMAL calling convention in FCalls

### DIFF
--- a/src/classlibnative/bcltype/decimal.cpp
+++ b/src/classlibnative/bcltype/decimal.cpp
@@ -210,7 +210,7 @@ FCIMPL2_IV(void, COMDecimal::DoToCurrency, CY * result, DECIMAL d)
 }
 FCIMPLEND
 
-FCIMPL1(double, COMDecimal::ToDouble, DECIMAL d)
+FCIMPL1(double, COMDecimal::ToDouble, FC_DECIMAL d)
 {
     FCALL_CONTRACT;
 
@@ -223,12 +223,7 @@ FCIMPL1(double, COMDecimal::ToDouble, DECIMAL d)
 }
 FCIMPLEND
 
-#ifdef _MSC_VER
-// C4702: unreachable code on IA64 retail
-#pragma warning(push)
-#pragma warning(disable:4702)
-#endif
-FCIMPL1(INT32, COMDecimal::ToInt32, DECIMAL d)
+FCIMPL1(INT32, COMDecimal::ToInt32, FC_DECIMAL d)
 {
     FCALL_CONTRACT;
 
@@ -259,11 +254,8 @@ FCIMPL1(INT32, COMDecimal::ToInt32, DECIMAL d)
     FCThrowRes(kOverflowException, W("Overflow_Int32"));    
 }
 FCIMPLEND
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
-FCIMPL1(float, COMDecimal::ToSingle, DECIMAL d)
+FCIMPL1(float, COMDecimal::ToSingle, FC_DECIMAL d)
 {
     FCALL_CONTRACT;
 

--- a/src/classlibnative/bcltype/decimal.h
+++ b/src/classlibnative/bcltype/decimal.h
@@ -39,10 +39,10 @@ public:
     static FCDECL1(void, DoTruncate, DECIMAL * d);
     static FCDECL1(void, DoFloor, DECIMAL * d);
 
-    static FCDECL1(double, ToDouble, DECIMAL d);
-    static FCDECL1(float, ToSingle, DECIMAL d);
-    static FCDECL1(INT32, ToInt32, DECIMAL d);	
-    static FCDECL1(Object*, ToString, DECIMAL d);
+    static FCDECL1(double, ToDouble, FC_DECIMAL d);
+    static FCDECL1(float, ToSingle, FC_DECIMAL d);
+    static FCDECL1(INT32, ToInt32, FC_DECIMAL d);	
+    static FCDECL1(Object*, ToString, FC_DECIMAL d);
     
     static void DecimalToNumber(DECIMAL* value, NUMBER* number);
     static int NumberToDecimal(NUMBER* number, DECIMAL* value);

--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -2416,7 +2416,7 @@ ParseSection:
 #pragma warning(pop)
 #endif
 
-FCIMPL3_VII(Object*, COMNumber::FormatDecimal, DECIMAL value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE)
+FCIMPL3_VII(Object*, COMNumber::FormatDecimal, FC_DECIMAL value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE)
 {
     FCALL_CONTRACT;
 

--- a/src/classlibnative/bcltype/number.h
+++ b/src/classlibnative/bcltype/number.h
@@ -41,7 +41,7 @@ struct NUMBER {
 class COMNumber
 {
 public:
-    static FCDECL3_VII(Object*, FormatDecimal, DECIMAL value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);
+    static FCDECL3_VII(Object*, FormatDecimal, FC_DECIMAL value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);
     static FCDECL3_VII(Object*, FormatDouble,  double  value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);
     static FCDECL3_VII(Object*, FormatSingle,  float   value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);
     static FCDECL3(Object*, FormatInt32,   INT32      value, StringObject* formatUNSAFE, NumberFormatInfo* numfmtUNSAFE);

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -1320,8 +1320,10 @@ typedef UINT16 FC_UINT16_RET;
 // Explicitly pass the TypedReferences by reference 
 // UNIXTODO: Remove once the proper managed calling convention for struct is in place
 #define FC_TypedByRef   TypedByRef&
+#define FC_DECIMAL      DECIMAL&
 #else
 #define FC_TypedByRef   TypedByRef
+#define FC_DECIMAL      DECIMAL
 #endif
 
 


### PR DESCRIPTION
Workaround for #200 not implemented yet to unblock xunit testing