### PR TITLE
Change paths and os names to match corefx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,6 @@ bld/
 [Bb]in/
 [Oo]bj/
 msbuild.log
-binaries
-intermediates
 
 # Roslyn stuff
 *.sln.ide

--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,8 @@
 usage()
 {
     echo "Usage: $0 [BuildArch] [BuildType] [clean]"
-    echo "BuildArch can be: amd64"
-    echo "BuildType can be: debug, release"
+    echo "BuildArch can be: x64"
+    echo "BuildType can be: Debug, Release"
     echo "clean - optional argument to force a clean build."
 
     exit 1
@@ -96,35 +96,35 @@ __BuildArch=x64
 OSName=$(uname -s)
 case $OSName in
     Linux)
-        __BuildOS=linux
+        __BuildOS=Linux
         ;;
 
     Darwin)
-        __BuildOS=mac
+        __BuildOS=OSX
         ;;
 
     FreeBSD)
-        __BuildOS=freebsd
+        __BuildOS=FreeBSD
         ;;
 
     OpenBSD)
-        __BuildOS=openbsd
+        __BuildOS=OpenBSD
         ;;
 
     *)
         echo "Unsupported OS $OSName detected, configuring as if for Linux"
-        __BuildOS=linux
+        __BuildOS=Linux
         ;;
 esac
 __MSBuildBuildArch=x64
-__BuildType=debug
+__BuildType=Debug
 __CMakeArgs=DEBUG
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
 __ProjectDir="$__ProjectRoot"
 __SourceDir="$__ProjectDir/src"
 __PackagesDir="$__ProjectDir/packages"
-__RootBinDir="$__ProjectDir/binaries"
+__RootBinDir="$__ProjectDir/bin"
 __LogsDir="$__RootBinDir/Logs"
 __UnprocessedBuildArgs=
 __MSBCleanBuildArgs=
@@ -143,10 +143,10 @@ for i in "$@"
         __MSBuildBuildArch=x64
         ;;
         debug)
-        __BuildType=debug
+        __BuildType=Debug
         ;;
         release)
-        __BuildType=release
+        __BuildType=Release
         __CMakeArgs=RELEASE
         ;;
         clean)
@@ -162,7 +162,7 @@ __BinDir="$__RootBinDir/Product/$__BuildOS.$__BuildArch.$__BuildType"
 __PackagesBinDir="$__BinDir/.nuget"
 __ToolsDir="$__RootBinDir/tools"
 __TestWorkingDir="$__RootBinDir/tests/$__BuildOS.$__BuildArch.$__BuildType"
-__IntermediatesDir="$__RootBinDir/intermediates/$__BuildOS.$__BuildArch.$__BuildType"
+__IntermediatesDir="$__RootBinDir/obj/$__BuildOS.$__BuildArch.$__BuildType"
 
 # Specify path to be set for CMAKE_INSTALL_PREFIX.
 # This is where all built CoreClr libraries will copied to.

--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -94,7 +94,7 @@
     <FeatureSvrGc Condition="'$(TargetArch)' != 'arm'">true</FeatureSvrGc>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)' == 'Unix'">
+  <PropertyGroup Condition="'$(TargetsUnix)' == 'true'">
     <FeaturePal>true</FeaturePal>
 
     <FeatureStubsAsIL>true</FeatureStubsAsIL>

--- a/clr.defines.targets
+++ b/clr.defines.targets
@@ -219,6 +219,6 @@
         <DefineConstants Condition="'$(FeatureWinDbAppCompat)' == 'true'">$(DefineConstants);FEATURE_WIN_DB_APPCOMPAT</DefineConstants>
         <DefineConstants Condition="'$(FeatureReadyToRun)' == 'true'">$(DefineConstants);FEATURE_READYTORUN</DefineConstants>
 
