### PR TITLE
Define PAL_CS_NATIVE_DATA_SIZE for FreeBSD x86_64

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3050,6 +3050,8 @@ PAL_GetLogicalCpuCountFromOS();
 
 #if defined(__FreeBSD__) && defined(_X86_)
 #define PAL_CS_NATIVE_DATA_SIZE 12
+#elif defined(__FreeBSD__) && defined(__x86_64__)
+#define PAL_CS_NATIVE_DATA_SIZE 24
 #elif defined(__sun__)
 #define PAL_CS_NATIVE_DATA_SIZE 48
 #elif defined(__hpux__) && (defined(__hppa__) || defined (__ia64__))


### PR DESCRIPTION
Based on patch from @Aesthetikx which uses the program [defined here](https://github.com/dotnet/coreclr/issues/60#issuecomment-73670124) to determine the correct native size.

Without this patch the following build-error occurs:

    /home/josteink/build/coreclr/src/pal/inc/pal.h:3066:2: error: PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
     #error  PAL_CS_NATIVE_DATA_SIZE is not defined for this architecture
     ^
     /home/josteink/build/coreclr/src/pal/inc/pal.h:3085:34: error: use of undeclared identifier 'PAL_CS_NATIVE_DATA_SIZE'
            BYTE rgNativeDataStorage[PAL_CS_NATIVE_DATA_SIZE];
