### PR TITLE
Make managed debugging on Linux possible 

### DIFF
--- a/src/debug/di/module.cpp
+++ b/src/debug/di/module.cpp
@@ -814,11 +814,12 @@ HRESULT CordbModule::InitPublicMetaDataFromFile()
         // Its possible that the debugger would still load the NGEN image sometime in the future and we will miss a sharing
         // opportunity. Its an acceptable loss from an imperfect heuristic.
         if (NULL == WszGetModuleHandle(szFullPathName))
+#endif            
         {
             szFullPathName = NULL;
             fDebuggerLoadingNgen = false;
         }
-#endif
+
     }
 
     // If we don't have or decided not to load the NGEN image, check to see if IL image is available
@@ -880,6 +881,11 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
                                                 DWORD dwOpenFlags,
                                                 bool validateFileInfo)
 {
+#ifdef FEATURE_PAL    
+    // TODO: Some intricate details of file mapping don't work on Linux as on Windows.
+    // We have to revisit this and try to fix it for POSIX system. 
+    return E_FAIL;
+#else    
     if (validateFileInfo)
     {
         // Check that we've got the right file to target.
@@ -988,6 +994,7 @@ HRESULT CordbModule::InitPublicMetaDataFromFile(const WCHAR * pszFullPathName,
     }
 
     return hr;
+#endif // FEATURE_PAL     
 }
 
 //---------------------------------------------------------------------------------------
@@ -2550,6 +2557,7 @@ HRESULT CordbModule::CreateReaderForInMemorySymbols(REFIID riid, void** ppObj)
         ReleaseHolder<ISymUnmanagedBinder> pBinder;
         if (symFormat == IDacDbiInterface::kSymbolFormatPDB)
         {
+#ifndef FEATURE_PAL
             // PDB format - use diasymreader.dll with COM activation
             InlineSString<_MAX_PATH> ssBuf;
             IfFailThrow(FakeCoCreateInstanceEx(CLSID_CorSymBinder_SxS,
@@ -2557,6 +2565,11 @@ HRESULT CordbModule::CreateReaderForInMemorySymbols(REFIID riid, void** ppObj)
                                                IID_ISymUnmanagedBinder,
                                                (void**)&pBinder,
                                                NULL));
+#else
+            IfFailThrow(FakeCoCreateInstance(CLSID_CorSymBinder_SxS,
+                                             IID_ISymUnmanagedBinder,
+                                             (void**)&pBinder));
+#endif
         }
         else if (symFormat == IDacDbiInterface::kSymbolFormatILDB)
         {

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -16732,6 +16732,18 @@ void *DebuggerHeap::Alloc(DWORD size)
     ret = pCanary->GetUserAddr();
 #endif
 
+#ifdef FEATURE_PAL
+    // We don't have executable heap in PAL, but we still need to allocate 
+    // executable memory, that's why have change protection level for 
+    // each allocation. 
+    // TODO: We need to look how JIT solves this problem.
+    DWORD unusedFlags;
+    if (!VirtualProtect(ret, size, PAGE_EXECUTE_READWRITE, &unusedFlags))
+    {
+        _ASSERTE(!"VirtualProtect failed to make this memory executable");
+    }
+#endif // FEATURE_PAL
+
     return ret;
 }
 

--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -581,7 +581,7 @@ void * __cdecl operator new[](size_t n, const CExecutable&, const NoThrow&)
 // This is a DEBUG routing to verify that a memory region complies with executable requirements
 BOOL DbgIsExecutable(LPVOID lpMem, SIZE_T length)
 {
-#if defined(CROSSGEN_COMPILE) 
+#if defined(CROSSGEN_COMPILE) || defined(FEATURE_PAL)
     // No NX support on PAL or for crossgen compilations.
     return TRUE;
 #else // !defined(CROSSGEN_COMPILE) 


### PR DESCRIPTION
attach, load, bp, exceptions, stacktrace

Fixes that were required to achieve that
1. Funnel SIGTRAP into EE debugger.
2. Making that memory allocated by EE debugger is executable.
3. Disable metadata reading optimizations which are not working on Linux.
4. Workaround RtlRestoreContext not properly working with EFlags.
5. Avoid calls to ShimRemoteDataTarget.GetContext on Linux, it is not
implemented and not needed for pure managed debugging.
6. Adjust IP value after breakpoint SIGTRAP to meet debuggers expectations.