### PR TITLE
Fix an issue in ExceptionTracker::FindParentStackFrameHelper that resulted in an AV during GC stack root scanning.

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -6144,12 +6144,16 @@ StackFrame ExceptionTracker::FindParentStackFrameHelper(CrawlFrame* pCF,
 
             // Check if the caller IP is in mscorwks.  If it is not, then it is an out-of-line finally.
             // Normally, the caller of a finally is ExceptionTracker::CallHandler().
+#ifdef FEATURE_PAL
+            fIsCallerInVM = !ExecutionManager::IsManagedCode(callerIP);
+#else
 #if defined(DACCESS_COMPILE)
             HMODULE_TGT hEE = DacGlobalBase();
 #else  // !DACCESS_COMPILE
             HMODULE_TGT hEE = g_pMSCorEE;
 #endif // !DACCESS_COMPILE
             fIsCallerInVM = IsIPInModule(hEE, callerIP);
+#endif // FEATURE_PAL
 
             if (!fIsCallerInVM)
             {


### PR DESCRIPTION
This change fixes the second issue reported in https://github.com/dotnet/coreclr/issues/566. The problem is that ExceptionTracker::FindParentStackFrameHelper uses IsIPInModule to determine whether an IP address belongs to VM or managed code but this function is not implemented when FEATURE_PAL is defined.
We should not really need the actual implementation of IsIPInModule on Unix. It is sufficient to just differentiate between managed and other code using ExecutionManager::IsManagedCode on Unix.