### PR TITLE
Normalize array element type of ldnull to stack size for verification

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8178,7 +8178,7 @@ GenTreePtr Compiler::impCastClassOrIsInstToTree(GenTreePtr op1, GenTreePtr op2, 
     //             op1Copy CNS_INT
     //                      null
     //                      
-    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_I_IMPL));  
+    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_REF));
 
     //
     // expand the true and false trees for the condMT

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8178,7 +8178,7 @@ GenTreePtr Compiler::impCastClassOrIsInstToTree(GenTreePtr op1, GenTreePtr op2, 
     //             op1Copy CNS_INT
     //                      null
     //                      
-    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_REF));
+    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_I_IMPL));  
 
     //
     // expand the true and false trees for the condMT
@@ -9374,8 +9374,8 @@ RET:
                     {
                         Verify(tiRetVal.IsType(arrayElemTi.GetType()), "bad array");
                     }
-                    tiRetVal.NormaliseForStack();
                 }
+                tiRetVal.NormaliseForStack();
             }
 ARR_LD_POST_VERIFY:
    


### PR DESCRIPTION

Stephen Toub reported a RyuJIT assertion failure in System.Linq.Expressions.Tests.dll on unix.
The debug assertion was firing to ensure that the verification element type is normalized to
the stack slot sized type for verification purpose in later code that expects this convention.

Testing: DDR_And_JitSelfHost_diffs al clean with no asm diffs.
Performance: 0 asm diffs so no impact
