### PR TITLE
Fix about 12 kinds of warnings over the codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,26 +264,19 @@ add_definitions(-DDISABLE_CONTRACTS)
 add_compile_options(-ferror-limit=4096)
 
 # Disabled warnings
-add_compile_options(-Wno-reorder)
-add_compile_options(-Wno-ignored-attributes)
 add_compile_options(-Wno-unknown-pragmas)
 add_compile_options(-Wno-unused-private-field)
-add_compile_options(-Wno-new-returns-null)
 add_compile_options(-Wno-dangling-else)
 add_compile_options(-Wno-implicit-exception-spec-mismatch)
-add_compile_options(-Wno-deprecated-register)
+# Using the result of an assignment as a condition without parentheses
 add_compile_options(-Wno-parentheses)
 add_compile_options(-Wno-overloaded-virtual)
 add_compile_options(-Wno-unused-variable)
-add_compile_options(-Wno-missing-declarations)
+# Enum value is not handled in a switch (and there is no default clause)
+# Remaining cases are in JIT only
 add_compile_options(-Wno-switch)
-add_compile_options(-Wno-extern-initializer)
 add_compile_options(-Wno-microsoft)
-add_compile_options(-Wno-mismatched-tags)
-add_compile_options(-Wno-ignored-qualifiers)
-add_compile_options(-Wno-tautological-constant-out-of-range-compare)
-add_compile_options(-Wno-c++11-compat-deprecated-writable-strings)
-add_compile_options(-Wno-unneeded-internal-declaration)
+# This warning is caused by comparing 'this' to NULL
 add_compile_options(-Wno-tautological-compare)
 add_compile_options(-Wno-constant-logical-operand)
 add_compile_options(-Wno-unused-function)
@@ -296,18 +289,17 @@ add_compile_options(-Wno-unknown-warning-option)
 
 #These seem to indicate real issues
 add_compile_options(-Wno-invalid-offsetof)
-add_compile_options(-Wno-return-type)
-add_compile_options(-Wno-dynamic-class-memaccess)
-add_compile_options(-Wno-int-to-pointer-cast)
 add_compile_options(-Wno-delete-non-virtual-dtor)
-add_compile_options(-Wno-enum-compare)
+# The following warning indicates that an attribute __attribute__((__ms_struct__)) was applied 
+# to a struct or a class that has virtual members or a base class. In that case, clang
+# may not generate the same object layout as MSVC.
+add_compile_options(-Wno-incompatible-ms-struct)
 
 # The -fms-extensions enable the stuff like __if_exists, __declspec(uuid()), etc.
 add_compile_options(-fms-extensions )
 #-fms-compatibility      Enable full Microsoft Visual C++ compatibility
 #-fms-extensions         Accept some non-standard constructs supported by the Microsoft compiler
-# The newer version of clang hits this seemly benign error that this disables.
-add_compile_options(-Wno-incompatible-ms-struct)
+
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(src/debug/debug-pal)

