### PR TITLE
marshaller-friendly PAL wrappers on  networking API

### DIFF
--- a/src/corefx/CMakeLists.txt
+++ b/src/corefx/CMakeLists.txt
@@ -13,4 +13,5 @@
 
 if(CLR_CMAKE_PLATFORM_UNIX)
   add_subdirectory(System.Security.Cryptography.Native)
+    add_subdirectory(System.Net.Native)
 endif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/corefx/System.Net.Native/CMakeLists.txt
+++ b/src/corefx/System.Net.Native/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+project(System.Net.Native)
+add_compile_options(-fPIC)
+
+add_definitions(-DPLATFORM_UNIX=1)
+add_definitions(-D__LINUX__=1)
+add_definitions(-DLP64COMPATIBLE=1)
+add_definitions(-DFEATURE_PAL=1)
+add_definitions(-DCORECLR=1)
+add_definitions(-DPIC=1)
+add_definitions(-DBIT64=1)
+add_definitions(-D_WIN64=1)
+
+include_directories(${COREPAL_SOURCE_DIR}/src/include)
+include_directories(${COREPAL_SOURCE_DIR}/inc)
+include_directories(${COREPAL_SOURCE_DIR}/src)
+include_directories(${COREPAL_SOURCE_DIR}/../inc)
+include_directories(${COREPAL_BINARY_DIR}/src)
+
+
+add_subdirectory(src)
+add_subdirectory(tests)
+

--- a/src/corefx/System.Net.Native/src/CMakeLists.txt
+++ b/src/corefx/System.Net.Native/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+project(System.Net.Native)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+
+set(NATIVENET_SOURCES
+    corefxnet.cpp
+    corefxnet.h
+)
+
+add_library(System.Net.Native
+    SHARED
+    ${NATIVENET_SOURCES}
+)
+
+
+# Disable the "lib" prefix.
+set_target_properties(System.Net.Native PROPERTIES PREFIX "")
+
+# This is so we can use the tracing facilities of coreclrpal library
+target_link_libraries(System.Net.Native
+    coreclrpal)
+
+install (TARGETS System.Net.Native DESTINATION .)

