### PR TITLE
Fix two sources of warnings in cor{,info}.h

### DIFF
--- a/src/inc/cor.h
+++ b/src/inc/cor.h
@@ -2509,7 +2509,7 @@ inline ULONG CorSigUncompressPointer(   // return number of bytes of that compre
     PCCOR_SIGNATURE pData,              // [IN] compressed data
     void **         ppvPointer)         // [OUT] the expanded *pData
 {
-    *ppvPointer = *(void * UNALIGNED *)pData;
+    *ppvPointer = *(void * const UNALIGNED *)pData;
     return sizeof(void *);
 }
 

--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1978,18 +1978,11 @@ struct CORINFO_Object
     CORINFO_MethodPtr      *methTable;      // the vtable for the object
 };
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4200)     // disable zero-sized array warning
-#endif
 struct CORINFO_String : public CORINFO_Object
 {
     unsigned                stringLen;
-    const wchar_t           chars[0];       // actually of variable size
+    const wchar_t           chars[1];       // actually of variable size
 };
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 struct CORINFO_Array : public CORINFO_Object
 {


### PR DESCRIPTION
- cor.h was incorrectly casting a pointer-to-const to a
  pointer-to-non-const.
- corinfo.h contained a 0-sized array, which is not standard C++,
  and therefore generates a warning on compilers without MSVC
  extensions enabled. Using a 1-sized array (which is already done
  elsewhere in the same file) prevents this warning.