### PR TITLE
Fix a casing problem in lldbplugin/CMakeLists.txt

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT ENABLE_LLDBPLUGIN)
 endif()
 
 # Check for LLDB library
-find_library(LLDB NAMES lldb-3.6 lldb-3.5 LLDB PATHS "${WITH_LLDB_LIBS}")
+find_library(LLDB NAMES lldb-3.6 lldb-3.5 LLDB lldb PATHS "${WITH_LLDB_LIBS}")
 if(LLDB STREQUAL LLDB-NOTFOUND)
     if(REQUIRE_LLDBPLUGIN)
         message(FATAL_ERROR "Cannot find lldb-3.5 or lldb-3.6. Try installing lldb-3.6-dev (or the appropriate package for your platform)")


### PR DESCRIPTION
On Linux, liblldb is installed by default as 'liblldb'. lldbplugin's CMake
file is currently looking for libLLDB, which is necessary for OS X. This
change allows either casing.