--- a/src/corefx/System.Net.Native/src/corefxnet.cpp
+++ b/src/corefx/System.Net.Native/src/corefxnet.cpp
@@ -1,0 +1,182 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+/*++
+
+  Module Name:
+  
+  corenet.cpp
+
+  Abstract:
+
+  Implementation of Networking APIs meant to be consumed by CoreFX (net) libraries.
+
+  The API present here are meant to be wrappers around networking API of the underlying OS such that,
+  (a) the arguments passed are Marshaller-friendly (eg: getaddrinfo involves complex structures (a linked list of addrinfo), while
+  the wrappers takes simple datatypes and returns an array of relatively simple structure)
+  (b) there is less dependency on platform specific constants like AF_INET
+  --*/
+
+#include "pal/palinternal.h"
+#include "pal/dbgmsg.h"
+#include "pal/module.h"
+#include <corefxnet.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <unistd.h>
+#include <dlfcn.h>
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h>
+#endif // __APPLE__
+
+#ifdef PLATFORM_UNIX
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <stdlib.h>
+#endif // PLATFORM_UNIX
+
+SET_DEFAULT_DEBUG_CHANNEL(MISC);
+
+static int
+addrInfoNodeToIPAddress(
+                        struct addrinfo *addrInfo,
+                        struct IPAddress *ipAddresses,
+                        int index)
+{
+    struct IPAddress ipAddress = ipAddresses[index];
+  
+    if (addrInfo == NULL) {
+        return 0;
+    }
+    if (AF_INET == addrInfo->ai_family) {
+        struct sockaddr_in *ip4Addr = NULL;
+        long l;
+
+        ip4Addr = (struct sockaddr_in *)(addrInfo->ai_addr);
+        ipAddress.isIPV4 = 1;
+        ipAddress.port = ip4Addr->sin_port;
+        ipAddress.scopeId = 0;
+        l = ip4Addr->sin_addr.s_addr;    
+        (ipAddress.bytes)[0] = (l >> 24) & 0xFF;
+        (ipAddress.bytes)[1] = (l >> 16) & 0xFF;
+        (ipAddress.bytes)[2] = (l >> 8) & 0xFF;
+        (ipAddress.bytes)[3] = l & 0xFF;
+    }
+    else if (AF_INET6 == addrInfo->ai_family) {
+        struct sockaddr_in6 *ip6Addr = NULL;
+        ip6Addr = (struct sockaddr_in6 *)(addrInfo->ai_addr);
+        ipAddress.isIPV4 = 0;
+        ipAddress.port = ip6Addr->sin6_port;
+        ipAddress.scopeId = ip6Addr->sin6_scope_id;
+        memcpy(ipAddress.bytes, &(ip6Addr->sin6_addr), 16); 
+    }
+    else {
+        return 0;
+    }
+    return 1;
+}
+
+/*++
+  Function:
+  GetIPAddresses
+
+  Used by System.Net.Dns to resolve hostname
+
+  This function invokes getaddrinfo and traverses the resultant list of addrinfo to create an array of IPAddresses.
+
+  The function returns COREFX_NET_SUCCESS in case of success and COREFX_NET_INVALID_PARAM in case of failure.
+  It sets:
+  the out-parameter, canonicalName, to the value of ai_canonname.
+  the out-parameter, result, to the array of created ip addresses
+  the addressCount to the number of entries in the array of returning addresses.
+  --*/
+
+int
+PALAPI
+GetIPAddresses(const char* hostName, // host name
+               char **canonicalName, //canonicalName 
+               struct IPAddress **result,// array of ipAddresses
+               int *addressCount) // number of addresses returned
+{
+    int success = COREFX_NET_SUCCESS;
+    struct addrinfo *addrInfo = NULL;
+    struct addrinfo *node = NULL;
+    struct addrinfo hints;
+    int err;
+    int index;
+
+    PERF_ENTRY(GetIPAddresses);
+    ENTRY("GetIPAddresses (hostName=%p (%s))\n",
+          hostName, hostName ? hostName : "NULL");
+
+    // Validate arguments
+    if (NULL == hostName) {
+        ASSERT("hostName should not be NULL\n");
+        success = COREFX_NET_INVALID_PARAM;
+        goto done;
+    }
+
+    hints.ai_family = AF_UNSPEC; // IPV6 and IPV4
+    hints.ai_socktype = 0;
+    hints.ai_protocol = 0;
+    hints.ai_flags = AI_CANONNAME;
+    err = getaddrinfo(hostName, NULL, &hints, &addrInfo);
+
+    if ((err != 0) || (NULL == addrInfo)) {
+        success = COREFX_NET_INVALID_PARAM;
+        goto done;
+    }
+
+    // copy the name, if it is not null 
+    if (NULL == addrInfo->ai_canonname) {
+        *canonicalName = NULL;
+    }
+    else {
+        *canonicalName = (char *)calloc(strlen(addrInfo->ai_canonname) + 1,sizeof(char));
+        strcpy(*canonicalName, addrInfo->ai_canonname);
+    }
+
+    // iterate over addrInfo, twice
+    // first get the length
+    node = addrInfo;
+    index = 0;
+    while (NULL != node) {
+        if ((AF_INET6 == node->ai_family) || (AF_INET == node->ai_family)) {
+            index++;
+        }
+        node = node->ai_next;
+    }
+
+    // now do the actual parsing
+    *addressCount = index;
+    if (0 != *addressCount) {
+        index = 0;
+        *result = (struct IPAddress *)calloc(*addressCount, sizeof(struct IPAddress));
+        node = addrInfo;
+        while (NULL != node) {
+            if (0 != addrInfoNodeToIPAddress(node, *result, index)) {
+                index++;
+            }
+            node = node->ai_next;
+        }
+    }
+    
+ done:
+    // free addrinfo regardless of the result
+    freeaddrinfo(addrInfo);
+    if (COREFX_NET_SUCCESS != success) {
+        if (*canonicalName != NULL) {
+            free(*canonicalName);
+        }
+        *addressCount=0;
+        *result = NULL;
+        *canonicalName  = NULL;
+    }
+    return success;
+}

