### PR TITLE
Add Stat like methods to CoreFX PAL

### DIFF
--- a/src/pal/inc/pal_corefx.h
+++ b/src/pal/inc/pal_corefx.h
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -45,9 +45,37 @@ ForkAndExecProcess(
            int* stdoutFd,
            int* stderrFd);
 
+struct fileinfo {
+    int32_t  flags;   /* flags for testing if some members are present */
+    int32_t  mode;    /* protection */
+    int32_t  uid;     /* user ID of owner */
+    int32_t  gid;     /* group ID of owner */
+    int64_t  size;    /* total size, in bytes */
+    int64_t  atime;   /* time of last access */
+    int64_t  mtime;   /* time of last modification */
+    int64_t  ctime;   /* time of last status change */
+    int64_t  btime;   /* time the file was created (birthtime) */
+};
+
+#define FILEINFO_FLAGS_NONE 0x0
+#define FILEINFO_FLAGS_HAS_BTIME 0x1
+
+PALIMPORT
+int
+PALAPI
+GetFileInformationFromPath(
+    const char* path,
+    struct fileinfo* buf);
+
+PALIMPORT
+int
+PALAPI
+GetFileInformationFromFd(
+    int fd,
+    struct fileinfo* buf);
+
 #ifdef  __cplusplus
 } // extern "C"
 #endif
 
 #endif // __PAL_COREFX_H__
-

--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -47,9 +47,12 @@
 #cmakedefine01 HAS_SYSV_SEMAPHORES
 #cmakedefine01 HAS_PTHREAD_MUTEXES
 #cmakedefine01 HAVE_TTRACE
+#cmakedefine01 HAVE_STAT64
+#cmakedefine01 HAVE_STAT
 
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_NSEC
+#cmakedefine01 HAVE_STAT_BIRTHTIME
 #cmakedefine01 HAVE_TM_GMTOFF
 
 #cmakedefine01 HAVE_BSD_REGS_T

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -52,9 +52,12 @@ check_function_exists(directio HAVE_DIRECTIO)
 check_function_exists(semget HAS_SYSV_SEMAPHORES)
 check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
+check_function_exists(stat64 HAVE_STAT64)
+check_function_exists(stat HAVE_STAT)
 
 check_struct_has_member ("struct stat" st_atimespec "sys/types.h;sys/stat.h" HAVE_STAT_TIMESPEC)
 check_struct_has_member ("struct stat" st_atimensec "sys/types.h;sys/stat.h" HAVE_STAT_NSEC)
+check_struct_has_member ("struct stat" st_birthtime "sys/types.h;sys/stat.h" HAVE_STAT_BIRTHTIME)
 check_struct_has_member ("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
 check_struct_has_member ("ucontext_t" uc_mcontext.gregs[0] ucontext.h HAVE_GREGSET_T)
 

--- a/src/pal/src/misc/corefx.cpp
+++ b/src/pal/src/misc/corefx.cpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
 /*++
@@ -20,8 +20,10 @@ Abstract:
 #include "pal/module.h"
 #include <pal_corefx.h>
 
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <errno.h>
-#include <unistd.h> 
+#include <unistd.h>
 #include <dlfcn.h>
 
 #ifdef __APPLE__
@@ -187,7 +189,7 @@ Used by System.Diagnostics.Process.Start to fork/exec a new process.
 
 This function takes the place of directly using fork and execve from managed code,
 in order to avoid executing managed code in the child process in the window between
-fork and execve, which is not safe.  
+fork and execve, which is not safe.
 
 As would have been the case with fork/execve, a return value of 0 is success and -1
 is failure; if failure, error information is provided in errno.
@@ -226,7 +228,7 @@ ForkAndExecProcess(
     ENTRY("ForkAndExecProcess(filename=%p (%s), argv=%p, envp=%p, cwd=%p (%s), "
            "redirectStdin=%d, redirectStdout=%d, redirectStderr=%d, "
            "childPid=%p, stdinFd=%p, stdoutFd=%p, stderrFd=%p)\n",
-           filename, filename ? filename : "NULL", 
+           filename, filename ? filename : "NULL",
            argv, envp,
            cwd, cwd ? cwd : "NULL",
            redirectStdin, redirectStdout, redirectStderr,
@@ -237,19 +239,19 @@ ForkAndExecProcess(
         NULL == stdinFd || NULL == stdoutFd || NULL == stderrFd ||
         NULL == childPid)
     {
-        ASSERT("%s should not be NULL\n", 
-            filename == NULL ? "filename" : 
-            argv == NULL ? "argv" : 
+        ASSERT("%s should not be NULL\n",
+            filename == NULL ? "filename" :
+            argv == NULL ? "argv" :
             envp == NULL ? "envp" :
-            stdinFd == NULL ? "stdinFd" : 
-            stdoutFd == NULL ? "stdoutFd" : 
+            stdinFd == NULL ? "stdinFd" :
+            stdoutFd == NULL ? "stdoutFd" :
             stderrFd == NULL ? "stderrFd" :
             "childPid");
         errno = EINVAL;
         success = FALSE;
         goto done;
     }
-    if ((redirectStdin  & ~1) != 0 || 
+    if ((redirectStdin  & ~1) != 0 ||
         (redirectStdout & ~1) != 0 ||
         (redirectStderr & ~1) != 0)
     {
@@ -279,8 +281,8 @@ ForkAndExecProcess(
         goto done;
     }
 
-    /* From the time the child process (processId == 0) begins running from fork to when 
-     * it reaches execve, the child process must not touch anything in the PAL.  Doing so 
+    /* From the time the child process (processId == 0) begins running from fork to when
+     * it reaches execve, the child process must not touch anything in the PAL.  Doing so
      * is not safe. The parent process (processId >= 0) may continue to use the PAL.
      */
 
@@ -346,3 +348,74 @@ done:
     return success ? 0 : -1;
 }
 
