### PR TITLE
Add Directed/StructPromote test cases for JIT

### DIFF
--- a/tests/src/JIT/Directed/StructPromote/SP1.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP1.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP1
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(S s)
+    {
+        return s.i0 * 10 + s.i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1)
+    {
+        S s;
+        s.i0 = i1;
+        s.i1 = i0;
+        return Foo(s);  // r0 <= r1, r1 <= r0
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(1, 2);
+        Console.WriteLine("M(1, 2) is {0}.", res);
+        if (res == 21)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP1a.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP1a.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP1a
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(int i, S s)
+    {
+        return 100 * s.i0 + 10 * s.i1 + i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2)
+    {
+        S s;
+        s.i0 = i2;
+        s.i1 = i1;
+        return Foo(i0, s); // r0 <= r0; r1 <= r2; r2 <= r1
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(1, 2, 3);
+        Console.WriteLine("M(1, 2, 3) is {0}.", res);
+        if (res == 321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP1a2.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP1a2.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP1a2
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(int i, S s, int j)
+    {
+        return 1000 * j + 100 * s.i0 + 10 * s.i1 + i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2, int i3)
+    {
+        S s;
+        s.i0 = i2;
+        s.i1 = i1;
+        return Foo(i0, s, i3);
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(1, 2, 3, 4);
+        Console.WriteLine("M(1, 2, 3, 4) is {0}.", res);
+        if (res == 4321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP1b.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP1b.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP1b
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(int i, int j, S s)
+    {
+        return 1000 * s.i0 + 100 * s.i1 + 10 * i + j;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2, int i3)
+    {
+        S s;
+        s.i0 = i3;
+        s.i1 = i2;
+        return Foo(i1, i0, s);  // r0 <= r1; r1 <= r0; r2 <= r3; r3 <= r2
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(1, 2, 3, 4);
+        Console.WriteLine("M(1, 2, 3, 4) is {0}.", res);
+        if (res == 4321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP1c.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP1c.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP1c
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(int i, int j, int k, S s)
+    {
+        return 10000 * s.i0 + 1000 * s.i1 + 100 * i + 10 * j + k;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2, int i3, int i4)
+    {
+        S s;
+        s.i0 = i3;
+        s.i1 = i2;
+        return Foo(i1, i0, i4, s);  // r0 <= r1; r1 <= r0; r2 <= inarg[0]; r3 <= r3; outarg[0] <= r2
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(2, 3, 4, 5, 1);
+        Console.WriteLine("M(2, 3, 4, 5, 1) is {0}.", res);
+        if (res == 54321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP1d.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP1d.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP1d
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(int i, int j, int k, int k2, int k3, S s)
+    {
+        return 1000000 * s.i0 + 100000 * s.i1 + 10000 * i + 1000 * j + 100 * k + 10 * k2 + k3;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2, int i3, int i4, int i5, int i6)
+    {
+        S s;
+        s.i0 = i3;
+        s.i1 = i2;
+        return Foo(i1, i0, i4, i5, i6, s); // r0 <= r1; r1 <= r0; r2 <= inarg[0]; r3 <= inarg[4]; 
+        // outarg[0] <= inarg[8]; outarg[4] <= r3; outarg[8] <= r2
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(4, 5, 6, 7, 3, 2, 1);
+        Console.WriteLine("M(4, 5, 6, 7, 3, 2, 1) is {0}.", res);
+        if (res == 7654321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP2.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP2.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#define USE_STRUCT
+using System.Runtime.CompilerServices;
+using System;
+
+class SP2
+{
+
+#if USE_STRUCT
+    // Struct in reg (int, long)
+    struct S
+    {
+        public int i0;
+        public long l1;
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+#if USE_STRUCT
+    static long Foo(S s)
+    {
+        return 10 * (long)s.i0 + s.l1;
+    }
+#else
+    static long Foo(int i0, long l1) {
+        return 10*(long)i0 + l1;
+    }
+#endif
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long M(long l0, int i1)
+    {
+#if USE_STRUCT
+        S s;
+        s.i0 = i1;
+        s.l1 = l0;
+        return Foo(s);   // r0 <= r2; r2/r3 <= r0/r1
+#else
+        return Foo(i1, l0);
+#endif
+    }
+
+    public static int Main(String[] args)
+    {
+        long res = M(1, 2);
+        Console.WriteLine("M(1, 2) is {0}.", res);
+        if (res == 21)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP2a.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP2a.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP2a
+{
+
+    // Struct in reg (long, int)
+    struct S
+    {
+        public long l0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long Foo(int i, S s)
+    {
+        return 100 * (long)s.i1 + 10 * s.l0 + (long)i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long M(long l0, int i1, int i2)
+    {
+        S s;
+        s.i1 = i1;
+        s.l0 = l0;
+        return Foo(i2, s);  // r0 <= r3; r2/r3 <= r0/r1; outarg[0] <= r3
+    }
+
+    public static int Main(String[] args)
+    {
+        long res = M(2, 3, 1);
+        Console.WriteLine("M(2, 3, 1) is {0}.", res);
+        if (res == 321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP2b.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP2b.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP2b
+{
+
+    // Struct in reg (int, long)
+    struct S
+    {
+        public int i0;
+        public long l1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long Foo(int i, S s)
+    {
+        return 100 * (long)s.i0 + 10 * s.l1 + (long)i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long M(long l0, int i1, int i2)
+    {
+        S s;
+        s.i0 = i1;
+        s.l1 = l0;
+        return Foo(i2, s); // r0 <= r3; r2 <= r2; outarg[0/4] <= r0/r1;
+    }
+
+    public static int Main(String[] args)
+    {
+        long res = M(2, 3, 1);
+        Console.WriteLine("M(2, 3, 1) is {0}.", res);
+        if (res == 321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SP2c.cs
+++ b/tests/src/JIT/Directed/StructPromote/SP2c.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SP2c
+{
+
+    // Struct in reg (int, long)
+    struct S
+    {
+        public int i0;
+        public long l1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long Foo(int i, long l, S s)
+    {
+        return l * 1000 + 100 * (long)s.i0 + 10 * s.l1 + (long)i;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static long M(long l0, long l1, int i1, int i2)
+    {
+        S s;
+        s.i0 = i1;
+        s.l1 = l1;
+        return Foo(i2, l0, s); // r0 <= inarg[4]; r2/r3 <= r0/r1; outarg[0] <= inarg[0]; outarg[8/12] <= r2/r3
+    }
+
+    public static int Main(String[] args)
+    {
+        long res = M(4, 2, 3, 1);
+        Console.WriteLine("M(4, 2, 3, 1) is {0}.", res);
+        if (res == 4321)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SpAddr.cs
+++ b/tests/src/JIT/Directed/StructPromote/SpAddr.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SpAddr
+{
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(S s0, S s1)
+    {
+        // Console.WriteLine("s0 = [{0}, {1}], s1 = [{2}, {3}]", s0.i0, s0.i1, s1.i0, s1.i1);
+        return s0.i0 + s0.i1 + s1.i0 + s1.i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2, int i3)
+    {
+        S s0;
+        s0.i0 = i1;
+        s0.i1 = i0;
+        S s1;
+        s1.i0 = i2;
+        s1.i1 = i3;
+        return Foo(s0, s1); // r0 <= r1; r1 <= r0; r2 <= r3; r3 <= r2
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(1, 2, 3, 4);
+        Console.WriteLine("M(1, 2, 3, 4) is {0}.", res);
+        if (res == 10)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/SpAddrAT.cs
+++ b/tests/src/JIT/Directed/StructPromote/SpAddrAT.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+using System;
+
+class SpAddrAT
+{
+
+    // This one makes sure that we don't (independently) promote a struct local that is address-taken.
+
+    // Struct in reg (2 ints)
+    struct S
+    {
+        public int i0;
+        public int i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Foo(S s0, S s1)
+    {
+        return s0.i0 + s0.i1 + s1.i0 + s1.i1;
+    }
+
+    static int Bar(ref S s0)
+    {
+        return s0.i0 + s0.i1;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int M(int i0, int i1, int i2, int i3)
+    {
+        S s0;
+        s0.i0 = i1;
+        s0.i1 = i0;
+        S s1;
+        s1.i0 = i2;
+        s1.i1 = i3;
+        int x = Bar(ref s0);
+        return Foo(s0, s1) + x;  // r0 <= &s0[0]; r1 <= &s0[4]; r2 <= r2; r3 <= r3
+    }
+
+    public static int Main(String[] args)
+    {
+        int res = M(1, 2, 3, 4);
+        Console.WriteLine("M(1, 2, 3, 4) is {0}.", res);
+        if (res == 13)
+            return 100;
+        else
+            return 99;
+    }
+}

--- a/tests/src/JIT/Directed/StructPromote/StructPromote.csproj
+++ b/tests/src/JIT/Directed/StructPromote/StructPromote.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Directed/StructPromote/app.config
+++ b/tests/src/JIT/Directed/StructPromote/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Directed/StructPromote/cs_template.proj
+++ b/tests/src/JIT/Directed/StructPromote/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Directed/StructPromote/packages.config
+++ b/tests/src/JIT/Directed/StructPromote/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+</packages>


### PR DESCRIPTION
Add Directed/StructPromote test cases for JIT. Related proj, config files
added. Solution file update is delayed to later PRs for parallel working.
Passed build, buildtest, runtest.