### PR TITLE
Fix invocation of shared generic multicast delegate

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -3145,10 +3145,13 @@ MethodDesc * CEEInfo::GetMethodForSecurity(CORINFO_METHOD_HANDLE callerHandle)
         return m_pMethodForSecurity_Value;
     }
 
+    MethodDesc * pCallerMethod = (MethodDesc *)callerHandle;
+
     //If the caller is generic, load the open type and then load the field again,  This allows us to
     //differentiate between BadGeneric<T> containing a memberRef for a field of type InaccessibleClass and
     //GoodGeneric<T> containing a memberRef for a field of type T instantiated over InaccessibleClass.
-    MethodDesc * pMethodForSecurity = ((MethodDesc *)callerHandle)->LoadTypicalMethodDefinition();
+    MethodDesc * pMethodForSecurity = pCallerMethod->IsILStub() ? 
+        pCallerMethod : pCallerMethod->LoadTypicalMethodDefinition();
 
     m_hMethodForSecurity_Key = callerHandle;
     m_pMethodForSecurity_Value = pMethodForSecurity;


### PR DESCRIPTION
JITing of IL stubs for invocation of shared generic multicast delegates
 e.g. Action<string> a = .. + ..; a(); crashed in JIT on security check
because of IL stubs have non-standard MethodDesc. The security check is
unnecessary for IL stubs - the fix is to shortcircuit it for IL stubs.