### PR TITLE
Detect clang35 on FreeBSD.

### DIFF
--- a/src/pal/tools/setup-compiler-clang.sh
+++ b/src/pal/tools/setup-compiler-clang.sh
@@ -7,6 +7,10 @@ if which clang-3.5 > /dev/null 2>&1
     then  
         export CC="$(which clang-3.5)" 
         export CXX="$(which clang++-3.5)"    
+elif which clang35 > /dev/null 2>&1 
+    then  
+        export CC="$(which clang35)" 
+        export CXX="$(which clang++35)"    
 elif which clang > /dev/null 2>&1 
     then 
         export CC="$(which clang)" 


### PR DESCRIPTION
clang-3.5 is required to build correctly, but is not detected on FreeBSD where it is aliased as clang35 and clang++35, not clang-3.5 and clang++-3.5.

This closes https://github.com/dotnet/coreclr/issues/615