-        <DefineConstants Condition="'$(OS)' == 'Unix'">$(DefineConstants);PLATFORM_UNIX</DefineConstants>
+        <DefineConstants Condition="'$(TargetsUnix)' == 'true'">$(DefineConstants);PLATFORM_UNIX</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/dir.props
+++ b/dir.props
@@ -24,7 +24,7 @@
     <PackagesDir Condition="'$(__PackagesDir)'==''">$(ProjectDir)\packages\</PackagesDir>
 
     <RootBinDir>$(__RootBinDir)\</RootBinDir>
-    <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)\binaries\</RootBinDir>
+    <RootBinDir Condition="'$(__RootBinDir)'==''">$(ProjectDir)\bin\</RootBinDir>
 
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)\Product\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
@@ -55,7 +55,15 @@
     <NuSpecs Condition="'$(Configuration)'=='Debug'" Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.Debug.Development.nuspec" />
   </ItemGroup>
 
+  <!-- Setup common target properties that we use to conditionally include sources -->
+  <PropertyGroup>
+    <TargetsWindows Condition="'$(BuildOS)' == 'Windows_NT'">true</TargetsWindows>
+    <TargetsLinux Condition="'$(BuildOS)' == 'Linux'">true</TargetsLinux>
+    <TargetsOSX Condition="'$(BuildOS)' == 'OSX'">true</TargetsOSX>
 
+    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true'">true</TargetsUnix>
+  </PropertyGroup>
+  
   <!-- Common NuGet properties -->
   <PropertyGroup>
     <NuGetToolPath>$(ToolsDir)NuGet.exe</NuGetToolPath>

--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -104,7 +104,7 @@
   
   <!-- Output paths -->
   <PropertyGroup>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)intermediates</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)obj</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(Configuration)</IntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(Configuration)</OutputPath>
     <FinalOutputPath Condition="'$(FinalOutputPath)' == ''">$(BinDir)</FinalOutputPath>

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -776,7 +776,7 @@
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\UmAlQuraCalendar.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\UnicodeCategory.cs " /> 
   </ItemGroup>
-  <ItemGroup Condition="'$(FeatureCoreFxGlobalization)' == 'true' and '$(OS)' == 'Unix'">
+  <ItemGroup Condition="'$(FeatureCoreFxGlobalization)' == 'true' and '$(TargetsUnix)' == 'true'">
     <GlobalizationSources Include="$(BclSourcesRoot)\System\Globalization\EncodingTable.Unix.cs" />
     <GlobalizationSources Include="$(BclSourcesRoot)\System\Globalization\EncodingDataItem.Unix.cs" />
 

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -8,15 +8,15 @@ set "__SourceDir=%__ProjectDir%\src"
 set "__TestDir=%__ProjectDir%\tests"
 set "__ProjectFilesDir=%__TestDir%"
 set "__PackagesDir=%__ProjectDir%\packages"
-set "__RootBinDir=%__ProjectDir%\binaries"
+set "__RootBinDir=%__ProjectDir%\bin"
 set "__LogsDir=%__RootBinDir%\Logs"
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
 if /i "%1" == "x64"    (set __BuildArch=x64&shift&goto Arg_Loop)
 
-if /i "%1" == "debug"    (set __BuildType=debug&shift&goto Arg_Loop)
-if /i "%1" == "release"   (set __BuildType=release&shift&goto Arg_Loop)
+if /i "%1" == "debug"    (set __BuildType=Debug&shift&goto Arg_Loop)
+if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
 
 if /i "%1" == "clean"   (set __CleanBuild=1&shift&goto Arg_Loop)
 
@@ -27,14 +27,14 @@ goto Usage
 
 
 if not defined __BuildArch set __BuildArch=x64
-if not defined __BuildType set __BuildType=debug
+if not defined __BuildType set __BuildType=Debug
 if not defined __BuildOS set __BuildOS=Windows_NT
 
 set "__TestBinDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
 :: We have different managed and native intermediate dirs because the managed bits will include
 :: the configuration information deeper in the intermediates path.
