### PR TITLE
Special-case value.Length == 0 in LastIndexOfOrdinal

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -54,6 +54,12 @@ namespace System.Globalization
             Contract.Assert(value != null);
 
             // TODO: Implement This Fully.
+
+            if (value.Length == 0)
+            {
+                return startIndex;
+            }
+
             if (ignoreCase)
             {
                 source = source.ToUpper(CultureInfo.InvariantCulture);


### PR DESCRIPTION
With https://github.com/dotnet/coreclr/pull/579, I added to IndexOfOrdinal a check for value.Length == 0, to avoid returning bad data in that case.  But in doing so, and in neglecting to add a similar check to LastIndexOfOrdinal (which is currently implemented in terms of IndexOfOrdinal), I introduced an infinite loop into LastIndexOfOrdinal when value.Length == 0.  Fixing by adding a similar special-case.