### PR TITLE
Fix warnings in the jitter code

### DIFF
--- a/src/jit/bitset.h
+++ b/src/jit/bitset.h
@@ -64,7 +64,7 @@ public:
         const char* m_fileName;
         FILE* OpOutputFile;
       public:
-        BitSetOpCounter(const char* fileName) : m_fileName(fileName), TotalOps(0), OpOutputFile(NULL)
+        BitSetOpCounter(const char* fileName) : TotalOps(0), m_fileName(fileName), OpOutputFile(NULL)
         {
             for (unsigned i = 0; i < BSOP_NUMOPS; i++)
             {

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -947,11 +947,11 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
     GenTree* FirstNonPhiDefOrCatchArgAsg();
 
     BasicBlock() :
+#if ASSERTION_PROP
+        BLOCKSET_INIT_NOCOPY(bbDoms, BlockSetOps::UninitVal()),
+#endif // ASSERTION_PROP
         VARSET_INIT_NOCOPY(bbLiveIn, VarSetOps::UninitVal()),
         VARSET_INIT_NOCOPY(bbLiveOut, VarSetOps::UninitVal())
-#if ASSERTION_PROP
-        , BLOCKSET_INIT_NOCOPY(bbDoms, BlockSetOps::UninitVal())
-#endif // ASSERTION_PROP
     {
     }
 

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -87,9 +87,9 @@ CodeGenInterface *getCodeGenerator(Compiler *comp)
 
 // CodeGen constructor
 CodeGenInterface::CodeGenInterface(Compiler* theCompiler) :
-    compiler(theCompiler),
     gcInfo(theCompiler),
-    regSet(theCompiler, gcInfo)
+    regSet(theCompiler, gcInfo),
+    compiler(theCompiler)
 {
 }
 

--- a/src/jit/codegeninterface.h
+++ b/src/jit/codegeninterface.h
@@ -88,6 +88,8 @@ public:
 
     void                genCalcFrameSize ();
 
+    GCInfo              gcInfo;
+
     RegSet              regSet;
     RegState            intRegState;
     RegState            floatRegState;
@@ -319,7 +321,6 @@ protected:
 #endif // LATE_DISASM
 
 public:
-    GCInfo              gcInfo;
 
 #ifdef DEBUG
     void                setVerbose(bool value)      { verbose = value; }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4686,8 +4686,8 @@ protected:
         }
 
         LoopHoistContext(Compiler* comp) :
-            m_hoistedInParentLoops(comp->getAllocatorLoopHoist()),
             m_pHoistedInCurLoop(nullptr),
+            m_hoistedInParentLoops(comp->getAllocatorLoopHoist()),
             m_curLoopVnInvariantCache(comp->getAllocatorLoopHoist())
             {}
     };

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1341,7 +1341,8 @@ void                GenTree::CopyFrom(const GenTree* src, Compiler* comp)
     assert((gtFlags & GTF_NODE_LARGE) || GenTree::s_gtNodeSizes[src->gtOper] == TREE_NODE_SZ_SMALL);
     GenTreePtr prev = gtPrev;
     GenTreePtr next = gtNext;
-    memcpy(this, src, src->GetNodeSize());
+    // The VTable pointer is copied intentionally here
+    memcpy((void*)this, (void*)src, src->GetNodeSize());
     this->gtPrev = prev;
     this->gtNext = next;
 #ifdef DEBUG

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -563,11 +563,11 @@ void                Compiler::eeDispVar(ICorDebugInfo::NativeVarInfo* var)
     case VLT_REG_BYREF:
     case VLT_REG_FP:
         printf("%s", getRegName(var->loc.vlReg.vlrReg));
-        if (var->loc.vlType == VLT_REG_BYREF)
+        if (var->loc.vlType == (ICorDebugInfo::VarLocType)VLT_REG_BYREF)
         {
             printf(" byref");
         }
-        break; 
+        break;
 
     case VLT_STK:
     case VLT_STK_BYREF:
@@ -580,7 +580,7 @@ void                Compiler::eeDispVar(ICorDebugInfo::NativeVarInfo* var)
         {
             printf(STR_SPBASE "'[%d] (1 slot)",  var->loc.vlStk.vlsOffset);
         }
-        if (var->loc.vlType == VLT_REG_BYREF)
+        if (var->loc.vlType == (ICorDebugInfo::VarLocType)VLT_REG_BYREF)
         {
             printf(" byref");
         }
