### PR TITLE
Clear last error for SetLastError=true P/Invoke

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -11334,6 +11334,7 @@
     </Type>
 
     <Type Status="ImplRoot" Name="System.StubHelpers.StubHelpers">
+      <Member Name="ClearLastError" />
       <Member Name="SetLastError" />
       <Member Name="IsQCall(System.IntPtr)" />
       <Member Name="InitDeclaringType(System.IntPtr)" />

--- a/src/mscorlib/src/System/StubHelpers.cs
+++ b/src/mscorlib/src/System/StubHelpers.cs
@@ -1598,6 +1598,11 @@ namespace  System.StubHelpers {
         static internal extern void DemandPermission(IntPtr pNMD);
 #endif // !FEATURE_CORECLR
 
+#if FEATURE_CORECLR
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        static internal extern void ClearLastError();
+#endif
+
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static internal extern void SetLastError();
 

--- a/src/pal/src/include/pal/process.h
+++ b/src/pal/src/include/pal/process.h
@@ -42,8 +42,6 @@ extern Volatile<LONG> terminator;
 extern DWORD gPID;
 extern LPWSTR pAppDir;
 
-extern DWORD StartupLastError;
-
 /*++
 Function:
   PROCGetProcessIDFromHandle

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -497,19 +497,21 @@ namespace CorUnix
             return synchronizationInfo.TryAcquireNativeWaitLock();
         }
 
-        void
+        static void
         SetLastError(
             DWORD dwLastError
             )
         {
-            errno = dwLastError;    
+            // Reuse errno to store last error
+            errno = dwLastError;
         };
 
-        DWORD
+        static DWORD
         GetLastError(
             void
             )
         {
+            // Reuse errno to store last error
             return errno;
         };
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -192,13 +192,14 @@ Initialize(
        case, since debug channels are not initialized yet. So in that case the
        ENTRY will be called after the DBG channels initialization */
     ENTRY_EXTERNAL("PAL_Initialize(argc = %d argv = %p)\n", argc, argv);
-    /*Firstly initiate a temporary lastError storage */
-    StartupLastError = ERROR_GEN_FAILURE;
+
+    /*Firstly initiate a lastError */
+    SetLastError(ERROR_GEN_FAILURE);
 
 #ifdef __APPLE__
     if (!RunningNatively())
     {
-        StartupLastError = ERROR_BAD_FORMAT;
+        SetLastError(ERROR_BAD_FORMAT);
         goto exit;
     }
 #endif // __APPLE__

--- a/src/pal/src/misc/error.cpp
+++ b/src/pal/src/misc/error.cpp
@@ -28,8 +28,6 @@ using namespace CorUnix;
 
 SET_DEFAULT_DEBUG_CHANNEL(MISC);
 
-DWORD StartupLastError;
-
 /*++
 Function:
   SetErrorMode
@@ -96,25 +94,7 @@ PALAPI
 GetLastError(
          VOID)
 {
-    DWORD retval;
-    CPalThread *pThread;
-
-    PERF_ENTRY(GetLastError);
-    ENTRY("GetLastError ()\n");
-    
-    pThread = InternalGetCurrentThread();
-    if (pThread == NULL)
-    {
-        retval = StartupLastError;
-        goto done;
-    }
-
-    retval = pThread->GetLastError();
-
-done:
-    LOGEXIT("GetLastError returns %d\n",retval);
-    PERF_EXIT(GetLastError);
-    return retval;
+    return CPalThread::GetLastError();
 }
 
 
@@ -142,24 +122,6 @@ PALAPI
 SetLastError(
          IN DWORD dwErrCode)
 {
-    CPalThread *pThread;
-  
-    PERF_ENTRY(SetLastError);
-    ENTRY("SetLastError (dwErrCode=%u)\n", dwErrCode);
-
-    pThread = InternalGetCurrentThread();
-    if (pThread == NULL)
-    {
-        StartupLastError = dwErrCode;
-        goto done;
-    }
-
-    pThread->SetLastError(dwErrCode);
-
-done:
-    LOGEXIT("SetLastError returns\n");
-    PERF_EXIT(SetLastError);
+    CPalThread::SetLastError(dwErrCode);
 }
-
-
 

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -1632,8 +1632,8 @@ CorUnix::CreateThreadData(
     {
         goto CreateThreadDataExit;
     }
-    
-    pThread->SetLastError(StartupLastError);
+
+    pThread->SetLastError(0);
 
     pThread->m_threadId = THREADSilentGetCurrentThreadId();
     pThread->m_pthreadSelf = pthread_self();

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -906,13 +906,23 @@ public:
         }
 #endif // MDA_SUPPORTED
 
+#ifdef FEATURE_CORECLR
+        // For CoreClr, clear the last error before calling the target that returns last error.
+        // There isn't always a way to know the function have failed without checking last error,
+        // in particular on Unix.
+        if (m_fSetLastError && SF_IsForwardStub(m_dwStubFlags))
+        {
+            pcsDispatch->EmitCALL(METHOD__STUBHELPERS__CLEAR_LAST_ERROR, 0, 0);
+        }
+#endif // FEATURE_CORECLR
+
         // Invoke the target (calli, call method, call delegate, get/set field, etc.)
         EmitInvokeTarget(pStubMD);
 
         // Saving last error must be the first thing we do after returning from the target
         if (m_fSetLastError && SF_IsForwardStub(m_dwStubFlags))
         {
-            m_slIL.EmitSetLastError(pcsDispatch);
+            pcsDispatch->EmitCALL(METHOD__STUBHELPERS__SET_LAST_ERROR, 0, 0);
         }
 
 #if defined(_TARGET_X86_)
@@ -2445,14 +2455,6 @@ void NDirectStubLinker::End(DWORD dwStubFlags)
     {
         pcs->EmitLDLOC(m_dwRetValLocalNum);
     }
-}
-
-
-void NDirectStubLinker::EmitSetLastError(ILCodeStream* pcsEmit)
-{
-    STANDARD_VM_CONTRACT;
-
-    pcsEmit->EmitCALL(METHOD__STUBHELPERS__SET_LAST_ERROR, 0, 0);
 }
 
 void NDirectStubLinker::DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, MethodDesc * pStubMD)
@@ -7294,6 +7296,10 @@ VOID NDirect::NDirectLink(NDirectMethodDesc *pMD)
 
 EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 {
+    LPVOID ret = NULL;
+
+    BEGIN_PRESERVE_LAST_ERROR;
+
     CONTRACTL
     {
         THROWS;
@@ -7302,8 +7308,6 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
         SO_TOLERANT;
     }
     CONTRACTL_END;
-
-    LPVOID ret = NULL;
 
     // this function is called by CLR to native assembly stubs which are called by 
     // managed code as a result, we need an unwind and continue handler to translate 
@@ -7362,6 +7366,8 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 
     UNINSTALL_UNWIND_AND_CONTINUE_HANDLER;
 
+    END_PRESERVE_LAST_ERROR;
+
     return ret;
 }
 
@@ -7372,6 +7378,8 @@ EXTERN_C LPVOID STDCALL NDirectImportWorker(NDirectMethodDesc* pMD)
 
 EXTERN_C void STDCALL VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock, VASigCookie *pVASigCookie, MethodDesc *pMD)
 {
+    BEGIN_PRESERVE_LAST_ERROR;
+
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
     STATIC_CONTRACT_MODE_COOPERATIVE;
@@ -7394,10 +7402,14 @@ EXTERN_C void STDCALL VarargPInvokeStubWorker(TransitionBlock * pTransitionBlock
     GetILStubForCalli(pVASigCookie, pMD);
 
     pFrame->Pop(CURRENT_THREAD);
+
+    END_PRESERVE_LAST_ERROR;
 }
 
 EXTERN_C void STDCALL GenericPInvokeCalliStubWorker(TransitionBlock * pTransitionBlock, VASigCookie * pVASigCookie, PCODE pUnmanagedTarget)
 {
+    BEGIN_PRESERVE_LAST_ERROR;
+
     STATIC_CONTRACT_THROWS;
     STATIC_CONTRACT_GC_TRIGGERS;
     STATIC_CONTRACT_MODE_COOPERATIVE;
@@ -7419,6 +7431,8 @@ EXTERN_C void STDCALL GenericPInvokeCalliStubWorker(TransitionBlock * pTransitio
     GetILStubForCalli(pVASigCookie, NULL);
 
     pFrame->Pop(CURRENT_THREAD);
+
+    END_PRESERVE_LAST_ERROR;
 }
 
 PCODE GetILStubForCalli(VASigCookie *pVASigCookie, MethodDesc *pMD)

--- a/src/vm/dllimport.h
+++ b/src/vm/dllimport.h
@@ -468,7 +468,6 @@ public:
 
     void    Begin(DWORD dwStubFlags);
     void    End(DWORD dwStubFlags);
-    void    EmitSetLastError(ILCodeStream* pcsEmit);
     void    DoNDirect(ILCodeStream *pcsEmit, DWORD dwStubFlags, MethodDesc * pStubMD);
     void    EmitLogNativeArgument(ILCodeStream* pslILEmit, DWORD dwPinnedLocal);
     void    LoadCleanupWorkList(ILCodeStream* pcsEmit);

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -1963,6 +1963,9 @@ FCFuncStart(gStubHelperFuncs)
     FCIntrinsic("GetNDirectTarget", StubHelpers::GetNDirectTarget, CORINFO_INTRINSIC_StubHelpers_GetNDirectTarget)
     FCFuncElement("GetDelegateTarget", StubHelpers::GetDelegateTarget)
     FCFuncElement("SetLastError", StubHelpers::SetLastError)
+#ifdef FEATURE_CORECLR
+    FCFuncElement("ClearLastError", StubHelpers::ClearLastError)
+#endif
     FCFuncElement("ThrowInteropParamException", StubHelpers::ThrowInteropParamException)
     FCFuncElement("InternalGetHRExceptionObject", StubHelpers::GetHRExceptionObject)
 #ifdef FEATURE_COMINTEROP

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1765,6 +1765,9 @@ DEFINE_METHOD(STUBHELPERS,          TRIGGER_EXCEPTION_SWALLOWED_MDA,          Tr
 DEFINE_METHOD(STUBHELPERS,          CHECK_COLLECTED_DELEGATE_MDA, CheckCollectedDelegateMDA, SM_IntPtr_RetVoid)
 #endif // MDA_SUPPORTED
 DEFINE_METHOD(STUBHELPERS,          SET_LAST_ERROR,         SetLastError,               SM_RetVoid)
+#ifdef FEATURE_CORECLR
+DEFINE_METHOD(STUBHELPERS,          CLEAR_LAST_ERROR,       ClearLastError,             SM_RetVoid)
+#endif
 
 DEFINE_METHOD(STUBHELPERS,          THROW_INTEROP_PARAM_EXCEPTION, ThrowInteropParamException,   SM_Int_Int_RetVoid)
 DEFINE_METHOD(STUBHELPERS,          ADD_TO_CLEANUP_LIST,    AddToCleanupList,           SM_RefCleanupWorkList_SafeHandle_RetIntPtr)

--- a/src/vm/stubhelpers.h
+++ b/src/vm/stubhelpers.h
@@ -90,6 +90,7 @@ public:
 #endif // FEATURE_COMINTEROP
 
     static FCDECL0(void,            SetLastError            );
+    static FCDECL0(void,            ClearLastError          );
     static FCDECL1(FC_BOOL_RET,     IsQCall,                NDirectMethodDesc* pNMD);
     static FCDECL1(void,            InitDeclaringType,      NDirectMethodDesc* pMND);
     static FCDECL1(void*,           GetNDirectTarget,       NDirectMethodDesc* pNMD);


### PR DESCRIPTION
There isn't always a way to know the system function has failed without checking last error, in particular on Unix. Moreover, CLR does not guarantee that the last error is preserved while the managed code is running so this issue cannot be worked around calling SetLastError.

This change adds clearing of last error for P/Invokes with SetLastError=true. The cost of doing so is negligible, it makes error handling for P/Invokes of the above system functions possible, and all the other P/Invokes more robust.

I also made GetLastError/SetLastError implementation in the Unix PAL more efficient while I was on it.