### PR TITLE
Fix loading of PAL on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,11 @@ cmake_minimum_required(VERSION 2.8.12)
 # Set the project name
 project(CoreCLR)
 
-if(APPLE)
-    # Enable @rpath support for shared libraries.
-    set(MACOSX_RPATH ON)
-    if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
-        cmake_policy(SET CMP0042 NEW)
-    endif()
+# Enable @rpath support for shared libraries.
+set(MACOSX_RPATH ON)
+
+if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+    cmake_policy(SET CMP0042 NEW)
 endif()
 
 set(CLR_DIR ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -121,6 +121,13 @@ if(WIN32)
     )
 endif(WIN32)
 
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    # add @loader_path to the rpath so that the loader can find libcoreclrpal which is
+    # sxs with libcoreclr
+    set_target_properties(coreclr PROPERTIES INSTALL_RPATH "@loader_path")
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+
 # add the install targets
 install (TARGETS coreclr DESTINATION .)
 if(WIN32)

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -6,6 +6,13 @@ project(coreclrpal)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
+# Enable @rpath support for shared libraries.
+set(MACOSX_RPATH ON)
+
+if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+    cmake_policy(SET CMP0042 NEW)
+endif()
+
 # Include directories
 
 include_directories(include)


### PR DESCRIPTION
On OSX our trick to preload the PAL from the host before trying to load
coreclr doesn't actually cause the OSX loader to correctly resolve the
dependency.

This change moves to use rpath and then add an entry to the rpath list
for libcoreclr to @loader_path.

This way, we can load libcoreclr even in cases where the path to the PAL
is not on DYLD_LIBRARY_PATH and your CWD is not the doesn't have a copy.

Related issues are #709 and #719