### PR TITLE
Ensure we differentiate between division by zero and overflow

### DIFF
--- a/src/debug/ee/amd64/amd64walker.cpp
+++ b/src/debug/ee/amd64/amd64walker.cpp
@@ -205,7 +205,7 @@ void NativeWalker::Decode()
                     {
                         if ((base & 0x07) == 5) 
                         {
-                            result = result + *((UINT32*)ip);
+                            result = result + *((INT32*)ip);
                             displace = 7;
                         } 
                         else 
@@ -215,12 +215,12 @@ void NativeWalker::Decode()
                     } 
                     else if (mod == 1) 
                     {
-                        result = result + *((UINT8*)ip);
+                        result = result + *((INT8*)ip);
                         displace = 4;
                     } 
                     else // mod == 2
                     {
-                        result = result + *((UINT32*)ip);
+                        result = result + *((INT32*)ip);
                         displace = 7;
                     }
 
@@ -247,12 +247,12 @@ void NativeWalker::Decode()
                         } 
                         else if (mod == 1) 
                         {
-                            result = result + *((UINT8*)ip);
+                            result = result + *((INT8*)ip);
                             displace = 3;
                         } 
                         else // mod == 2
                         {
-                            result = result + *((UINT32*)ip);
+                            result = result + *((INT32*)ip);
                             displace = 6;
                         }
                     }


### PR DESCRIPTION
This change implements parsing of the IDIV instruction operand so that
we can find whether an integer division error was a division by zero or
an integer overflow.
It replaces the previous functionality that was implemented for OSX only
and was incomplete (it didn't handle memory operands) and partially incorrect
(not handling R8..R15 properly).
I have reused code from https://github.com/dotnet/coreclr/blob/master/src/debug/ee/amd64/amd64walker.cpp#L27, 
but I have enhanced it to be complete w.r.t. the multiple possible operand sizes. The original code was created for parsing `call` / `jmp` operand where only the 64 bit operand was possible. In the `idiv`, 8, 16, 32 or 64 bit operands are possible.