### PR TITLE
Clean up PLA thread id usage.

### DIFF
--- a/src/pal/src/arch/i386/context.cpp
+++ b/src/pal/src/arch/i386/context.cpp
@@ -351,7 +351,7 @@ CONTEXT_GetThreadContext(
         goto EXIT;
     }
     
-    /* How to consider the case when dwThreadId is different from the current
+    /* How to consider the case when self is different from the current
        thread of its owner process. Machine registers values could be retreived
        by a ptrace(pid, ...) call or from the "/proc/%pid/reg" file content. 
        Unfortunately, these two methods only depend on process ID, not on 
@@ -408,11 +408,7 @@ See MSDN doc.
 BOOL
 CONTEXT_SetThreadContext(
            DWORD dwProcessId,
-#if !defined(_AMD64_)
-           DWORD dwThreadId,
-#else // defined(_AMD64_)
-           DWORD64 dwThreadId,
-#endif // !defined(_AMD64_)
+           pthread_t self,
            DWORD dwLwpId,
            CONST CONTEXT *lpContext)
 {
@@ -431,7 +427,7 @@ CONTEXT_SetThreadContext(
         goto EXIT;
     }
     
-    /* How to consider the case when dwThreadId is different from the current
+    /* How to consider the case when self is different from the current
        thread of its owner process. Machine registers values could be retreived
        by a ptrace(pid, ...) call or from the "/proc/%pid/reg" file content. 
        Unfortunately, these two methods only depend on process ID, not on 
@@ -1063,7 +1059,7 @@ CONTEXT_GetThreadContext(
     
     if (GetCurrentProcessId() == dwProcessId)
     {
-        if (dwThreadId != THREADSilentGetCurrentThreadId())
+        if (self != pthread_self())
         {
             // the target thread is in the current process, but isn't 
             // the current one: extract the CONTEXT from the Mach thread.            

--- a/src/pal/src/arch/i386/context.cpp
+++ b/src/pal/src/arch/i386/context.cpp
@@ -337,11 +337,7 @@ See MSDN doc.
 BOOL
 CONTEXT_GetThreadContext(
          DWORD dwProcessId,
-#if !defined(_AMD64_)
-         DWORD dwThreadId,
-#else // defined(_AMD64_)
-         DWORD64 dwThreadId,
-#endif // !defined(_AMD64_)
+         pthread_t self,
          DWORD dwLwpId,
          LPCONTEXT lpContext)
 {    
@@ -363,7 +359,7 @@ CONTEXT_GetThreadContext(
 
     if (dwProcessId == GetCurrentProcessId())
     {
-        if (dwThreadId != THREADSilentGetCurrentThreadId())
+        if (self != pthread_self())
         {
             DWORD flags;
             // There aren't any APIs for this. We can potentially get the
@@ -1052,11 +1048,7 @@ See MSDN doc.
 BOOL
 CONTEXT_GetThreadContext(
          DWORD dwProcessId,
-#if !defined(_AMD64_)
-         DWORD dwThreadId,
-#else // defined(_AMD64_)
-         DWORD64 dwThreadId,
-#endif // !defined(_AMD64_)
+         pthread_t self,
          DWORD dwLwpId,
          LPCONTEXT lpContext)
 {
@@ -1076,7 +1068,7 @@ CONTEXT_GetThreadContext(
             // the target thread is in the current process, but isn't 
             // the current one: extract the CONTEXT from the Mach thread.            
             mach_port_t mptPort;
-            mptPort = pthread_mach_thread_np((pthread_t)dwThreadId);
+            mptPort = pthread_mach_thread_np(self);
    
             ret = (CONTEXT_GetThreadContextFromPort(mptPort, lpContext) == KERN_SUCCESS);
         }
@@ -1289,11 +1281,7 @@ See MSDN doc.
 BOOL
 CONTEXT_SetThreadContext(
            DWORD dwProcessId,
-#if !defined(_AMD64_)
-           DWORD dwThreadId,
-#else // defined(_AMD64_)
-           DWORD64 dwThreadId,
-#endif // !defined(_AMD64_)
+           pthread_t self,
            DWORD dwLwpId,
            CONST CONTEXT *lpContext)
 {
@@ -1314,14 +1302,14 @@ CONTEXT_SetThreadContext(
         goto EXIT;
     }
 
-    if (dwThreadId != THREADSilentGetCurrentThreadId())
+    if (self != pthread_self())
     {
         // hThread is in the current process, but isn't the current
         // thread.  Extract the CONTEXT from the Mach thread.
 
         mach_port_t mptPort;
 
-        mptPort = pthread_mach_thread_np((pthread_t)dwThreadId);
+        mptPort = pthread_mach_thread_np(self);
     
         ret = (CONTEXT_SetThreadContextOnPort(mptPort, lpContext) == KERN_SUCCESS);
     } 

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -431,7 +431,7 @@ GetThreadContext(
         {
             ret = CONTEXT_GetThreadContext(
                 GetCurrentProcessId(),
-                pTargetThread->GetThreadId(),
+                pTargetThread->GetPThreadSelf(),
                 pTargetThread->GetLwpId(),
                 lpContext
                 );

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -494,7 +494,7 @@ SetThreadContext(
         {
             ret = CONTEXT_SetThreadContext(
                 GetCurrentProcessId(),
-                pTargetThread->GetThreadId(),
+                pTargetThread->GetPThreadSelf(),
                 pTargetThread->GetLwpId(),
                 lpContext
                 );

--- a/src/pal/src/exception/machexception.cpp
+++ b/src/pal/src/exception/machexception.cpp
@@ -238,7 +238,7 @@ PAL_ERROR CorUnix::CPalThread::EnableMachExceptions()
         
         NONPAL_TRACE("Enabling %s handlers for thread %08X\n",
                      hExceptionPort == s_TopExceptionPort ? "top" : "bottom",
-                     pthread_mach_thread_np((pthread_t)GetThreadId()));
+                     pthread_mach_thread_np(GetPThreadSelf()));
 
         // Swap current handlers into temporary storage first. That's because it's possible (even likely) that
         // some or all of the handlers might still be ours. In those cases we don't want to overwrite the

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -28,6 +28,7 @@ extern "C"
 #endif // __cplusplus
 
 #include <signal.h>
+#include <pthread.h>
 
 #if !HAVE_MACH_EXCEPTIONS
 /* A type to wrap the native context type, which is ucontext_t on some
@@ -78,11 +79,7 @@ Return value :
 BOOL
 CONTEXT_SetThreadContext(
     DWORD dwProcessId,
-#if !defined(_AMD64_)
-    DWORD dwThreadId,
-#else // defined(_AMD64_)
-    DWORD64 dwThreadId,
-#endif // !defined(_AMD64_)
+    pthread_t self,
     DWORD dwLwpId,
     CONST CONTEXT *lpContext
     );
@@ -104,11 +101,7 @@ Return value :
 BOOL
 CONTEXT_GetThreadContext(
          DWORD dwProcessId,
-#if !defined(_AMD64_)
-         DWORD dwThreadId,
-#else // defined(_AMD64_)
-         DWORD64 dwThreadId,
-#endif // !defined(_AMD64_)
+         pthread_t self,
          DWORD dwLwpId,
          LPCONTEXT lpContext);
 

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -318,6 +318,7 @@ namespace CorUnix
 
         SIZE_T m_threadId;
         DWORD m_dwLwpId;
+        pthread_t m_pthreadSelf;        
 
         //
         // Start info
@@ -401,6 +402,7 @@ namespace CorUnix
             m_pThreadObject(NULL),
             m_threadId(0),
             m_dwLwpId(0),
+            m_pthreadSelf(0),
             m_lpStartAddress(NULL),
             m_lpStartParameter(NULL),
             m_bCreateSuspended(FALSE),
@@ -543,6 +545,14 @@ namespace CorUnix
             )
         {
             return m_dwLwpId;
+        };
+
+        pthread_t
+        GetPThreadSelf(
+            void
+            )
+        {
+            return m_pthreadSelf;
         };
 
         LPTHREAD_START_ROUTINE

--- a/src/pal/src/misc/perftrace.cpp
+++ b/src/pal/src/misc/perftrace.cpp
@@ -60,8 +60,6 @@ Abstract:
 #include <dirent.h>
 #include <unistd.h>
 
-#define THREADSilentGetCurrentThreadId() (DWORD) pthread_self()
-
 SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #endif  //End of PLATFORM_UNIX
 

--- a/src/pal/src/shmemory/shmemory.cpp
+++ b/src/pal/src/shmemory/shmemory.cpp
@@ -873,7 +873,7 @@ void SHMCleanup(void)
     _ASSERT_MSG(header->spinlock != my_pid,
             "SHMCleanup called while the current process still owns the lock "
             "[owner thread=%u, current thread: %u]\n", 
-            locking_thread.Load(), pthread_self());
+            locking_thread.Load(), THREADSilentGetCurrentThreadId());
 
     /* Now for the interprocess stuff. */
     DeleteCriticalSection(&shm_critsec);

