### PR TITLE
Tweak IndexOfOrdinal on Unix for empty value

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -21,7 +21,7 @@ namespace System.Globalization
 
             if (value.Length == 0)
             {
-                return 0;
+                return startIndex;
             }
 
             if (ignoreCase)


### PR DESCRIPTION
A System.Runtime test was failing on Unix because IndexOf should return the startIndex rather than 0 when passed an empty search value.