### PR TITLE
Fix missing RuneLocale on FreeBSD.

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -14,6 +14,7 @@
 #cmakedefine01 HAVE_PTHREAD_NP_H
 #cmakedefine01 HAVE_SYS_LWP_H
 #cmakedefine01 HAVE_LIBUNWIND_H
+#cmakedefine01 HAVE_RUNETYPE_H
 
 #cmakedefine01 HAVE_KQUEUE
 #cmakedefine01 HAVE_GETPWUID_R

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -22,6 +22,7 @@ check_include_files(sys/time.h HAVE_SYS_TIME_H)
 check_include_files(pthread_np.h HAVE_PTHREAD_NP_H)
 check_include_files(sys/lwp.h HAVE_SYS_LWP_H)
 check_include_files(libunwind.h HAVE_LIBUNWIND_H)
+check_include_files(runetype.h HAVE_RUNETYPE_H)
 
 check_function_exists(kqueue HAVE_KQUEUE)
 check_function_exists(getpwuid_r HAVE_GETPWUID_R)

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -553,6 +553,9 @@ function_name() to call the system's implementation
 #undef _WCHAR_T_DEFINED
 
 #define _DONT_USE_CTYPE_INLINE_
+#if defined(__FreeBSD__)
+#include <runetype.h>
+#endif
 #include <ctype.h>
 
 #include <stdio.h>

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -553,7 +553,7 @@ function_name() to call the system's implementation
 #undef _WCHAR_T_DEFINED
 
 #define _DONT_USE_CTYPE_INLINE_
-#if defined(__FreeBSD__)
+#if HAVE_RUNETYPE_H
 #include <runetype.h>
 #endif
 #include <ctype.h>


### PR DESCRIPTION
Without this patch the build breaks with errors like this:

    /usr/include/xlocale/_ctype.h:52:1: error: unknown type name '_RuneLocale'
    _RuneLocale     *__runes_for_locale(locale_t, int*);
    ^