### PR TITLE
Add missing MIT license headers

### DIFF
--- a/src/ToolBox/SOS/Strike/ApolloNative.rc
+++ b/src/ToolBox/SOS/Strike/ApolloNative.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft NTSD extension for .NET Runtime\0"
 

--- a/src/ToolBox/SOS/Strike/Native.rc
+++ b/src/ToolBox/SOS/Strike/Native.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft NTSD extension for .NET Runtime\0"
 

--- a/src/ToolBox/SOS/Strike/sos.def
+++ b/src/ToolBox/SOS/Strike/sos.def
@@ -1,8 +1,7 @@
-; ==++==
-; 
-;   Copyright (c) Microsoft Corporation.  All rights reserved.
-; 
-; ==--==
+;
+; Copyright (c) Microsoft. All rights reserved.
+; Licensed under the MIT license. See LICENSE file in the project root for full license information.
+;
 LIBRARY STRIKE
 EXPORTS
     AnalyzeOOM

--- a/src/coreclr/hosts/coreconsole/native.rc
+++ b/src/coreclr/hosts/coreconsole/native.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft CoreCLR Program launcher\0"
 
 #include <fxver.h>

--- a/src/coreclr/hosts/corerun/native.rc
+++ b/src/coreclr/hosts/corerun/native.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft CoreCLR EXE launcher\0"
 
 #include <fxver.h>

--- a/src/dlls/clretwrc/clretwrc.rc
+++ b/src/dlls/clretwrc/clretwrc.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime resources\0"
 
 #include <fxver.h>

--- a/src/dlls/dbgshim/dbgshim.rc
+++ b/src/dlls/dbgshim/dbgshim.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #include "resource.h"
 

--- a/src/dlls/mscordac/Native.rc
+++ b/src/dlls/mscordac/Native.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET External Data Access Support\0"
 

--- a/src/dlls/mscordbi/Native.rc
+++ b/src/dlls/mscordbi/Native.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Debugging Services\0"
 

--- a/src/dlls/mscoree/Native.rc
+++ b/src/dlls/mscoree/Native.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Common Language Runtime - WorkStation\0"
 

--- a/src/dlls/mscorrc/fuslog.rc
+++ b/src/dlls/mscorrc/fuslog.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 #include "fusres.h"
 
 #ifdef FEATURE_FUSION

--- a/src/dlls/mscorrc/include.rc
+++ b/src/dlls/mscorrc/include.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #include "mscorrc.rc"
 #include "fuslog.rc"

--- a/src/dlls/mscorrc/mscorrc.common.rc
+++ b/src/dlls/mscorrc/mscorrc.common.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 STRINGTABLE DISCARDABLE 
 BEGIN
     IDS_EE_NAME_UNKNOWN_UNQ                 "<Unknown %1>"

--- a/src/dlls/mscorrc/mscorrc.rc
+++ b/src/dlls/mscorrc/mscorrc.rc
@@ -1,8 +1,8 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 //Microsoft Developer Studio generated resource script.
 //
 #include "resource.h"

--- a/src/dlls/mscorrc/mscorrc.small.rc
+++ b/src/dlls/mscorrc/mscorrc.small.rc
@@ -1,8 +1,8 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 //Microsoft Developer Studio generated resource script.
 //
 #include "resource.h"

--- a/src/dlls/mscorrc/nativelog.rc
+++ b/src/dlls/mscorrc/nativelog.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 #include "nativeres.h"
 
 #ifdef FEATURE_FUSION

--- a/src/inc/CrstTypes.def
+++ b/src/inc/CrstTypes.def
@@ -1,8 +1,7 @@
-// ==++==
 //
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-// ==--==
 
 //
 // This file is used to describe the different types of Crst and their dependencies on other Crst types (in

--- a/src/inc/cordebug_mktlb.rc
+++ b/src/inc/cordebug_mktlb.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Debugging Interfaces\0"
 #define FX_VER_INTERNALNAME_STR CORDEBUG.IDL

--- a/src/inc/metahost_mktlb.rc
+++ b/src/inc/metahost_mktlb.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Metahosting Interfaces\0"
 #define FX_VER_INTERNALNAME_STR METAHOST.IDL

--- a/src/inc/mscoree_mktlb.rc
+++ b/src/inc/mscoree_mktlb.rc
@@ -1,8 +1,7 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
 
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime CLR Loading and Configuration Interfaces\0"
 #define FX_VER_INTERNALNAME_STR MSCOREE.DLL

--- a/src/inc/opcode.def
+++ b/src/inc/opcode.def
@@ -1,8 +1,8 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 /*****************************************************************************
  **                                                                         **
  ** Opcode.def - COM+ Intrinsic Opcodes and Macros.                         **

--- a/src/jit/Native.rc
+++ b/src/jit/Native.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft .NET Runtime Just-In-Time Compiler\0"
 
 #include <fxver.h>

--- a/src/jit/smopcode.def
+++ b/src/jit/smopcode.def
@@ -1,8 +1,8 @@
-// ==++==
 //
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
-// ==--==
+
 /*******************************************************************************************
  **                                                                                       **
  ** Auto-generated file. Do NOT modify!                                                   **

--- a/src/jit/smopcodemap.def
+++ b/src/jit/smopcodemap.def
@@ -1,8 +1,8 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 /*******************************************************************************************
  **                                                                                       **
  ** OpcodeMap.def - Mapping between opcodes in EE to opcodes in the state machine in JIT. **

--- a/src/mscorlib/Tools/Versioning/NativeVersion.rc
+++ b/src/mscorlib/Tools/Versioning/NativeVersion.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 #include "GeneratedVersion.h"
 
 #include <windows.h>

--- a/src/pal/prebuilt/corerror/mscorurt.rc
+++ b/src/pal/prebuilt/corerror/mscorurt.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 STRINGTABLE DISCARDABLE
 BEGIN
 	MSG_FOR_URT_HR(CORDBG_S_AT_END_OF_STACK) "The stack walk has reached the end of the stack.  There are no more frames to walk."

--- a/src/tools/crossgen/Native.rc
+++ b/src/tools/crossgen/Native.rc
@@ -1,3 +1,8 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
 #define FX_VER_FILEDESCRIPTION_STR "Microsoft Common Language Runtime native cross compiler\0"
 
 #include "..\..\dlls\mscorrc\mscorrc.rc"


### PR DESCRIPTION
.rc and .def files were missing the MIT license headers, so this
change adds them.