### PR TITLE
CQ fix for generic handle lookup in GenericHandleWorker

### DIFF
--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -3742,7 +3742,8 @@ JIT_GenericHandleWorker(
             {
                 // Add the denormalized key for faster lookup next time. This is not a critical entry - no need 
                 // to specify appdomain affinity.
-                AddToGenericHandleCache(&key, res);
+                JitGenericHandleCacheKey denormKey((CORINFO_CLASS_HANDLE)pMT, NULL, signature);
+                AddToGenericHandleCache(&denormKey, res);
                 return (CORINFO_GENERIC_HANDLE) (DictionaryEntry) res;                
             }
         }
@@ -3765,6 +3766,8 @@ JIT_GenericHandleWorker(
             pDictDomain = pMD->GetDomain();
         }
 
+        // Add the normalized key (pDeclaringMT) here so that future lookups of any
+        // inherited types are faster next time rather than just just for this specific pMT.
         JitGenericHandleCacheKey key((CORINFO_CLASS_HANDLE)pDeclaringMT, (CORINFO_METHOD_HANDLE)pMD, signature, pDictDomain);
         AddToGenericHandleCache(&key, (HashDatum)result);
     }


### PR DESCRIPTION
When looking up the runtime handle in the generic handle cache for a methodtable
we get the declaring methodtable in the hierarchy and then lookup the handle in
the cache from that methodtable. When found we should insert the handle back into
the table using the original methodtable as the key and not the declaring MT
so that later lookups are faster. Inserting the handle back into the table under
the original key was a noop.

Desktop DDR and JITSH testing clean. The test case in Github issue #55 is now
3x faster. Benchmarked roslyn performance which shows no change in performance.

This is a fix related to issue #55 reported by alexandr. See for more details.
@jkotas @briansull 