### PR TITLE
Fix FormatMessageW in PAL

### DIFF
--- a/src/pal/src/misc/fmtmessage.cpp
+++ b/src/pal/src/misc/fmtmessage.cpp
@@ -711,7 +711,7 @@ FormatMessageW(
 
                     if ( !bIsVaList )
                     {
-                        lpInsertString = (LPWSTR)Arguments[ Index - 1 ];
+                        lpInsertString = ((LPWSTR*)Arguments)[ Index - 1 ];
                     }
                     else
                     {
@@ -791,7 +791,7 @@ FormatMessageW(
 
                     if ( !bIsVaList )
                     {
-                         lpInsert = (LPWSTR)Arguments[ Index - 1 ];
+                        lpInsert = ((LPWSTR*)Arguments)[Index - 1];
                     }
                     else
                     {


### PR DESCRIPTION
The function was not properly accessing the Arguments list when the
FORMAT_MESSAGE_ARGUMENT_ARRAY flag was set. The va_list on Linux is
a struct with four members, so indexing Arguments array without
casting it first to a WCHAR** gets completely wrong results.