### PR TITLE
Various DBI related fixes that make it possible to load DBI on Linux

### DIFF
--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -57,7 +57,14 @@ DllMain(HANDLE instance, DWORD reason, LPVOID reserved)
     {
         if (g_procInitialized)
         {
-            return FALSE;   // should only get called once
+#ifdef FEATURE_PAL            
+            // Double initialization can happen on Unix 
+            // in case of manual load of DAC shared lib and calling DllMain
+            // not a big deal, we just ignore it. 
+            return TRUE;
+#else
+            return FALSE;            
+#endif            
         }
 
 #ifdef FEATURE_PAL
@@ -5492,16 +5499,26 @@ ClrDataAccess::Initialize(void)
 
     // Determine our platform based on the pre-processor macros set when we were built
 
-#if defined(_TARGET_X86_)
-    CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_X86;
-#elif defined(_TARGET_AMD64_)
-    CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_AMD64;
-#elif defined(_TARGET_ARM_)
-    CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_ARM;
-#elif defined(_TARGET_ARM64_)
-    CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_ARM64;
+#ifdef FEATURE_PAL
+     #if defined(DBG_TARGET_X86)
+         CorDebugPlatform hostPlatform = CORDB_PLATFORM_MAC_X86;
+     #elif defined(DBG_TARGET_AMD64)
+         CorDebugPlatform hostPlatform = CORDB_PLATFORM_MAC_AMD64;
+     #else
+         #error Unknown Processor.
+     #endif
 #else
-#error Unknown processor.
+    #if defined(DBG_TARGET_X86)
+        CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_X86;
+    #elif defined(DBG_TARGET_AMD64)
+        CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_AMD64;
+    #elif defined(DBG_TARGET_ARM)
+        CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_ARM;
+    #elif defined(DBG_TARGET_ARM64)
+        CorDebugPlatform hostPlatform = CORDB_PLATFORM_WINDOWS_ARM64;
+    #else
+        #error Unknown Processor.
+    #endif
 #endif
 
     CorDebugPlatform targetPlatform;

--- a/src/debug/debug-pal/unix/dynamiclibaddress.cpp
+++ b/src/debug/debug-pal/unix/dynamiclibaddress.cpp
@@ -4,11 +4,20 @@
 //
 #include "windefs.h"
 #include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
 
 
 void *GetDynamicLibraryAddressInProcess(DWORD pid, const char *libraryName)
 {
-#ifdef HAVE_PROCFS_CTL
+
+// We don't have proper API detection in debug-pal
+// that's why so far we'll just assume that we run on OS with ProcFS (which is not true on OS)
+#define HAVE_PROCFS_CTL 
+#ifdef HAVE_PROCFS_CTL 
+
     // Here we read /proc/<pid>/maps file in order to parse it and figure out what it says 
     // about a library we are looking for. This file looks something like this:
     //
@@ -77,5 +86,5 @@ void *GetDynamicLibraryAddressInProcess(DWORD pid, const char *libraryName)
 #else
     _ASSERTE(!"Not implemented on this platform");
     return NULL;
-#endif    
+#endif
 }

--- a/src/debug/debug-pal/unix/dynamiclibaddress.cpp
+++ b/src/debug/debug-pal/unix/dynamiclibaddress.cpp
@@ -14,7 +14,8 @@ void *GetDynamicLibraryAddressInProcess(DWORD pid, const char *libraryName)
 {
 
 // We don't have proper API detection in debug-pal
-// that's why so far we'll just assume that we run on OS with ProcFS (which is not true on OS)
+// that's why so far we'll just assume that we run on OS with ProcFS (which is not true on Mac OS)
+// TODO: We need to implement this function for Mac OS
 #define HAVE_PROCFS_CTL 
 #ifdef HAVE_PROCFS_CTL 
 

--- a/src/debug/di/cordb.cpp
+++ b/src/debug/di/cordb.cpp
@@ -174,17 +174,6 @@ STDAPI CoreCLRCreateCordbObject(int iDebuggerVersion, DWORD pid, HMODULE hmodTar
 //*****************************************************************************
 BOOL WINAPI DbgDllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 {
-#if defined(_DEBUG)
-    static int BreakOnDILoad = -1;
-    if (BreakOnDILoad == -1)
-        BreakOnDILoad = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_BreakOnDILoad);
-
-    if (BreakOnDILoad)
-    {
-        _ASSERTE(!"DI Loaded");
-    }
-#endif
-
     // Save off the instance handle for later use.
     switch (dwReason)
     {
@@ -192,6 +181,25 @@ BOOL WINAPI DbgDllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
         case DLL_PROCESS_ATTACH:
         {
             g_hInst = hInstance;
+
+#ifdef FEATURE_PAL
+            int err = PAL_InitializeDLL();
+            if(err != 0)
+            {
+                return FALSE;
+            }
+#endif
+
+#if defined(_DEBUG)
+            static int BreakOnDILoad = -1;
+            if (BreakOnDILoad == -1)
+                BreakOnDILoad = CLRConfig::GetConfigValue(CLRConfig::INTERNAL_BreakOnDILoad);
+
+            if (BreakOnDILoad)
+            {
+                _ASSERTE(!"DI Loaded");
+            }
+#endif
 
 #if defined(LOGGING)
             {

--- a/src/debug/di/shimprocess.cpp
+++ b/src/debug/di/shimprocess.cpp
@@ -1871,9 +1871,16 @@ DWORD ShimProcess::ResolveHostName(ICorDebugRemoteTarget * pRemoteTarget)
 
 HMODULE ShimProcess::GetDacModule()
 {
-    WCHAR wszAccessDllPath[MAX_PATH];
+    
     HModuleHolder hDacDll;
 
+#ifdef FEATURE_PAL
+    // For now on Unix we'll just search for DAC in the default location.
+    // Debugger can always control it by setting LD_LIBRARY_PATH env var.
+    WCHAR wszAccessDllPath[MAX_PATH] = MAKEDLLNAME_W(W("mscordaccore"));
+
+#else    
+    WCHAR wszAccessDllPath[MAX_PATH];
     //
     // Load the access DLL from the same directory as the the current CLR Debugging Services DLL.
     //
@@ -1908,6 +1915,7 @@ HMODULE ShimProcess::GetDacModule()
     {
         ThrowHR(E_INVALIDARG);
     }
+#endif //!FEATURE_PAL  
 
     hDacDll.Assign(WszLoadLibrary(wszAccessDllPath));
     if (!hDacDll)

--- a/src/debug/di/stdafx.h
+++ b/src/debug/di/stdafx.h
@@ -25,11 +25,16 @@
     #define RSCONTRACTS
 #endif
 
+
+// In case of FEATURE_DBGIPC_TRANSPORT_DI we use pipe for debugger debugee communication
+// and event redirection is not needed. (won't work anyway)
+#ifndef FEATURE_DBGIPC_TRANSPORT_DI
 // Currently, we only can redirect exception events. Since real interop-debugging
 // neeeds all events, redirection can't work in real-interop. 
 // However, whether we're interop-debugging is determined at runtime, so we always
 // enable at compile time and then we need a runtime check later.
 #define ENABLE_EVENT_REDIRECTION_PIPELINE
+#endif
 
 #include "ex.h"
 

--- a/src/debug/shared/dbgtransportsession.cpp
+++ b/src/debug/shared/dbgtransportsession.cpp
@@ -1107,8 +1107,9 @@ HRESULT DbgTransportSession::CheckBufferAccess(__in_ecount(cbBuffer) PBYTE pbBuf
         return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
     }
 
-    // TODO: VirtualQuery from PAL doesn't seem to provide correct result for DAC globals on Linux.
-    // We need to look into it, but for now I just disable these checks on Unix
+    // VirtualQuery doesn't know much about memory allocated outside of PAL's VirtualAlloc 
+    // that's why on Unix we can't rely on in to detect invalid memory reads  
+    // TODO: We need to find and use appropriate memory map API on other operating systems. 
 #ifndef FEATURE_PAL
     do 
     {

--- a/src/debug/shared/dbgtransportsession.cpp
+++ b/src/debug/shared/dbgtransportsession.cpp
@@ -1107,6 +1107,9 @@ HRESULT DbgTransportSession::CheckBufferAccess(__in_ecount(cbBuffer) PBYTE pbBuf
         return HRESULT_FROM_WIN32(ERROR_ARITHMETIC_OVERFLOW);
     }
 
+    // TODO: VirtualQuery from PAL doesn't seem to provide correct result for DAC globals on Linux.
+    // We need to look into it, but for now I just disable these checks on Unix
+#ifndef FEATURE_PAL
     do 
     {
         // Find the attributes of the largest set of pages with common attributes starting from our base address.
@@ -1146,6 +1149,7 @@ HRESULT DbgTransportSession::CheckBufferAccess(__in_ecount(cbBuffer) PBYTE pbBuf
         }
     }
     while (cbBuffer > 0);
+#endif
 
     // The specified region has passed all of our checks.
     return S_OK;

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -65,6 +65,10 @@ elseif(CLR_CMAKE_PLATFORM_UNIX)
     # if they are defined after they are used. Having all libs twice makes sure that ld will actually
     # find all symbols.
     target_link_libraries(mscordbi ${COREDBI_LIBRARIES} ${COREDBI_LIBRARIES})
+
+    # This option is necessary to ensure that the overloaded new/delete operators defined inside
+    # of the utilcode will be used instead of the standard library delete operator.
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")    
     
 endif(WIN32)
 


### PR DESCRIPTION
This change make it possible to write a managed debugger on Linux that can
1. Load and initialized DBI
2. Create and setup CorDebug interface
3. Successfully call CreateProcess or DebugActiveProcess process (hr = 0)
4. then crash :) 