### PR TITLE
PAL: Use /usr/local/include for includes on FreeBSD.

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -10,6 +10,11 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 include_directories(include)
 
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  # required for libunwind
+  include_directories("/usr/local/include/")
+endif()
+
 # Compile options
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
This commit ensures `/usr/local/include` is added to the include-directories list on FreeBSD. This is required because `libunwind.h` (and its dependencies) when installed with `pkg install`are installed to `/usr/local/include`.

Together with [this other PR](https://github.com/dotnet/coreclr/pull/634), this PR resolves all errors encountered in the following issue:

https://github.com/dotnet/coreclr/issues/626