--- a/src/pal/src/sync/cs.cpp
+++ b/src/pal/src/sync/cs.cpp
@@ -338,7 +338,7 @@ VOID InternalDeleteCriticalSection(
     if (0 != pPalCriticalSection->LockCount)
     {
         SIZE_T tid;
-        tid = (NULL != pThread ? pThread->GetThreadId() : (SIZE_T)pthread_self());
+        tid = (NULL != pThread ? pThread->GetThreadId() : THREADSilentGetCurrentThreadId());
         int iWaiterCount = (int)PALCS_GETWCOUNT(pPalCriticalSection->LockCount);
 
         if (0 != (PALCS_LOCK_BIT & pPalCriticalSection->LockCount))
@@ -681,11 +681,11 @@ namespace CorUnix
         if(pThread)
         {
             threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == (SIZE_T)pthread_self());            
+            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
         }
         else 
         {
-            threadId = (SIZE_T)pthread_self();
+            threadId = THREADSilentGetCurrentThreadId();
             CS_TRACE("Early EnterCriticalSection, no pthread data, getting TID "
                      "internally\n");
         }
@@ -860,11 +860,11 @@ namespace CorUnix
         if(pThread)
         {
             threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == (SIZE_T)pthread_self());            
+            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
         }
         else 
         {
-            threadId = (SIZE_T)pthread_self();
+            threadId = THREADSilentGetCurrentThreadId();
             CS_TRACE("Early LeaveCriticalSection, no pthread data, getting TID "
                      "internally\n");
         }
