### PR TITLE
Ensure FEATURE_COREFX_GLOBALIZATION is defined for the runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,7 @@ endif (WIN32)
 if (CLR_CMAKE_PLATFORM_UNIX)
   add_definitions(-DPLATFORM_UNIX=1)
   add_definitions(-DFEATURE_PAL_SXS)
+  add_definitions(-DFEATURE_COREFX_GLOBALIZATION)
 
   if(IS_64BIT_BUILD)
     add_definitions(-DBIT64=1)

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -25,7 +25,6 @@ add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
 if(CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-fPIC)
-    add_definitions(-DFEATURE_COREFX_GLOBALIZATION)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 set(VM_SOURCES_DAC_AND_WKS_COMMON


### PR DESCRIPTION
A bunch of our System.Runtime.Tests.dll, System.Xml.XDocument.Properties.dll, and other tests were failing with formatting errors.  The runtime tests were also triggering a runtime assert at shutdown.  It appears that all of these stem from a mismatch between some data structure layouts in mscorlib and the runtime, in particular with NumberFormatInfo.

Several fields throughout NumberFormatInfo are included conditionally based on the  FEATURE_COREFX_GLOBALIZATION flag not being defined.  This flag is being set for the compilation of mscorlib, but it appears not to be set when compiling all relevant parts of the runtime, such that the native structure has extra fields not present in the managed structure.  This is resulting in fields being misinterpreted by the runtime when using the structure for formatting (and presumably it's also leading to some potential corruption).

This fix simply adds a define for FEATURE_COREFX_GLOBALIZATION to the makefile.  The tests that were failing now pass, and the runtime assertion is no longer firing.