### PR TITLE
Enable generic IReadOnlyCollection interfaces on array for Unix

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -2908,10 +2908,8 @@ void SystemDomain::LoadBaseSystemClasses()
     MscorlibBinder::GetClass(CLASS__IENUMERABLEGENERIC);
     MscorlibBinder::GetClass(CLASS__ICOLLECTIONGENERIC);
     MscorlibBinder::GetClass(CLASS__ILISTGENERIC);
-#if !defined(FEATURE_CORECLR) || defined(FEATURE_COMINTEROP)
     MscorlibBinder::GetClass(CLASS__IREADONLYCOLLECTIONGENERIC);
     MscorlibBinder::GetClass(CLASS__IREADONLYLISTGENERIC);
-#endif
 
     // Load String
     g_pStringClass = MscorlibBinder::LoadPrimitiveType(ELEMENT_TYPE_STRING);

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -1328,12 +1328,9 @@ BOOL IsImplicitInterfaceOfSZArray(MethodTable *pInterfaceMT)
     // Is target interface IList<T> or one of its ancestors, or IReadOnlyList<T>?
     return (rid == MscorlibBinder::GetExistingClass(CLASS__ILISTGENERIC)->GetTypeDefRid() ||
             rid == MscorlibBinder::GetExistingClass(CLASS__ICOLLECTIONGENERIC)->GetTypeDefRid() ||
-            rid == MscorlibBinder::GetExistingClass(CLASS__IENUMERABLEGENERIC)->GetTypeDefRid()
-#if !defined(FEATURE_CORECLR) || defined(FEATURE_COMINTEROP)
-            || rid == MscorlibBinder::GetExistingClass(CLASS__IREADONLYCOLLECTIONGENERIC)->GetTypeDefRid()
-            || rid == MscorlibBinder::GetExistingClass(CLASS__IREADONLYLISTGENERIC)->GetTypeDefRid()
-#endif
-            );
+            rid == MscorlibBinder::GetExistingClass(CLASS__IENUMERABLEGENERIC)->GetTypeDefRid() ||
+            rid == MscorlibBinder::GetExistingClass(CLASS__IREADONLYCOLLECTIONGENERIC)->GetTypeDefRid() ||
+            rid == MscorlibBinder::GetExistingClass(CLASS__IREADONLYLISTGENERIC)->GetTypeDefRid());
 }
 
 //---------------------------------------------------------------------

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -2140,11 +2140,9 @@ DEFINE_CLASS(IENUMERABLEGENERIC,    CollectionsGeneric,     IEnumerable`1)
 DEFINE_CLASS(IENUMERATORGENERIC,    CollectionsGeneric,     IEnumerator`1)
 DEFINE_CLASS(ICOLLECTIONGENERIC,    CollectionsGeneric,     ICollection`1)
 DEFINE_CLASS(ILISTGENERIC,          CollectionsGeneric,     IList`1)
-#if !defined(FEATURE_CORECLR) || defined(FEATURE_COMINTEROP)  // Silverlight 5 does not contain IReadOnlyList<T>, but we should add it to Silverlight 6.
 DEFINE_CLASS(IREADONLYCOLLECTIONGENERIC,CollectionsGeneric, IReadOnlyCollection`1)
 DEFINE_CLASS(IREADONLYLISTGENERIC,  CollectionsGeneric,     IReadOnlyList`1)
 DEFINE_CLASS(IREADONLYDICTIONARYGENERIC,CollectionsGeneric, IReadOnlyDictionary`2)
-#endif
 DEFINE_CLASS(IDICTIONARYGENERIC,    CollectionsGeneric,     IDictionary`2)
 DEFINE_CLASS(KEYVALUEPAIRGENERIC,   CollectionsGeneric,     KeyValuePair`2)
 


### PR DESCRIPTION
IReadOnlyCollection support on array was incorrectly enabled for COM interop only