### PR TITLE
Fix reporting of callee saved registers with nongnu libuwind

### DIFF
--- a/src/vm/amd64/AsmHelpers.asm
+++ b/src/vm/amd64/AsmHelpers.asm
@@ -141,6 +141,7 @@ RestoreReg macro reg, regnum
         cmove   reg, [rax]
         endm
 
+        ; regnum has to match ENUM_CALLEE_SAVED_REGISTERS macro
         RestoreReg Rdi, 0
         RestoreReg Rsi, 1
         RestoreReg Rbx, 2

--- a/src/vm/amd64/AsmHelpers.asm
+++ b/src/vm/amd64/AsmHelpers.asm
@@ -134,21 +134,21 @@ endif
         ; So, if m_pReg points into the MachState, we need to update
         ; the register here.  That's what this macro does.
         ;
-RestoreReg macro reg
-        lea     rax, [rcx + OFFSETOF__MachState__m_Capture&reg]
-        mov     rdx, [rcx + OFFSETOF__MachState__m_p&reg]
+RestoreReg macro reg, regnum
+        lea     rax, [rcx + OFFSETOF__MachState__m_Capture + 8 * regnum]
+        mov     rdx, [rcx + OFFSETOF__MachState__m_Ptrs + 8 * regnum]
         cmp     rax, rdx
         cmove   reg, [rax]
         endm
 
-        RestoreReg Rdi
-        RestoreReg Rsi
-        RestoreReg Rbx
-        RestoreReg Rbp
-        RestoreReg R12
-        RestoreReg R13
-        RestoreReg R14
-        RestoreReg R15
+        RestoreReg Rdi, 0
+        RestoreReg Rsi, 1
+        RestoreReg Rbx, 2
+        RestoreReg Rbp, 3
+        RestoreReg R12, 4
+        RestoreReg R13, 5
+        RestoreReg R14, 6
+        RestoreReg R15, 7
 
         xor     eax, eax
         ret

--- a/src/vm/amd64/asmconstants.h
+++ b/src/vm/amd64/asmconstants.h
@@ -374,87 +374,35 @@ ASMCONSTANTS_C_ASSERT(   CORINFO_ArgumentException_ASM
 
 // MachState offsets (AMD64\gmscpu.h)
 
-#define               OFFSETOF__MachState__m_Rip             0x00
+#define               OFFSETOF__MachState__m_Rip            0x00
 ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_Rip
                     == offsetof(MachState, m_Rip));
 
-#define               OFFSETOF__MachState__m_Rsp             0x08
+#define               OFFSETOF__MachState__m_Rsp            0x08
 ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_Rsp
                     == offsetof(MachState, m_Rsp));
 
-#define               OFFSETOF__MachState__m_CaptureRdi      0x10
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureRdi
-                    == offsetof(MachState, m_CaptureRdi));
+#define               OFFSETOF__MachState__m_Capture        0x10
+ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_Capture
+                    == offsetof(MachState, m_Capture));
 