--- a/src/corefx/System.Net.Native/src/corefxnet.h
+++ b/src/corefx/System.Net.Native/src/corefxnet.h
@@ -1,0 +1,47 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+/*++
+
+Module Name:
+
+    pal_corefxnet.h
+
+Abstract:
+
+    Header file for functions meant to be consumed by the CoreFX Net libraries.
+
+--*/
+
+#ifndef __PAL_COREFX_NET_H__
+#define __PAL_COREFX_NET_H__
+
+#ifdef  __cplusplus
+extern "C" {
+#endif
+
+#define COREFX_NET_SUCCESS 0x00000000
+#define COREFX_NET_INVALID_PARAM 0xc000000d
+
+  
+  struct IPAddress {
+    unsigned char isIPV4;
+    int port;
+    unsigned int scopeId;
+    unsigned char bytes[16];
+  };
+
+  PALIMPORT
+  int
+  GetIPAddresses(const char* hostName, // host name
+		 char **canonicalName, //hostname
+		 struct IPAddress **result, //array of ipAddresses
+		 int *addressCount); // number of addresses returned
+  
+#ifdef  __cplusplus
+} // extern "C"
+#endif
+
+#endif // __PAL_COREFX_NET_H__

--- a/src/corefx/System.Net.Native/tests/CMakeLists.txt
+++ b/src/corefx/System.Net.Native/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 2.8.12.2)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+set(SOURCES
+  localhostaddrs.c
+)
+
+include_directories(${PROJECT_SOURCE_DIR}/src)
+include_directories(${PALTESTSUITE_SOURCE_DIR}/common)
+
+add_executable(corefxtest_getaddrs_test1
+  ${SOURCES}
+)
+
+
+add_dependencies(corefxtest_getaddrs_test1 System.Net.Native)
+
+target_link_libraries(corefxtest_getaddrs_test1
+  pthread
+  m
+  System.Net.Native
+)

--- a/src/corefx/System.Net.Native/tests/localhostaddrs.c
+++ b/src/corefx/System.Net.Native/tests/localhostaddrs.c
@@ -1,0 +1,81 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
+/*=============================================================================
+**
+** Source: localhostaddrs.c
+**
+** Purpose: Test to ensure GetIPAddresses is working well for local host
+**
+** Dependencies: PAL_Initialize
+**               GetIPAddresses
+** 
+
+**
+**===========================================================================*/
+#include <palsuite.h>
+#include "corefxnet.h"
+
+void checkValidAddress(struct IPAddress *ipAddresses, int index)
+{
+    struct IPAddress address;
+    int i = 0;
+
+    address = ipAddresses[index];
+    if (address.isIPV4) {
+	if (address.scopeId != 0) {
+	    Fail("Unexpected scope Id for IP v4 addresses: %du" , address.scopeId);
+	}
+	for (i=4;i<16;i++) {
+	    if (address.bytes[i] != 0) {
+		Fail("Unexpected non-zero byte %x at index %d for IP v4 address", address.bytes[i], i);
+	    }
+	}
+    }
+    if (address.port < 0) {
+	Fail("negative value of port: %d", address.port);
+    }
+}
+
+/**
+ * main
+ *
+ * executable entry point
+ */
+int __cdecl main(int argc, const char * const* argv )
+{
+    const char *localHost = "localhost";
+    int addrCount = 0;
+    struct IPAddress *addresses = NULL;
+    char *canonicalName = NULL;
+    int ret,index;
+
+    /*PAL initialization */
+    if ((PAL_Initialize(argc, argv)) != 0 ) {
+	    return FAIL;
+    }
+
+    ret = GetIPAddresses(localHost, &canonicalName, &addresses, &addrCount);
+    if (COREFX_NET_SUCCESS != ret) {
+	Fail("GetIPAddresses failed for %s ", localHost);
+    }
+    printf("addrCount = %d\n",addrCount);
+    for (index = 0; index < addrCount; index++)
+	checkValidAddress(addresses, index);
+
+    if (canonicalName) {
+        /* use some string api to ensure that the string has been copied properly */
+        printf("%d is the length of %s\n", strlen(canonicalName), canonicalName);
+    }
+    else {
+        Fail("CanonicalName is null ");
+    }
+  
+    free(addresses);
+    free(canonicalName);
+
+    PAL_Terminate();
+    return PASS;
+}


### PR DESCRIPTION
A wrapper on top of getaddrinfo that is needed for networking API. getaddrinfo is a generic API and deals with complex datastructures that are not very Marshaller friendly.
This checkin introduces the needed wrapper on top of that function. Also included is the test thereof.