+void CopyStatToFileInfo(struct fileinfo* dst, const struct stat* src)
+{
+    dst->flags = FILEINFO_FLAGS_NONE;
+    dst->mode = src->st_mode;
+    dst->uid = src->st_uid;
+    dst->gid = src->st_gid;
+    dst->size = src->st_size;
+    dst->atime = src->st_atime;
+    dst->mtime = src->st_mtime;
+    dst->ctime = src->st_ctime;
+
+    #if __APPLE__
+    dst->btime = src->st_birthtime;
+    dst->flags |= FILEINFO_FLAGS_HAS_BTIME;
+    #endif
+}
+
+int
+PALAPI
+GetFileInformationFromPath(
+    const char* path,
+    struct fileinfo* buf)
+{
+    PERF_ENTRY(GetFileInformationFromPath);
+    ENTRY("GetFileInformationFromPath(path=%p (%s), buf=%p\n",
+          path, path ? path : "NULL",
+          buf);
+
+    int success = FALSE;
+    struct stat result;
+
+    int ret = stat(path, &result);
+
+    if (ret == 0)
+    {
+        CopyStatToFileInfo(buf, &result);
+        success = TRUE;
+    }
+
+    LOGEXIT("GetFileInformationFromPath returns BOOL %d with error %d\n", success, success ? 0 : errno);
+    PERF_EXIT(GetFileInformationFromPath);
+
+    return success ? 0 : -1;
+}
+
+int
+PALAPI
+GetFileInformationFromFd(
+    int fd,
+    struct fileinfo* buf)
+{
+    PERF_ENTRY(GetFileInformationFromFd);
+    ENTRY("GetFileInformationFromFd(fd=%d, buf=%p\n",
+          fd, buf);
+
+    int success = FALSE;
+    struct stat result;
+
+    int ret = fstat(fd, &result);
+
+    if (ret == 0)
+    {
+        CopyStatToFileInfo(buf, &result);
+        success = TRUE;
+    }
+
+    LOGEXIT("GetFileInformationFromFd returns BOOL %d with error %d\n", success, success ? 0 : errno);
+    PERF_EXIT(GetFileInformationFromFd);
+
+    return success ? 0 : -1;
+}


### PR DESCRIPTION
CoreFX would like to be able to call stat(2) and fstat(2) but directly
pinvoking to them from managed code is a bit of a chore, since the calls
depend on both the platform and architecture of the target platform.

This change adds stable versions of these APIs that the managed code can
interact with, internally the runtime calls the APIs using the platform
specific APIs and structures.

Long term it might be a good idea to move some of this stuff out of the
runtime and to a native helper library in CoreFX, so we have one less
dependency on the runtime and the ABI between managed and native code
for these methods can version withour reving the runtime, but for now we
put them in the runtime, like our other CoreFX PAL functions, since we
don't have a great way of building native code (let alone platform
specific native code) in CoreFX.