### PR TITLE
Share hardware exception between coreclr and DAC

### DIFF
--- a/dac.cmake
+++ b/dac.cmake
@@ -1,6 +1,7 @@
 # Contains the dac build specific definitions. Included by the leaf dac cmake files.
 
 add_definitions(-DDACCESS_COMPILE)
+add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
 if(WIN32)
     remove_definitions(-DPROFILING_SUPPORTED)
     add_definitions(-DPROFILING_SUPPORTED_DATA)

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -37,15 +37,6 @@ HINSTANCE g_thisModule;
 
 extern VOID STDMETHODCALLTYPE TLS_FreeMasterSlotIndex();
 
-#ifdef FEATURE_PAL
-
-VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
-{
-    throw *ex;
-}
-
-#endif // FEATURE_PAL
-
 EXTERN_C BOOL WINAPI
 DllMain(HANDLE instance, DWORD reason, LPVOID reserved)
 {
@@ -73,8 +64,6 @@ DllMain(HANDLE instance, DWORD reason, LPVOID reserved)
         {
             return FALSE;
         }
-        // Register handler of hardware exceptions like null reference in PAL
-        PAL_SetHardwareExceptionHandler(HandleHardwareException);
 #endif
         InitializeCriticalSection(&g_dacCritSec);
 

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -1996,6 +1996,9 @@ HRESULT Debugger::Startup(void)
 
     DebuggerLockHolder dbgLockHolder(this);
 
+#ifdef FEATURE_PAL
+    DacGlobals::Initialize();
+#endif
 
     // Stubs in Stacktraces are always enabled.
     g_EnableSIS = true;
@@ -2545,6 +2548,10 @@ void Debugger::StopDebugger(void)
     }
     CONTRACTL_END;
    
+#ifdef FEATURE_PAL
+    PAL_CleanupDacTableAddress();
+#endif
+
     // Leak almost everything on process exit. The OS will clean it up anyways and trying to 
     // clean it up ourselves is just one more place we may AV / deadlock.
 

--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -180,9 +180,6 @@ BOOL WINAPI DllMain(HANDLE hInstance, DWORD dwReason, LPVOID lpReserved)
             // If buffer is overrun, it is possible the saved callback has been trashed.
             // The callback is unsafe.
             //SetBufferOverrunHandler();
-#ifdef FEATURE_PAL
-            DacGlobals::Initialize();
-#endif
             if (!EEDllMain((HINSTANCE)hInstance, dwReason, lpReserved))
             {
                 return FALSE;
@@ -196,9 +193,6 @@ BOOL WINAPI DllMain(HANDLE hInstance, DWORD dwReason, LPVOID lpReserved)
 
     case DLL_PROCESS_DETACH:
         {
-#ifdef FEATURE_PAL
-            PAL_CleanupDacTableAddress();
-#endif
             EEDllMain((HINSTANCE)hInstance, dwReason, lpReserved);
 
 #ifdef FEATURE_MERGE_JIT_AND_ENGINE

--- a/src/pal/src/exception/machexception.cpp
+++ b/src/pal/src/exception/machexception.cpp
@@ -532,20 +532,11 @@ void PAL_DispatchException(DWORD64 dwRDI, DWORD64 dwRSI, DWORD64 dwRDX, DWORD64 
     }
 #endif // FEATURE_PAL_SXS
 
-    if (g_hardwareExceptionHandler != NULL)
-    {
-        PAL_SEHException exception(pExRecord, pContext);
+    EXCEPTION_POINTERS pointers;
+    pointers.ExceptionRecord = pExRecord;
+    pointers.ContextRecord = pContext;
 
-        g_hardwareExceptionHandler(&exception);
-
-        ASSERT("HandleHardwareException has returned, it should not.\n");
-    }
-    else
-    {
-        ASSERT("Unhandled hardware exception\n");
-    }
-
-    ExitProcess(pExRecord->ExceptionCode);
+    SEHProcessException(&pointers);
 }
 
 #if defined(_X86_) || defined(_AMD64_)

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -225,13 +225,13 @@ int LOADGetLibRotorPalSoFileName(LPSTR pszBuf);
     mscorwks).
 
 Parameters:
