### PR TITLE
Added params overload with StringSplitOptions

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -949,6 +949,12 @@ namespace System {
         }
 
         [ComVisible(false)]
+        public String[] Split(StringSplitOptions options, params char[] separator) {
+            Contract.Ensures(Contract.Result<String[]>() != null);
+            return SplitInternal(separator, Int32.MaxValue, options);
+        }
+
+        [ComVisible(false)]
         public String[] Split(char[] separator, int count, StringSplitOptions options)
         {
             Contract.Ensures(Contract.Result<String[]>() != null);


### PR DESCRIPTION
This seems to be missing in Split function overloads... Not sure if
right change, because this function would have different argument order,
because params must always be the last argument.