-#define               OFFSETOF__MachState__m_CaptureRsi      0x18
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureRsi
-                    == offsetof(MachState, m_CaptureRsi));
-
-#define               OFFSETOF__MachState__m_CaptureRbx      0x20
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureRbx
-                    == offsetof(MachState, m_CaptureRbx));
-
-#define               OFFSETOF__MachState__m_CaptureRbp      0x28
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureRbp
-                    == offsetof(MachState, m_CaptureRbp));
-
-#define               OFFSETOF__MachState__m_CaptureR12      0x30
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureR12
-                    == offsetof(MachState, m_CaptureR12));
-
-#define               OFFSETOF__MachState__m_CaptureR13      0x38
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureR13
-                    == offsetof(MachState, m_CaptureR13));
-
-#define               OFFSETOF__MachState__m_CaptureR14      0x40
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureR14
-                    == offsetof(MachState, m_CaptureR14));
-
-#define               OFFSETOF__MachState__m_CaptureR15      0x48
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_CaptureR15
-                    == offsetof(MachState, m_CaptureR15));
-
-#define               OFFSETOF__MachState__m_pRdi     0x50
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pRdi
-                    == offsetof(MachState, m_pRdi));
-
-#define               OFFSETOF__MachState__m_pRsi     0x58
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pRsi
-                    == offsetof(MachState, m_pRsi));
-
-#define               OFFSETOF__MachState__m_pRbx     0x60
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pRbx
-                    == offsetof(MachState, m_pRbx));
-
-#define               OFFSETOF__MachState__m_pRbp     0x68
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pRbp
-                    == offsetof(MachState, m_pRbp));
-
-#define               OFFSETOF__MachState__m_pR12     0x70
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pR12
-                    == offsetof(MachState, m_pR12));
-
-#define               OFFSETOF__MachState__m_pR13     0x78
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pR13
-                    == offsetof(MachState, m_pR13));
-
-#define               OFFSETOF__MachState__m_pR14     0x80
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pR14
-                    == offsetof(MachState, m_pR14));
-
-#define               OFFSETOF__MachState__m_pR15     0x88
-ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_pR15
-                    == offsetof(MachState, m_pR15));
-
-#define               OFFSETOF__MachState___pRetAddr  0x90
+#ifdef UNIX_AMD64_ABI
+#define               OFFSETOF__MachState__m_Ptrs           0x40
+#define               OFFSETOF__MachState___pRetAddr        0x70
+#define               OFFSETOF__LazyMachState__m_CaptureRip 0xA8
+#define               OFFSETOF__LazyMachState__m_CaptureRsp 0xB0
+#else
+#define               OFFSETOF__MachState__m_Ptrs           0x50
+#define               OFFSETOF__MachState___pRetAddr        0x90
+#define               OFFSETOF__LazyMachState__m_CaptureRip 0x98
+#define               OFFSETOF__LazyMachState__m_CaptureRsp 0xA0
+#endif
+ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState__m_Ptrs
+                    == offsetof(MachState, m_Ptrs));
 ASMCONSTANTS_C_ASSERT(OFFSETOF__MachState___pRetAddr
                     == offsetof(MachState, _pRetAddr));
-
-#define               OFFSETOF__LazyMachState__m_CaptureRip      0x98
 ASMCONSTANTS_C_ASSERT(OFFSETOF__LazyMachState__m_CaptureRip
                     == offsetof(LazyMachState, m_CaptureRip));
-
-#define               OFFSETOF__LazyMachState__m_CaptureRsp      0xA0
 ASMCONSTANTS_C_ASSERT(OFFSETOF__LazyMachState__m_CaptureRsp
                     == offsetof(LazyMachState, m_CaptureRsp));
 

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -173,27 +173,7 @@ typedef INT64 StackElemType;
 // This represents some of the TransitionFrame fields that are
 // stored at negative offsets.
 //--------------------------------------------------------------------
-typedef DPTR(struct CalleeSavedRegisters) PTR_CalleeSavedRegisters;
-struct CalleeSavedRegisters {
-#ifndef UNIX_AMD64_ABI
-    INT_PTR     rdi;
-    INT_PTR     rsi;
-    INT_PTR     rbx;
-    INT_PTR     rbp;
-#endif
-    INT_PTR     r12;
-    INT_PTR     r13;
-    INT_PTR     r14;
-    INT_PTR     r15;
-#ifdef UNIX_AMD64_ABI
-    INT_PTR     rbx;
-    INT_PTR     rbp;
-#endif
-};
-
 struct REGDISPLAY;
-
-void UpdateRegDisplayFromCalleeSavedRegisters(REGDISPLAY * pRD, CalleeSavedRegisters * pRegs);
 
 //--------------------------------------------------------------------
 // This represents the arguments that are stored in volatile registers.
