### PR TITLE
Create shared PAL module and change all the modules to use it

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -89,10 +89,11 @@ else(WIN32)
   )
 
   set(SOS_LIBRARY
+    CoreClrPal
     corguids
-    mscordaccore
     debugshim
     dbgutil
+    palrt
   )
 endif(WIN32)
 

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -57,7 +57,8 @@ if(WIN32)
 elseif(CLR_CMAKE_PLATFORM_UNIX)
     list(APPEND COREDBI_LIBRARIES
         mdhotdata_full
-        mscordaccore
+        CoreClrPal
+        palrt
     )
 
     # COREDBI_LIBRARIES is mentioned twice because ld is one pass linker and will not find symbols

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -94,9 +94,7 @@ if(WIN32)
     )
 else()
     list(APPEND CORECLR_LIBRARIES
-        ${START_WHOLE_ARCHIVE} # force all PAL objects to be included so all exports are available 
         CoreClrPal
-        ${END_WHOLE_ARCHIVE}
         palrt
     )
 endif(WIN32)

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -150,18 +150,18 @@ set(SOURCES
 )
 
 add_library(CoreClrPal
-  STATIC
+  SHARED
   ${SOURCES}
   ${PLATFORM_SOURCES}
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-target_link_libraries(CoreClrPal
-  pthread
-  rt
-  dl
-  unwind
-)
+  target_link_libraries(CoreClrPal
+    pthread
+    rt
+    dl
+    unwind
+  )
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
@@ -178,3 +178,5 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 add_subdirectory(examples)
+
+install(TARGETS CoreClrPal DESTINATION .)

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1397,7 +1397,11 @@ static HMODULE LOADLoadLibrary(LPCSTR ShortAsciiName, BOOL fDynamic)
     {
         // See GetProcAddress for an explanation why we leave the PAL.
         PAL_LeaveHolder holder;
-        dl_handle = dlopen(ShortAsciiName, RTLD_LAZY);
+        dl_handle = dlopen(ShortAsciiName, RTLD_LAZY | RTLD_NOLOAD); 
+        if (!dl_handle)
+        {
+            dl_handle = dlopen(ShortAsciiName, RTLD_LAZY);
+        }
 
         // P/Invoke calls are often defined without an extension in the name of the 
         // target library. So if we failed to load the specified library, try adding
@@ -1406,7 +1410,11 @@ static HMODULE LOADLoadLibrary(LPCSTR ShortAsciiName, BOOL fDynamic)
         {
             if (snprintf(fullLibraryName, MAX_PATH, "%s%s", ShortAsciiName, PAL_SHLIB_SUFFIX) < MAX_PATH)
             {
-                dl_handle = dlopen(fullLibraryName, RTLD_LAZY);
+                dl_handle = dlopen(fullLibraryName, RTLD_LAZY | RTLD_NOLOAD); 
+                if (!dl_handle)
+                {
+                    dl_handle = dlopen(fullLibraryName, RTLD_LAZY);
+                }
                 if (dl_handle)
                 {
                     ShortAsciiName = fullLibraryName;


### PR DESCRIPTION
For the short term to allow managed debugging, use one PAL instance across all the debugger modules and coreclr so we don't have to deal with all the multiple PAL instance issues.