-    void
+    Core CLR path
 
 Return value:
     TRUE if successful
     FALSE if failure
 --*/
-BOOL LOADInitCoreCLRModules();
+BOOL LOADInitCoreCLRModules(const char *szCoreCLRPath);
 
 #if defined(CORECLR) && defined(__APPLE__)
 // Abstract the API used to load and query for functions in the CoreCLR binary to make it easier to change the

--- a/src/pal/src/include/pal/seh.hpp
+++ b/src/pal/src/include/pal/seh.hpp
@@ -25,8 +25,6 @@ Abstract:
 #include "pal/palinternal.h"
 #include "pal/corunix.hpp"
 
-extern PHARDWARE_EXCEPTION_HANDLER g_hardwareExceptionHandler;
-
 // Uncomment this define to turn off the signal handling thread.
 // #define DO_NOT_USE_SIGNAL_HANDLING_THREAD
 
@@ -45,7 +43,8 @@ Return value:
     FALSE otherwise
 
 --*/
-BOOL SEHInitialize(CorUnix::CPalThread *pthrCurrent, DWORD flags);
+BOOL 
+SEHInitialize(CorUnix::CPalThread *pthrCurrent, DWORD flags);
 
 /*++
 Function :
@@ -58,7 +57,24 @@ Parameters:
 
     (no return value)
 --*/
-void SEHCleanup(DWORD flags);
+VOID 
+SEHCleanup(DWORD flags);
+
+/*++
+Function:
+    SEHProcessException
+
+    Build the PAL exception and sent it to any handler registered.
+
+Parameters:
+    None
+
+Return value:
+    Does not return
+--*/
+PAL_NORETURN
+VOID 
+SEHProcessException(PEXCEPTION_POINTERS pointers);
 
 /*++
 Function :

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -658,12 +658,14 @@ PAL_InitializeCoreCLR(
     int result = PAL_Initialize(1, &szExePath);
 #endif // __APPLE__
     if (result != 0)
+    {
         return GetLastError();
+    }
 
     // Now that the PAL is initialized it's safe to call the initialization methods for the code that used to
     // be dynamically loaded libraries but is now statically linked into CoreCLR just like the PAL, i.e. the
     // PAL RT and mscorwks.
-    if (!LOADInitCoreCLRModules())
+    if (!LOADInitCoreCLRModules(g_szCoreCLRPath))
     {
         return ERROR_DLL_INIT_FAILED;
     }

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -37,8 +37,6 @@ Revision History:
 #include <mach-o/dyld.h>
 #endif // __APPLE__
 
-extern char g_szCoreCLRPath[MAX_PATH];
-
 SET_DEFAULT_DEBUG_CHANNEL(MISC);
 
 static const char RANDOM_DEVICE_NAME[] ="/dev/random";
@@ -71,6 +69,11 @@ PAL_GetPALDirectoryW( OUT LPWSTR lpDirectoryName, IN UINT cchDirectoryName )
     ENTRY( "PAL_GetPALDirectoryW( %p, %d )\n", lpDirectoryName, cchDirectoryName );
 
     lpFullPathAndName = pal_module.lib_name;
+    if (lpFullPathAndName == NULL)
+    {
+        SetLastError(ERROR_INTERNAL_ERROR);
+        goto EXIT;
+    }
     lpEndPoint = PAL_wcsrchr( lpFullPathAndName, '/' );
     if ( lpEndPoint )
     {

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4985,8 +4985,6 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             }
             UNREACHABLE();
         }
-
-        _ASSERTE(!"HandleHardwareException: Hardware exception happened out of managed code");        
     }
     else 
     {
@@ -5015,7 +5013,6 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             }
         }
     }
-    EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);
 }
 
 #endif // FEATURE_PAL


### PR DESCRIPTION
Changed the VM's hardware exception to return if not in manged code. For DAC's hardware exception handling, add hardware exception holder used to determine if a C++ exception should be thrown for a hardware exception. Cleaned up PAL initialization interactions between the debugger modules (PAL_InitializeDLL) and coreclr (PAL_InitializeCoreCLR).