### PR TITLE
Fix next round of warning types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,26 +264,23 @@ add_definitions(-DDISABLE_CONTRACTS)
 add_compile_options(-ferror-limit=4096)
 
 # Disabled warnings
-add_compile_options(-Wno-unknown-pragmas)
 add_compile_options(-Wno-unused-private-field)
 add_compile_options(-Wno-dangling-else)
 add_compile_options(-Wno-implicit-exception-spec-mismatch)
-# Using the result of an assignment as a condition without parentheses
-add_compile_options(-Wno-parentheses)
+# A derived class defines a virtual method with the same name as its base
+# class, but different set of parameters.
 add_compile_options(-Wno-overloaded-virtual)
 add_compile_options(-Wno-unused-variable)
 # Enum value is not handled in a switch (and there is no default clause)
 # Remaining cases are in JIT only
 add_compile_options(-Wno-switch)
+# Explicit constructor calls are not supported by clang (this->ClassName::ClassName())
 add_compile_options(-Wno-microsoft)
 # This warning is caused by comparing 'this' to NULL
 add_compile_options(-Wno-tautological-compare)
+# There are constants of type BOOL used in a condition. But BOOL is defined as int
+# and so the compiler thinks that there is a mistake.
 add_compile_options(-Wno-constant-logical-operand)
-add_compile_options(-Wno-unused-function)
-add_compile_options(-Wno-extra-tokens)
-add_compile_options(-Wno-self-assign)
-add_compile_options(-Wno-bitfield-constant-conversion)
-add_compile_options(-Wno-unused-value)
 
 add_compile_options(-Wno-unknown-warning-option)
 

--- a/src/ToolBox/SOS/Strike/stressLogDump.cpp
+++ b/src/ToolBox/SOS/Strike/stressLogDump.cpp
@@ -249,7 +249,7 @@ void formatOutput(struct IDebugDataSpaces* memCallBack, __in FILE* file, __inout
                     }
                 }
             }
-            else if (*ptr == 's' || *ptr == 'h' && *(ptr+1) == 's' && ++ptr) 
+            else if (*ptr == 's' || (*ptr == 'h' && *(ptr+1) == 's' && ++ptr)) 
             {
                 HRESULT     hr;
 
@@ -266,7 +266,7 @@ void formatOutput(struct IDebugDataSpaces* memCallBack, __in FILE* file, __inout
 
                 args[iArgCount] = strBuf;                    
             }
-            else if (*ptr == 'S' || *ptr == 'l' && *(ptr+1) == 's' && ++ptr) 
+            else if (*ptr == 'S' || (*ptr == 'l' && *(ptr+1) == 's' && ++ptr)) 
             {
                 HRESULT     hr;
 

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -1427,7 +1427,7 @@ DllsName(
 inline
 BOOL IsElementValueType (CorElementType cet)
 {
-    return cet >= ELEMENT_TYPE_BOOLEAN && cet <= ELEMENT_TYPE_R8 
+    return (cet >= ELEMENT_TYPE_BOOLEAN && cet <= ELEMENT_TYPE_R8) 
         || cet == ELEMENT_TYPE_VALUETYPE || cet == ELEMENT_TYPE_I || cet == ELEMENT_TYPE_U;
 }
 

--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -469,66 +469,6 @@ namespace BINDER_SPACE
         Exit:
             return hr;
         }
-
-        // Host assembly "equivalence" relation
-        HRESULT IsValidHostAssembly(AssemblyName     *pProposedAssemblyName,
-                                    AssemblyName     *pRequestedAssemblyName,
-                                    VersionMatchMode  versionMatchMode,
-                                    BOOL              fRequireHigherSV,
-                                    BOOL             *pFIsValidHostAssembly)
-        {
-            HRESULT hr = S_OK;
-
-            AssemblyVersion *pProposedVersion = pProposedAssemblyName->GetVersion();
-            AssemblyVersion *pRequestedVersion = pRequestedAssemblyName->GetVersion();
-
-            if (pProposedVersion->IsEqualFeatureVersion(pRequestedVersion))
-            {
-                if (fRequireHigherSV)
-                {
-                    *pFIsValidHostAssembly =
-                        pProposedVersion->IsLargerServiceVersion(pRequestedVersion);
-                }
-                else if (versionMatchMode == kVersionExact)
-                {
-                    *pFIsValidHostAssembly =
-                        pProposedVersion->IsEqualServiceVersion(pRequestedVersion);
-                }
-                else
-                {
-                    *pFIsValidHostAssembly =
-                        (pProposedVersion->IsLargerServiceVersion(pRequestedVersion) ||
-                         pProposedVersion->IsEqualServiceVersion(pRequestedVersion));
-                }
-            }
-            else if ((versionMatchMode == kVersionFeatureRollForward) &&
-                     (pProposedVersion->IsLargerFeatureVersion(pRequestedVersion)))
-            {
-                *pFIsValidHostAssembly = TRUE;
-            }
-            else
-            {
-               *pFIsValidHostAssembly = FALSE;
-            }
-
-            return hr;
-        }
-
-        inline DWORD BindingStoreEnumToDWORD(INT32 kBindingStore)
-        {
-            switch (kBindingStore)
-            {
-            case 0:
-                return kBindingStoreGAC;
-            case 1:
-                return kBindingStoreManifest;
-            case 2:
-                return kBindingStoreHost;
-            default:
-                _ASSERTE(0);
-                return 0;
-            }
-        }
     };
 
     /* static */
@@ -700,8 +640,7 @@ namespace BINDER_SPACE
 #ifdef FEATURE_VERSIONING_LOG
             hr = LogBindResult(pApplicationContext, hr, &bindResult);
 #else // FEATURE_VERSIONING_LOG
-            // Shut up GCC
-            hr = hr;
+            ;
 #endif // FEATURE_VERSIONING_LOG
 
 #ifndef CROSSGEN_COMPILE

--- a/src/binder/textualidentityparser.cpp
+++ b/src/binder/textualidentityparser.cpp
@@ -189,19 +189,6 @@ namespace BINDER_SPACE
             return NULL;
         }
 