@@ -882,14 +882,14 @@ CORINFO_FIELD_HANDLE Compiler::eeFindJitDataOffs(unsigned dataOffs)
 {
     // Data offsets are marked by the fact that the low two bits are 0b01 0x1
     assert(dataOffs < 0x40000000);
-    return (CORINFO_FIELD_HANDLE)((dataOffs << iaut_SHIFT) | iaut_DATA_OFFSET);
+    return (CORINFO_FIELD_HANDLE)(size_t)((dataOffs << iaut_SHIFT) | iaut_DATA_OFFSET);
 }
 
 bool Compiler::eeIsJitDataOffs(CORINFO_FIELD_HANDLE field)
 {
     // if 'field' is a jit data offset it has to fit into a 32-bit unsigned int
     unsigned value = (unsigned) field;
-    if (((CORINFO_FIELD_HANDLE ) value) != field)
+    if (((CORINFO_FIELD_HANDLE)(size_t)value) != field)
     {
         return false;   // upper bits were set, not a jit data offset
     }
@@ -903,7 +903,7 @@ int Compiler::eeGetJitDataOffs(CORINFO_FIELD_HANDLE  field)
     if (eeIsJitDataOffs(field))
     {
         unsigned dataOffs = (unsigned) field;
-        assert(((CORINFO_FIELD_HANDLE ) dataOffs) == field);
+        assert(((CORINFO_FIELD_HANDLE)(size_t)dataOffs) == field);
         assert(dataOffs < 0x40000000);
         return ((int) field) >> iaut_SHIFT;
     }
@@ -936,7 +936,7 @@ const char* jitHlpFuncTable[CORINFO_HELP_COUNT] =
 *  On Unix compilers don't support SEH.
 */
 
-static struct FilterSuperPMIExceptionsParam_ee_il
+struct FilterSuperPMIExceptionsParam_ee_il
 {
     Compiler*               pThis;
     Compiler::Info*         pJitInfo;

--- a/src/jit/eeinterface.cpp
+++ b/src/jit/eeinterface.cpp
@@ -34,7 +34,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 *  On Unix compilers don't support SEH.
 */
 
-static struct FilterSuperPMIExceptionsParam_eeinterface
+struct FilterSuperPMIExceptionsParam_eeinterface
 {
     Compiler*                   pThis;
     Compiler::Info*             pJitInfo;

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1586,6 +1586,8 @@ public:
 #ifdef DEBUG
   private:
     GenTree& operator=(const GenTree& gt) {
+        _ASSERTE(!"Don't copy");
+        return *this;
     }
 #endif // DEBUG
 

--- a/src/jit/hashbv.h
+++ b/src/jit/hashbv.h
@@ -216,7 +216,7 @@ class hashBv
 
  public:
 
-    inline hashBvNode *hashBv::getOrAddNodeForIndex(indexType index)
+    inline hashBvNode *getOrAddNodeForIndex(indexType index)
     {
         hashBvNode *temp = getNodeForIndexHelper(index, true);
         return temp;

--- a/src/jit/jitstd/allocator.h
+++ b/src/jit/jitstd/allocator.h
@@ -38,7 +38,7 @@ public:
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
     typedef void* pointer;
-    typedef const pointer const_pointer;
+    typedef const void* const_pointer;
     typedef void value_type;
 
     template <typename U>
@@ -98,8 +98,8 @@ public:
     typedef ptrdiff_t difference_type;
     typedef T* pointer;
     typedef T& reference;
-    typedef const pointer const_pointer;
-    typedef const reference const_reference;
+    typedef const T* const_pointer;
+    typedef const T& const_reference;
     typedef T value_type;
 
 private:

--- a/src/jit/jitstd/list.h
+++ b/src/jit/jitstd/list.h
@@ -35,8 +35,8 @@ public:
     typedef Allocator allocator_type;
     typedef T* pointer;
     typedef T& reference;
-    typedef const pointer const_pointer;
-    typedef const reference const_reference;
+    typedef const T* const_pointer;
+    typedef const T& const_reference;
 
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
@@ -248,9 +248,9 @@ private:
         Node* m_pNext;
         Node* m_pPrev;
         Node(Node* pPrev, Node* pNext, const T& value)
-            : m_pPrev(pPrev)
+            : m_value(value)
             , m_pNext(pNext)
-            , m_value(value)
+            , m_pPrev(pPrev)
         {
         }
     };

--- a/src/jit/jitstd/vector.h
+++ b/src/jit/jitstd/vector.h
@@ -35,8 +35,8 @@ public:
     typedef Allocator allocator_type;
     typedef T* pointer;
     typedef T& reference;
-    typedef const pointer const_pointer;
-    typedef const reference const_reference;
+    typedef const T* const_pointer;
+    typedef const T& const_reference;
 
     typedef size_t size_type;
     typedef ptrdiff_t difference_type;
@@ -398,7 +398,7 @@ typename vector<T, Allocator>::reference
 }
 
 template <typename T, typename Allocator>
-typename vector<T, Allocator>::reference
+typename vector<T, Allocator>::const_reference
     vector<T, Allocator>::back() const
 {
     return operator[](m_nSize - 1);

--- a/src/jit/loopcloning.h
+++ b/src/jit/loopcloning.h
@@ -185,10 +185,10 @@ struct LcMdArrayOptInfo : public LcOptInfo
     ArrIndex* index;                    // "index" cached computation in the form of an ArrIndex representation.
 
     LcMdArrayOptInfo(GenTreeArrElem* arrElem, unsigned dim)
-        : arrElem(arrElem)
+        : LcOptInfo(this, LcMdArray)
+        , arrElem(arrElem)
         , dim(dim)
-        , index(nullptr)
-        , LcOptInfo(this, LcMdArray) {}
+        , index(nullptr) {}
 
     ArrIndex* GetArrIndexForDim(IAllocator* alloc)
     {
@@ -219,10 +219,10 @@ struct LcJaggedArrayOptInfo : public LcOptInfo
     GenTreePtr stmt;               // "stmt" where the optimization opportunity occurs.
 
     LcJaggedArrayOptInfo(ArrIndex& arrIndex, unsigned dim, GenTreePtr stmt)
-        : arrIndex(arrIndex)
+        : LcOptInfo(this, LcJaggedArray)
         , dim(dim)
-        , stmt(stmt)
-        , LcOptInfo(this, LcJaggedArray) {}
+        , arrIndex(arrIndex)
+        , stmt(stmt) {}
 };
 
 /**
@@ -265,9 +265,9 @@ struct LC_Array
                             //     Example 1: a[0][1][2] and dim =  2 implies a[0][1].length
                             //     Example 2: a[0][1][2] and dim = -1 implies a[0][1][2].length
     LC_Array() : type(Invalid), dim(-1) {}
-    LC_Array(ArrType type, ArrIndex* arrIndex, int dim, OperType oper) : type(type), arrIndex(arrIndex), dim(dim), oper(oper) {}
+    LC_Array(ArrType type, ArrIndex* arrIndex, int dim, OperType oper) : type(type), arrIndex(arrIndex), oper(oper), dim(dim) {}
 
-    LC_Array(ArrType type, ArrIndex* arrIndex, OperType oper) : type(type), arrIndex(arrIndex), dim(-1), oper(oper) {}
+    LC_Array(ArrType type, ArrIndex* arrIndex, OperType oper) : type(type), arrIndex(arrIndex), oper(oper), dim(-1) {}
 
     // Equality operator
     bool operator==(const LC_Array& that) const
@@ -503,8 +503,8 @@ struct LC_Deref
     unsigned level;
 
     LC_Deref(const LC_Array& array, unsigned level)
-        : children(nullptr)
-        , array(array)
+        : array(array)
+        , children(nullptr)
         , level(level)
     { }
 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -161,7 +161,7 @@ public:
     }
 
 void
-RegRecord::init(regNumber reg)
+init(regNumber reg)
 {
 #ifdef _TARGET_ARM64_
     // The Zero register, or the SP
@@ -503,7 +503,7 @@ private:
                                       LSRA_ALWAYS_INSERT_RELOAD         = 0x400,
                                       LSRA_RELOAD_MASK                  = 0x400 };
     LsraReload                  getLsraReload()                 { return (LsraReload) (lsraStressMask & LSRA_RELOAD_MASK); }
-    bool                        alwaysInsertReload()            { return getLsraSpill() == LSRA_ALWAYS_INSERT_RELOAD; }
+    bool                        alwaysInsertReload()            { return getLsraReload() == LSRA_ALWAYS_INSERT_RELOAD; }
 
     // This controls whether we spill everywhere
     enum LsraSpill                  { LSRA_DONT_SPILL_ALWAYS            = 0,

--- a/src/jit/rangecheck.cpp
+++ b/src/jit/rangecheck.cpp
@@ -16,11 +16,11 @@ static const int MAX_VISIT_BUDGET = 8192;
 
 // RangeCheck constructor.
 RangeCheck::RangeCheck(Compiler* pCompiler)
-    : m_pCompiler(pCompiler)
-    , m_pDefTable(nullptr)
+    : m_pOverflowMap(nullptr)
     , m_pRangeMap(nullptr)
-    , m_pOverflowMap(nullptr)
     , m_fMappedDefs(false)
+    , m_pDefTable(nullptr)
+    , m_pCompiler(pCompiler)
     , m_nVisitBudget(MAX_VISIT_BUDGET)
 {
 }
@@ -1020,8 +1020,8 @@ struct Node
     Range range;
     Node* next;
     Node()
-        : next(NULL)
-        , range(Limit(Limit::keUndef)) {}
+        : range(Limit(Limit::keUndef)),
+          next(NULL) {}
 };
 
 // Compute the range recursively by asking for the range of each variable in the dependency chain.

--- a/src/jit/rangecheck.h
+++ b/src/jit/rangecheck.h
@@ -108,8 +108,8 @@ struct Limit
     }
 
     Limit(LimitType type, int cns)
-        : type(type)
-        , cns(cns)
+        : cns(cns),
+          type(type)
     {
         assert(type == keConstant);
     }
@@ -264,14 +264,14 @@ struct Range
     Limit lLimit;
 
     Range(const Limit& limit)
-        : lLimit(limit)
-        , uLimit(limit)
+        : uLimit(limit),
+          lLimit(limit)
     {
     }
 
     Range(const Limit& lLimit, const Limit& uLimit)
-        : lLimit(lLimit)
-        , uLimit(uLimit)
+        : uLimit(uLimit),
+          lLimit(lLimit)
     {
     }
 

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -23,16 +23,16 @@ public:
     GenTree* tree;
     BasicBlock* block;
 
-    Location() : block(nullptr), tree(nullptr) {}
+    Location() : tree(nullptr), block(nullptr) {}
 
-    Location(GenTree* t, BasicBlock* b) : block(b), tree(t)
+    Location(GenTree* t, BasicBlock* b) : tree(t), block(b)
     {
         DBEXEC(TRUE, Validate());
     }
 
     // construct a location consisting of the first tree after the start of the given block
     // (and the corresponding block, which may not be the same as the one passed in)
-    Location(BasicBlock* b) : block(b), tree(nullptr)
+    Location(BasicBlock* b) : tree(nullptr), block(b)
     {
         Initialize();
     }

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -35,8 +35,8 @@ SsaRenameState::SsaRenameState(const jitstd::allocator<int>& alloc, unsigned lva
     , definedLocs(alloc)
     , heapStack(alloc)
     , heapCount(0)
-    , m_alloc(alloc)
     , lvaCount(lvaCount)
+    , m_alloc(alloc)
 {
 }
 

--- a/src/jit/unwindamd64.cpp
+++ b/src/jit/unwindamd64.cpp
@@ -636,9 +636,9 @@ void Compiler::unwindEmitFuncHelper(FuncInfoDsc* func, void* pHotCode, void* pCo
 void Compiler::unwindEmitFunc(FuncInfoDsc* func, void* pHotCode, void* pColdCode)
 {
     // Verify that the JIT enum is in sync with the JIT-EE interface enum
-    static_assert_no_msg(FUNC_ROOT    == CORJIT_FUNC_ROOT);
-    static_assert_no_msg(FUNC_HANDLER == CORJIT_FUNC_HANDLER); 
-    static_assert_no_msg(FUNC_FILTER  == CORJIT_FUNC_FILTER);
+    static_assert_no_msg(FUNC_ROOT    == (FuncKind)CORJIT_FUNC_ROOT);
+    static_assert_no_msg(FUNC_HANDLER == (FuncKind)CORJIT_FUNC_HANDLER); 
+    static_assert_no_msg(FUNC_FILTER  == (FuncKind)CORJIT_FUNC_FILTER);
 
     unwindEmitFuncHelper(func, pHotCode, pColdCode, true);
 


### PR DESCRIPTION
This change fixes some of the warnings in the jitter code on Linux. With this change
combined with an upcoming change in the rest of the codebase, 16 warning disabling
options can be removed.

The issues in the jitter were:
1) Incorrect typedefs for const_reference and const_pointer (the const was ignored)
2) Member initiazalization order in class constructor didn't correspond to the member order in some classes
3) Objects with vtables were copied via memcpy. While this is intentional, cast of the pointers to void*
   is required to silence clang warning
4) Comparing values of different enums - there are cases of two enums containing the same values.
5) Casting int to pointer - the cast was legal (forming a handle), adding cast to size_t in between used to fix the warning
6) "static struct" - removed the static keyword
7) Missing return value in methods with _ASSERTE
8) Class name classifier on methods in the .h
9) Specialized template member functions need to be defined out of the class