### PR TITLE
Fixes to string comparison in stubbed out Unix globalization 

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -185,11 +185,11 @@ namespace System.Globalization
                     char c1 = ignoreCase ? TextInfo.ChangeCaseAscii(s1[i]) : s1[i];
                     char c2 = ignoreCase ? TextInfo.ChangeCaseAscii(s2[i]) : s2[i];
 
-                    if (TextInfo.ChangeCaseAscii(s1[i]) < TextInfo.ChangeCaseAscii(s2[i]))
+                    if (c1 < c2)
                     {
                         return -1;
                     }
-                    else if (TextInfo.ChangeCaseAscii(s1[i]) > TextInfo.ChangeCaseAscii(s2[i]))
+                    else if (c1 > c2)
                     {
                         return 1;
                     }

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
@@ -31,7 +31,7 @@ namespace System.Globalization
                 sb.Append(ChangeCaseAscii(s[i], toUpper));
             }
 
-            return s.ToString();
+            return sb.ToString();
         }
 
         private unsafe char ChangeCase(char c, bool toUpper)


### PR DESCRIPTION
A few small tweaks to fix various test failures related to key comparisons.