### PR TITLE
Fix hardware exception handling in interleaved handling case

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4640,7 +4640,17 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             GCX_COOP();
             fef.InitAndLink(&ex->ContextRecord);
 
-            DispatchManagedException(*ex);
+            // We throw the exception and catch it right away so that in case the DispatchManagedException
+            // needs to cross managed to native stack frames boundary, there is an exception that can
+            // be rethrow in the StartUnwindingNativeFrames.
+            try
+            {
+                throw *ex;
+            }
+            catch (PAL_SEHException& ex2)
+            {
+                DispatchManagedException(ex2);
+            }
             UNREACHABLE();
         }
 


### PR DESCRIPTION
The issue is that HandleHardwareException doesn't actually throw an exception, but it calls
directly the DispatchManagedException. In case the exception propagation crosses managed to
native boundary, the exception dispatching code uses throw; to unwind the native frames.
But in this particular case, there was no exception thrown and so the rethrow aborts.
The fix is to add try / catch to the HandleHardwareException that throws the PAL_SEHException
that it got as a parameter, catches it right away and then calls the DispatchManagedException
from the catch handler.