@@ -1028,11 +1028,11 @@ namespace CorUnix
         if(pThread)
         {
             threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == (SIZE_T)pthread_self());            
+            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
         }
         else 
         {
-            threadId = (SIZE_T)pthread_self();
+            threadId = THREADSilentGetCurrentThreadId();
             CS_TRACE("Early TryEnterCriticalSection, no pthread data, getting TID "
                      "internally\n");            
         }
@@ -1557,11 +1557,11 @@ namespace CorUnix
         if(pThread)
         {
             threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == (SIZE_T)pthread_self()); 
+            _ASSERTE(threadId == THREADSilentGetCurrentThreadId()); 
         }
         else 
         {
-            threadId = (SIZE_T)pthread_self();
+            threadId = THREADSilentGetCurrentThreadId();
             CS_TRACE("Early EnterCriticalSection, no pthread data, getting TID "
                      "internally\n");
         }
@@ -1619,11 +1619,11 @@ namespace CorUnix
         if(pThread)
         {
             threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == (SIZE_T)pthread_self());            
+            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
         }
         else 
         {
-            threadId = (SIZE_T)pthread_self();
+            threadId = THREADSilentGetCurrentThreadId();
             CS_TRACE("Early LeaveCriticalSection, no pthread data, getting TID "
                      "internally\n");
         }
@@ -1683,11 +1683,11 @@ namespace CorUnix
         if(pThread)
         {
             threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == (SIZE_T)pthread_self());            
