### PR TITLE
Use "x64" and not "amd64" in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -84,7 +84,7 @@ echo "Commencing CoreCLR Repo build"
 
 # Argument types supported by this script:
 #
-# Build architecture - valid value is: Amd64.
+# Build architecture - valid value is: x64.
 # Build Type         - valid values are: Debug, Release
 #
 # Set the default arguments for build
@@ -138,7 +138,7 @@ for i in "$@"
         usage
         exit 1
         ;;
-        amd64)
+        x64)
         __BuildArch=x64
         __MSBuildBuildArch=x64
         ;;


### PR DESCRIPTION
The help text for build.sh said that you should pass "x64" as a
paramter for the build architecture.  However, the script was looking
for amd64.  Update the script to look for x64 since that's what we use
everywhere else (and the behavior you got if you didn't pass an
argument to this script.)

Fixes #689