--- a/src/ToolBox/SOS/Strike/sos.h
+++ b/src/ToolBox/SOS/Strike/sos.h
@@ -554,7 +554,7 @@ namespace sos
          */
         inline operator void *() const
         {
-            return (void*)(mCurrHeap == mNumHeaps ? 0 : 1);
+            return (void*)(SIZE_T)(mCurrHeap == mNumHeaps ? 0 : 1);
         }
 
         /* Do not use.
@@ -723,7 +723,7 @@ namespace sos
 
         inline operator void *() const
         {
-            return (void*)(mCurr <= mTotal ? 1 : 0);
+            return (void*)(SIZE_T)(mCurr <= mTotal ? 1 : 0);
         }
 
     private:

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -820,7 +820,7 @@ namespace Output
                 char buffer[64];
                 if (mFormat == Formats::Default || mFormat == Formats::Pointer)
                 {
-                    sprintf_s(buffer, _countof(buffer), "%p", (int *)mValue);
+                    sprintf_s(buffer, _countof(buffer), "%p", (int *)(SIZE_T)mValue);
                     ConvertToLower(buffer, _countof(buffer));
                 }
                 else

--- a/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
@@ -118,7 +118,7 @@ typedef class IDebugControl2* PDEBUG_CONTROL2;
 // IDebugDataSpaces
 //----------------------------------------------------------------------------
 
-class IDebugDataSpaces
+struct IDebugDataSpaces
 {
 public:
     virtual HRESULT ReadVirtual(
@@ -128,7 +128,7 @@ public:
         PULONG bytesRead) = 0;
 };
 
-typedef class IDebugDataSpaces* PDEBUG_DATA_SPACES;
+typedef IDebugDataSpaces* PDEBUG_DATA_SPACES;
 
 //----------------------------------------------------------------------------
 // IDebugSymbols

--- a/src/classlibnative/inc/nlsinfo.h
+++ b/src/classlibnative/inc/nlsinfo.h
@@ -156,7 +156,7 @@ public:
     static FCDECL6(INT32, InternalGetCaseInsHash, INT_PTR handle, INT_PTR handleOrigin, StringObject* localeNameUNSAFE, LPVOID strA, CLR_BOOL bForceRandomizedHashing, INT64 additionalEntropy);
     static INT32 QCALLTYPE InternalCompareStringOrdinalIgnoreCase(LPCWSTR string1, INT32 index1, LPCWSTR string2, INT32 index2, INT32 length1, INT32 length2);
 
-    static BOOL QCALLTYPE COMNlsInfo::InternalTryFindStringOrdinalIgnoreCase(
+    static BOOL QCALLTYPE InternalTryFindStringOrdinalIgnoreCase(
         __in                   DWORD       dwFindNLSStringFlags, // mutually exclusive flags: FIND_FROMSTART, FIND_STARTSWITH, FIND_FROMEND, FIND_ENDSWITH
         __in_ecount(cchSource) LPCWSTR     lpStringSource,       // the string we search in
         __in                   int         cchSource,            // number of characters lpStringSource after sourceIndex

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -7468,13 +7468,13 @@ STDAPI CLRDataAccessCreateInstance(ICLRDataTarget * pLegacyTarget,
 // This is the legacy entrypoint to DAC, used by dbgeng/dbghelp (windbg, SOS, watson, etc).
 //
 //----------------------------------------------------------------------------
+#ifdef __llvm__
+__attribute__((used))
+#endif // __llvm__
 STDAPI
 CLRDataCreateInstance(REFIID iid,
                       ICLRDataTarget * pLegacyTarget,
                       void ** iface)
-#ifdef __llvm__
-__attribute__((used))
-#endif // __llvm__
 {
     if ((pLegacyTarget == NULL) || (iface == NULL))
     {

--- a/src/debug/daccess/dacdbiimpl.h
+++ b/src/debug/daccess/dacdbiimpl.h
@@ -286,9 +286,9 @@ public:
     VMPTR_TypeHandle GetApproxTypeHandle(TypeInfoList * pTypeData);
 
     // Get the exact type handle from type data
-    HRESULT DacDbiInterfaceImpl::GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
-                                                    ArgInfoList *   pArgInfo,
-                                                    VMPTR_TypeHandle& vmTypeHandle);
+    HRESULT GetExactTypeHandle(DebuggerIPCE_ExpandedTypeData * pTypeData,
+                               ArgInfoList *   pArgInfo,
+                               VMPTR_TypeHandle& vmTypeHandle);
 
     // Retrieve the generic type params for a given MethodDesc.  This function is specifically 
     // for stackwalking because it requires the generic type token on the stack.

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -1473,9 +1473,9 @@ public:
                                              __out_ecount(cchPath) LPWSTR wszPath,
                                              const DWORD cchPath);
 #if defined(FEATURE_CORESYSTEM)
-    static bool ClrDataAccess::GetILImageNameFromNgenImage(LPCWSTR ilExtension,
-                                                 __out_ecount(cchFilePath) LPWSTR wszFilePath,
-                                                 const DWORD cchFilePath);
+    static bool GetILImageNameFromNgenImage(LPCWSTR ilExtension,
+                                            __out_ecount(cchFilePath) LPWSTR wszFilePath,
+                                            const DWORD cchFilePath);
 #endif // FEATURE_CORESYSTEM
 };
 

--- a/src/debug/daccess/fntableaccess.cpp
+++ b/src/debug/daccess/fntableaccess.cpp
@@ -438,6 +438,8 @@ extern "C" NTSTATUS OutOfProcessFunctionTableCallbackEx(IN  ReadMemoryFunction  
                 pnEntries,
                 ppFunctions);
 #endif // DEBUGSUPPORT_STUBS_HAVE_UNWIND_INFO
+    default:
+        break;
     }
 
     return STATUS_UNSUCCESSFUL;

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -2836,7 +2836,7 @@ IMetaDataImport2 * NativeImageDumper::TypeToString(PTR_CCOR_SIGNATURE &sig,
     {
         buf.AppendPrintf( "%s", elementNames[type] );
     }
-    else switch (type)
+    else switch ((DWORD)type)
     {
     case ELEMENT_TYPE_CANON_ZAPSIG:
         buf.Append( W("System.__Canon") );

--- a/src/debug/di/module.cpp
+++ b/src/debug/di/module.cpp
@@ -2790,10 +2790,10 @@ BOOL CordbModule::IsWinMD()
 CordbCode::CordbCode(CordbFunction * pFunction, UINT_PTR id, SIZE_T encVersion, BOOL fIsIL)
   : CordbBase(pFunction->GetProcess(), id, enumCordbCode),
     m_fIsIL(fIsIL),
-    m_pFunction(pFunction),
     m_nVersion(encVersion),
     m_rgbCode(NULL),
-    m_continueCounterLastSync(0)
+    m_continueCounterLastSync(0),
+    m_pFunction(pFunction)
 {
     _ASSERTE(pFunction != NULL);
     _ASSERTE(m_nVersion >= CorDB_DEFAULT_ENC_FUNCTION_VERSION);

--- a/src/debug/di/rsenumerator.hpp
+++ b/src/debug/di/rsenumerator.hpp
@@ -71,8 +71,8 @@ CordbEnumerator<ElemType,
                                                 ElemType *items,
                                                 DWORD countItems) :
 CordbBase(pProcess, 0, enumCordbEnumerator),
-m_nextIndex(0),
-m_countItems(countItems)
+m_countItems(countItems),
+m_nextIndex(0)
 {
     m_items = new ElemType[countItems];
     for(UINT i = 0; i < countItems; i++)

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -3380,7 +3380,7 @@ inline void * __cdecl operator new[](size_t n, const InteropSafe&)
     return result;
 }
 
-inline void * __cdecl operator new(size_t n, const InteropSafe&, const NoThrow&)
+inline void * __cdecl operator new(size_t n, const InteropSafe&, const NoThrow&) throw()
 {
     CONTRACTL
     {
@@ -3399,7 +3399,7 @@ inline void * __cdecl operator new(size_t n, const InteropSafe&, const NoThrow&)
     return result;
 }
 
-inline void * __cdecl operator new[](size_t n, const InteropSafe&, const NoThrow&)
+inline void * __cdecl operator new[](size_t n, const InteropSafe&, const NoThrow&) throw()
 {
     CONTRACTL
     {
@@ -3505,7 +3505,7 @@ inline void * __cdecl operator new(size_t n, const InteropSafeExecutable&)
     return result;
 }
 
-inline void * __cdecl operator new(size_t n, const InteropSafeExecutable&, const NoThrow&)
+inline void * __cdecl operator new(size_t n, const InteropSafeExecutable&, const NoThrow&) throw()
 {
     CONTRACTL
     {

--- a/src/dlls/mscordac/mscordac.cpp
+++ b/src/dlls/mscordac/mscordac.cpp
@@ -10,11 +10,11 @@
 //
 // This dummy reference to CLRDataCreateInstance prevents the LLVM toolchain from optimizing this important export out.
 //
-void
-DummyReferenceToExportedAPI()
 #ifdef __llvm__
 __attribute__((used))
 #endif // __llvm__
+void
+DummyReferenceToExportedAPI()
 {
     CLRDataCreateInstance(IID_ICLRDataTarget, NULL, NULL);
 }

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -284,7 +284,7 @@ void GCStatistics::DisplayAndUpdate()
         fflush(logFile);
     }
 
-    memcpy(&g_LastGCStatistics, this, sizeof(g_LastGCStatistics));
+    g_LastGCStatistics = *this;
 
     ngc.Reset();
     fgc.Reset();
@@ -5643,7 +5643,7 @@ void void_allocation (alloc_context* acontext)
 
 void gc_heap::fix_allocation_contexts (BOOL for_gc_p)
 {
-    CNameSpace::GcFixAllocContexts ((void*)for_gc_p, __this);
+    CNameSpace::GcFixAllocContexts ((void*)(size_t)for_gc_p, __this);
     fix_youngest_allocation_area (for_gc_p);
     fix_large_allocation_area (for_gc_p);
 }

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -1767,7 +1767,7 @@ protected:
     PER_HEAP
     BOOL is_mark_bit_set (BYTE* add);
     PER_HEAP
-    void gc_heap::gmark_array_set_marked (BYTE* add);
+    void gmark_array_set_marked (BYTE* add);
     PER_HEAP
     void set_mark_array_bit (size_t mark_bit);
     PER_HEAP

--- a/src/inc/dacprivate.h
+++ b/src/inc/dacprivate.h
@@ -874,7 +874,7 @@ struct DacpJitManagerInfo : ZeroInit<DacpJitManagerInfo>
     CLRDATA_ADDRESS ptrHeapList;    // A HeapList * if IsMiIL(codeType)
 };
 
-typedef enum CodeHeapType {CODEHEAP_LOADER=0,CODEHEAP_HOST,CODEHEAP_UNKNOWN};
+enum CodeHeapType {CODEHEAP_LOADER=0,CODEHEAP_HOST,CODEHEAP_UNKNOWN};
 
 struct DacpJitCodeHeapInfo : ZeroInit<DacpJitCodeHeapInfo>
 {

--- a/src/inc/debugmacros.h
+++ b/src/inc/debugmacros.h
@@ -241,13 +241,13 @@ namespace clr
         template < typename T >
         void PoisonMem(T &val)
         {
-            ZeroMemory(&val, sizeof(T));
+            ZeroMemory((void*)&val, sizeof(T));
         }
 
         template < typename T >
         void PoisonMem(T* ptr, size_t len)
         {
-            ZeroMemory(ptr, sizeof(T) * len);
+            ZeroMemory((void*)ptr, sizeof(T)* len);
         }
     }
 }

--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -465,11 +465,11 @@ bool EnumGcRefs(PREGDISPLAY     pContext,
 #ifdef FEATURE_CONSERVATIVE_GC
 // Temporary conservative collection, for testing purposes, until we have
 // accurate gc info from the JIT.
-bool EECodeManager::EnumGcRefsConservative(PREGDISPLAY     pRD,
-                                           EECodeInfo     *pCodeInfo,
-                                           unsigned        flags,
-                                           GCEnumCallback  pCallBack,
-                                           LPVOID          hCallBack);
+bool EnumGcRefsConservative(PREGDISPLAY     pRD,
+                            EECodeInfo     *pCodeInfo,
+                            unsigned        flags,
+                            GCEnumCallback  pCallBack,
+                            LPVOID          hCallBack);
 #endif // FEATURE_CONSERVATIVE_GC
 
 /*

--- a/src/inc/holder.h
+++ b/src/inc/holder.h
@@ -658,6 +658,18 @@ class BaseWrapper : public BaseHolder<TYPE, BASE, DEFAULTVALUE, IS_NULL, VALIDAT
     {
         return !!(this->m_value != TYPE(value));
     }
+#ifdef __llvm__
+    // This handles the NULL value that is an int and clang
+    // doesn't want to convert int to a pointer
+    FORCEINLINE bool operator==(int value) const
+    {
+        return !!(this->m_value == TYPE((void*)(SIZE_T)value));
+    }
+    FORCEINLINE bool operator!=(int value) const
+    {
+        return !!(this->m_value != TYPE((void*)(SIZE_T)value));
+    }
+#endif // __llvm__
     FORCEINLINE const TYPE &operator->() const
     {
         return this->m_value;

--- a/src/inc/simplerhash.h
+++ b/src/inc/simplerhash.h
@@ -201,7 +201,7 @@ class SimplerHashTable
   private:
 
     // Forward declaration of the linked-list node class.
-    class Node;
+    struct Node;
 
     // If the table has a mapping for "k", return the node containing
     // that mapping, else "NULL".
@@ -408,7 +408,7 @@ class SimplerHashTable
         Key   m_key;
         Value m_val;
 
-        Node(Key k, Value v, Node* next): m_key(k), m_val(v), m_next(next) {}
+        Node(Key k, Value v, Node* next) : m_next(next), m_key(k), m_val(v) {}
 
         void* operator new(size_t sz, IAllocator* alloc)
         {

--- a/src/inc/simplerhash.inl
+++ b/src/inc/simplerhash.inl
@@ -46,8 +46,8 @@ template <typename Key, typename KeyFuncs, typename Value, typename Behavior>
 SimplerHashTable<Key,KeyFuncs,Value,Behavior>::SimplerHashTable(IAllocator* alloc)
   : m_alloc(alloc),
     m_table(NULL),
-    m_tableCount(0),
     m_tableSizeInfo(),
+    m_tableCount(0),
     m_tableMax(0)
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/inc/stresslog.h
+++ b/src/inc/stresslog.h
@@ -331,49 +331,49 @@ public:
     static void LogMsgOL(const char* format, T1 data1)
     {
         static_assert_no_msg(sizeof(T1) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 1, format, (void*)data1); 
+        LogMsg(LL_ALWAYS, LF_GC, 1, format, (void*)(size_t)data1);
     }
 
     template < typename T1, typename T2 >
     static void LogMsgOL(const char* format, T1 data1, T2 data2)
     {
         static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 2, format, (void*)data1, (void*)data2); 
+        LogMsg(LL_ALWAYS, LF_GC, 2, format, (void*)(size_t)data1, (void*)(size_t)data2);
     }
 
     template < typename T1, typename T2, typename T3 >
     static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3)
     { 
         static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 3, format, (void*)data1, (void*)data2, (void*)data3); 
+        LogMsg(LL_ALWAYS, LF_GC, 3, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3);
     }
 
     template < typename T1, typename T2, typename T3, typename T4 >
     static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4)
     { 
         static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 4, format, (void*)data1, (void*)data2, (void*)data3, (void*)data4); 
+        LogMsg(LL_ALWAYS, LF_GC, 4, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4);
     }
 
     template < typename T1, typename T2, typename T3, typename T4, typename T5 >
     static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5)
     { 
         static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 5, format, (void*)data1, (void*)data2, (void*)data3, (void*)data4, (void*)data5); 
+        LogMsg(LL_ALWAYS, LF_GC, 5, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5);
     }
 
     template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6 >
     static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6)
     { 
         static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 6, format, (void*)data1, (void*)data2, (void*)data3, (void*)data4, (void*)data5, (void*)data6); 
+        LogMsg(LL_ALWAYS, LF_GC, 6, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6);
     }
 
     template < typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7 >
     static void LogMsgOL(const char* format, T1 data1, T2 data2, T3 data3, T4 data4, T5 data5, T6 data6, T7 data7)
     { 
         static_assert_no_msg(sizeof(T1) <= sizeof(void*) && sizeof(T2) <= sizeof(void*) && sizeof(T3) <= sizeof(void*) && sizeof(T4) <= sizeof(void*) && sizeof(T5) <= sizeof(void*) && sizeof(T6) <= sizeof(void*) && sizeof(T7) <= sizeof(void*)); 
-        LogMsg(LL_ALWAYS, LF_GC, 7, format, (void*)data1, (void*)data2, (void*)data3, (void*)data4, (void*)data5, (void*)data6, (void*)data7); 
+        LogMsg(LL_ALWAYS, LF_GC, 7, format, (void*)(size_t)data1, (void*)(size_t)data2, (void*)(size_t)data3, (void*)(size_t)data4, (void*)(size_t)data5, (void*)(size_t)data6, (void*)(size_t)data7); 
     }
 
 #ifdef _MSC_VER
@@ -460,7 +460,7 @@ struct StressLogChunk
 #if !defined(STRESS_LOG_READONLY)
     static HANDLE s_LogChunkHeap; 
 
-    void * operator new (size_t)
+    void * operator new (size_t) throw()
     {
         if (IsInCantAllocStressLogRegion ())
         {

--- a/src/md/compiler/importhelper.h
+++ b/src/md/compiler/importhelper.h
@@ -23,7 +23,7 @@ class ImportHelper
 {
 public:
     // Options for code:FindMemberRef.
-    typedef enum HashSearchOption
+    enum HashSearchOption
     {
         DoNotCreateHash,    // Do not create hash if it does not exist (faster for isolated calls)
         CreateHash          // Create hash if it does not exist (faster for multiple calls)

--- a/src/md/datasource/targettypes.h
+++ b/src/md/datasource/targettypes.h
@@ -64,7 +64,11 @@ public:
 private:
     // don't copy this type - avoids needing to deep copy m_pColDefs
     Target_CMiniTableDef(const Target_CMiniTableDef & rhs) { _ASSERTE(!"Don't copy"); }
-    Target_CMiniTableDef & operator=(const Target_CMiniTableDef &) { _ASSERTE(!"Don't copy"); }
+    Target_CMiniTableDef & operator=(const Target_CMiniTableDef &) 
+    { 
+        _ASSERTE(!"Don't copy"); 
+        return *this;
+    }
 };
 
 class Target_CMiniMdBase : public TargetObject

--- a/src/md/inc/metamodelrw.h
+++ b/src/md/inc/metamodelrw.h
@@ -583,7 +583,7 @@ public:
     VOID OrganizeStringPool(CorProfileData *pProfileData);
     
     // Result of hash search
-    typedef enum HashSearchResult
+    enum HashSearchResult
     {
         Found,      // Item was found.
         NotFound,   // Item not found.

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -164,7 +164,6 @@ extern "C" {
 #endif // CORECLR
 #endif // !_MSC_VER
 
-
 #if defined(_MSC_VER) || defined(__llvm__)
 #define DECLSPEC_ALIGN(x)   __declspec(align(x))
 #else
@@ -744,8 +743,12 @@ GenerateConsoleCtrlEvent(
 
 // From win32.h
 #ifndef _CRTIMP
+#ifdef __llvm__
+#define _CRTIMP
+#else // __llvm__
 #define _CRTIMP __declspec(dllimport)
-#endif
+#endif // __llvm__
+#endif // _CRTIMP
 
 /******************* winbase.h Entrypoints and defines ************************/
 PALIMPORT

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -309,7 +309,8 @@ typedef signed __int64 LONG64;
 
 #if _WIN64
 
