### PR TITLE
Fixed lldb not found error on fedora

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -18,7 +18,7 @@ if(NOT ENABLE_LLDBPLUGIN)
 endif()
 
 # Check for LLDB library
-find_library(LLDB NAMES lldb-3.6 lldb-3.5 LLDB lldb PATHS "${WITH_LLDB_LIBS}")
+find_library(LLDB NAMES lldb-3.6 lldb-3.5 LLDB lldb PATHS "${WITH_LLDB_LIBS}" PATH_SUFFIXES llvm)
 if(LLDB STREQUAL LLDB-NOTFOUND)
     if(REQUIRE_LLDBPLUGIN)
         message(FATAL_ERROR "Cannot find lldb-3.5 or lldb-3.6. Try installing lldb-3.6-dev (or the appropriate package for your platform)")


### PR DESCRIPTION
liblldb is installed in /usr/lib64/llvm/liblldb.so

Without the patch the error is (when calling: `./build.sh`):
>CMake Error at src/ToolBox/SOS/lldbplugin/CMakeLists.txt:24 (message):
  Cannot find lldb-3.5 or lldb-3.6.  Try installing lldb-3.6-dev (or the
  appropriate package for your platform)

With fix:
>-- LLDB: /usr/lib64/llvm/liblldb.so
-- LLDB_H: /usr/include
-- Looking for include file ieeefp.h

If this isn't something you are willing to accept right because of other priorities feel free to close this one.
Thanks:)