### PR TITLE
Update Path.InvalidFileNameChars on Unix

### DIFF
--- a/src/mscorlib/src/System/IO/Path.cs
+++ b/src/mscorlib/src/System/IO/Path.cs
@@ -86,7 +86,11 @@ namespace System.IO {
         // is legal in a path name).
         // Note: This list is duplicated in CheckInvalidPathChars
         [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
+#if !PLATFORM_UNIX
         public static readonly char[] InvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+#else
+        public static readonly char[] InvalidPathChars = { '\0' };
+#endif // !PLATFORM_UNIX
 
         // Trim trailing white spaces, tabs etc but don't be aggressive in removing everything that has UnicodeCategory of trailing space.
         // String.WhitespaceChars will trim aggressively than what the underlying FS does (for ex, NTFS, FAT).    
@@ -105,7 +109,7 @@ namespace System.IO {
         // This is used by HasIllegalCharacters
         private static readonly char[] InvalidPathCharsWithAdditionalChecks = { '\0', '*', '?' };
 
-        private static readonly char[] InvalidFileNameChars = { '\0', '*', '?', '\\', '/' };
+        private static readonly char[] InvalidFileNameChars = { '\0', '/' };
 #endif // !PLATFORM_UNIX
 
 #if !PLATFORM_UNIX


### PR DESCRIPTION
Path.InvalidFileNameChars included '*', '?', and '\\', which are actually valid in filenames. While fixing that, I also fixed up InvalidPathChars, even though it's obsolete and I don't think anything uses it on Unix.