### PR TITLE
Fix an IndexOutOfRangeException in IndexOfOrdinal on Unix

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -26,9 +26,7 @@ namespace System.Globalization
 
             source = source.Substring(startIndex, count);
 
-            if (value.Length > source.Length) return -1;
-
-            for (int i = 0; i < source.Length; i++)
+            for (int i = 0; i + value.Length <= source.Length; i++)
             {
                 for (int j = 0; j < value.Length; j++) {
                    if (source[i + j] != value[j]) {


### PR DESCRIPTION
In the temporary implementation of CompareInfo.IndexOfOrdinal on Unix, we sometimes hit an IndexOutOfRangeException as the inner loop tries to go past the end of the source string.