### PR TITLE
Enable UseLatestBehaviorWhenTFMNotSpecified for Unix corerun

### DIFF
--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -327,7 +327,8 @@ int ExecuteManagedAssembly(
                 "TRUSTED_PLATFORM_ASSEMBLIES",
                 "APP_PATHS",
                 "APP_NI_PATHS",
-                "NATIVE_DLL_SEARCH_DIRECTORIES"
+                "NATIVE_DLL_SEARCH_DIRECTORIES",
+                "AppDomainCompatSwitch"
             };
             const char *propertyValues[] = {
                 // TRUSTED_PLATFORM_ASSEMBLIES
@@ -337,7 +338,9 @@ int ExecuteManagedAssembly(
                 // APP_NI_PATHS
                 appPath.c_str(),
                 // NATIVE_DLL_SEARCH_DIRECTORIES
-                nativeDllSearchDirs.c_str()
+                nativeDllSearchDirs.c_str(),
+                // AppDomainCompatSwitch
+                "UseLatestBehaviorWhenTFMNotSpecified"
             };
 
             HRESULT st = executeAssembly(


### PR DESCRIPTION
While root causing some of our test failures on Linux, I found that quirks were enabled, causing tests expecting new behavior to fail when they encountered the old behavior.

This commit modifies the Unix corerun to include the "UseLatestBehaviorWhenTFMNotSpecified" AppDomain compat switch (as the Windows version of corerun does) so that execution on Unix picks up the latest behavior rather than falling back to the old quirked behavior.