### PR TITLE
Implement ExpandEnvironmentVariables on Unix

### DIFF
--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -428,6 +428,28 @@ namespace System {
 
             int currentSize = 100;
             StringBuilder blob = new StringBuilder(currentSize); // A somewhat reasonable default size
+
+#if PLATFORM_UNIX // Win32Native.ExpandEnvironmentStrings isn't available
+            int lastPos = 0, pos;
+            while (lastPos < name.Length && (pos = name.IndexOf('%', lastPos + 1)) >= 0)
+            {
+                if (name[lastPos] == '%')
+                {
+                    string key = name.Substring(lastPos + 1, pos - lastPos - 1);
+                    string value = Environment.GetEnvironmentVariable(key);
+                    if (value != null)
+                    {
+                        blob.Append(value);
+                        lastPos = pos + 1;
+                        continue;
+                    }
+                }
+                blob.Append(name.Substring(lastPos, pos - lastPos));
+                lastPos = pos;
+            }
+            blob.Append(name.Substring(lastPos));
+#else
+
             int size;
 
 #if !FEATURE_CORECLR
@@ -501,6 +523,7 @@ namespace System {
                 if (size == 0)
                     Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
             }
+#endif // PLATFORM_UNIX
 
             return blob.ToString();
         }


### PR DESCRIPTION
The Environment type exposes ExpandEnvironmentVariables, but the corresponding Win32 function isn't available in the PAL, and thus calling Environment.ExpandEnvironmentVariables fails with an EntryPointNotFoundException from libcoreclr.dll.

This commit provides a basic implementation of the function in the managed ExpandEnvironmentVariables method on Unix.  It passes all of the corresponding tests in System.Runtime.Extensions.Tests.dll.