@@ -215,6 +195,16 @@ void UpdateRegDisplayFromCalleeSavedRegisters(REGDISPLAY * pRD, CalleeSavedRegis
 
 #define NUM_ARGUMENT_REGISTERS 6
 
+#define ENUM_CALLEE_SAVED_REGISTERS() \
+    CALLEE_SAVED_REGISTER(R12) \
+    CALLEE_SAVED_REGISTER(R13) \
+    CALLEE_SAVED_REGISTER(R14) \
+    CALLEE_SAVED_REGISTER(R15) \
+    CALLEE_SAVED_REGISTER(Rbx) \
+    CALLEE_SAVED_REGISTER(Rbp)
+
+#define NUM_CALLEE_SAVED_REGISTERS 8
+
 #else // UNIX_AMD64_ABI
 
 #define ENUM_ARGUMENT_REGISTERS() \
@@ -225,6 +215,18 @@ void UpdateRegDisplayFromCalleeSavedRegisters(REGDISPLAY * pRD, CalleeSavedRegis
 
 #define NUM_ARGUMENT_REGISTERS 4
 
+#define ENUM_CALLEE_SAVED_REGISTERS() \
+    CALLEE_SAVED_REGISTER(Rdi) \
+    CALLEE_SAVED_REGISTER(Rsi) \
+    CALLEE_SAVED_REGISTER(Rbx) \
+    CALLEE_SAVED_REGISTER(Rbp) \
+    CALLEE_SAVED_REGISTER(R12) \
+    CALLEE_SAVED_REGISTER(R13) \
+    CALLEE_SAVED_REGISTER(R14) \
+    CALLEE_SAVED_REGISTER(R15)
+
+#define NUM_CALLEE_SAVED_REGISTERS 8
+
 #endif // UNIX_AMD64_ABI
 
 typedef DPTR(struct ArgumentRegisters) PTR_ArgumentRegisters;
@@ -232,6 +234,13 @@ struct ArgumentRegisters {
     #define ARGUMENT_REGISTER(regname) INT_PTR regname;
     ENUM_ARGUMENT_REGISTERS();
     #undef ARGUMENT_REGISTER
+};
+
+typedef DPTR(struct CalleeSavedRegisters) PTR_CalleeSavedRegisters;
+struct CalleeSavedRegisters {
+    #define CALLEE_SAVED_REGISTER(regname) INT_PTR regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+    #undef CALLEE_SAVED_REGISTER
 };
 
 #define SCRATCH_REGISTER_X86REG kRAX
@@ -252,6 +261,9 @@ struct FloatArgumentRegisters {
 };
 
 #endif
+
+
+void UpdateRegDisplayFromCalleeSavedRegisters(REGDISPLAY * pRD, CalleeSavedRegisters * pRegs);
 
 
 // Sufficient context for Try/Catch restoration.

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -195,6 +195,8 @@ struct REGDISPLAY;
 
 #define NUM_ARGUMENT_REGISTERS 6
 
+// The order of registers in this macro is hardcoded in assembly code
+// at number of places
 #define ENUM_CALLEE_SAVED_REGISTERS() \
     CALLEE_SAVED_REGISTER(R12) \
     CALLEE_SAVED_REGISTER(R13) \
@@ -203,7 +205,7 @@ struct REGDISPLAY;
     CALLEE_SAVED_REGISTER(Rbx) \
     CALLEE_SAVED_REGISTER(Rbp)
 
-#define NUM_CALLEE_SAVED_REGISTERS 8
+#define NUM_CALLEE_SAVED_REGISTERS 6
 
 #else // UNIX_AMD64_ABI
 
@@ -215,6 +217,8 @@ struct REGDISPLAY;
 
 #define NUM_ARGUMENT_REGISTERS 4
 
+// The order of registers in this macro is hardcoded in assembly code
+// at number of places
 #define ENUM_CALLEE_SAVED_REGISTERS() \
     CALLEE_SAVED_REGISTER(Rdi) \
     CALLEE_SAVED_REGISTER(Rsi) \
@@ -239,6 +243,12 @@ struct ArgumentRegisters {
 typedef DPTR(struct CalleeSavedRegisters) PTR_CalleeSavedRegisters;
 struct CalleeSavedRegisters {
     #define CALLEE_SAVED_REGISTER(regname) INT_PTR regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+    #undef CALLEE_SAVED_REGISTER
+};
+
+struct CalleeSavedRegistersPointers {
+    #define CALLEE_SAVED_REGISTER(regname) PTR_TADDR p##regname;
     ENUM_CALLEE_SAVED_REGISTERS();
     #undef CALLEE_SAVED_REGISTER
 };

--- a/src/vm/amd64/getstate.S
+++ b/src/vm/amd64/getstate.S
@@ -29,14 +29,12 @@ LEAF_ENTRY LazyMachStateCaptureState, _TEXT
 
         mov     rdx, [rsp]      // get the return address
         
-        mov     [rdi + OFFSETOF__MachState__m_CaptureRdi], rdi
-        mov     [rdi + OFFSETOF__MachState__m_CaptureRsi], rsi
-        mov     [rdi + OFFSETOF__MachState__m_CaptureRbx], rbx
-        mov     [rdi + OFFSETOF__MachState__m_CaptureRbp], rbp
-        mov     [rdi + OFFSETOF__MachState__m_CaptureR12], r12
-        mov     [rdi + OFFSETOF__MachState__m_CaptureR13], r13
-        mov     [rdi + OFFSETOF__MachState__m_CaptureR14], r14
-        mov     [rdi + OFFSETOF__MachState__m_CaptureR15], r15
+        mov     [rdi + OFFSETOF__MachState__m_Capture + 0*8], r12
+        mov     [rdi + OFFSETOF__MachState__m_Capture + 1*8], r13
+        mov     [rdi + OFFSETOF__MachState__m_Capture + 2*8], r14
+        mov     [rdi + OFFSETOF__MachState__m_Capture + 3*8], r15
+        mov     [rdi + OFFSETOF__MachState__m_Capture + 4*8], rbx
+        mov     [rdi + OFFSETOF__MachState__m_Capture + 5*8], rbp
 
         mov     qword ptr [rdi + OFFSETOF__MachState___pRetAddr], 0
 

--- a/src/vm/amd64/getstate.asm
+++ b/src/vm/amd64/getstate.asm
@@ -64,14 +64,14 @@ LEAF_ENTRY LazyMachStateCaptureState, _TEXT
 
         mov     rdx, [rsp]      ; get the return address
         
-        mov     [rcx + OFFSETOF__MachState__m_CaptureRdi], rdi
-        mov     [rcx + OFFSETOF__MachState__m_CaptureRsi], rsi
-        mov     [rcx + OFFSETOF__MachState__m_CaptureRbx], rbx
-        mov     [rcx + OFFSETOF__MachState__m_CaptureRbp], rbp
-        mov     [rcx + OFFSETOF__MachState__m_CaptureR12], r12
-        mov     [rcx + OFFSETOF__MachState__m_CaptureR13], r13
-        mov     [rcx + OFFSETOF__MachState__m_CaptureR14], r14
-        mov     [rcx + OFFSETOF__MachState__m_CaptureR15], r15
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 0*8], rdi
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 1*8], rsi
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 2*8], rbx
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 3*8], rbp
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 4*8], r12
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 5*8], r13
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 6*8], r14
+        mov     [rcx + OFFSETOF__MachState__m_Capture + 7*8], r15
 
         mov     qword ptr [rcx + OFFSETOF__MachState___pRetAddr], 0
 

