### PR TITLE
Fixed the dac table file problem 

### DIFF
--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -7196,11 +7196,9 @@ HRESULT
 ClrDataAccess::GetDacGlobals()
 {
 #ifdef FEATURE_PAL
-    // TODO - 3/5/15 - the DAC side needs the debuggee pid
-    DWORD pid = 0;
     PVOID dacTableAddress = nullptr;
     ULONG dacTableSize = 0;
-    DWORD err = PAL_GetDacTableAddress(pid, &dacTableAddress, &dacTableSize);
+    DWORD err = PAL_GetDacTableAddress((PVOID)m_globalBase, &dacTableAddress, &dacTableSize);
     if (err != ERROR_SUCCESS)
     {
         return CORDBG_E_MISSING_DEBUGGER_EXPORTS;

--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -58,7 +58,7 @@ void DacGlobals::Initialize()
 #ifdef FEATURE_SVR_GC
     g_dacTable.InitializeSVREntries(baseAddress);
 #endif
-    PAL_PublishDacTableAddress(&g_dacTable, sizeof(g_dacTable));
+    PAL_PublishDacTableAddress((PVOID)baseAddress, &g_dacTable, sizeof(g_dacTable));
 }
 
 // Initializes the non-SVR table entries

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -1996,10 +1996,6 @@ HRESULT Debugger::Startup(void)
 
     DebuggerLockHolder dbgLockHolder(this);
 
-#ifdef FEATURE_PAL
-    DacGlobals::Initialize();
-#endif
-
     // Stubs in Stacktraces are always enabled.
     g_EnableSIS = true;
 
@@ -2548,10 +2544,6 @@ void Debugger::StopDebugger(void)
     }
     CONTRACTL_END;
    
-#ifdef FEATURE_PAL
-    PAL_CleanupDacTableAddress();
-#endif
-
     // Leak almost everything on process exit. The OS will clean it up anyways and trying to 
     // clean it up ourselves is just one more place we may AV / deadlock.
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -580,23 +580,25 @@ PALIMPORT
 DWORD
 PALAPI
 PAL_PublishDacTableAddress(
-    IN PVOID address,
-    IN ULONG size
+    IN PVOID baseAddress,
+    IN PVOID tableAddress,
+    IN ULONG tableSize
     );
 
 PALIMPORT
 DWORD
 PALAPI
 PAL_GetDacTableAddress(
-    IN DWORD pid,
-    OUT PVOID *pAddress,
-    OUT PULONG pSize
+    IN PVOID baseAddress,
+    OUT PVOID *tableAddress,
+    OUT PULONG tableSize
     );
 
 PALIMPORT
 VOID
 PALAPI
 PAL_CleanupDacTableAddress(
+    IN PVOID baseAddress
     );
 
 

--- a/src/pal/src/misc/dactableaddress.cpp
+++ b/src/pal/src/misc/dactableaddress.cpp
@@ -37,9 +37,11 @@ Function
 
 Parameters
 
-    address
+    baseAddress
+       [in] base address of CLR module
+    tableAddress
        [in] address of dac table
-    size
+    tableSize
        [in] size of dac table
 
 Return Values
@@ -50,24 +52,22 @@ PALIMPORT
 DWORD
 PALAPI
 PAL_PublishDacTableAddress(
-    IN PVOID address,
-    IN ULONG size)
+    IN PVOID baseAddress,
+    IN PVOID tableAddress,
+    IN ULONG tableSize)
 {
     DWORD ret = NO_ERROR;
 
-    // TODO - 3/5/15 - the DAC side needs the debuggee pid
-    // pid_t pid = getpid();
-    pid_t pid = 0;
     char fileName[100]; 
-    snprintf(fileName, sizeof(fileName), "/tmp/%d_dacTable", pid);
+    snprintf(fileName, sizeof(fileName), "/tmp/%p_dacTable", baseAddress);
 
     FILE *file = fopen(fileName, "w+");
     if (file != nullptr) 
     {
-        char dacTableAddress[100]; 
-        snprintf(dacTableAddress, sizeof(dacTableAddress), "%p %d\n", address, size);
+        char dacTableInfo[100]; 
+        snprintf(dacTableInfo, sizeof(dacTableInfo), "%p %d\n", tableAddress, tableSize);
 
-        if (fputs(dacTableAddress, file) < 0)
+        if (fputs(dacTableInfo, file) < 0)
         {
             ret = ERROR_INVALID_DATA;
         }
@@ -89,11 +89,11 @@ Function
 
 Parameters
 
-    pid
-       [in] process id to get the data
-    pAddress
+    baseAddress
+       [in] base address of CLR module
+    tableAddress
        [out] pointer to put DAC table address
-    pSize
+    tableSize
        [out] pointer to put DAC table size
 
 Return Values
@@ -104,14 +104,14 @@ PALIMPORT
 DWORD
 PALAPI
 PAL_GetDacTableAddress(
-    IN DWORD pid,
-    OUT PVOID *pAddress,
-    OUT PULONG pSize)
+    IN PVOID baseAddress,
+    OUT PVOID *tableAddress,
+    OUT PULONG tableSize)
 {
     DWORD ret = NO_ERROR;
 
     char fileName[100]; 
-    snprintf(fileName, sizeof(fileName), "/tmp/%d_dacTable", pid);
+    snprintf(fileName, sizeof(fileName), "/tmp/%p_dacTable", baseAddress);
 
     FILE *file = fopen(fileName, "r");
     if (file != nullptr) 
@@ -119,7 +119,7 @@ PAL_GetDacTableAddress(
         char data[100]; 
         if (fgets(data, sizeof(data), file) != nullptr)
         {
-            if (sscanf(data, "%p %d\n", pAddress, pSize) != 2)
+            if (sscanf(data, "%p %d\n", tableAddress, tableSize) != 2)
             {
                 ret = ERROR_INVALID_DATA;
             }
@@ -152,12 +152,10 @@ Return Values
 PALIMPORT
 VOID
 PALAPI
-PAL_CleanupDacTableAddress()
+PAL_CleanupDacTableAddress(
+    IN PVOID baseAddress)
 {
-    //pid_t pid = getpid();
-    pid_t pid = 0;
     char fileName[100]; 
-    snprintf(fileName, sizeof(fileName), "/tmp/%d_dacTable", pid);
-
+    snprintf(fileName, sizeof(fileName), "/tmp/%p_dacTable", baseAddress);
     remove(fileName);
 }

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1417,6 +1417,10 @@ HRESULT EEStartup(COINITIEE fFlags)
 
     _ASSERTE(!g_fEEStarted && !g_fEEInit && SUCCEEDED (g_EEStartupStatus));
 
+#ifdef FEATURE_PAL
+    DacGlobals::Initialize();
+#endif
+
     PAL_TRY(COINITIEE *, pfFlags, &fFlags)
     {
         EEStartupHelper(*pfFlags);


### PR DESCRIPTION
The file name used isn't unique if there is more than one process running managed code.  As a temporary fix (using a file is very temporary anyway), use the CLR module base address in the file name.  Even if there is more than one process with managed code/coreclr running if the base address is the same the dac table address will be the same.