### PR TITLE
Fix issue with the disabled tail calls via helpers

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5638,6 +5638,13 @@ GenTreePtr          Compiler::fgMorphCall(GenTreeCall* call)
             compCurBB->bbJumpKind = BBJ_RETURN;
 #endif
 
+#ifdef FEATURE_PAL
+        if (!canFastTailCall)
+        {
+            goto NO_TAIL_CALL;
+        }
+#endif // FEATURE_PAL
+
         // Set this flag before calling fgMorphCall() to prevent inlining this call.
         call->gtCallMoreFlags |=  GTF_CALL_M_TAILCALL;
 
@@ -5646,11 +5653,7 @@ GenTreePtr          Compiler::fgMorphCall(GenTreeCall* call)
         // fast calls.
         if (!canFastTailCall)
         {
-#ifndef FEATURE_PAL
             fgMorphTailCall(call);
-#else // FEATURE_PAL
-            goto NO_TAIL_CALL;
-#endif // FEATURE_PAL
         }
 
         // Implementation note : If we optimize tailcall to do a direct jump


### PR DESCRIPTION
This change fixes an issue that occured after I've disabled tail calls via
helpers. The problem was that the goto to NO_TAIL_CALL needs to happen
before the GTF_CALL_M_TAILCALL flag is set, otherwise the jitter
doesn't emit any call.