### PR TITLE
Add back security class vtables to dac global table 

### DIFF
--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -1864,6 +1864,9 @@ public: name(TADDR addr, TADDR vtAddr);                         \
 #define VPTR_ABSTRACT_VTABLE_CLASS(name, base)                  \
 public: name(TADDR addr, TADDR vtAddr) : base(addr, vtAddr) {}
 
+#define VPTR_ABSTRACT_VTABLE_CLASS_AND_CTOR(name, base) \
+        VPTR_ABSTRACT_VTABLE_CLASS(name, base)
+
 #define VPTR_ABSTRACT_VTABLE_CLASS_NO_CTOR_BODY(name, base)     \
 public: name(TADDR addr, TADDR vtAddr);
 
@@ -2131,6 +2134,10 @@ public: name(int dummy) {}
         friend struct _DacGlobals; \
 public: name(int dummy) : base(dummy) {}
 
+#define VPTR_ABSTRACT_VTABLE_CLASS_AND_CTOR(name, base) \
+        VPTR_ABSTRACT_VTABLE_CLASS(name, base) \
+        name() : base() {}
+
 #else // FEATURE_PAL
 
 #define VPTR_VTABLE_CLASS(name, base)
@@ -2140,6 +2147,7 @@ public: name(int dummy) : base(dummy) {}
 #define VPTR_BASE_VTABLE_CLASS(name)
 #define VPTR_BASE_VTABLE_CLASS_AND_CTOR(name)
 #define VPTR_ABSTRACT_VTABLE_CLASS(name, base)
+#define VPTR_ABSTRACT_VTABLE_CLASS_AND_CTOR(name, base)
 
 #endif // FEATURE_PAL
 

--- a/src/inc/vptr_list.h
+++ b/src/inc/vptr_list.h
@@ -153,7 +153,5 @@ VPTR_CLASS(GlobalLoaderAllocator)
 VPTR_CLASS(AppDomainLoaderAllocator)
 VPTR_CLASS(AssemblyLoaderAllocator)
 
-#ifndef FEATURE_PAL
 VPTR_CLASS(AssemblySecurityDescriptor)
 VPTR_CLASS(ApplicationSecurityDescriptor)
-#endif // FEATURE_PAL

--- a/src/vm/security.h
+++ b/src/vm/security.h
@@ -248,9 +248,8 @@ namespace Security
 class ISecurityDescriptor
 {
 public:
-#ifndef FEATURE_PAL
-    VPTR_BASE_VTABLE_CLASS(ISecurityDescriptor)
-#endif
+    VPTR_BASE_VTABLE_CLASS_AND_CTOR(ISecurityDescriptor)
+
     virtual ~ISecurityDescriptor() { LIMITED_METHOD_CONTRACT; }
 
     virtual BOOL IsFullyTrusted() = 0;
@@ -278,9 +277,7 @@ public:
 class IApplicationSecurityDescriptor : public ISecurityDescriptor
 {
 public:
-#ifndef FEATURE_PAL
-    VPTR_ABSTRACT_VTABLE_CLASS(IApplicationSecurityDescriptor, ISecurityDescriptor)
-#endif
+    VPTR_ABSTRACT_VTABLE_CLASS_AND_CTOR(IApplicationSecurityDescriptor, ISecurityDescriptor)
 
 #ifndef DACCESS_COMPILE
 public:
@@ -324,9 +321,7 @@ public:
 class IAssemblySecurityDescriptor : public ISecurityDescriptor
 {
 public:
-#ifndef FEATURE_PAL
-    VPTR_ABSTRACT_VTABLE_CLASS(IAssemblySecurityDescriptor, ISecurityDescriptor)
-#endif
+    VPTR_ABSTRACT_VTABLE_CLASS_AND_CTOR(IAssemblySecurityDescriptor, ISecurityDescriptor)
 
 #ifndef DACCESS_COMPILE
     virtual SharedSecurityDescriptor *GetSharedSecDesc() = 0;

--- a/src/vm/securitydescriptor.h
+++ b/src/vm/securitydescriptor.h
@@ -132,16 +132,17 @@ protected:
     //--------------------
 #ifndef DACCESS_COMPILE
     inline SecurityDescriptor(AppDomain *pAppDomain, DomainAssembly *pAssembly, PEFile* pPEFile, LoaderAllocator *pLoaderAllocator);    
-#endif // #ifndef DACCESS_COMPILE
+#ifdef FEATURE_PAL
+    SecurityDescriptor() {}
+#endif // FEATURE_PAL
+#endif // !DACCESS_COMPILE
 };
 
 template<typename IT>
 class SecurityDescriptorBase : public IT, public SecurityDescriptor
 {
 public:
-#ifndef FEATURE_PAL
     VPTR_ABSTRACT_VTABLE_CLASS(SecurityDescriptorBase, IT) // needed for the DAC
-#endif
 
     inline SecurityDescriptorBase(AppDomain *pAppDomain, DomainAssembly *pAssembly, PEFile* pPEFile, LoaderAllocator *pLoaderAllocator);
 

--- a/src/vm/securitydescriptorappdomain.h
+++ b/src/vm/securitydescriptorappdomain.h
@@ -36,9 +36,7 @@
 class ApplicationSecurityDescriptor : public SecurityDescriptorBase<IApplicationSecurityDescriptor>
 {
 public:
-#ifndef FEATURE_PAL
     VPTR_VTABLE_CLASS(ApplicationSecurityDescriptor, SecurityDescriptorBase<IApplicationSecurityDescriptor>)
-#endif
 
 private:
     // Dependency in managed : System.Security.HostSecurityManager.cs

--- a/src/vm/securitydescriptorassembly.h
+++ b/src/vm/securitydescriptorassembly.h
@@ -57,9 +57,7 @@ void StoreObjectInLazyHandle(LOADERHANDLE& handle, OBJECTREF ref, LoaderAllocato
 class AssemblySecurityDescriptor : public SecurityDescriptorBase<IAssemblySecurityDescriptor>
 {
 public:
-#ifndef FEATURE_PAL
     VPTR_VTABLE_CLASS(AssemblySecurityDescriptor, SecurityDescriptorBase<IAssemblySecurityDescriptor>)
-#endif
 
 private:
     PsetCacheEntry*   m_arrPassedLinktimeDemands[MAX_PASSED_DEMANDS];


### PR DESCRIPTION
Two security classes were disabled because of build problems that are now solved.