### PR TITLE
Fix some of the issues found by Viva64 static analyser

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6973,7 +6973,7 @@ void                Compiler::gtDispNode(GenTreePtr     tree,
         return;
     }
 
-    if  (tree && printFlags)
+    if  (printFlags)
     {
         /* First print the flags associated with the node */
         switch (tree->gtOper)
@@ -9188,7 +9188,9 @@ GenTreePtr                  Compiler::gtFoldExprConst(GenTreePtr tree)
             // If we fold a unary oper, then the folded constant 
             // is considered a ConstantIndexField if op1 was one
             //
-            if (op1->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
+
+            if ((op1->gtIntCon.gtFieldSeq != nullptr) &&
+                 op1->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
             {
                 fieldSeq = op1->gtIntCon.gtFieldSeq;
             }
@@ -9732,12 +9734,14 @@ CHK_OVF:
             // For the very particular case of the "constant array index" pseudo-field, we
             // assume that multiplication is by the field width, and preserves that field.
             // This could obviously be made more robust by a more complicated set of annotations...
-            if (op1->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
+            if ((op1->gtIntCon.gtFieldSeq != nullptr) &&
+                 op1->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
             {
                 assert(op2->gtIntCon.gtFieldSeq == FieldSeqStore::NotAField());
                 fieldSeq = op1->gtIntCon.gtFieldSeq;
             } 
-            else if (op2->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
+            else if ((op2->gtIntCon.gtFieldSeq != nullptr) &&
+                      op2->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
             {
                 assert(op1->gtIntCon.gtFieldSeq == FieldSeqStore::NotAField());
                 fieldSeq = op2->gtIntCon.gtFieldSeq;
@@ -12730,15 +12734,13 @@ CORINFO_FIELD_HANDLE FieldSeqStore::ConstantIndexPseudoField = (CORINFO_FIELD_HA
 
 bool FieldSeqNode::IsFirstElemFieldSeq()
 {
-    if (this == nullptr)
-        return false;
+    // this must be non-null per ISO C++
     return m_fieldHnd == FieldSeqStore::FirstElemPseudoField;
 }
 
 bool FieldSeqNode::IsConstantIndexFieldSeq()
 {
-    if (this == nullptr)
-        return false;
+    // this must be non-null per ISO C++
     return m_fieldHnd == FieldSeqStore::ConstantIndexPseudoField;
 }
 

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -3419,14 +3419,8 @@ instruction         CodeGen::ins_Copy(var_types   dstType)
     }
     else if (varTypeIsFloating(dstType))
     {
-        if (dstType == TYP_FLOAT)
-        {
-            return INS_movaps;
-        }
-        else
-        {
-            return INS_movaps;
-        }
+       // Both float and double copy can use movaps
+       return INS_movaps;
     }
     else
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9606,6 +9606,7 @@ CM_ADD_OP:
 
             ssize_t mult = op2->gtIntConCommon.IconValue();
             bool op2IsConstIndex = op2->OperGet() == GT_CNS_INT &&
+                                   op2->gtIntCon.gtFieldSeq != nullptr &&
                                    op2->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq();
 
             assert(!op2IsConstIndex || op2->AsIntCon()->gtFieldSeq->m_next == nullptr);
@@ -9644,6 +9645,7 @@ CM_ADD_OP:
                 // If "op2" is a constant array index, the other multiplicand must be a constant.
                 // Transfer the annotation to the other one.
                 if (op2->OperGet() == GT_CNS_INT &&
+                    op2->gtIntCon.gtFieldSeq != nullptr &&
                     op2->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
                 {
                     assert(op2->gtIntCon.gtFieldSeq->m_next == nullptr);
@@ -10900,7 +10902,9 @@ ASG_OP:
                 // we are reusing the shift amount node here, but the type we want is that of the shift result
                 op2->gtType = op1->gtType;
 
-                if (cns->gtOper == GT_CNS_INT && cns->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
+                if (cns->gtOper == GT_CNS_INT &&
+                    cns->gtIntCon.gtFieldSeq != nullptr &&
+                    cns->gtIntCon.gtFieldSeq->IsConstantIndexFieldSeq())
                 {
                     assert(cns->gtIntCon.gtFieldSeq->m_next == nullptr);
                     op2->gtIntCon.gtFieldSeq = cns->gtIntCon.gtFieldSeq;


### PR DESCRIPTION
This change handles the issues mentioned in #474 on the JIT codebase.

Eliminate some unnecessary null check.
Remove null-checks on this and guard instance calls with null-checks.
Collapse a redundant then/else case.
