### PR TITLE
Fix .rc processing issue on FreeBSD

### DIFF
--- a/src/dlls/mscorrc/processrc.awk
+++ b/src/dlls/mscorrc/processrc.awk
@@ -45,6 +45,8 @@ BEGIN {
         cmd = "echo $(("expression"))";
         cmd | getline var;
         close(cmd);
+        # in case shell returned the result as a string, ensure the var has numeric type
+        var = var + 0;
         # sprintf can only handle signed ints, so we need to convert
         # values >= 0x80000000 to negative values
         if (var >= 2147483648)


### PR DESCRIPTION
This change fixes issue that occurs on FreeBSD when compiling the
.rc files into the gettext format. For some reason, the shell
expression evaluation returns the resulting resource id as a string
datatype. That leads to a failure when trying to format the result
as a hex number using sprintf.
The change ensures that if that happens, the type is changed to numeric.