### PR TITLE
Add additional headers to the CoreCLR package to describe its interface.

### DIFF
--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
@@ -39,5 +39,7 @@
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />
     <file src="..\inc\corinfo.h" target="inc\corinfo.h" />
     <file src="..\inc\corjit.h" target="inc\corjit.h" />
+    <file src="..\inc\opcode.def" target="inc\opcode.def" />
+    <file src="..\inc\openum.h" target="inc\openum.h" />
   </files>
 </package>

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
@@ -39,5 +39,7 @@
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />
     <file src="..\inc\corinfo.h" target="inc\corinfo.h" />
     <file src="..\inc\corjit.h" target="inc\corjit.h" />
+    <file src="..\inc\opcode.def" target="inc\opcode.def" />
+    <file src="..\inc\openum.h" target="inc\openum.h" />
   </files>
 </package>

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -63,4 +63,10 @@ add_library(corguids ${CORGUIDS_SOURCES})
 
 # Binplace the inc files for packaging later.
 
-install (FILES cor.h corhdr.h corinfo.h corjit.h DESTINATION inc)
+install (FILES cor.h
+               corhdr.h
+               corinfo.h
+               corjit.h
+               opcode.def
+               openum.h
+               DESTINATION inc)


### PR DESCRIPTION
Adds headers:
- opcode.def and openum.h to describe the MSIL opcodes.
- StaticContract.h to describe the shared contracts used in the interface between CoreCLR and JITs.
- switches.h to describe the feature defines of the CoreCLR.

Run debug builds and testruns for sanity, but changes should just impact development package contents.

@mmitche, @jkotas PTAL