+            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
         }
         else 
         {
-            threadId = (SIZE_T)pthread_self();
+            threadId = THREADSilentGetCurrentThreadId();
             CS_TRACE("Early EnterCriticalSection, no pthread data, getting TID "
                      "internally\n");
         }

--- a/src/pal/src/sync/cs.cpp
+++ b/src/pal/src/sync/cs.cpp
@@ -184,6 +184,25 @@ namespace CorUnix
 }
 #endif // _DEBUG
 
+#define ObtainCurrentThreadId(thread) ObtainCurrentThreadIdImpl(thread, __func__)
+static SIZE_T ObtainCurrentThreadIdImpl(CPalThread *pCurrentThread, const char *callingFuncName)
+{
+    SIZE_T threadId;
+    if(pCurrentThread)
+    {
+        threadId = pCurrentThread->GetThreadId();
+        _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
+    }
+    else 
+    {
+        threadId = THREADSilentGetCurrentThreadId();
+        CS_TRACE("Early %s, no pthread data, getting TID internally\n", callingFuncName);
+    }
+    _ASSERTE(0 != threadId);
+
+    return threadId;
+}
+
 /*++
 Function:
   InitializeCriticalSection
@@ -338,7 +357,7 @@ VOID InternalDeleteCriticalSection(
     if (0 != pPalCriticalSection->LockCount)
     {
         SIZE_T tid;
-        tid = (NULL != pThread ? pThread->GetThreadId() : THREADSilentGetCurrentThreadId());
+        tid = ObtainCurrentThreadId(pThread);
         int iWaiterCount = (int)PALCS_GETWCOUNT(pPalCriticalSection->LockCount);
 
         if (0 != (PALCS_LOCK_BIT & pPalCriticalSection->LockCount))
@@ -678,20 +697,8 @@ namespace CorUnix
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
-        if(pThread)
-        {
-            threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
-        }
-        else 
-        {
-            threadId = THREADSilentGetCurrentThreadId();
-            CS_TRACE("Early EnterCriticalSection, no pthread data, getting TID "
-                     "internally\n");
-        }
-
-        _ASSERTE(0 != threadId);
-
+        threadId = ObtainCurrentThreadId(pThread);
+        
 
         // Check if the current thread already owns the CS
         //
@@ -857,19 +864,7 @@ namespace CorUnix
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
-        if(pThread)
-        {
-            threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
-        }
-        else 
-        {
-            threadId = THREADSilentGetCurrentThreadId();
-            CS_TRACE("Early LeaveCriticalSection, no pthread data, getting TID "
-                     "internally\n");
-        }
-
-        _ASSERTE(0 != threadId);
+        threadId = ObtainCurrentThreadId(pThread);
         _ASSERTE(threadId == pPalCriticalSection->OwningThread);
 #endif // _DEBUG
 
@@ -1025,19 +1020,7 @@ namespace CorUnix
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
-        if(pThread)
-        {
-            threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
-        }
-        else 
-        {
-            threadId = THREADSilentGetCurrentThreadId();
-            CS_TRACE("Early TryEnterCriticalSection, no pthread data, getting TID "
-                     "internally\n");            
-        }
-
-        _ASSERTE(0 != threadId);
+        threadId = ObtainCurrentThreadId(pThread);
 
         if (pPalCriticalSection->fInternal && NULL != pThread)
         {
@@ -1554,19 +1537,7 @@ namespace CorUnix
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
-        if(pThread)
-        {
-            threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == THREADSilentGetCurrentThreadId()); 
-        }
-        else 
-        {
-            threadId = THREADSilentGetCurrentThreadId();
-            CS_TRACE("Early EnterCriticalSection, no pthread data, getting TID "
-                     "internally\n");
-        }
-        
-        _ASSERTE(0 != threadId);
+        threadId = ObtainCurrentThreadId(pThread);
 
         /* check if the current thread already owns the criticalSection */
         if (pPalCriticalSection->OwningThread == threadId)
