### PR TITLE
Initialize TextInfo's m_textInfoName in stubbed out globalization on Unix

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
@@ -17,6 +17,9 @@ namespace System.Globalization
         internal unsafe TextInfo(CultureData cultureData)
         {
             // TODO: Implement this fully.
+            this.m_cultureData = cultureData;
+            this.m_cultureName = this.m_cultureData.CultureName;
+            this.m_textInfoName = this.m_cultureData.STEXTINFO;
         }
 
         private unsafe string ChangeCase(string s, bool toUpper)


### PR DESCRIPTION
Some System.Runtime.Extensions tests are failing due to IsAsciiCasingSameAsInvariant trying to use a null m_textInfoName.