### PR TITLE
Make stresslog work for libraries other than CoreClr (I need it for DBI)

### DIFF
--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -53,7 +53,7 @@ DacGlobals g_dacTable;
 // DAC global pointer table initialization
 void DacGlobals::Initialize()
 {
-    TADDR baseAddress = PTR_TO_TADDR(PAL_GetCoreClrModuleBase());
+    TADDR baseAddress = PTR_TO_TADDR(PAL_GetPalModuleBase());
     g_dacTable.InitializeEntries(baseAddress);
 #ifdef FEATURE_SVR_GC
     g_dacTable.InitializeSVREntries(baseAddress);

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3340,6 +3340,14 @@ PALAPI
 LPCVOID
 PAL_GetCoreClrModuleBase();
 
+
+// Get base address of the module containing this function 
+// (in case of CoreCLR process PAL_GetPalModuleBase() == PAL_GetCoreClrModuleBase())
+PALAPI
+LPCVOID
+PAL_GetPalModuleBase();
+
+
 PALIMPORT
 LPVOID
 PALAPI

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3335,14 +3335,7 @@ GetModuleFileNameW(
 #define GetModuleFileName GetModuleFileNameA
 #endif
 
-// Get base address of the coreclr module
-PALAPI
-LPCVOID
-PAL_GetCoreClrModuleBase();
-
-
 // Get base address of the module containing this function 
-// (in case of CoreCLR process PAL_GetPalModuleBase() == PAL_GetCoreClrModuleBase())
 PALAPI
 LPCVOID
 PAL_GetPalModuleBase();

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1913,7 +1913,7 @@ PAL_GetCoreClrModuleBase()
 {
     LPCVOID retval = NULL;
 
-    PERF_ENTRY(PAL_GetModuleBaseFromHModule);
+    PERF_ENTRY(PAL_GetCoreClrModuleBase);
     ENTRY("PAL_GetCoreClrModuleBase\n");
 
     if(pal_module.dl_handle != NULL)
@@ -1949,4 +1949,33 @@ PAL_GetCoreClrModuleBase()
     LOGEXIT("PAL_GetCoreClrModuleBase returns %p\n", retval);
     PERF_EXIT(PAL_GetCoreClrModuleBase);
     return retval;
+}
+
+// Get base address of the module containing this function 
+// (in case of CoreCLR process PAL_GetPalModuleBase() == PAL_GetCoreClrModuleBase())
+PALAPI
+LPCVOID
+PAL_GetPalModuleBase()
+{
+    LPCVOID retval = NULL;
+
+    PERF_ENTRY(PAL_GetPalModuleBase);
+    ENTRY("PAL_GetPalModuleBase\n");
+
+    Dl_info info;
+    void *current_func = reinterpret_cast<void *>(PAL_GetPalModuleBase);
+    if (dladdr(current_func, &info) != 0)
+    {
+        retval = info.dli_fbase;
+    }
+    else 
+    {
+        TRACE("Can't get base address of the current module\n");
+        SetLastError(ERROR_INVALID_DATA);
+    }
+
+    LOGEXIT("PAL_GetPalModuleBase returns %p\n", retval);
+    PERF_EXIT(PAL_GetPalModuleBase);
+    return retval;
+
 }

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1906,53 +1906,7 @@ BOOL LOADInitCoreCLRModules()
     return g_pRuntimeDllMain((HMODULE)&pal_module, DLL_PROCESS_ATTACH, NULL);
 }
 
-// Get base address of the coreclr module
-PALAPI
-LPCVOID
-PAL_GetCoreClrModuleBase()
-{
-    LPCVOID retval = NULL;
-
-    PERF_ENTRY(PAL_GetCoreClrModuleBase);
-    ENTRY("PAL_GetCoreClrModuleBase\n");
-
-    if(pal_module.dl_handle != NULL)
-    {
-        // To lookup module base address, we need an address inside of the module.
-        // The coreclr.so contains the DllMain function, so we use it here.
-        void* dllMain = dlsym(pal_module.dl_handle, "DllMain");
-        if (dllMain != NULL)
-        {
-            Dl_info info;
-            if (dladdr(dllMain, &info) != 0)
-            {
-                retval = info.dli_fbase;
-            }
-            else 
-            {
-                TRACE("Can't get base address of the libcoreclr.so\n");
-                SetLastError(ERROR_INVALID_DATA);
-            }
-        }
-        else
-        {
-            TRACE("Can't find DllMain in libcoreclr.so\n");
-            SetLastError(ERROR_INVALID_DATA);
-        }
-    }
-    else 
-    {
-        TRACE("Can't get libcoreclr.so base - the pal_module is not initialized\n");
-        SetLastError(ERROR_MOD_NOT_FOUND);
-    }
-
-    LOGEXIT("PAL_GetCoreClrModuleBase returns %p\n", retval);
-    PERF_EXIT(PAL_GetCoreClrModuleBase);
-    return retval;
-}
-
 // Get base address of the module containing this function 
-// (in case of CoreCLR process PAL_GetPalModuleBase() == PAL_GetCoreClrModuleBase())
 PALAPI
 LPCVOID
 PAL_GetPalModuleBase()

--- a/src/utilcode/stresslog.cpp
+++ b/src/utilcode/stresslog.cpp
@@ -185,7 +185,7 @@ void StressLog::Initialize(unsigned facilities,  unsigned level, unsigned maxByt
 #endif // _DEBUG
 
 #else // !FEATURE_PAL
-    theLog.moduleOffset = (SIZE_T)PAL_GetCoreClrModuleBase();
+    theLog.moduleOffset = (SIZE_T)PAL_GetPalModuleBase();
 #endif // !FEATURE_PAL
 
 #if !defined (STRESS_LOG_READONLY)    


### PR DESCRIPTION
Introducing of PAL_GetPalModuleBase removes dependency on CoreCLR name for
stress log module address.