### PR TITLE
PInvoke to libcoreclr for three APIs

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -700,6 +700,7 @@ namespace Microsoft.Win32 {
         internal const String KERNEL32 = "libcoreclrpal";
         internal const String USER32   = "libcoreclrpal";
         internal const String OLE32    = "libcoreclrpal";
+        internal const String LIBCORECLR = "libcoreclr";
 #endif //FEATURE_PAL         
         internal const String ADVAPI32 = "advapi32.dll";
         internal const String OLEAUT32 = "oleaut32.dll";
@@ -1372,17 +1373,29 @@ namespace Microsoft.Win32 {
         [DllImport(KERNEL32, CharSet=CharSet.Auto, BestFitMapping=false)]
         internal extern static int GetComputerName([Out]StringBuilder nameBuffer, ref int bufferSize);
 
+#if !FEATURE_PAL
         [DllImport(OLE32)]
+#else
+        [DllImport(LIBCORECLR)]
+#endif
         internal extern static int CoCreateGuid(out Guid guid);
 
-        [DllImport(Win32Native.OLE32)]
+#if !FEATURE_PAL
+        [DllImport(OLE32)]
+#else
+        [DllImport(LIBCORECLR)]
+#endif
         internal static extern IntPtr CoTaskMemAlloc(UIntPtr cb);
 
-        [DllImport(Win32Native.OLE32)]
-        internal static extern IntPtr CoTaskMemRealloc(IntPtr pv, UIntPtr cb);
-
-        [DllImport(Win32Native.OLE32)]
+#if !FEATURE_PAL
+        [DllImport(OLE32)]
+#else
+        [DllImport(LIBCORECLR)]
+#endif
         internal static extern void CoTaskMemFree(IntPtr ptr);
+
+        [DllImport(OLE32)]
+        internal static extern IntPtr CoTaskMemRealloc(IntPtr pv, UIntPtr cb);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
         internal struct COORD


### PR DESCRIPTION
After pulling the PAL out of the runtime, we redirected all the PInvokes
which were going to libcoreclr to libcoreclrpal. It turns out that
CoTaskMemAlloc, CoTaskMemFree and CoCreateGuid are still exported by the
runtime itself and not the PAL.

Update the three PInvokes for these functions from managed code to point
at the runtime itself.