--- a/src/vm/amd64/gmsamd64.cpp
+++ b/src/vm/amd64/gmsamd64.cpp
@@ -10,6 +10,8 @@
 #include "common.h"
 #include "gmscpu.h"
 
+
+
 void LazyMachState::unwindLazyState(LazyMachState* baseState,
                                     MachState* unwoundState,
                                     int funCallDepth /* = 1 */,
@@ -30,30 +32,18 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     ctx.Rip = baseState->m_CaptureRip;
     ctx.Rsp = baseState->m_CaptureRsp + 8; // +8 for return addr pushed before calling LazyMachStateCaptureState
     
-#ifndef UNIX_AMD64_ABI
-    ctx.Rdi = unwoundState->m_CaptureRdi = baseState->m_CaptureRdi;
-    ctx.Rsi = unwoundState->m_CaptureRsi = baseState->m_CaptureRsi;
-#endif
-    ctx.Rbx = unwoundState->m_CaptureRbx = baseState->m_CaptureRbx;
-    ctx.Rbp = unwoundState->m_CaptureRbp = baseState->m_CaptureRbp;
-    ctx.R12 = unwoundState->m_CaptureR12 = baseState->m_CaptureR12;
-    ctx.R13 = unwoundState->m_CaptureR13 = baseState->m_CaptureR13;
-    ctx.R14 = unwoundState->m_CaptureR14 = baseState->m_CaptureR14;
-    ctx.R15 = unwoundState->m_CaptureR15 = baseState->m_CaptureR15;
-    
+#define CALLEE_SAVED_REGISTER(regname) ctx.regname = unwoundState->m_Capture.regname = baseState->m_Capture.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
 #if !defined(DACCESS_COMPILE)
+
     // For DAC, if we get here, it means that the LazyMachState is uninitialized and we have to unwind it.
     // The API we use to unwind in DAC is StackWalk64(), which does not support the context pointers.
-#ifndef UNIX_AMD64_ABI
-    nonVolRegPtrs.Rdi = &unwoundState->m_CaptureRdi;
-    nonVolRegPtrs.Rsi = &unwoundState->m_CaptureRsi;
-#endif
-    nonVolRegPtrs.Rbx = &unwoundState->m_CaptureRbx;
-    nonVolRegPtrs.Rbp = &unwoundState->m_CaptureRbp;
-    nonVolRegPtrs.R12 = &unwoundState->m_CaptureR12;
-    nonVolRegPtrs.R13 = &unwoundState->m_CaptureR13;
-    nonVolRegPtrs.R14 = &unwoundState->m_CaptureR14;
-    nonVolRegPtrs.R15 = &unwoundState->m_CaptureR15;
+#define CALLEE_SAVED_REGISTER(regname) nonVolRegPtrs.regname = (PDWORD64)&unwoundState->m_Capture.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
 #endif // !DACCESS_COMPILE
 
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    LazyMachState::unwindLazyState(ip:%p,sp:%p)\n", baseState->m_CaptureRip, baseState->m_CaptureRsp));
@@ -112,30 +102,25 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
     // For DAC, the return value of this function may be used after unwoundState goes out of scope. so we cannot do
     // "unwoundState->_pRetAddr = PTR_TADDR(&unwoundState->m_Rip)".
     unwoundState->_pRetAddr = PTR_TADDR(unwoundState->m_Rsp - 8);
-    
-#if defined(DACCESS_COMPILE)
-    // For DAC, we have to update the registers directly, since we don't have context pointers.
-#ifndef UNIX_AMD64_ABI
-    unwoundState->m_CaptureRdi = ctx.Rdi;
-    unwoundState->m_CaptureRsi = ctx.Rsi;
-#endif
-    unwoundState->m_CaptureRbx = ctx.Rbx;
-    unwoundState->m_CaptureRbp = ctx.Rbp;
-    unwoundState->m_CaptureR12 = ctx.R12;
-    unwoundState->m_CaptureR13 = ctx.R13;
-    unwoundState->m_CaptureR14 = ctx.R14;
-    unwoundState->m_CaptureR15 = ctx.R15;
 
-#else  // !DACCESS_COMPILE 
-#ifndef UNIX_AMD64_ABI
-    unwoundState->m_pRdi = PTR_ULONG64(nonVolRegPtrs.Rdi);
-    unwoundState->m_pRsi = PTR_ULONG64(nonVolRegPtrs.Rsi);
+#ifdef FEATURE_PAL
+#define CALLEE_SAVED_REGISTER(regname) unwoundState->m_Unwound.regname = ctx.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
 #endif
-    unwoundState->m_pRbx = PTR_ULONG64(nonVolRegPtrs.Rbx);
-    unwoundState->m_pRbp = PTR_ULONG64(nonVolRegPtrs.Rbp);
-    unwoundState->m_pR12 = PTR_ULONG64(nonVolRegPtrs.R12);
-    unwoundState->m_pR13 = PTR_ULONG64(nonVolRegPtrs.R13);
-    unwoundState->m_pR14 = PTR_ULONG64(nonVolRegPtrs.R14);
-    unwoundState->m_pR15 = PTR_ULONG64(nonVolRegPtrs.R15);
+
+#if defined(DACCESS_COMPILE)
+
+    // For DAC, we have to update the registers directly, since we don't have context pointers.
+#define CALLEE_SAVED_REGISTER(regname) unwoundState->m_Capture.regname = ctx.regname;
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
+#else  // !DACCESS_COMPILE
+
+#define CALLEE_SAVED_REGISTER(regname) unwoundState->m_Ptrs.p##regname = PTR_ULONG64(nonVolRegPtrs.regname);
+    ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+
 #endif // DACCESS_COMPILE 
 }

