### PR TITLE
Issue #609 & #610: Fix precedence issues

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2814,6 +2814,12 @@ private:
     bool                impIsThis               (GenTreePtr     obj);
     bool                impIsLDFTN_TOKEN        (const BYTE * delegateCreateStart, const BYTE * newobjCodeAddr);
     bool                impIsDUP_LDVIRTFTN_TOKEN(const BYTE * delegateCreateStart, const BYTE * newobjCodeAddr);
+    bool                impIsAnySTLOC           (OPCODE         opcode)
+    {
+        return     ((opcode == CEE_STLOC)   ||
+                    (opcode == CEE_STLOC_S) ||
+                    ((opcode >= CEE_STLOC_0) && (opcode <= CEE_STLOC_3)));
+    }
 
     GenTreeArgList*     impPopList              (unsigned       count,
                                                  unsigned *     flagsPtr,


### PR DESCRIPTION
Near line 6089 in importer.cpp, enforcing the precedence indicated by
the indentation resulted in no diffs, which at first seemed surprising.
However, this is because we never encounter the other mask values
without calli.

Near line 10483, this is where we convert (dup, stloc) to (stloc, ldloc).
This was clearly intended only for non-debug mode, but the original code
in the importer was like this:

     if (!opts.compDbgCode &&
         (nextOpcode == CEE_STLOC)   ||
         (nextOpcode == CEE_STLOC_S) ||
         ((nextOpcode >= CEE_STLOC_0) &&
         (nextOpcode <= CEE_STLOC_3)))
     {
         insertLdloc = true;

Due to the fact that the parens don't support the apparent intended
precedence, the condition is equivalent to:

    if ((!opts.compDbgCode && (nextOpcode == CEE_STLOC)   ||
       (nextOpcode == CEE_STLOC_S)                        ||
       ((nextOpcode >= CEE_STLOC_0) && (nextOpcode <= CEE_STLOC_3)))

Changing it the apparent original meaning caused regressions.  This is
because it is often cheaper to load a local (i.e. the insertLdloc case)
than to do a dup, which may 1) cause a temp to be created to store the
value on the stack, or 2) result in a tree (e.g. a large constant) which
is cloneable but which is more expensive in code bytes than a ldloc.

The original code clearly intended to do this only in the non-debug case,
but with the incorrect parens it was doing it for any short stloc.  I'm
not sure that it is 100% OK to do this transformation on dbg code, but
we've apparently been doing it for some time (it's the same way in
jit32).

Adding the apparently intended parens caused regressions (158392 bytes
over all the MCH files). The change in this shelveset has a net
improvement (3848 bytes over all jitAsmDiffs).  (Doing this
transformation in all cases, i.e. just eliminating the !opts.compDbgCode,
causes zero diffs, indicating that we don't have any instances of dups
followed by non-short stlocs.)

Fix #609
Fix #610