### PR TITLE
build.sh: Fix CPU-count detection on FreeBSD.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,11 @@ build_coreclr()
     # Get the number of processors available to the scheduler
     # Other techniques such as `nproc` only get the number of
     # processors available to a single process.
-    NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
+    if [ `uname` = "FreeBSD" ]; then
+	NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
+    else
+	NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
+    fi
     
     # Build CoreCLR
     


### PR DESCRIPTION
Demo output on FreeBSD system:

    [josteink@ ~]$ sysctl hw.ncpu
    hw.ncpu: 2
    [josteink@ ~]$ sysctl hw.ncpu | awk '{ print $2+1 }'
    3