### PR TITLE
Fix IndexOfOrdinal on Unix for empty strings

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -18,6 +18,12 @@ namespace System.Globalization
             Contract.Assert(value != null);
 
             // TODO: Implement This Fully.
+
+            if (value.Length == 0)
+            {
+                return 0;
+            }
+
             if (ignoreCase)
             {
                 source = source.ToUpper(CultureInfo.InvariantCulture);


### PR DESCRIPTION
IndexOfOrdinal searching for an empty string should return 0.  It's currently returning -1.