--- a/src/vm/amd64/gmscpu.h
+++ b/src/vm/amd64/gmscpu.h
@@ -65,26 +65,23 @@ protected:
     // because the context pointers below may point up to these 
     // fields.
     //
-    ULONG64 m_CaptureRdi;
-    ULONG64 m_CaptureRsi;
-    ULONG64 m_CaptureRbx;
-    ULONG64 m_CaptureRbp;
-    ULONG64 m_CaptureR12;
-    ULONG64 m_CaptureR13;
-    ULONG64 m_CaptureR14;
-    ULONG64 m_CaptureR15;
+    CalleeSavedRegisters m_Capture;
     
     // context pointers for preserved registers
-    PTR_ULONG64 m_pRdi;
-    PTR_ULONG64 m_pRsi;
-    PTR_ULONG64 m_pRbx;
-    PTR_ULONG64 m_pRbp;
-    PTR_ULONG64 m_pR12;
-    PTR_ULONG64 m_pR13;
-    PTR_ULONG64 m_pR14;
-    PTR_ULONG64 m_pR15;
+    struct {
+#define CALLEE_SAVED_REGISTER(regname) PTR_TADDR p##regname;
+        ENUM_CALLEE_SAVED_REGISTERS();
+#undef CALLEE_SAVED_REGISTER
+    } m_Ptrs;
 
     PTR_TADDR _pRetAddr;