-#define _atoi64 atol
+// UNIXTODO: Implement proper _atoi64, the atol returns 32 bit result
+#define _atoi64 (__int64)atol
 
 typedef __int64 INT_PTR, *PINT_PTR;
 typedef unsigned __int64 UINT_PTR, *PUINT_PTR;

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1089,6 +1089,8 @@ inline int __cdecl _sscanf_unsafe(const char *_Dst, const char *_Format,...)
 
     ret = sscanf(_Dst, _Format, _ArgList);
     va_end(_ArgList);
+
+    return ret;
 }
 
 inline errno_t __cdecl _wfopen_unsafe(FILE * *ff, const wchar_t *fileName, const wchar_t *mode)

--- a/src/pal/inc/rt/rpc.h
+++ b/src/pal/inc/rt/rpc.h
@@ -21,7 +21,7 @@
 #define __RPC_FAR
 
 #define DECLSPEC_UUID(x) __declspec(uuid(x))
-#define MIDL_INTERFACE(x)   struct DECLSPEC_UUID(x) __declspec(novtable)
+#define MIDL_INTERFACE(x)   struct DECLSPEC_UUID(x)
 
 #define EXTERN_GUID(itf,l1,s1,s2,c1,c2,c3,c4,c5,c6,c7,c8) \
     EXTERN_C const IID DECLSPEC_SELECTANY itf = {l1,s1,s2,{c1,c2,c3,c4,c5,c6,c7,c8}}

