### PR TITLE
Stub out more globalization with values rather than with exceptions

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
@@ -13,33 +13,33 @@ namespace System.Globalization
         private bool LoadCalendarDataFromSystem(String localeName, CalendarId calendarId)
         {
             // TODO: Implement this.
-            throw new NotImplementedException();            
+            return false;
         }
 
         // Get native two digit year max
         internal static int GetTwoDigitYearMax(CalendarId calendarId)
         {
             // TODO: Implement this.
-            throw new NotImplementedException();            
+            return -1;
         }
 
         internal static CalendarData GetCalendarData(CalendarId calendarId)
         {
             // TODO: Implement this.
-            throw new NotImplementedException();            
+            return new CalendarData("", calendarId, false);
         }
 
         // Call native side to figure out which calendars are allowed
         internal static int GetCalendars(String localeName, bool useUserOverride, CalendarId[] calendars)
         {
             // TODO: Implement this.
-            throw new NotImplementedException();            
+            return 0;
         }
 
         private static bool SystemSupportsTaiwaneseCalendar()
         {
             // TODO: Implement this.
-            throw new NotImplementedException();            
+            return false;
         }
 
         // PAL Layer ends here

--- a/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
@@ -48,6 +48,7 @@ namespace System.Globalization
             sSpecificCulture = "";
             sName = "";
             bNeutral = false;
+            sNegativeSign = "-";
 
             return true;
         }
@@ -228,7 +229,7 @@ namespace System.Globalization
         private static string GetRegionDisplayName(string isoCountryCode)
         {
             // TODO: Implement this fully.
-            throw new NotImplementedException();
+            return "";
         }
 
         private static CultureInfo GetUserDefaultCulture()
@@ -239,8 +240,8 @@ namespace System.Globalization
 
         private static bool IsCustomCultureId(int cultureId)
         {
-           // TODO: Implement this fully.
-            throw new NotImplementedException();
+            // TODO: Implement this fully.
+            return false;
         }
 
         // PAL methods end here.


### PR DESCRIPTION
Much of our globalization support on Unix is not yet implemented and is appropriately throwing NotImplementedException.  However, this is hindering progress in other areas of the system that end up relying on globalization.  This commit just changes the common cases where we were throwing NotImplementedException to instead return a default value; the "TODO: Implement this" comments have been left in place.