@@ -1616,19 +1587,7 @@ namespace CorUnix
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
-        if(pThread)
-        {
-            threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
-        }
-        else 
-        {
-            threadId = THREADSilentGetCurrentThreadId();
-            CS_TRACE("Early LeaveCriticalSection, no pthread data, getting TID "
-                     "internally\n");
-        }
-
-        _ASSERTE(0 != threadId);
+        threadId = ObtainCurrentThreadId(pThread);
         _ASSERTE(threadId == pPalCriticalSection->OwningThread);
 
         if (0 >= pPalCriticalSection->RecursionCount)
@@ -1680,19 +1639,7 @@ namespace CorUnix
 
         _ASSERTE(PalCsNotInitialized != pPalCriticalSection->cisInitState);
 
-        if(pThread)
-        {
-            threadId = pThread->GetThreadId();
-            _ASSERTE(threadId == THREADSilentGetCurrentThreadId());            
-        }
-        else 
-        {
-            threadId = THREADSilentGetCurrentThreadId();
-            CS_TRACE("Early EnterCriticalSection, no pthread data, getting TID "
-                     "internally\n");
-        }
-
-        _ASSERTE(0 != threadId);
+        threadId = ObtainCurrentThreadId(pThread);
 
         /* check if the current thread already owns the criticalSection */
         if (pPalCriticalSection->OwningThread == threadId)

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -3571,7 +3571,7 @@ CorUnix::CPalThread *PROCThreadFromMachPort(mach_port_t hTargetThread)
     pThread = pGThreadList;
     while (pThread)
     {
-        pthread_t pPThread = (pthread_t)pThread->GetThreadId();
+        pthread_t pPThread = pThread->GetPThreadSelf();
         mach_port_t hThread = pthread_mach_thread_np(pPThread);
         if (hThread == hTargetThread)
             break;

--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -282,7 +282,7 @@ CThreadSuspensionInfo::InternalSuspendThreadFromData(
 #if USE_SIGNALS_FOR_THREAD_SUSPENSION
                 pthrTarget->suspensionInfo.SetSuspendSignalSent(TRUE);
                 // Send the SIGUSR1 to the target thread and wait for it to post, immediately prior to suspension.
-                nPthreadRet = pthread_kill((pthread_t)pthrTarget->GetThreadId(), SIGUSR1);
+                nPthreadRet = pthread_kill(pthrTarget->GetPThreadSelf(), SIGUSR1);
                 if (nPthreadRet == 0)
                 {
                     if (!fSelfSuspend)
@@ -668,7 +668,7 @@ CThreadSuspensionInfo::InternalResumeThreadFromData(
 
 #if USE_SIGNALS_FOR_THREAD_SUSPENSION
         pthrTarget->suspensionInfo.SetResumeSignalSent(TRUE);
-        dwPthreadRet = pthread_kill((pthread_t)pthrTarget->GetThreadId(), SIGUSR2);
+        dwPthreadRet = pthread_kill(pthrTarget->GetPThreadSelf(), SIGUSR2);
         if (dwPthreadRet == 0)
         {
             pthrTarget->suspensionInfo.WaitOnResumeSemaphore();
@@ -1763,9 +1763,9 @@ CThreadSuspensionInfo::THREADHandleSuspendNative(CPalThread *pthrTarget)
     }
     
 #if HAVE_PTHREAD_SUSPEND
-    dwPthreadRet = pthread_suspend((pthread_t)pthrTarget->GetThreadId());
+    dwPthreadRet = pthread_suspend(pthrTarget->GetPThreadSelf());
 #elif HAVE_MACH_THREADS
-    dwPthreadRet = thread_suspend(pthread_mach_thread_np((pthread_t)pthrTarget->GetThreadId()));
+    dwPthreadRet = thread_suspend(pthread_mach_thread_np(pthrTarget->GetPThreadSelf()));
 #elif HAVE_PTHREAD_SUSPEND_NP
 #if SELF_SUSPEND_FAILS_WITH_NATIVE_SUSPENSION
     if (pthrTarget->suspensionInfo.GetSelfSusp())
@@ -1775,7 +1775,7 @@ CThreadSuspensionInfo::THREADHandleSuspendNative(CPalThread *pthrTarget)
     else
 #endif // SELF_SUSPEND_FAILS_WITH_NATIVE_SUSPENSION
     {
-        dwPthreadRet = pthread_suspend_np((pthread_t)pthrTarget->GetThreadId());
+        dwPthreadRet = pthread_suspend_np(pthrTarget->GetPThreadSelf());
     }
 #else
     #error "Don't know how to suspend threads on this platform!"
@@ -1839,11 +1839,11 @@ CThreadSuspensionInfo::THREADHandleResumeNative(CPalThread *pthrTarget)
     do
     {
 #if HAVE_PTHREAD_CONTINUE
-        dwPthreadRet = pthread_continue((pthread_t)pthrTarget->GetThreadId());
+        dwPthreadRet = pthread_continue(pthrTarget->GetPThreadSelf());
 #elif HAVE_MACH_THREADS
-        dwPthreadRet = thread_resume(pthread_mach_thread_np((pthread_t)pthrTarget->GetThreadId()));
+        dwPthreadRet = thread_resume(pthread_mach_thread_np(pthrTarget->GetPThreadSelf()));
 #elif HAVE_PTHREAD_CONTINUE_NP
-        dwPthreadRet = pthread_continue_np((pthread_t)pthrTarget->GetThreadId());
+        dwPthreadRet = pthread_continue_np((pthrTarget->GetPThreadSelf());
 #elif HAVE_PTHREAD_RESUME_NP
 #if SELF_SUSPEND_FAILS_WITH_NATIVE_SUSPENSION  
         if (pthrTarget->suspensionInfo.GetSelfSusp())
@@ -1866,7 +1866,7 @@ CThreadSuspensionInfo::THREADHandleResumeNative(CPalThread *pthrTarget)
         else
 #endif // SELF_SUSPEND_FAILS_WITH_NATIVE_SUSPENSION  
         {
-            dwPthreadRet = pthread_resume_np((pthread_t)pthrTarget->GetThreadId());
+            dwPthreadRet = pthread_resume_np(pthrTarget->GetPThreadSelf());
         }
 #else
         #error "Don't know how to resume threads on this platform!"

--- a/src/pal/tests/palsuite/composite/synchronization/nativecriticalsection/mtx_critsect.cpp
+++ b/src/pal/tests/palsuite/composite/synchronization/nativecriticalsection/mtx_critsect.cpp
@@ -65,7 +65,7 @@ int MTXEnterCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
     DWORD thread_id;
     int retcode = 0;
 	
-    thread_id = (DWORD)pthread_self();
+    thread_id = (DWORD)THREADSilentGetCurrentThreadId();
 
     /* check if the current thread already owns the criticalSection */
     if (lpCriticalSection->OwningThread == (HANDLE)thread_id)

--- a/src/pal/tests/palsuite/composite/synchronization/nativecs_interlocked/mtx_critsect.cpp
+++ b/src/pal/tests/palsuite/composite/synchronization/nativecs_interlocked/mtx_critsect.cpp
@@ -66,7 +66,7 @@ int MTXEnterCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
     DWORD thread_id;
     int retcode = 0;
 	
-    thread_id = (DWORD)pthread_self();
+    thread_id = (DWORD)THREADSilentGetCurrentThreadId();
 
     /* check if the current thread already owns the criticalSection */
     if (lpCriticalSection->OwningThread == (HANDLE)thread_id)


### PR DESCRIPTION
After recent changes in implementation of GetCurrentThread(),
CPalThread::GetThreadId() became inconsistent with GetCurrentThread(). It leads to issues like CreateThread() returning incorrect thread id.

This changes makes a clean distinction between thread id and pthread handle (pthread_t), both get stored in CPalThread and both can be appropriately used when necessary.
General direction is that gettip() is used for communication with the outer world, and pthread_self() is used for internal work with pthread API.

This change is a part of an effort of making DBI work on Linux, I stumbled on the fact that CreateThread() returns incorrect id and decided to try to do a clean up of thread identities. 