-        BOOL ValidateAndConvertContentType(
-                SString &             ssContentType, 
-                AssemblyContentType * pkContentType)
-        {
-            if (EqualsCaseInsensitive(ssContentType, W("WindowsRuntime")))
-            {
-                *pkContentType = AssemblyContentType_WindowsRuntime;
-                return TRUE;
-            }
-            
-            return FALSE;
-        }
-        
         LPCWSTR ContentTypeToString(AssemblyContentType kContentType)
         {
             _ASSERTE(kContentType != AssemblyContentType_Default);

--- a/src/binder/variables.cpp
+++ b/src/binder/variables.cpp
@@ -19,6 +19,7 @@
 
 namespace BINDER_SPACE
 {
+#ifdef FEATURE_VERSIONING_LOG
     namespace
     {
         HRESULT CheckFileExistence(LPCWSTR pwzFile, LPDWORD pdwAttrib)
@@ -51,6 +52,7 @@ namespace BINDER_SPACE
             return hr;
         }
     };
+#endif // FEATURE_VERSIONING_LOG
 
     Variables *g_BinderVariables = NULL;
 

--- a/src/classlibnative/bcltype/decimal.cpp
+++ b/src/classlibnative/bcltype/decimal.cpp
@@ -335,10 +335,10 @@ int COMDecimal::NumberToDecimal(NUMBER* number, DECIMAL* value)
         }
     } else {
         if (e > DECIMAL_PRECISION) return 0;
-        while ((e > 0 || *p && e > -28) &&
-                (DECIMAL_HI32(d) < 0x19999999 || DECIMAL_HI32(d) == 0x19999999 &&
-                    (DECIMAL_MID32(d) < 0x99999999 || DECIMAL_MID32(d) == 0x99999999 &&
-                        (DECIMAL_LO32(d) < 0x99999999 || DECIMAL_LO32(d) == 0x99999999 && *p <= '5')))) {
+        while ((e > 0 || (*p && e > -28)) &&
+                (DECIMAL_HI32(d) < 0x19999999 || (DECIMAL_HI32(d) == 0x19999999 &&
+                    (DECIMAL_MID32(d) < 0x99999999 || (DECIMAL_MID32(d) == 0x99999999 &&
+                        (DECIMAL_LO32(d) < 0x99999999 || (DECIMAL_LO32(d) == 0x99999999 && *p <= '5'))))))) {
             DecMul10(&d);
             if (*p) DecAddInt32(&d, *p++ - '0');
             e--;
@@ -1306,10 +1306,10 @@ HaveScale64:
         rgulRem[1] = (rgulRem[1] << 1) + ulTmp;
         rgulRem[2] = (rgulRem[2] << 1) + ulTmp1;
 
-        if (rgulRem[2] > rgulDivisor[2] || rgulRem[2] == rgulDivisor[2] &&
-        (rgulRem[1] > rgulDivisor[1] || rgulRem[1] == rgulDivisor[1] &&
-        (rgulRem[0] > rgulDivisor[0] || rgulRem[0] == rgulDivisor[0] &&
-        (rgulQuo[0] & 1))))
+        if (rgulRem[2] > rgulDivisor[2] || (rgulRem[2] == rgulDivisor[2] &&
+        (rgulRem[1] > rgulDivisor[1] || (rgulRem[1] == rgulDivisor[1] &&
+        (rgulRem[0] > rgulDivisor[0] || (rgulRem[0] == rgulDivisor[0] &&
+        (rgulQuo[0] & 1)))))))
           goto RoundUp;
         break;
       }
@@ -1707,10 +1707,10 @@ HaveScale64:
         rgulRem[1] = (rgulRem[1] << 1) + ulTmp;
         rgulRem[2] = (rgulRem[2] << 1) + ulTmp1;
 
-        if (rgulRem[2] > rgulDivisor[2] || rgulRem[2] == rgulDivisor[2] &&
-        (rgulRem[1] > rgulDivisor[1] || rgulRem[1] == rgulDivisor[1] &&
-        (rgulRem[0] > rgulDivisor[0] || rgulRem[0] == rgulDivisor[0] &&
-        (rgulQuo[0] & 1))))
+        if (rgulRem[2] > rgulDivisor[2] || (rgulRem[2] == rgulDivisor[2] &&
+        (rgulRem[1] > rgulDivisor[1] || (rgulRem[1] == rgulDivisor[1] &&
+        (rgulRem[0] > rgulDivisor[0] || (rgulRem[0] == rgulDivisor[0] &&
+        (rgulQuo[0] & 1)))))))
           goto RoundUp;
         break;
       }

--- a/src/classlibnative/bcltype/number.cpp
+++ b/src/classlibnative/bcltype/number.cpp
@@ -1046,7 +1046,7 @@ wchar ParseFormatSpecifier(STRINGREF str, int* digits)
         _ASSERTE(p != NULL);
         wchar ch = *p;
         if (ch != 0) {
-            if (ch >= 'A' && ch <= 'Z' || ch >= 'a' && ch <= 'z') {
+            if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')) {
                 p++;
                 int n = -1;
                 if (*p >= '0' && *p <= '9') {

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -1887,7 +1887,7 @@ TypeHandle DacDbiInterfaceImpl::TypeDataWalk::ReadLoadedTypeArg(TypeHandleReadTy
     return ReadLoadedTypeHandle(kGetExact);
 #else
 
-    if ((retrieveWhich == kGetExact))
+    if (retrieveWhich == kGetExact)
         return ReadLoadedTypeHandle(kGetExact);
 
     // This nasty bit of code works out what the "canonicalization" of a

--- a/src/debug/di/rsthread.cpp
+++ b/src/debug/di/rsthread.cpp
@@ -8915,7 +8915,7 @@ HRESULT CordbJITILFrame::GetReturnValueForILOffsetImpl(ULONG32 ILoffset, ICorDeb
     bool found = false;
     ULONG32 currentOffset = m_nativeFrame->GetIPOffset();
     for (ULONG32 i = 0; i < count; ++i)
-        if (found = currentOffset == offsets[i])
+        if ((found = currentOffset == offsets[i]))
             break;
 
     if (!found)

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -8146,7 +8146,7 @@ void Debugger::SendCatchHandlerFound(
 
     LOG((LF_CORDB, LL_INFO10000, "D::FirstChanceManagedExceptionCatcherFound\n"));
 
-    if ((pThread == NULL))
+    if (pThread == NULL)
     {
         _ASSERTE(!"Bad parameter");
         LOG((LF_CORDB, LL_INFO10000, "D::FirstChanceManagedExceptionCatcherFound - Bad parameter.\n"));

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -225,7 +225,7 @@ private:
         startInCoop = bStartInCoop;
         conditional = bConditional;
 
-        if (!conditional || IFTHREAD && g_pEEInterface->GetThread() == NULL)
+        if (!conditional || (IFTHREAD && g_pEEInterface->GetThread() == NULL))
         {
             return;
         }
@@ -245,7 +245,7 @@ private:
 
     void LeaveInternal()
     {
-        if (!conditional || IFTHREAD && g_pEEInterface->GetThread() == NULL)
+        if (!conditional || (IFTHREAD && g_pEEInterface->GetThread() == NULL))
         {
             return;
         }

--- a/src/debug/ee/funceval.cpp
+++ b/src/debug/ee/funceval.cpp
@@ -1805,7 +1805,7 @@ void GatherFuncEvalArgInfo(DebuggerEval *pDE,
         // the sig says value class, but we've got a boxed value class, then remember that we need to unbox it.
         //
         bool fNeedBoxOrUnbox = ((argSigType == ELEMENT_TYPE_CLASS) && (pFEAD->argElementType == ELEMENT_TYPE_VALUETYPE)) ||
-            ((argSigType == ELEMENT_TYPE_VALUETYPE) && ((pFEAD->argElementType == ELEMENT_TYPE_CLASS) || (pFEAD->argElementType == ELEMENT_TYPE_OBJECT)) ||
+            (((argSigType == ELEMENT_TYPE_VALUETYPE) && ((pFEAD->argElementType == ELEMENT_TYPE_CLASS) || (pFEAD->argElementType == ELEMENT_TYPE_OBJECT))) ||
             // This is when method signature is expecting a BYREF ValueType, yet we recieve the boxed valuetype's handle.
             (pFEAD->argElementType == ELEMENT_TYPE_CLASS && argSigType == ELEMENT_TYPE_BYREF && byrefArgSigType == ELEMENT_TYPE_VALUETYPE));
 

--- a/src/debug/ee/rcthread.cpp
+++ b/src/debug/ee/rcthread.cpp
@@ -809,7 +809,7 @@ static LONG _debugFilter(LPEXCEPTION_POINTERS ep, PVOID pv)
     DWORD tid = GetCurrentThreadId();
 
     DebuggerIPCEventType type = (DebuggerIPCEventType) (event->type & DB_IPCE_TYPE_MASK);
-#endif _DEBUG || !FEATURE_CORESYSTEM
+#endif // _DEBUG || !FEATURE_CORESYSTEM
 
     // We should never AV here. In a debug build, throw up an assert w/ lots of useful (private) info.
 #ifdef _DEBUG

--- a/src/debug/inc/dacdbistructures.inl
+++ b/src/debug/inc/dacdbistructures.inl
@@ -343,7 +343,7 @@ DWORD SequencePoints::MapNativeOffsetToIL(DWORD                  dwNativeOffset,
         // If the end offset is 0, we want to check if we're in the prologue before concluding that the 
         // value of dwNativeOffset is out of range. 
         if ((dwNativeOffset >= m_map[i].nativeStartOffset) &&     
-            ((m_map[i].nativeEndOffset == 0) && (m_map[i].ilOffset != (ULONG)ICorDebugInfo::PROLOG) || 
+            (((m_map[i].nativeEndOffset == 0) && (m_map[i].ilOffset != (ULONG)ICorDebugInfo::PROLOG)) || 
              (dwNativeOffset < m_map[i].nativeEndOffset)))
         {
             ULONG uILOffset = m_map[i].ilOffset;

--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -728,6 +728,10 @@ STDAPI LoadStringRCEx(
 
 #if defined(FEATURE_CORECLR) || defined(CROSSGEN_COMPILE)
 
+extern HINSTANCE            g_pMSCorEE;
+
+#ifndef FEATURE_PAL
+
 //
 // Returns path name from a file name. The path name will be (null-terminated, incl. the last '\' if present).
 // Example: For input "C:\Windows\System.dll" returns "C:\Windows\".
@@ -787,10 +791,6 @@ HRESULT CopySystemDirectory(__in WCHAR *pFileName,
     }
     return hr;
 }
-
-extern HINSTANCE            g_pMSCorEE;
-
-#ifndef FEATURE_PAL
 
 BOOL PAL_GetPALDirectory(__out_ecount(cchBuffer) LPWSTR pbuffer, 
                          DWORD  cchBuffer)

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -6041,7 +6041,7 @@ size_t& gc_heap::bpromoted_bytes(int thread)
 #ifdef MULTIPLE_HEAPS
     return g_bpromoted [thread*16];
 #else //MULTIPLE_HEAPS
-    thread = thread;
+    UNREFERENCED_PARAMETER(thread);
     return g_bpromoted;
 #endif //MULTIPLE_HEAPS
 }
@@ -16269,7 +16269,7 @@ size_t& gc_heap::promoted_bytes(int thread)
 #ifdef MULTIPLE_HEAPS
     return g_promoted [thread*16];
 #else //MULTIPLE_HEAPS
-    thread = thread;
+    UNREFERENCED_PARAMETER(thread);
     return g_promoted;
 #endif //MULTIPLE_HEAPS
 }
@@ -16913,7 +16913,7 @@ __declspec(naked) void __fastcall Prefetch(void* addr)
 #else //PREFETCH
 inline void Prefetch (void* addr)
 {
-    addr = addr;
+    UNREFERENCED_PARAMETER(addr);
 }
 #endif //PREFETCH
 #ifdef MH_SC_MARK
@@ -17856,7 +17856,7 @@ void gc_heap::background_verify_mark (Object*& object, ScanContext* sc, DWORD fl
 
 void gc_heap::background_promote (Object** ppObject, ScanContext* sc, DWORD flags)
 {
-    sc;
+    UNREFERENCED_PARAMETER(sc);
     //in order to save space on the array, mark the object,
     //knowing that it will be visited later
     assert (settings.concurrent);
@@ -21434,7 +21434,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
                     generation* gen = generation_of (active_new_gen_number);
                     plan_generation_start (gen, consing_gen, 0);
 
-                    if ((demotion_low == MAX_PTR))
+                    if (demotion_low == MAX_PTR)
                     {
                         demotion_low = pplug;
                         dprintf (3, ("end plan: dlow->%Ix", demotion_low));
@@ -25824,7 +25824,7 @@ void gc_heap::background_grow_c_mark_list()
 void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
                                   DWORD flags)
 {
-    sc = sc;
+    UNREFERENCED_PARAMETER(sc);
     //in order to save space on the array, mark the object,
     //knowing that it will be visited later
     assert (settings.concurrent);
@@ -31326,7 +31326,7 @@ void gc_heap::descr_card_table ()
         {
             if (card_set_p (i))
             {
-                if ((min == -1))
+                if (min == -1)
                 {
                     min = i;
                 }
@@ -32415,7 +32415,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
         }
 
         // Are we at the end of the youngest_generation?
-        if ((seg == ephemeral_heap_segment))
+        if (seg == ephemeral_heap_segment)
         {
             if (curr_object >= end_youngest)
             {
@@ -34550,7 +34550,7 @@ GCHeap::GarbageCollectGeneration (unsigned int gen, gc_reason reason)
 #endif //!MULTIPLE_HEAPS
 
 #ifdef FEATURE_PREMORTEM_FINALIZATION
-    if (!pGenGCHeap->settings.concurrent && pGenGCHeap->settings.found_finalizers || 
+    if ((!pGenGCHeap->settings.concurrent && pGenGCHeap->settings.found_finalizers) || 
         FinalizerThread::HaveExtraWorkForFinalizer())
     {
         FinalizerThread::EnableFinalization();
@@ -34668,7 +34668,7 @@ bool GCHeap::IsThreadUsingAllocationContextHeap(alloc_context* acontext, int thr
 {
 #ifdef MULTIPLE_HEAPS
     return ((acontext->home_heap == GetHeap(thread_number)) ||
-            (acontext->home_heap == 0) && (thread_number == 0));
+            ((acontext->home_heap == 0) && (thread_number == 0)));
 #else
     return true;
 #endif //MULTIPLE_HEAPS

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -50,6 +50,11 @@ add_compile_options(/TC)
 else()
 
 #The MIDL tool exists for Windows only, so for other systems, we have the prebuilt xxx_i.c files checked in
+
+# The prebuilt files contain extra '!_MIDL_USE_GUIDDEF_' after the #endif, but not in the comment.
+# In order to not to have to modify these prebuilt files, we disable the extra tokens warning.
+add_compile_options(-Wno-extra-tokens)
+
 foreach(IDL_SOURCE IN LISTS CORGUIDS_IDL_SOURCES)
    get_filename_component(IDLNAME ${IDL_SOURCE} NAME_WE)
    set(C_SOURCE ../pal/prebuilt/idl/${IDLNAME}_i.c)

--- a/src/inc/arraylist.h
+++ b/src/inc/arraylist.h
@@ -421,7 +421,7 @@ public:
         ELEMENT_TYPE *pSrc;
         SIZE_T nSrc;
 
-        while (pSrc = iter.GetNext(&nSrc))
+        while ((pSrc = iter.GetNext(&nSrc)))
         {
             memcpy(pDest, pSrc, nSrc * sizeof(ELEMENT_TYPE));
             pDest += nSrc;
@@ -436,7 +436,7 @@ public:
         SIZE_T              count;
         SIZE_T              chunkBaseIndex = 0;
         
-        while (chunk = iter.GetNext(&count))
+        while ((chunk = iter.GetNext(&count)))
         {
             SIZE_T nextBaseIndex = chunkBaseIndex + count;
             if (nextBaseIndex > index)

--- a/src/inc/ceefilegenwriter.h
+++ b/src/inc/ceefilegenwriter.h
@@ -190,7 +190,7 @@ inline LPWSTR CeeFileGenWriter::getResourceFileName() {
 }
 
 inline HRESULT CeeFileGenWriter::setDllSwitch(bool dllSwitch) {
-    if(m_dllSwitch = dllSwitch) m_objSwitch = FALSE; return S_OK;
+    if((m_dllSwitch = dllSwitch)) m_objSwitch = FALSE; return S_OK;
 }
 
 inline bool CeeFileGenWriter::getDllSwitch() {
@@ -198,7 +198,7 @@ inline bool CeeFileGenWriter::getDllSwitch() {
 }
 
 inline HRESULT CeeFileGenWriter::setObjSwitch(bool objSwitch) {
-    if(m_objSwitch = objSwitch) m_dllSwitch = FALSE; return S_OK;
+    if((m_objSwitch = objSwitch)) m_dllSwitch = FALSE; return S_OK;
 }
 
 inline bool CeeFileGenWriter::getObjSwitch() {

--- a/src/inc/cortypeinfo.h
+++ b/src/inc/cortypeinfo.h
@@ -5,9 +5,11 @@
 
 // This describes information about the COM+ primitive types
 
+#define NO_SIZE 255
+
 // TYPEINFO(type (CorElementType),  namespace, class,          size,           gcType,         isArray,isPrim, isFloat,isModifier,isGenVariable)
 
-TYPEINFO(ELEMENT_TYPE_END,          NULL, NULL,                ~0,             TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x00
+TYPEINFO(ELEMENT_TYPE_END,          NULL, NULL,                NO_SIZE,        TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x00
 TYPEINFO(ELEMENT_TYPE_VOID,         "System", "Void",          0,              TYPE_GC_NONE,   false,  true,   false,  false,  false) // 0x01
 TYPEINFO(ELEMENT_TYPE_BOOLEAN,      "System", "Boolean",       1,              TYPE_GC_NONE,   false,  true,   false,  false,  false) // 0x02
 TYPEINFO(ELEMENT_TYPE_CHAR,         "System", "Char",          2,              TYPE_GC_NONE,   false,  true,   false,  false,  false) // 0x03
@@ -26,18 +28,18 @@ TYPEINFO(ELEMENT_TYPE_R8,           "System", "Double",        8,              T
 TYPEINFO(ELEMENT_TYPE_STRING,       "System", "String",        sizeof(void*),  TYPE_GC_REF,    false,  false,  false,  false,  false) // 0x0e
 TYPEINFO(ELEMENT_TYPE_PTR,          NULL, NULL,                sizeof(void*),  TYPE_GC_NONE,   false,  false,  false,  true,   false) // 0x0f
 TYPEINFO(ELEMENT_TYPE_BYREF,        NULL, NULL,                sizeof(void*),  TYPE_GC_BYREF,  false,  false,  false,  true,   false) // 0x10
-TYPEINFO(ELEMENT_TYPE_VALUETYPE,    NULL, NULL,                ~0,             TYPE_GC_OTHER,  false,  false,  false,  false,  false) // 0x11
+TYPEINFO(ELEMENT_TYPE_VALUETYPE,    NULL, NULL,                NO_SIZE,        TYPE_GC_OTHER,  false,  false,  false,  false,  false) // 0x11
 TYPEINFO(ELEMENT_TYPE_CLASS,        NULL, NULL,                sizeof(void*),  TYPE_GC_REF,    false,  false,  false,  false,  false) // 0x12
 TYPEINFO(ELEMENT_TYPE_VAR,          NULL, NULL,                sizeof(void*),  TYPE_GC_OTHER,  false,  false,  false,  false,  true)  // 0x13
 TYPEINFO(ELEMENT_TYPE_ARRAY,        NULL, NULL,                sizeof(void*),  TYPE_GC_REF,    true,   false,  false,  true,   false) // 0x14
 
 TYPEINFO(ELEMENT_TYPE_GENERICINST,  NULL, NULL,                sizeof(void*),  TYPE_GC_OTHER,  false,  false,  false,  false,  false) // 0x15
 TYPEINFO(ELEMENT_TYPE_TYPEDBYREF,   "System", "TypedReference",2*sizeof(void*),TYPE_GC_BYREF,  false,  false,  false,  false,  false) // 0x16
-TYPEINFO(ELEMENT_TYPE_VALUEARRAY_UNSUPPORTED, NULL,NULL,       ~0,             TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x17 (unsupported, not in the ECMA spec)
+TYPEINFO(ELEMENT_TYPE_VALUEARRAY_UNSUPPORTED, NULL,NULL,       NO_SIZE,        TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x17 (unsupported, not in the ECMA spec)
 
 TYPEINFO(ELEMENT_TYPE_I,            "System", "IntPtr",        sizeof(void*),  TYPE_GC_NONE,   false,  true,   false,  false,  false) // 0x18
 TYPEINFO(ELEMENT_TYPE_U,            "System", "UIntPtr",       sizeof(void*),  TYPE_GC_NONE,   false,  true,   false,  false,  false) // 0x19
-TYPEINFO(ELEMENT_TYPE_R_UNSUPPORTED,NULL, NULL,                ~0,             TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x1a (unsupported, not in the ECMA spec)
+TYPEINFO(ELEMENT_TYPE_R_UNSUPPORTED,NULL, NULL,                NO_SIZE,        TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x1a (unsupported, not in the ECMA spec)
 
 TYPEINFO(ELEMENT_TYPE_FNPTR,        NULL, NULL,                sizeof(void*),  TYPE_GC_NONE,   false,  false,  false,  false,  false) // 0x1b
 TYPEINFO(ELEMENT_TYPE_OBJECT,       "System", "Object",        sizeof(void*),  TYPE_GC_REF,    false,  false,  false,  false,  false) // 0x1c

--- a/src/inc/gcinfoencoder.h
+++ b/src/inc/gcinfoencoder.h
@@ -554,7 +554,7 @@ public:
             size_t currentChunk = ((size_t) n) & (numEncodings-1);
             size_t topmostBit = currentChunk & (numEncodings >> 1);
             n >>= base; // signed arithmetic shift
-            if( topmostBit && (n == (SSIZE_T)-1) || !topmostBit && (n == 0))
+            if((topmostBit && (n == (SSIZE_T)-1)) || (!topmostBit && (n == 0)))
             {
                 // The topmost bit correctly represents the sign
                 Write( currentChunk, base+1 ); // This sets the extension bit to zero

--- a/src/inc/internalunknownimpl.h
+++ b/src/inc/internalunknownimpl.h
@@ -70,7 +70,7 @@ namespace ComUtil
         typedef char (&_Yes)[1];
         typedef char (&_No)[2];
 
-        static _No _IsTypeWrapper(...);
+        static inline _No _IsTypeWrapper(...);
 
         template <typename T>
         static _Yes _IsTypeWrapper(T *, typename T::wrapped_type * = nullptr);

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3769,7 +3769,7 @@ EXPSET_TP Compiler::optImpliedByConstAssertion(AssertionDsc* constAssertion)
         case O2K_CONST_INT:
             // Is the const assertion's constant equal/not equal to the implied assertion?
             usable = ((impAssertion->assertionKind == OAK_EQUAL) && (impAssertion->op2.u1.iconVal == iconVal)) ||
-                      (impAssertion->assertionKind == OAK_NOT_EQUAL) && (impAssertion->op2.u1.iconVal != iconVal);
+                     ((impAssertion->assertionKind == OAK_NOT_EQUAL) && (impAssertion->op2.u1.iconVal != iconVal));
             break;
         }
 

--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -1925,12 +1925,11 @@ UNATIVE_OFFSET      emitter::emitInsSizeAM(instrDesc* id, size_t code)
         // Most 16-bit operands will require a size prefix .
         // This refers to 66h size prefix override.
 
-        if  (    (attrSize == EA_2BYTE)
 #if FEATURE_STACK_FP_X87
-              && (ins != INS_fldcw)
-              && (ins != INS_fnstcw)
+        if ((attrSize == EA_2BYTE) && (ins != INS_fldcw) && (ins != INS_fnstcw))
+#else // FEATURE_STACK_FP_X87
+        if (attrSize == EA_2BYTE)
 #endif // FEATURE_STACK_FP_X87
-              )
         {
             size++;
         }

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -5382,8 +5382,8 @@ DECODE_OPCODE:
         case CEE_CALLI:
             {
                 if (compIsForInlining() || // Ignore tail call in the inlinee. Period.
-                    !tailCall &&
-                    !compTailCallStress()  // A new BB with BBJ_RETURN would have been created
+                    (!tailCall &&
+                    !compTailCallStress())  // A new BB with BBJ_RETURN would have been created
 
                     // after a tailcall statement.
                     // We need to keep this invariant if we want to stress the tailcall.
@@ -21716,7 +21716,7 @@ JitInlineResult       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call)
                          pParam->pThis->eeGetMethodFullName(pParam->fncHandle),
                          pParam->pThis->dspPtr(pParam->inlineInfo->tokenLookupContextHandle)));
 
-            unsigned   compileFlagsForInlinee = pParam->pThis->opts.eeFlags & ~CORJIT_FLG_LOST_WHEN_INLINING
+            unsigned   compileFlagsForInlinee = (pParam->pThis->opts.eeFlags & ~CORJIT_FLG_LOST_WHEN_INLINING)
                                                          | CORJIT_FLG_SKIP_VERIFICATION;
 
 #ifdef DEBUG

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1913,9 +1913,9 @@ void                Compiler::impSpillSideEffects(bool      spillGlobEffects,
         GenTreePtr lclVarTree;
             
         if  ((tree->gtFlags & spillFlags) != 0        ||
-              spillGlobEffects &&                         // Only consider the following when  spillGlobEffects == TRUE               
+              (spillGlobEffects &&                        // Only consider the following when  spillGlobEffects == TRUE               
               !impIsAddressInLocal(tree, &lclVarTree) &&  // No need to spill the GT_ADDR node on a local.
-              gtHasLocalsWithAddrOp(tree))                // Spill if we still see GT_LCL_VAR that contains lvHasLdAddrOp or lvAddrTaken flag.
+              gtHasLocalsWithAddrOp(tree)))               // Spill if we still see GT_LCL_VAR that contains lvHasLdAddrOp or lvAddrTaken flag.
         {
             impSpillStackEntry(i, BAD_VAR_NUM 
                                DEBUGARG(false) DEBUGARG(reason));
@@ -6085,8 +6085,12 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
     }
     else
 #endif  //INLINE_NDIRECT
-    if  (opcode == CEE_CALLI &&
-         (sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_STDCALL  ||
+    // TODO-Review: the indentation below suggests different precedence of the && and ||
+    // operators than the one based on the parens around the first && term. 
+    // It needs to be investigated whether the indentation is wrong or the
+    // parens are wrong and all the || terms should be grouped together in parens.
+    if ((opcode == CEE_CALLI &&
+         (sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_STDCALL) ||
          (sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_C        ||
          (sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_THISCALL ||
          (sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_FASTCALL)
@@ -10488,8 +10492,12 @@ _CONV:
             if (codeAddr < codeEndp)
             {
                 OPCODE nextOpcode = (OPCODE) getU1LittleEndian(codeAddr);
-                if (!opts.compDbgCode &&
-                    (nextOpcode == CEE_STLOC)   ||
+                // TODO-Review: the indentation below suggests different precedence of the && and ||
+                // operators than the one based on the parens around the first && term. 
+                // It needs to be investigated whether the indentation is wrong or the
+                // parens are wrong and all the || terms should be grouped together in parens.
+                if ((!opts.compDbgCode &&
+                    (nextOpcode == CEE_STLOC))  ||
                     (nextOpcode == CEE_STLOC_S) ||
                     ((nextOpcode >= CEE_STLOC_0) && (nextOpcode <= CEE_STLOC_3)))
                 {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -7802,7 +7802,7 @@ LinearScan::handleOutoingCriticalEdges(BasicBlock*  block)
             // live only at another target), and we can't copy another lclVar into that reg in this block.
             regMaskTP sameToRegMask = genRegMask(sameToReg);
             if (maybeSameLivePaths &&
-                ((sameToRegMask & liveOutRegs) != RBM_NONE) || ((sameToRegMask & sameWriteRegs) != RBM_NONE))
+                (((sameToRegMask & liveOutRegs) != RBM_NONE) || ((sameToRegMask & sameWriteRegs) != RBM_NONE)))
             {
                 sameToReg = REG_NA;
             }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3880,11 +3880,11 @@ void            Compiler::fgSetRngChkTarget(GenTreePtr  tree,
 {
     GenTreeBoundsChk* bndsChk = NULL;
 
-    if ((tree->gtOper == GT_ARR_BOUNDS_CHECK)
 #ifdef FEATURE_SIMD
-        || (tree->gtOper == GT_SIMD_CHK)
+    if ((tree->gtOper == GT_ARR_BOUNDS_CHECK) || (tree->gtOper == GT_SIMD_CHK))
+#else // FEATURE_SIMD
+    if (tree->gtOper == GT_ARR_BOUNDS_CHECK)
 #endif // FEATURE_SIMD
-        )
     {
         bndsChk = tree->AsBoundsChk();
     }

--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -353,12 +353,13 @@ void                dspRegMask(regMaskTP regMask, size_t minSiz)
 #endif // _TARGET_*
             }
             // We've already printed a register. Is this the end of a range?
-            else if ((regNum == REG_INT_LAST)
 #if defined(_TARGET_ARM64_)
+            else if ((regNum == REG_INT_LAST)
                      || (regNum == REG_R17) // last register before TEB
-                     || (regNum == REG_R28) // last register before FP
+                     || (regNum == REG_R28)) // last register before FP
+#else // _TARGET_ARM64_
+            else if (regNum == REG_INT_LAST)
 #endif // _TARGET_ARM64_
-                    )
             {
                 const char* nam = getRegName(regNum);
                 printf("%s%s", sep, nam);

--- a/src/md/ceefilegen/blobfetcher.cpp
+++ b/src/md/ceefilegen/blobfetcher.cpp
@@ -14,14 +14,6 @@
 #include "log.h"
 
 //-----------------------------------------------------------------------------
-//  round a pointer back down to something aligned
-static inline char* truncateTo(__in char* val, unsigned align) {
-    _ASSERTE((align & (align - 1)) == 0);       // align must be a power of 2
-
-    return((char*) ((UINT_PTR)(val) & ~(((UINT_PTR)align)-1)));
-}
-
-//-----------------------------------------------------------------------------
 //  round up to a certain alignment
 static inline unsigned roundUp(unsigned val, unsigned align) {
     _ASSERTE((align & (align - 1)) == 0);       // align must be a power of 2

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1380,7 +1380,7 @@ typedef VOID (__stdcall *WAITORTIMERCALLBACK)(PVOID, BOOLEAN);
 #define PORTABILITY_ASSERT(message)     _ASSERTE(false && message)
 #endif
 
-#define UNREFERENCED_PARAMETER(P)          (P)
+#define UNREFERENCED_PARAMETER(P)          (void)(P)
 
 #ifdef _WIN64
 #define VALPTR(x) VAL64(x)

--- a/src/palrt/decarith.cpp
+++ b/src/palrt/decarith.cpp
@@ -1001,10 +1001,10 @@ HaveScale64:
             rgulRem[1] = (rgulRem[1] << 1) + ulTmp;
             rgulRem[2] = (rgulRem[2] << 1) + ulTmp1;
 
-            if (rgulRem[2] > rgulDivisor[2] || rgulRem[2] == rgulDivisor[2] &&
-                (rgulRem[1] > rgulDivisor[1] || rgulRem[1] == rgulDivisor[1] &&
-                (rgulRem[0] > rgulDivisor[0] || rgulRem[0] == rgulDivisor[0] &&
-                (rgulQuo[0] & 1))))
+            if (rgulRem[2] > rgulDivisor[2] || (rgulRem[2] == rgulDivisor[2] &&
+                (rgulRem[1] > rgulDivisor[1] || (rgulRem[1] == rgulDivisor[1] &&
+                (rgulRem[0] > rgulDivisor[0] || (rgulRem[0] == rgulDivisor[0] &&
+                (rgulQuo[0] & 1)))))))
               goto RoundUp;
             break;
           }

--- a/src/palrt/decconv.cpp
+++ b/src/palrt/decconv.cpp
@@ -186,7 +186,7 @@ VarDecFromR4(float fltIn, DECIMAL FAR* pdecOut)
     //
     ulMant = (LONG)dbl;
     dbl -= (double)ulMant;  // difference between input & integer
-    if ( dbl > 0.5 || dbl == 0.5 && (ulMant & 1) )
+    if ( dbl > 0.5 || (dbl == 0.5 && (ulMant & 1)) )
       ulMant++;
 
     if (ulMant == 0)
@@ -333,7 +333,7 @@ VarDecFromR8(double dblIn, DECIMAL FAR* pdecOut)
     //
     sdlMant.int64 = (LONGLONG)dbl;
     dbl -= (double)(LONGLONG)sdlMant.int64;  // dif between input & integer
-    if ( dbl > 0.5 || dbl == 0.5 && (sdlMant.u.Lo & 1) )
+    if ( dbl > 0.5 || (dbl == 0.5 && (sdlMant.u.Lo & 1)) )
       sdlMant.int64++;
 
     if (sdlMant.int64 == 0)
@@ -529,7 +529,7 @@ STDAPI VarCyFromDec(DECIMAL FAR* pdecIn, CY FAR* pcyOut)
       // Round result based on remainder in sdlTmp1.Hi.
       //
       ulPwr >>= 1;  // compare to power/2 (power always even)
-      if (sdlTmp1.u.Hi > ulPwr || sdlTmp1.u.Hi == ulPwr && (sdlTmp.u.Lo & 1))
+      if (sdlTmp1.u.Hi > ulPwr || (sdlTmp1.u.Hi == ulPwr && (sdlTmp.u.Lo & 1)))
         sdlTmp.int64++;
     }
     else {
@@ -584,8 +584,8 @@ STDAPI VarCyFromDec(DECIMAL FAR* pdecIn, CY FAR* pcyOut)
       // Current result is in sdlTmp.
       //
       ulPwr >>= 1;  // compare to power/2 (power always even)
-      if (sdlTmp1.u.Lo > ulPwr || sdlTmp1.u.Lo == ulPwr &&
-	  		((sdlTmp.u.Lo & 1) || sdlTmp1.u.Hi != 0))
+      if (sdlTmp1.u.Lo > ulPwr || (sdlTmp1.u.Lo == ulPwr &&
+	  		((sdlTmp.u.Lo & 1) || sdlTmp1.u.Hi != 0)))
         sdlTmp.int64++;
     }
 

--- a/src/utilcode/corimage.cpp
+++ b/src/utilcode/corimage.cpp
@@ -82,8 +82,8 @@ Cor_RtlImageRvaToSection32(PTR_IMAGE_NT_HEADERS32 NtHeaders,
     NtSection = PTR_IMAGE_FIRST_SECTION( NtHeaders );
     for (i=0; i<NtHeaders->FileHeader.NumberOfSections; i++) {
         if (FileLength &&
-            ((VAL32(NtSection->PointerToRawData) > FileLength)) ||
-            (VAL32(NtSection->SizeOfRawData) > FileLength - VAL32(NtSection->PointerToRawData)))
+            (((VAL32(NtSection->PointerToRawData) > FileLength)) ||
+            (VAL32(NtSection->SizeOfRawData) > FileLength - VAL32(NtSection->PointerToRawData))))
             return NULL;
         if (Rva >= VAL32(NtSection->VirtualAddress) &&
             Rva < VAL32(NtSection->VirtualAddress) + VAL32(NtSection->SizeOfRawData))
@@ -107,8 +107,8 @@ Cor_RtlImageRvaToSection64(PTR_IMAGE_NT_HEADERS64 NtHeaders,
     NtSection = PTR_IMAGE_FIRST_SECTION( NtHeaders );
     for (i=0; i<VAL16(NtHeaders->FileHeader.NumberOfSections); i++) {
         if (FileLength &&
-            ((VAL32(NtSection->PointerToRawData) > FileLength)) ||
-            (VAL32(NtSection->SizeOfRawData) > FileLength - VAL32(NtSection->PointerToRawData)))
+            (((VAL32(NtSection->PointerToRawData) > FileLength)) ||
+            (VAL32(NtSection->SizeOfRawData) > FileLength - VAL32(NtSection->PointerToRawData))))
             return NULL;
         if (Rva >= VAL32(NtSection->VirtualAddress) &&
             Rva < VAL32(NtSection->VirtualAddress) + VAL32(NtSection->SizeOfRawData))

--- a/src/utilcode/ex.cpp
+++ b/src/utilcode/ex.cpp
@@ -1815,16 +1815,20 @@ Exception *ExThrowWithInnerHelper(Exception *inner)
 
 #ifdef _DEBUG
 
-#pragma warning(disable: 4748)
+#ifdef _MSC_VER
 #pragma optimize("", off)
-#pragma warning(disable: 4748)
-
+#endif // _MSC_VER
 
 void ExThrowTrap(const char *fcn, const char *file, int line, const char *szType, HRESULT hr, const char *args)
 {
     SUPPORTS_DAC;
     return;
 }
+
+#ifdef _MSC_VER
+#pragma optimize("", on)
+#endif // _MSC_VER
+
 #endif
 
 

--- a/src/utilcode/rangetree.cpp
+++ b/src/utilcode/rangetree.cpp
@@ -357,8 +357,8 @@ BOOL RangeTree::OverlapsNode(Node *node, SIZE_T start, SIZE_T end, SIZE_T mask)
             && (end > node->start && start < node->end))
             return TRUE;
 
-        if (node->children[0] != NULL && OverlapsNode(node->children[0], start, end, mask)
-            || node->children[1] != NULL && OverlapsNode(node->children[1], start, end, mask))
+        if ((node->children[0] != NULL && OverlapsNode(node->children[0], start, end, mask))
+            || (node->children[1] != NULL && OverlapsNode(node->children[1], start, end, mask)))
             return TRUE;
 
         return FALSE;

--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -1980,7 +1980,7 @@ HRESULT validateTokenSig(
             if(i == IMAGE_CEE_CS_CALLCONV_FIELD) return validateOneArg(tk, &sig, NULL, pImport, TRUE);
             
             // EXPLICITTHIS and native call convs are for stand-alone sigs only (for calli)
-            if((i != IMAGE_CEE_CS_CALLCONV_DEFAULT)&&( i != IMAGE_CEE_CS_CALLCONV_VARARG)
+            if(((i != IMAGE_CEE_CS_CALLCONV_DEFAULT)&&( i != IMAGE_CEE_CS_CALLCONV_VARARG))
                 || (ulCallConv & IMAGE_CEE_CS_CALLCONV_EXPLICITTHIS)) return VLDTR_E_MD_BADCALLINGCONV;
             break;
             

--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -1393,9 +1393,9 @@ TypeHandle ClassLoader::LookupTypeHandleForTypeKeyInner(TypeKey *pKey, BOOL fChe
     // Check if it's the typical instantiation.  In this case it's not stored in the same
     // way as other constructed types.
     if (!pKey->IsConstructed() || 
-        pKey->GetKind() == ELEMENT_TYPE_CLASS && ClassLoader::IsTypicalInstantiation(pKey->GetModule(), 
-                                                                                     pKey->GetTypeToken(),
-                                                                                     pKey->GetInstantiation()))
+        (pKey->GetKind() == ELEMENT_TYPE_CLASS && ClassLoader::IsTypicalInstantiation(pKey->GetModule(), 
+                                                                                      pKey->GetTypeToken(),
+                                                                                      pKey->GetInstantiation())))
     {
         return TypeHandle(pKey->GetModule()->LookupTypeDef(pKey->GetTypeToken()));
     }
@@ -6235,7 +6235,7 @@ BOOL ClassLoader::CheckAccessMember(                // TRUE if access is allowed
     // it was already done in CanAccessClass above.
 
     if (accessCheckOptions.TransparencyCheckNeeded() &&
-        (checkTargetMethodTransparency && pOptionalTargetMethod ||
+        ((checkTargetMethodTransparency && pOptionalTargetMethod) ||
          pOptionalTargetField))
     {
         if (!CheckTransparentAccessToCriticalCode(

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -2393,7 +2393,7 @@ EEJitManager::DomainCodeHeapList *EEJitManager::GetCodeHeapList(MethodDesc *pMD,
     for (int i=0; i < count; i++)
     {
         if (ppList[i]->m_pAllocator == pAllocator ||
-            !fCanUnload && !ppList[i]->m_pAllocator->CanUnload())
+            (!fCanUnload && !ppList[i]->m_pAllocator->CanUnload()))
         {
             pList = ppList[i];
             break;

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -6226,8 +6226,8 @@ StackFrame ExceptionTracker::FindParentStackFrameHelper(CrawlFrame* pCF,
 
 lExit: ;
 
-    STRESS_LOG3(LF_EH|LF_GCROOTS, LL_INFO100, "Returning" FMT_ADDR "as the parent stack frame for %s" FMT_ADDR "\n",
-                DBG_ADDR(sfResult.SP), fIsFilterFunclet ? "filter funclet" : "funclet", DBG_ADDR(csfCurrent.SP));
+    STRESS_LOG3(LF_EH|LF_GCROOTS, LL_INFO100, "Returning 0x%p as the parent stack frame for %s 0x%p\n",
+                sfResult.SP, fIsFilterFunclet ? "filter funclet" : "funclet", csfCurrent.SP);
 
     return sfResult;
 }

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -490,7 +490,7 @@ Frame::~Frame()
         Pop(pThread);
     }
 }
-#endif FEATURE_PAL
+#endif // FEATURE_PAL
 
 //-----------------------------------------------------------------------
 #endif // #ifndef DACCESS_COMPILE

--- a/src/vm/gcenv.cpp
+++ b/src/vm/gcenv.cpp
@@ -327,25 +327,6 @@ StackWalkAction GcStackCrawlCallBack(CrawlFrame* pCF, VOID* pData)
     return SWA_CONTINUE;
 }
 
-static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
-{
-    LIMITED_METHOD_CONTRACT;
-
-    LOG((LF_GC, LL_INFO100000, LOG_HANDLE_OBJECT_CLASS("Checking referent of Weak-", pObjRef, "to ", *pObjRef)));
-
-    Object **pRef = (Object **)pObjRef;
-    if (!GCHeap::GetGCHeap()->IsPromoted(*pRef))
-    {
-        LOG((LF_GC, LL_INFO100, LOG_HANDLE_OBJECT_CLASS("Severing Weak-", pObjRef, "to unreachable ", *pObjRef)));
-
-        *pRef = NULL;
-    }
-    else
-    {
-        LOG((LF_GC, LL_INFO1000000, "reachable " LOG_OBJECT_CLASS(*pObjRef)));
-    }
-}
-
 VOID GCToEEInterface::SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, LPARAM lp1, LPARAM lp2)
 {
     CONTRACTL

--- a/src/vm/hash.h
+++ b/src/vm/hash.h
@@ -491,7 +491,7 @@ public:
         {
             LIMITED_METHOD_DAC_CONTRACT;
 
-            for (m_pBucket = m_pBucket;m_pBucket < m_pSentinel; m_pBucket++)
+            for (;m_pBucket < m_pSentinel; m_pBucket++)
             {   //loop thru all buckets
                 for (m_id = m_id+1; m_id < 4; m_id++)
                 {   //loop through all slots

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -1509,7 +1509,7 @@ ULONG SafeReleasePreemp(IUnknown * pUnk, RCW * pRCW)
     return res;
 }
 
-#ifdef _TARGET_AMD64_
+#if defined(_TARGET_AMD64_) && defined(_MSC_VER)
 // codegen bug on amd64 causes BBT to fail for the following function.  as a
 // workaround I have disabled optimizations for it until we get an updated toolset.
 #pragma optimize( "", off )
@@ -1600,7 +1600,7 @@ ULONG SafeRelease(IUnknown* pUnk, RCW* pRCW)
 
     return res;
 }
-#ifdef _TARGET_AMD64_
+#if defined(_TARGET_AMD64_) && defined(_MSC_VER)
 // turn optimizations back on
 #pragma optimize( "", on )
 #endif

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -4050,7 +4050,7 @@ DWORD CEEInfo::getClassAttribsInternal (CORINFO_CLASS_HANDLE clsHnd)
             if (pMT->ContainsStackPtr())
                 ret |= CORINFO_FLG_CONTAINS_STACK_PTR;
 
-            if (pClass->IsNotTightlyPacked() && (!pClass->IsManagedSequential() || pClass->HasExplicitSize()) ||
+            if ((pClass->IsNotTightlyPacked() && (!pClass->IsManagedSequential() || pClass->HasExplicitSize())) ||
                 pMT == g_TypedReferenceMT ||
                 VMClsHnd.IsNativeValueType())
             {

--- a/src/vm/object.cpp
+++ b/src/vm/object.cpp
@@ -2176,7 +2176,7 @@ INT32 StringObject::FastCompareStringHelper(DWORD* strAChars, INT32 countA, DWOR
             alignmentA = 0;
         }
 
-        if ((alignmentA == 0))
+        if (alignmentA == 0)
         {
             while (count >= 4)
             {

--- a/src/vm/securitymeta.cpp
+++ b/src/vm/securitymeta.cpp
@@ -1723,7 +1723,7 @@ void ModuleSecurityDescriptor::VerifyDataComputed()
 #endif // _DEBUG
 
 #ifdef FEATURE_CORECLR
-    if (pAssembly->IsSystem() || pAssembly->GetManifestFile()->HasOpenedILimage() && GetAppDomain()->IsImageFullyTrusted(pAssembly->GetManifestFile()->GetOpenedILimage()))
+    if (pAssembly->IsSystem() || (pAssembly->GetManifestFile()->HasOpenedILimage() && GetAppDomain()->IsImageFullyTrusted(pAssembly->GetManifestFile()->GetOpenedILimage())))
     {
         // Set the flag if the assembly is microsoft platform. This gets saved in Ngen Image
         // to determinne if the NI was genrated as full-trust. If NI is generated as full-trust

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -1121,7 +1121,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
         ClassLoader::NotFoundAction  notFoundAction;
         CorInternalStates            tdTypes;
 
-        switch(typ) {
+        switch((DWORD)typ) {
         case ELEMENT_TYPE_TYPEDBYREF:
         {
             thRet = TypeHandle(g_TypedReferenceMT);
@@ -1517,7 +1517,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
             // Check that the type that we loaded matches the signature
             //   with regards to ET_CLASS and ET_VALUETYPE
             // 
-            if ((fLoadTypes == ClassLoader::LoadTypes))
+            if (fLoadTypes == ClassLoader::LoadTypes)
             {
                 // Skip this check when using zap sigs; it should have been correctly computed at NGen time 
                 // and a change from one to the other would have invalidated the image. 
@@ -1811,7 +1811,7 @@ TypeHandle SigPointer::GetGenericInstType(Module *        pModule,
         }
 
 #ifndef DACCESS_COMPILE
-        if ((fLoadTypes == ClassLoader::LoadTypes))
+        if (fLoadTypes == ClassLoader::LoadTypes)
         {
             // Skip this check when using zap sigs; it should have been correctly computed at NGen time 
             // and a change from one to the other would have invalidated the image.  Leave in the code for debug so we can assert below.
@@ -4816,9 +4816,9 @@ BOOL MetaSig::CompareVariableConstraints(const Substitution *pSubst1,
         // b) may be implicit (ie. absent) in the overriden variable's declaration
         if (!(CompareTypeDefOrRefOrSpec(pModule1, tkConstraintType1, NULL, 
                                        MscorlibBinder::GetModule(), g_pObjectClass->GetCl(), NULL, NULL) || 
-          ((specialConstraints1 & gpNotNullableValueTypeConstraint) != 0) && 
+          (((specialConstraints1 & gpNotNullableValueTypeConstraint) != 0) && 
            (CompareTypeDefOrRefOrSpec(pModule1, tkConstraintType1, NULL, 
-                      MscorlibBinder::GetModule(), g_pValueTypeClass->GetCl(), NULL, NULL))))
+                      MscorlibBinder::GetModule(), g_pValueTypeClass->GetCl(), NULL, NULL)))))
         {
             HENUMInternalHolder hEnum2(pInternalImport2);
             mdGenericParamConstraint tkConstraint2;

--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -1972,8 +1972,8 @@ ProcessFuncletsForGCReporting:
                                     _ASSERTE(m_flags & GC_FUNCLET_REFERENCE_REPORTING);
 
                                     STRESS_LOG2(LF_GCROOTS, LL_INFO100, 
-                                    "STACKWALK: Reached parent of non-filter funclet @ CallerSP: " FMT_ADDR ", m_crawl.pFunc = " FMT_ADDR "\n", 
-                                    DBG_ADDR(m_sfParent.SP), DBG_ADDR(m_crawl.pFunc));
+                                    "STACKWALK: Reached parent of non-filter funclet @ CallerSP: %p, m_crawl.pFunc = %p\n",
+                                    m_sfParent.SP, m_crawl.pFunc);
 
                                     // by default a funclet's parent won't report its GC roots since they would have already
                                     // been reported by the funclet.  however there is a small window during unwind before
@@ -2008,8 +2008,8 @@ ProcessFuncletsForGCReporting:
                                         }
                                         
                                         STRESS_LOG4(LF_GCROOTS, LL_INFO100, 
-                                        "Funclet didn't report references: handling frame: " FMT_ADDR ", m_sfFuncletParent = " FMT_ADDR ", is funclet: %d, skip reporting %d\n", 
-                                        DBG_ADDR(pTracker->GetEstablisherOfActualHandlingFrame().SP), DBG_ADDR(m_sfFuncletParent.SP), m_crawl.IsFunclet(), shouldSkipReporting);
+                                        "Funclet didn't report references: handling frame: %p, m_sfFuncletParent = %p, is funclet: %d, skip reporting %d\n", 
+                                        pTracker->GetEstablisherOfActualHandlingFrame().SP, m_sfFuncletParent.SP, m_crawl.IsFunclet(), shouldSkipReporting);
                                     }
                                     m_crawl.fShouldParentToFuncletSkipReportingGCReferences = shouldSkipReporting;
 


### PR DESCRIPTION
This change fixes the following warnings:
1) Assignment in a condition should be wrapped in ()
2) Priority of && / || should be indicated by parentheses. It has uncovered 3 real bugs.
3) Unknown #pragma optimize ifdefed out for non MSVC
4) Unused functions deleted or put under #ifdef
5) Extra tokens warning disabling moved to the CMakeLists.txt in the src/inc
6) Self assignment of a member or local variable
7) Assigning ~0 to a bitfield member that was just 8 bit wide

It also fixes a bug in the STRESS_LOGxx macro invocation in exceptionhandling.cpp and
stackwalk.cpp related to recent adding the DBG_ADDR macro usage. This macro expanded
a single parameter into two expressions to extract high / low 32 bits separately.
But the STRESS_LOGxx parameters are passed to the StressLog::LogMsg method as follows:
(void*)(size_t)(data1)
That means that the expanded pair x, y would be inserted as data 1 and that leads
to ignoring the x due to the comma operator.