-set "__NativeTestIntermediatesDir=%__RootBinDir%\tests\intermediates\%__BuildOS%.%__BuildArch%.%__BuildType%"
-set "__ManagedTestIntermediatesDir=%__RootBinDir%\tests\intermediates"
+set "__NativeTestIntermediatesDir=%__RootBinDir%\tests\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__ManagedTestIntermediatesDir=%__RootBinDir%\tests\obj"
 set "__TestManagedBuildLog=%__LogsDir%\Tests_Managed_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
 set "__TestNativeBuildLog=%__LogsDir%\Tests_Native_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
 set "__XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildOS%__%__BuildArch%__%__BuildType%.log"

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -38,9 +38,9 @@ if not defined VSINSTALLDIR echo Error: runtest.cmd should be run from a Visual 
 if not defined __BuildArch set __BuildArch=x64
 if not defined __BuildType set __BuildType=debug
 if not defined __BuildOS set __BuildOS=Windows_NT
-if not defined __BinDir    set  __BinDir=%__ProjectFilesDir%..\binaries\Product\%__BuildOS%.%__BuildArch%.%__BuildType%
-if not defined __TestWorkingDir set __TestWorkingDir=%__ProjectFilesDir%..\binaries\tests\%__BuildOS%.%__BuildArch%.%__BuildType%
-if not defined __LogsDir        set  __LogsDir=%__ProjectFilesDir%..\binaries\Logs
+if not defined __BinDir    set  __BinDir=%__ProjectFilesDir%..\bin\Product\%__BuildOS%.%__BuildArch%.%__BuildType%
+if not defined __TestWorkingDir set __TestWorkingDir=%__ProjectFilesDir%..\bin\tests\%__BuildOS%.%__BuildArch%.%__BuildType%
+if not defined __LogsDir        set  __LogsDir=%__ProjectFilesDir%..\bin\Logs
 
 :: Default global test environmet variables
 if not defined XunitTestBinBase       set  XunitTestBinBase=%__TestWorkingDir%\

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -29,12 +29,12 @@
 
 <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
-    <BaseOutputPathWithConfig>$(ProjectDir)\..\binaries\tests\$(BuildOS).$(Platform).$(Configuration)\</BaseOutputPathWithConfig>
+    <BaseOutputPathWithConfig>$(ProjectDir)\..\bin\tests\$(BuildOS).$(Platform).$(Configuration)\</BaseOutputPathWithConfig>
     <BaseOutputPathWithConfig Condition="'$(__TestBinDir)' != ''">$(__TestBinDir)\</BaseOutputPathWithConfig>
     <BinDir>$(BaseOutputPathWithConfig)\..</BinDir>
-    <BaseIntermediateOutputPath>$(ProjectDir)\..\binaries\tests\intermediates\</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$(ProjectDir)\..\bin\tests\obj\</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="'$(__ManagedTestIntermediatesDir)' != ''">$(__ManagedTestIntermediatesDir)\</BaseIntermediateOutputPath>
-    <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\intermediates\$(BuildOS).$(Platform).$(Configuration)\))</__NativeTestIntermediatesDir>
+    <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\obj\$(BuildOS).$(Platform).$(Configuration)\))</__NativeTestIntermediatesDir>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
     <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))</BuildProjectRelativeDir>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)</IntermediateOutputPath>

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -36,7 +36,7 @@
     <ItemGroup>
       <PossibleTargetFrameworks Include="$(_TargetFrameworkDirectories)" />
       <ReferencePath Condition="'$(LinkLocalMscorlib)' != 'true'" Include="%(PossibleTargetFrameworks.Identity)mscorlib.dll" />
-      <ReferencePath Condition="'$(LinkLocalMscorlib)' == 'true'" Include="$(ProjectDir)\..\binaries\Product\$(BuildOS).$(BuildArch).$(BuildType)\mscorlib.dll" />
+      <ReferencePath Condition="'$(LinkLocalMscorlib)' == 'true'" Include="$(ProjectDir)\..\bin\Product\$(BuildOS).$(BuildArch).$(BuildType)\mscorlib.dll" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
* binaries is now bin, intermediates is now obj
* modifying unixmscorlib build to instead be linuxmscorlib + osxmscorlib.
* Change OS=Unix to OSLinux/OS=OSX and modified properties to mimic corefx's TargetsUnix.

Fixes #560 and #559 