### PR TITLE
Update EncodingTable.Unix to support additional encodings

### DIFF
--- a/src/mscorlib/src/System/Globalization/EncodingDataItem.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/EncodingDataItem.Unix.cs
@@ -9,24 +9,38 @@ namespace System.Globalization {
 
     [Serializable]
     internal class CodePageDataItem
-    {   
+    {
+        // TODO: Implement this fully.
+        private readonly string _webName;
+        private readonly int _uiFamilyCodePage;
+        private readonly string _headerName;
+        private readonly string _bodyName;
+        private readonly uint _flags;
+
         [SecurityCritical]
-        unsafe internal CodePageDataItem() {
+        unsafe internal CodePageDataItem(
+            string webName, int uiFamilyCodePage, string headerName,
+            string bodyName, uint flags) {
             // TODO: Implement this fully.
+            _webName = webName;
+            _uiFamilyCodePage = uiFamilyCodePage;
+            _headerName = headerName;
+            _bodyName = bodyName;
+            _flags = flags;
         }
 
         unsafe public String WebName {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
                 // TODO: Implement this fully.
-                return "utf-8";
+                return _webName;
             }
         }
     
         public virtual int UIFamilyCodePage {
             get {
                 // TODO: Implement this fully.
-                return 1200;
+                return _uiFamilyCodePage;
             }
         }
     
@@ -34,7 +48,7 @@ namespace System.Globalization {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
                 // TODO: Implement this fully.
-                return "utf-8";
+                return _headerName;
             }
         }
     
@@ -42,14 +56,14 @@ namespace System.Globalization {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
                 // TODO: Implement this fully.
-                return "utf-8";
+                return _bodyName;
             }
         }    
 
         unsafe public uint Flags {
             get {
                 // TODO: Implement this fully.
-                return 771;
+                return _flags;
             }
         }
 

--- a/src/mscorlib/src/System/Globalization/EncodingTable.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/EncodingTable.Unix.cs
@@ -21,8 +21,14 @@ namespace System.Globalization
         internal static unsafe EncodingInfo[] GetEncodings()
         {
             // TODO: Implement this fully.
-            return new EncodingInfo[] { new EncodingInfo(CodePageUtf8, "utf8", "Unicode (UTF-8)") };
-        }        
+            return new EncodingInfo[] {
+                new EncodingInfo(CodePageUtf7, "utf-7", "Unicode (UTF-7)"),
+                new EncodingInfo(CodePageUtf8, "utf-8", "Unicode (UTF-8)"),
+                new EncodingInfo(CodePageUtf16, "utf-16", "Unicode"),
+                new EncodingInfo(CodePageUtf16BE, "utf-16BE", "Unicode (Big-Endian)"),
+                new EncodingInfo(CodePageUtf32, "utf-32", "Unicode (UTF-32)"),
+            };
+        }
     
         /*=================================GetCodePageFromName==========================
         **Action: Given a encoding name, return the correct code page number for this encoding.
@@ -37,18 +43,59 @@ namespace System.Globalization
         internal static int GetCodePageFromName(String name)
         {
             // TODO: Implement this fully.
-            return CodePageUtf8;
+            switch (name)
+            {
+                case "utf-7":
+                    return CodePageUtf7; 
+
+                case "utf-8":
+                    return CodePageUtf8;
+
+                case "utf-16":
+                    return CodePageUtf16;
+
+                case "utf-16BE":
+                    return CodePageUtf16BE;
+
+                case "utf-32":
+                    return CodePageUtf32;
+
+                default:
+                    return CodePageUtf8;
+            }
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated
         unsafe internal static CodePageDataItem GetCodePageDataItem(int codepage) {
-
             // TODO: Implement this fully.
-            return new CodePageDataItem();
+            switch (codepage)
+            {
+                case CodePageUtf7:
+                    return new CodePageDataItem("utf-7", CodePageUtf7, "utf-7", "utf-7", 771);
+
+                case CodePageUtf8:
+                    return new CodePageDataItem("utf-8", CodePageUtf8, "utf-8", "utf-8", 771);
+
+                case CodePageUtf16:
+                    return new CodePageDataItem("utf-16", CodePageUtf16, "utf-16", "utf-16", 771);
+
+                case CodePageUtf16BE:
+                    return new CodePageDataItem("utf-16BE", CodePageUtf16BE, "utf-16BE", "utf-16BE", 771);
+
+                case CodePageUtf32:
+                    return new CodePageDataItem("utf-32", CodePageUtf32, "utf-32", "utf-32", 771);
+
+                default:
+                    return new CodePageDataItem("utf-8", CodePageUtf8, "utf-8", "utf-8", 771);
+            }
         }
 
         // PAL ends here.
 
+        const int CodePageUtf7 = 65000;
         const int CodePageUtf8 = 65001;
+        const int CodePageUtf16 = 1200;
+        const int CodePageUtf16BE = 1201;
+        const int CodePageUtf32 = 12000;
     }
 }


### PR DESCRIPTION
A variety of tests, in particular XML tests, are using some of the built-in encodings beyond UTF8, e.g. UnicodeEncoding, and are validating information about them, e.g. that an XML document encoded using UnicodeEncoding includes "utf-16" rather than "utf-8" in the output.  This commit augments the temporary globalization implementation with basic knowledge of UTF7, UTF16, UTF16BE, and UTF32.