### PR TITLE
Hardcode CP_ACP to UTF-8 on Linux

### DIFF
--- a/src/pal/src/include/pal/locale.h
+++ b/src/pal/src/include/pal/locale.h
@@ -69,15 +69,6 @@ struct _CP_MAPPING
 #else
 #error Insufficient platform support for text encodings
 #endif
-
-#if !HAVE_COREFOUNDATION || ENABLE_DOWNLEVEL_FOR_NLS
-BOOL CODEPAGEInit(void);
-void CODEPAGECleanup(void);
-BOOL CODEPAGEAcquireReadLock(void);
-BOOL CODEPAGEAcquireWriteLock(void);
-BOOL CODEPAGEReleaseLock(void);
-#endif /* !HAVE_COREFOUNDATION || ENABLE_DOWNLEVEL_FOR_NLS */
-
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -275,14 +275,6 @@ Initialize(
             // we use large numbers of threads or have many open files.
         }
 
-#if !HAVE_COREFOUNDATION || ENABLE_DOWNLEVEL_FOR_NLS
-        if( !CODEPAGEInit() )
-        {
-            ERROR( "Unable to initialize the locks or the codepage.\n" );
-            goto done;
-        }
-#endif // !HAVE_COREFOUNDATION || ENABLE_DOWNLEVEL_FOR_NLS
-
         /* initialize the shared memory infrastructure */
         if(!SHMInitialize())
         {
@@ -565,9 +557,6 @@ CLEANUP1a:
 CLEANUP1:
     SHMCleanup();
 CLEANUP0:
-#if !HAVE_COREFOUNDATION
-    CODEPAGECleanup();
-#endif // !HAVE_COREFOUNDATION
     ERROR("PAL_Initialize failed\n");
     SetLastError(palError);
 done:
@@ -889,9 +878,6 @@ PALCommonCleanup(PALCLEANUP_STEP step, BOOL full_cleanup)
 
                 MiscCleanup();
 
-#if !HAVE_COREFOUNDATION
-                CODEPAGECleanup();
-#endif // !HAVE_COREFOUNDATION
                 TLSCleanup();
             }
 

--- a/src/pal/tests/palsuite/locale_info/GetACP/test1/test1.c
+++ b/src/pal/tests/palsuite/locale_info/GetACP/test1/test1.c
@@ -16,16 +16,10 @@
 #include <palsuite.h>
 
 /* 
- * NOTE: The only supported code page on FreeBSD is 1252, Windows 3.1 Latin 1 
- *       (U.S., Western Europe), so that is the only thing we test against.
- *       On Darwin, we only support code page 65001 (UTF-8).
+ * NOTE: We only support code page 65001 (UTF-8).
  */
 
-#if __APPLE__
 #define EXPECTED_CP     65001
-#else
-#define EXPECTED_CP     1252
-#endif
 
 int __cdecl main(int argc, char *argv[])
 {

--- a/src/pal/tests/palsuite/locale_info/GetCPInfo/test1/test1.c
+++ b/src/pal/tests/palsuite/locale_info/GetCPInfo/test1/test1.c
@@ -30,11 +30,11 @@ int __cdecl main(int argc, char *argv[])
     {
         Fail("GetCPInfo() unable to get info for CP_ACP\n");
     }
-    if (!GetCPInfo(0x4E4, &cpinfo))
-    {
-        Fail("GetCPInfo() unable to get info for code page 0x4E4\n");
-    }
 
+    if (!GetCPInfo(65001, &cpinfo))
+    {
+        Fail("GetCPInfo() unable to get info for code page 65001 (utf8)\n");
+    }
 
     if (GetCPInfo(-1, &cpinfo))
     {

--- a/src/pal/tests/palsuite/locale_info/IsDBCSLeadByteEx/test1/test1.c
+++ b/src/pal/tests/palsuite/locale_info/IsDBCSLeadByteEx/test1/test1.c
@@ -65,7 +65,6 @@ int __cdecl main(int argc, char *argv[])
 
     DoTest(0);
     DoTest(CP_ACP);
-    DoTest(0x4E4);
 
     PAL_Terminate();
 


### PR DESCRIPTION
Previously, on Linux, the PAL would attempt to detect the current codepage via
setlocale and maintained a mapping from LC_TYPES to Win32 locale names.
On OSX, we didn't do any of this, instead we always used UTF-8 as the
current codepage.

This change moves to this model on Linux as well, something we want to
do because it will enable us to use Ansi marshalling during PInvoke to
marshall UTF-8 data to native code (which is common when interoping with
existing native libraries on Linux) and allows us to remove a bunch of
code we don't want to carry forward from the PAL.