+
+#ifdef FEATURE_PAL
+    // On PAL, we don't always have the context pointers available due to
+    // a limitation of an unwinding library. In such case, preserve
+    // the unwound values.
+    CalleeSavedRegisters m_Unwound;
+#endif
 };
 
 /********************************************************************/
@@ -126,9 +123,6 @@ struct LazyMachState : public MachState
     ULONG64 m_CaptureRsp;
 };
 
-// rdi, rsi, rbx, rbp, r12, r13, r14, r15 
-#define NUM_NONVOLATILE_CONTEXT_POINTERS 8 
-
 inline void LazyMachState::setLazyStateFromUnwind(MachState* copy)
 {
     LIMITED_METHOD_CONTRACT;
@@ -142,31 +136,26 @@ inline void LazyMachState::setLazyStateFromUnwind(MachState* copy)
     this->m_Rip = copy->m_Rip;
     this->m_Rsp = copy->m_Rsp;
 
+#ifdef FEATURE_PAL
+    this->m_Unwound = copy->m_Unwound;
+#endif
+
     // Capture* has already been set, so there is no need to touch it
 
-    // loop over the nonvolatile context pointers for 
-    // rdi, rsi, rbx, rbp, r12, r13, r14, r15 and make
+    // loop over the nonvolatile context pointers and make 
     // sure to properly copy interior pointers into the 
     // new struct
     
-    PULONG64* pSrc = &copy->m_pRdi;
-    PULONG64* pDst = &this->m_pRdi;
+    PULONG64* pSrc = (PULONG64 *)&copy->m_Ptrs;
+    PULONG64* pDst = (PULONG64 *)&this->m_Ptrs;
 
     const PULONG64 LowerBoundDst = (PULONG64) this;
     const PULONG64 LowerBoundSrc = (PULONG64) copy;
 
-    const PULONG64 UpperBoundSrc = (PULONG64) (((BYTE*)LowerBoundSrc) + sizeof(*copy) - sizeof(_pRetAddr));
+    const PULONG64 UpperBoundSrc = (PULONG64) ((BYTE*)LowerBoundSrc + sizeof(*copy));
 
-#ifdef _DEBUG
-    int count = 0;
-#endif // _DEBUG
-
-    while (((PULONG64)pSrc) < UpperBoundSrc)
+    for (int i = 0; i < NUM_CALLEE_SAVED_REGISTERS; i++)
     {
-#ifdef _DEBUG
-        count++;
-#endif // _DEBUG
-        
         PULONG64 valueSrc = *pSrc++;
 
         if ((LowerBoundSrc <= valueSrc) && (valueSrc < UpperBoundSrc))
@@ -177,8 +166,6 @@ inline void LazyMachState::setLazyStateFromUnwind(MachState* copy)
 
         *pDst++ = valueSrc;
     }
-
-    CONSISTENCY_CHECK_MSGF(count == NUM_NONVOLATILE_CONTEXT_POINTERS, ("count != NUM_NONVOLATILE_CONTEXT_POINTERS, actually = %d", count));
 
     // this has to be last because we depend on write ordering to 
     // synchronize the race implicit in updating this struct

--- a/src/vm/amd64/gmscpu.h
+++ b/src/vm/amd64/gmscpu.h
@@ -68,11 +68,7 @@ protected:
     CalleeSavedRegisters m_Capture;
     
     // context pointers for preserved registers
-    struct {
-#define CALLEE_SAVED_REGISTER(regname) PTR_TADDR p##regname;
-        ENUM_CALLEE_SAVED_REGISTERS();
-#undef CALLEE_SAVED_REGISTER
-    } m_Ptrs;
+    CalleeSavedRegistersPointers m_Ptrs;
 
     PTR_TADDR _pRetAddr;
 

--- a/src/vm/amd64/unixasmhelpers.S
+++ b/src/vm/amd64/unixasmhelpers.S
@@ -68,8 +68,8 @@ DoRestore:
         mov     rdx, [rdi + OFFSETOF__MachState__m_Ptrs + 8 * regnum]; \
         cmp     rax, rdx; \
         cmove   reg, [rax];
-// .endm
 
+        // regnum has to match ENUM_CALLEE_SAVED_REGISTERS macro
         RestoreReg(R12, 0)
         RestoreReg(R13, 1)
         RestoreReg(R14, 2)

--- a/src/vm/amd64/unixasmhelpers.S
+++ b/src/vm/amd64/unixasmhelpers.S
@@ -63,21 +63,19 @@ DoRestore:
         // So, if m_pReg points into the MachState, we need to update
         // the register here.  That's what this macro does.
         //
-#define RestoreReg(reg) \
-        lea     rax, [rdi + OFFSETOF__MachState__m_Capture##reg]; \
-        mov     rdx, [rdi + OFFSETOF__MachState__m_p##reg]; \
+#define RestoreReg(reg, regnum) \
+        lea     rax, [rdi + OFFSETOF__MachState__m_Capture + 8 * regnum]; \
+        mov     rdx, [rdi + OFFSETOF__MachState__m_Ptrs + 8 * regnum]; \
         cmp     rax, rdx; \
         cmove   reg, [rax];
 // .endm
 
-        //RestoreReg(Rdi)
-        //RestoreReg(Rsi)
-        RestoreReg(Rbx)
-        RestoreReg(Rbp)
-        RestoreReg(R12)
-        RestoreReg(R13)
-        RestoreReg(R14)
-        RestoreReg(R15)
+        RestoreReg(R12, 0)
+        RestoreReg(R13, 1)
+        RestoreReg(R14, 2)
+        RestoreReg(R15, 3)
+        RestoreReg(Rbx, 4)
+        RestoreReg(Rbp, 5)
 
         xor     eax, eax
         ret

--- a/src/vm/gcinfodecoder.cpp
+++ b/src/vm/gcinfodecoder.cpp
@@ -1823,7 +1823,19 @@ OBJECTREF* GcInfoDecoder::GetStackSlot(
         _ASSERTE( GC_FRAMEREG_REL == spBase );
         _ASSERTE( NO_STACK_BASE_REGISTER != m_StackBaseRegister );
 
-        pObjRef = (OBJECTREF*)((*((SIZE_T*)(GetRegisterSlot( m_StackBaseRegister, pRD )))) + spOffset);
+        SIZE_T * pFrameReg = (SIZE_T*) GetRegisterSlot(m_StackBaseRegister, pRD);
+
+#ifdef FEATURE_PAL
+        // On PAL, we don't always have the context pointers available due to
+        // a limitation of an unwinding library. In such case, the context
+        // pointers for some nonvolatile registers are NULL.
+        if (pFrameReg == NULL)
+        {
+            pFrameReg = (SIZE_T*) GetCapturedRegister(m_StackBaseRegister, pRD);
+        }
+#endif // FEATURE_PAL
+
+        pObjRef = (OBJECTREF*)(*pFrameReg + spOffset);
     }
 
     return pObjRef;


### PR DESCRIPTION
The callee saved registers were not preserved for GC stackwalk with nongnu
libunwind that does not provide context pointers. Fixed by adding an extra
space to MachState to preserve them.

To avoid large amounts of copy&pasted code, introduced macro to enumerate
all callee saved registers, similar to existing macro to enumerate all
argument registers. This macro makes the code to copy the register values
between different structures more compact, and less prone to typos.

This is fixing #512