### PR TITLE
Avoid widening small integer return values for calls

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7169,6 +7169,17 @@ public :
         inline bool         IsReadyToRun() { return false; }
 #endif
 
+        // true if we must generate compatible code with Jit64 quirks
+        inline bool         IsJit64Compat()
+        {
+#if defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
+            // JIT64 interop not required for ReadyToRun since it can simply fall-back
+            return !IsReadyToRun();
+#else // defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
+            return false;
+#endif
+        }
+
 #ifdef DEBUGGING_SUPPORT
         bool                compScopeInfo;  // Generate the LocalVar info ?
         bool                compDbgCode;    // Generate debugger-friendly code?

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5449,19 +5449,14 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 #endif // _TARGET_ARM64_
 
     // We only need to cast the return value of pinvoke inlined calls that return small types
-    bool            checkForSmallType = false;
-
-#ifdef _TARGET_AMD64_
 
     // TODO-AMD64-Cleanup: Remove this when we stop interoperating with JIT64, or if we decide to stop
-    // widening everything!
-
+    // widening everything! CoreCLR does not support JIT64 interoperation so no need to widen there.
     // The existing x64 JIT doesn't bother widening all types to int, so we have to assume for
     // the time being that the callee might be compiled by the other JIT and thus the return
     // value will need to be widened by us (or not widened at all...)
-    checkForSmallType = true;
 
-#endif // _TARGET_AMD64_
+    bool            checkForSmallType = opts.IsJit64Compat();
 
     bool            bIntrinsicImported = false;
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1383,12 +1383,12 @@ void Lowering::LowerCall(GenTree* node)
     comp->fgDebugCheckNodeLinks(comp->compCurBB, callStmt);
 #endif
 
-#if defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
-    CheckVSQuirkStackPaddingNeeded(call);
-#endif
+    if (comp->opts.IsJit64Compat())
+    {
+        CheckVSQuirkStackPaddingNeeded(call);
+    }
 }
 
-#if defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
 // Though the below described issue gets fixed in intellitrace dll of VS2015 (a.k.a Dev14), 
 // we still need this quirk for desktop so that older version of VS (e.g. VS2010/2012)
 // continues to work.
@@ -1438,6 +1438,7 @@ void Lowering::LowerCall(GenTree* node)
 // more tolerant fix.  One such fix is to padd the struct.
 void Lowering::CheckVSQuirkStackPaddingNeeded(GenTreeCall* call)
 {
+    assert(comp->opts.IsJit64Compat());
     // Confine this to IL stub calls which aren't marked as unmanaged.
     if (call->IsPInvoke() && !call->IsUnmanaged())
     {
@@ -1490,7 +1491,6 @@ void Lowering::CheckVSQuirkStackPaddingNeeded(GenTreeCall* call)
         }
     }
 }
-#endif //_TARGET_AMD64_ && !FEATURE_CORECLR
 
 // Inserts profiler hook, GT_PROF_HOOK for a tail call node.
 //

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -42,10 +42,7 @@ private:
     void DecomposeNode(GenTreePtr* tree, Compiler::fgWalkData* data);
     void LowerNode(GenTreePtr* tree, Compiler::fgWalkData* data);
     GenTreeStmt* LowerMorphAndSeqTree(GenTree *tree);
-    
-#ifdef _TARGET_AMD64_
     void CheckVSQuirkStackPaddingNeeded(GenTreeCall* call);
-#endif
 
     // ------------------------------
     // Call Lowering


### PR DESCRIPTION
Disable the compatibility mode for small return values with Desktop 4.5 64-bit JIT
on CoreCLR since it is not supported there. This means no need to properly extend small integer call return values which means fewer sign/zero-extensions (lower dynamic instruction count and smaller encoding). 0.3% code-size reduction on all FX assemblies.