### PR TITLE
Replay the fix for #450

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8178,7 +8178,7 @@ GenTreePtr Compiler::impCastClassOrIsInstToTree(GenTreePtr op1, GenTreePtr op2, 
     //             op1Copy CNS_INT
     //                      null
     //                      
-    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_I_IMPL));  
+    condNull = gtNewOperNode(GT_EQ, TYP_INT, gtClone(op1), gtNewIconNode(0, TYP_REF));
 
     //
     // expand the true and false trees for the condMT


### PR DESCRIPTION
The fix for #450 that was made in  96f473c  has been accidentally reverted in  68562e7 . This checks that change back in.