--- a/src/pal/prebuilt/inc/sospriv.h
+++ b/src/pal/prebuilt/inc/sospriv.h
@@ -134,8 +134,8 @@ typedef int ModuleMapType;
 typedef int VCSHeapType;
 
 #endif
-typedef enum ModuleMapType { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE };
-typedef enum VCSHeapType {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap};
+enum ModuleMapType { TYPEDEFTOMETHODTABLE, TYPEREFTOMETHODTABLE };
+enum VCSHeapType {IndcellHeap, LookupHeap, ResolveHeap, DispatchHeap, CacheEntryHeap};
 typedef void ( *MODULEMAPTRAVERSE )( 
     UINT index,
     CLRDATA_ADDRESS methodTable,

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -533,7 +533,6 @@ static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
     check_pal_initialize(code);
     sigset_t signal_set;
     CONTEXT context;
-    CPalThread *pthrCurrent = InternalGetCurrentThread();
 
     // Fill context record with required information. from pal.h :
     // On non-Win32 platforms, the CONTEXT pointer in the

--- a/src/unwinder/amd64/unwinder_amd64.cpp
+++ b/src/unwinder/amd64/unwinder_amd64.cpp
@@ -92,8 +92,8 @@ public:
 
     // Construct the InstructionBuffer for the given address in the target process
     InstructionBuffer(SIZE_T address)
-      : m_address(address),
-        m_offset(0)
+      : m_offset(0),
+        m_address(address)
     {
         HRESULT hr = Load();
         if (FAILED(hr))

--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -647,7 +647,7 @@ IExecutionEngine *GetExecutionEngine()
         // Create a local copy on the stack and then copy it over to the static instance.
         // This avoids race conditions caused by multiple initializations of vtable in the constructor
         UtilExecutionEngine local;
-        memcpy(&g_ExecutionEngineInstance, &local, sizeof(UtilExecutionEngine));
+        memcpy((void*)&g_ExecutionEngineInstance, (void*)&local, sizeof(UtilExecutionEngine));
         pExecutionEngine = (IExecutionEngine*)(UtilExecutionEngine*)&g_ExecutionEngineInstance;
 #else
         // statically linked.

--- a/src/utilcode/ex.cpp
+++ b/src/utilcode/ex.cpp
@@ -47,7 +47,7 @@ Exception * Exception::GetOOMException()
         // This avoids race conditions caused by multiple initializations of vtable in the constructor       
 
         OutOfMemoryException local(TRUE);  // Construct a "preallocated" instance.
-        memcpy(&g_OOMExceptionInstance, &local, sizeof(OutOfMemoryException));           
+        memcpy((void*)&g_OOMExceptionInstance, (void*)&local, sizeof(OutOfMemoryException));
 
         g_OOMException = (OutOfMemoryException*)&g_OOMExceptionInstance;
     }

--- a/src/utilcode/makepath.cpp
+++ b/src/utilcode/makepath.cpp
@@ -40,7 +40,7 @@
 *******************************************************************************/
 
 void MakePath (
-        __out_ecount (MAX_PATH) register WCHAR *path,
+        __out_ecount (MAX_PATH) WCHAR *path,
         __in LPCWSTR drive,
         __in LPCWSTR dir,
         __in LPCWSTR fname,
@@ -55,8 +55,8 @@ void MakePath (
         }
         CONTRACTL_END
 
-        register const WCHAR *p;
-        register DWORD count = 0;
+        const WCHAR *p;
+        DWORD count = 0;
 
         /* we assume that the arguments are in the following form (although we
          * do not diagnose invalid arguments or illegal filenames (such as

--- a/src/utilcode/sigparser.cpp
+++ b/src/utilcode/sigparser.cpp
@@ -32,7 +32,7 @@ HRESULT SigParser::SkipExactlyOne()
         
     if (!CorIsPrimitiveType(typ))
     {
-        switch (typ)
+        switch ((DWORD)typ)
         {
             default:
                 // _ASSERT(!"Illegal or unimplement type in COM+ sig.");

--- a/src/utilcode/splitpath.cpp
+++ b/src/utilcode/splitpath.cpp
@@ -43,7 +43,7 @@
 *******************************************************************************/
 
 void SplitPath(
-        register const WCHAR *path,
+        const WCHAR *path,
         __inout_z __inout_ecount_opt(driveSizeInWords) WCHAR *drive, int driveSizeInWords,
         __inout_z __inout_ecount_opt(dirSizeInWords) WCHAR *dir, int dirSizeInWords,
         __inout_z __inout_ecount_opt(fnameSizeInWords) WCHAR *fname, size_t fnameSizeInWords,
@@ -91,7 +91,7 @@ void    SplitPathInterior(
     _ASSERTE(!!pwszFileName == !!pcchFileName);
     _ASSERTE(!!pwszExt == !!pcchExt);
 
-    register WCHAR *p;
+    WCHAR *p;
     LPCWSTR last_slash = NULL, dot = NULL;
 
     /* we assume that the path argument has the following form, where any

--- a/src/utilcode/util_nodependencies.cpp
+++ b/src/utilcode/util_nodependencies.cpp
@@ -18,9 +18,9 @@
 
 #if !defined(FEATURE_UTILCODE_NO_DEPENDENCIES) || defined(_DEBUG)
 
-extern RunningOnStatusEnum gRunningOnStatus = RUNNING_ON_STATUS_UNINITED;
-extern BOOL gExInfoAvailable = FALSE;
-extern BOOL gExInfoIsServer = TRUE;
+RunningOnStatusEnum gRunningOnStatus = RUNNING_ON_STATUS_UNINITED;
+BOOL gExInfoAvailable = FALSE;
+BOOL gExInfoIsServer = TRUE;
 
 #define NON_SUPPORTED_PLATFORM_MSGBOX_TITLE             W("Platform not supported")
 #define NON_SUPPORTED_PLATFORM_MSGBOX_TEXT              W("The minimum supported platform is Windows 2000")

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -439,7 +439,7 @@ inline BOOL IsUnmanagedValueTypeReturnedByRef(UINT sizeofvaluetype)
 }
 
 #include <pshpack1.h>
-DECLSPEC_ALIGN(8) struct UMEntryThunkCode
+struct DECLSPEC_ALIGN(8) UMEntryThunkCode
 {
     // padding                  // CC CC CC CC
     // mov r10, pUMEntryThunk   // 49 ba xx xx xx xx xx xx xx xx    // METHODDESC_REGISTER

--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -140,7 +140,6 @@ Assembly::Assembly(BaseDomain *pDomain, PEAssembly* pFile, DebuggerAssemblyContr
     m_pbStrongNameKeyPair(NULL),
     m_pwStrongNameKeyContainer(NULL),
     m_isDynamic(false),
-    m_isDisabledPrivateReflection(0),
 #ifdef FEATURE_COLLECTIBLE_TYPES
     m_isCollectible(fIsCollectible),
 #endif
@@ -148,6 +147,7 @@ Assembly::Assembly(BaseDomain *pDomain, PEAssembly* pFile, DebuggerAssemblyContr
     m_dwDynamicAssemblyAccess(ASSEMBLY_ACCESS_RUN),
     m_nextAvailableModuleIndex(1),
     m_pLoaderAllocator(NULL),
+    m_isDisabledPrivateReflection(0),
 #ifdef FEATURE_COMINTEROP
     m_pITypeLib(NULL),
     m_winMDStatus(WinMDStatus_Unknown),

--- a/src/vm/assemblynative.hpp
+++ b/src/vm/assemblynative.hpp
@@ -281,7 +281,7 @@ public:
     static void QCALLTYPE LoadFromPath(INT_PTR ptrNativeAssemblyLoadContext, LPCWSTR pwzILPath, LPCWSTR pwzNIPath, QCall::ObjectHandleOnStack retLoadedAssembly);
     static void QCALLTYPE LoadFromStream(INT_PTR ptrNativeAssemblyLoadContext, INT_PTR ptrAssemblyArray, INT32 cbAssemblyArrayLength, INT_PTR ptrSymbolArray, INT32 cbSymbolArrayLength, QCall::ObjectHandleOnStack retLoadedAssembly);
     static Assembly* LoadFromPEImage(CLRPrivBinderAssemblyLoadContext* pBinderContext, PEImage *pILImage, PEImage *pNIImage);
-    static INT_PTR QCALLTYPE AssemblyNative::GetLoadContextForAssembly(QCall::AssemblyHandle pAssembly);
+    static INT_PTR QCALLTYPE GetLoadContextForAssembly(QCall::AssemblyHandle pAssembly);
 };
 
 #endif

--- a/src/vm/customattribute.cpp
+++ b/src/vm/customattribute.cpp
@@ -1171,7 +1171,7 @@ TypeHandle COMCustomAttribute::GetTypeHandleFromBlob(Assembly *pCtorAssembly,
     TypeHandle nullTH;
     TypeHandle RtnTypeHnd;
 
-    switch (objType) {
+    switch ((DWORD)objType) {
     case SERIALIZATION_TYPE_BOOLEAN:
     case SERIALIZATION_TYPE_I1:
     case SERIALIZATION_TYPE_U1:
@@ -1333,7 +1333,7 @@ void COMCustomAttribute::ReadArray(Assembly *pCtorAssembly,
     
     ARG_SLOT element = 0;
 
-    switch (arrayType) {
+    switch ((DWORD)arrayType) {
     case SERIALIZATION_TYPE_BOOLEAN:
     case SERIALIZATION_TYPE_I1:
     case SERIALIZATION_TYPE_U1:
@@ -1457,7 +1457,7 @@ ARG_SLOT COMCustomAttribute::GetDataFromBlob(Assembly *pCtorAssembly,
     TypeHandle nullTH;
     TypeHandle typeHnd;
 
-    switch (type) {
+    switch ((DWORD)type) {
 
     case SERIALIZATION_TYPE_BOOLEAN:
     case SERIALIZATION_TYPE_I1:

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -2602,6 +2602,10 @@ BOOL DomainAssembly::ShouldLoadDomainNeutralHelper()
 
     case AppDomain::SHARE_POLICY_NEVER:
         return FALSE;
+
+    case AppDomain::SHARE_POLICY_UNSPECIFIED:
+    case AppDomain::SHARE_POLICY_COUNT:
+        break;
     }
     
     return FALSE; // No meaning in doing costly closure walk for CoreCLR.

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7617,7 +7617,7 @@ bool ShouldHandleManagedFault(
 
 LONG WINAPI CLRVectoredExceptionHandlerPhase2(PEXCEPTION_POINTERS pExceptionInfo);
 
-typedef enum VEH_ACTION
+enum VEH_ACTION
 {
     VEH_NO_ACTION = 0,
     VEH_EXECUTE_HANDLE_MANAGED_EXCEPTION,

--- a/src/vm/fcall.cpp
+++ b/src/vm/fcall.cpp
@@ -28,7 +28,7 @@ NOINLINE LPVOID __FCThrow(LPVOID __me, RuntimeExceptionKind reKind, UINT resID, 
 
     // side effect the compiler can't remove
     if (FC_NO_TAILCALL != 1)
-        return (LPVOID)(FC_NO_TAILCALL + 1);
+        return (LPVOID)(SIZE_T)(FC_NO_TAILCALL + 1);
 
     FC_CAN_TRIGGER_GC();
     INCONTRACT(FCallCheck __fCallCheck(__FILE__, __LINE__));
@@ -72,7 +72,7 @@ NOINLINE LPVOID __FCThrowArgument(LPVOID __me, RuntimeExceptionKind reKind, LPCW
 
     // side effect the compiler can't remove
     if (FC_NO_TAILCALL != 1)
-        return (LPVOID)(FC_NO_TAILCALL + 1);
+        return (LPVOID)(SIZE_T)(FC_NO_TAILCALL + 1);
 
     FC_CAN_TRIGGER_GC();
     INCONTRACT(FCallCheck __fCallCheck(__FILE__, __LINE__));

--- a/src/vm/ilstubcache.cpp
+++ b/src/vm/ilstubcache.cpp
@@ -207,7 +207,8 @@ MethodDesc* ILStubCache::CreateNewMethodDesc(LoaderHeap* pCreationHeap, MethodTa
 
     pMD->m_pResolver = (ILStubResolver*)pamTracker->Track(pCreationHeap->AllocMem(S_SIZE_T(sizeof(ILStubResolver))));
 #ifdef _DEBUG
-    memset(pMD->m_pResolver, 0xCC, sizeof(ILStubResolver));
+    // Poison the ILStubResolver storage
+    memset((void*)pMD->m_pResolver, 0xCC, sizeof(ILStubResolver));
 #endif // _DEBUG
     pMD->m_pResolver = new (pMD->m_pResolver) ILStubResolver();
 

--- a/src/vm/ilstubresolver.cpp
+++ b/src/vm/ilstubresolver.cpp
@@ -296,8 +296,8 @@ MethodDesc* ILStubResolver::GetStubMethodDesc()
 
 ILStubResolver::ILStubResolver() : 
     m_pCompileTimeState(dac_cast<PTR_CompileTimeState>(ILNotYetGenerated)),
-    m_pStubMD(dac_cast<PTR_MethodDesc>(NULL)),
-    m_pStubTargetMD(dac_cast<PTR_MethodDesc>(NULL)),
+    m_pStubMD(dac_cast<PTR_MethodDesc>(nullptr)),
+    m_pStubTargetMD(dac_cast<PTR_MethodDesc>(nullptr)),
     m_type(Unassigned),
     m_dwJitFlags(0)
 {

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -370,7 +370,7 @@ class Object
         return (psb && psb->IsAppDomainAgile());
     }
 
-    BOOL Object::IsCheckedForAppDomainAgile()
+    BOOL IsCheckedForAppDomainAgile()
     {
         WRAPPER_NO_CONTRACT;
 
@@ -378,7 +378,7 @@ class Object
         return (psb && psb->IsCheckedForAppDomainAgile());
     }
 
-    void Object::SetIsCheckedForAppDomainAgile()
+    void SetIsCheckedForAppDomainAgile()
     {
         WRAPPER_NO_CONTRACT;
 

--- a/src/vm/pefile.inl
+++ b/src/vm/pefile.inl
@@ -320,12 +320,12 @@ inline PTR_PEAssembly PEFile::AsAssembly()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    if (this == NULL)
-        return dac_cast<PTR_PEAssembly>(NULL);
+    if (this == nullptr)
+        return dac_cast<PTR_PEAssembly>(nullptr);
     if (IsAssembly())
         return dac_cast<PTR_PEAssembly>(this);
     else
-        return dac_cast<PTR_PEAssembly>(NULL);
+        return dac_cast<PTR_PEAssembly>(nullptr);
 }
 
 inline BOOL PEFile::IsModule() const
@@ -340,12 +340,12 @@ inline PTR_PEModule PEFile::AsModule()
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
-    if (this == NULL)
-        return dac_cast<PTR_PEModule>(NULL);
+    if (this == nullptr)
+        return dac_cast<PTR_PEModule>(nullptr);
     if (IsModule())
         return dac_cast<PTR_PEModule>(this);
     else
-        return dac_cast<PTR_PEModule>(NULL);
+        return dac_cast<PTR_PEModule>(nullptr);
 }
 
 inline BOOL PEFile::IsSystem() const

--- a/src/vm/stackingallocator.cpp
+++ b/src/vm/stackingallocator.cpp
@@ -344,7 +344,7 @@ void * __cdecl operator new[](size_t n, StackingAllocator * alloc)
     return retval;
 }
 
-void * __cdecl operator new(size_t n, StackingAllocator * alloc, const NoThrow&)
+void * __cdecl operator new(size_t n, StackingAllocator * alloc, const NoThrow&) throw()
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_FAULT;
@@ -358,7 +358,7 @@ void * __cdecl operator new(size_t n, StackingAllocator * alloc, const NoThrow&)
     return alloc->UnsafeAllocNoThrow((unsigned)n);
 }
 
-void * __cdecl operator new[](size_t n, StackingAllocator * alloc, const NoThrow&)
+void * __cdecl operator new[](size_t n, StackingAllocator * alloc, const NoThrow&) throw()
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_FAULT;

--- a/src/vm/stackingallocator.h
+++ b/src/vm/stackingallocator.h
@@ -306,8 +306,8 @@ private :
 
 void * __cdecl operator new(size_t n, StackingAllocator *alloc);
 void * __cdecl operator new[](size_t n, StackingAllocator *alloc);
-void * __cdecl operator new(size_t n, StackingAllocator *alloc, const NoThrow&);
-void * __cdecl operator new[](size_t n, StackingAllocator *alloc, const NoThrow&);
+void * __cdecl operator new(size_t n, StackingAllocator *alloc, const NoThrow&) throw();
+void * __cdecl operator new[](size_t n, StackingAllocator *alloc, const NoThrow&) throw();
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/src/vm/stackwalktypes.h
+++ b/src/vm/stackwalktypes.h
@@ -105,8 +105,9 @@ struct StackwalkCacheUnwindInfo
     #define STACKWALK_CACHE_ENTRY_ALIGN_BOUNDARY 0x8
 #endif // !_WIN64
 
-DECLSPEC_ALIGN(STACKWALK_CACHE_ENTRY_ALIGN_BOUNDARY) 
-struct StackwalkCacheEntry
+struct 
+DECLSPEC_ALIGN(STACKWALK_CACHE_ENTRY_ALIGN_BOUNDARY)
+StackwalkCacheEntry
 {
     //
     //  don't rearrange the fields, so that invalid value 0x8000000000000000 will never appear

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -66,7 +66,7 @@ BOOL ZapSig::GetSignatureForTypeDesc(TypeDesc * desc, SigBuilder * pSigBuilder)
     }
     else
     {
-        switch (elemType)
+        switch ((DWORD)elemType)
         {
         case ELEMENT_TYPE_FNPTR:
             {
@@ -365,7 +365,7 @@ BOOL ZapSig::GetSignatureForTypeHandle(TypeHandle      handle,
     CorElementType sigType     = CorSigUncompressElementType(pSig);
     CorElementType handleType  = handle.GetSignatureCorElementType();
 
-    switch (sigType)
+    switch ((DWORD)sigType)
     {
         default:
         {


### PR DESCRIPTION
This change fixes:
1) Member initiazalization order in class constructor didn't correspond to the member order in some classes
2) Objects with vtables were copied via memcpy. While this is intentional, cast of the pointers to void*
is required to silence clang warning
3) Switch case statements containing values of different enums
4) Casting int to pointer
5) Missing return value in methods with _ASSERTE
6) Class name classifier on methods in the .h
7) Invalid position of the DECLSPEC_ALIGN at few places - it had no effect
8) Invalid position of the 'used' attribute
9) Issue with comparing holders to NULL
10) Operator 'new' returning NULL without being marked with throw() or noexcept
11) Variables marked as 'extern' at the declaration / initialization place
12) Data structure declared as struct at one place and forward declared as class at another

Some disabled warnings were no longer happening, so options to disable them were removed too