### PR TITLE
Xplat build changes

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -20,6 +20,7 @@
     <SourceDir>$(__SourceDir)\</SourceDir>
     <SourceDir Condition="'$(__SourceDir)'==''">$(ProjectDir)\src\</SourceDir>
 
+    <PackagesGlobalConfig>$(SourceDir).nuget\packages.config</PackagesGlobalConfig>
     <PackagesDir>$(__PackagesDir)\</PackagesDir>
     <PackagesDir Condition="'$(__PackagesDir)'==''">$(ProjectDir)\packages\</PackagesDir>
 

--- a/dir.targets
+++ b/dir.targets
@@ -36,7 +36,7 @@
     <!-- Restore build tools -->
     <Exec
       StandardOutputImportance="Low"
-      Command="&quot;$(NuGetToolPath)&quot; install &quot; $(SourceDir).nuget\packages.config &quot;  -o &quot; $(ToolsDir) &quot; $(NuGetConfigCommandLine)" />
+      Command="&quot;$(NuGetToolPath)&quot; install &quot;$(PackagesGlobalConfig)&quot;  -o &quot;$(ToolsDir.Trim('\'))&quot; $(NuGetConfigCommandLine)" />
 
     <Touch Files="$(BuildToolsInstallSemaphore)" AlwaysCreate="true" />
   </Target>


### PR DESCRIPTION
Move the path of the global packages.config into a separate property.
This allows xplat MSBuild to detect the path and adjust for non-Win
systems.