### PR TITLE
Fix file paths when restoring nuget packages on Unix.

### DIFF
--- a/dir.targets
+++ b/dir.targets
@@ -1,5 +1,22 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
+
+  <UsingTask TaskName="FixFilePath" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
+    <ParameterGroup>
+      <FilePath ParameterType="System.String" Required="true" />
+      <FixedFilePath ParameterType="System.String" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+           FixedFilePath = Path.DirectorySeparatorChar != '\\' ?
+             FilePath.Replace('\\', Path.DirectorySeparatorChar) :
+             FilePath;
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
   <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
   <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
     <ParameterGroup>
@@ -27,6 +44,18 @@
     Outputs="$(BuildToolsCoreCLRTargetOutputs)"
     >
 
+    <FixFilePath FilePath="$(NugetToolPath)">
+      <Output PropertyName="NugetToolPath" TaskParameter="FixedFilePath" />
+    </FixFilePath>
+
+    <FixFilePath FilePath="$(SourceDir).nuget\packages.config">
+      <Output PropertyName="PackagesConfigPath" TaskParameter="FixedFilePath" />
+    </FixFilePath>
+
+    <FixFilePath FilePath="$(ToolsDir)">
+      <Output PropertyName="ToolsDir" TaskParameter="FixedFilePath" />
+    </FixFilePath>
+
     <!-- Download latest nuget.exe -->
     <DownloadFile
       Condition="!Exists($(NuGetToolPath))"
@@ -36,7 +65,7 @@
     <!-- Restore build tools -->
     <Exec
       StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; install &quot; $(SourceDir).nuget\packages.config &quot;  -o &quot; $(ToolsDir) &quot; $(NuGetConfigCommandLine)" />
+      Command="&quot;$(NuGetToolPath)&quot; install &quot;$(PackagesConfigPath)&quot;  -o &quot;$(ToolsDir)&quot; $(NuGetConfigCommandLine)" />
 
     <Touch Files="$(BuildToolsInstallSemaphore)" AlwaysCreate="true" />
   </Target>


### PR DESCRIPTION
Related to issue #170.

I attempted to build mscorlib on Linux using an xplat build of MSBuild (`mono MSBuild.exebuild.proj -nologo -p:OS=Unix -t:rebuild -p:BuildNugetPackage=false`) and ran into issues when a custom code task attempted to download NuGet and perform a NuGet restore because the associated paths used the Windows directory delimiter (`\`) instead of the Unix directory delimiter (`/`).

This pull request adds a new `FixFilePath` task that will rewrite (or create) a path using the OS-appropriate delimiter. It also uses this new task to generate appropriate paths for NuGet download/restore.

After applying this commit, the build will still fail, but it does so at a later stage (running ResGen).

This is also related to [issue 55](https://github.com/Microsoft/msbuild/issues/55) on MSBuild.

Additional note: there are some whitespace changes on line 68 to remove spaces from the inside of quoted strings. Apparently, these spaces were being ignored on Windows, but on Unix they are treated as part of the file name.