### PR TITLE
Change null constant type to be TYP_REF for isinst nullcheck expansion

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8178,7 +8178,7 @@ GenTreePtr Compiler::impCastClassOrIsInstToTree(GenTreePtr op1, GenTreePtr op2, 
     //             op1Copy CNS_INT
     //                      null
     //                      
-    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_I_IMPL));  
+    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_REF));
 
     //
     // expand the true and false trees for the condMT


### PR DESCRIPTION
In the importer, when inlining the fast expansion sequence for
isinst/castclass, the code was typing the constant 0 source of the
compare with TYP_I_IMPL instead of TYP_REF. Not only does this create
an inconsistently typed compare against the object reference, but it causes
value-numbering of the same 0 constants but of different type from other
null-check comparisons to not be equal. This blocks later assertion propagation
from eliminating these null-checks.

This change changes the type of the constant gtNode to be TYP_REF.
Ran testing in desktop branch including SuperPMI asm diffs. Asm
diffs show hundreds of methods with improvements in framework
, Roslyn, and other internal assemblies. All diffs are elimination of redundant
null-checks. With this change there are many good diffs in the frameworks and
other assemblies. Overall ~3200 methods have differences in all framework
assemblies combined leading to about 27K reduction in code size combined.