### PR TITLE
Removing static PAL from SOS and DBI

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -89,8 +89,7 @@ else(WIN32)
 
   set(SOS_LIBRARY
     corguids
-    CoreClrPal
-    palrt
+    mscordaccore
   )
 endif(WIN32)
 

--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -53,7 +53,7 @@ DacGlobals g_dacTable;
 // DAC global pointer table initialization
 void DacGlobals::Initialize()
 {
-    TADDR baseAddress = PTR_TO_TADDR(PAL_GetPalModuleBase());
+    TADDR baseAddress = PTR_TO_TADDR(PAL_GetSymbolModuleBase((void *)DacGlobals::Initialize));
     g_dacTable.InitializeEntries(baseAddress);
 #ifdef FEATURE_SVR_GC
     g_dacTable.InitializeSVREntries(baseAddress);

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -57,8 +57,7 @@ if(WIN32)
 elseif(CLR_CMAKE_PLATFORM_UNIX)
     list(APPEND COREDBI_LIBRARIES
         mdhotdata_full
-        palrt
-        CoreClrPal
+        mscordaccore
     )
 
     # COREDBI_LIBRARIES is mentioned twice because ld is one pass linker and will not find symbols
@@ -69,6 +68,8 @@ elseif(CLR_CMAKE_PLATFORM_UNIX)
     # This option is necessary to ensure that the overloaded new/delete operators defined inside
     # of the utilcode will be used instead of the standard library delete operator.
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")    
+
+    add_dependencies(mscordbi mscordaccore)
     
 endif(WIN32)
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3340,11 +3340,10 @@ GetModuleFileNameW(
 #define GetModuleFileName GetModuleFileNameA
 #endif
 
-// Get base address of the module containing this function 
+// Get base address of the module containing a given symbol 
 PALAPI
 LPCVOID
-PAL_GetPalModuleBase();
-
+PAL_GetSymbolModuleBase(void *symbol);
 
 PALIMPORT
 LPVOID

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1906,26 +1906,33 @@ BOOL LOADInitCoreCLRModules()
     return g_pRuntimeDllMain((HMODULE)&pal_module, DLL_PROCESS_ATTACH, NULL);
 }
 
-// Get base address of the module containing this function 
+// Get base address of the module containing a given symbol 
 PALAPI
 LPCVOID
-PAL_GetPalModuleBase()
+PAL_GetSymbolModuleBase(void *symbol)
 {
     LPCVOID retval = NULL;
 
     PERF_ENTRY(PAL_GetPalModuleBase);
     ENTRY("PAL_GetPalModuleBase\n");
 
-    Dl_info info;
-    void *current_func = reinterpret_cast<void *>(PAL_GetPalModuleBase);
-    if (dladdr(current_func, &info) != 0)
+    if (symbol == NULL)
     {
-        retval = info.dli_fbase;
+        TRACE("Can't get base address. Argument symbol == NULL\n");
+        SetLastError(ERROR_INVALID_DATA);
     }
     else 
     {
-        TRACE("Can't get base address of the current module\n");
-        SetLastError(ERROR_INVALID_DATA);
+        Dl_info info;
+        if (dladdr(symbol, &info) != 0)
+        {
+            retval = info.dli_fbase;
+        }
+        else 
+        {
+            TRACE("Can't get base address of the current module\n");
+            SetLastError(ERROR_INVALID_DATA);
+        }        
     }
 
     LOGEXIT("PAL_GetPalModuleBase returns %p\n", retval);

--- a/src/utilcode/stresslog.cpp
+++ b/src/utilcode/stresslog.cpp
@@ -185,7 +185,7 @@ void StressLog::Initialize(unsigned facilities,  unsigned level, unsigned maxByt
 #endif // _DEBUG
 
 #else // !FEATURE_PAL
-    theLog.moduleOffset = (SIZE_T)PAL_GetPalModuleBase();
+    theLog.moduleOffset = (SIZE_T)PAL_GetSymbolModuleBase((void *)StressLog::Initialize);
 #endif // !FEATURE_PAL
 
 #if !defined (STRESS_LOG_READONLY)    


### PR DESCRIPTION
Right now DBI, DAC and SOS each has PAL statically linked to it. It causes issues when threads and handles travel between different PALs, because each PAL has its own global state. It also creates unnecessary code bloat. This change removes PAL from SOS and DBI and make them depend on DAC to provide PAL for them.