### PR TITLE
Fix the two remaining linker errors on FreeBSD.

### DIFF
--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -15,9 +15,12 @@ add_executable(corerun
     ${CORERUN_SOURCES}
 )
 
-target_link_libraries(corerun 
-    dl
-)
+# FreeBSD implements dlopen in libc
+if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    target_link_libraries(corerun 
+        dl
+    )
+endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
 add_dependencies(corerun
     coreclr

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 
 add_definitions(-DNO_CRT_INIT)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 # This option is necessary to ensure that the overloaded delete operator defined inside
 # of the utilcode will be used instead of the standard library delete operator.
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")
@@ -26,7 +26,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 # These options are used to force every object to be included even if it's unused.
     set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
     set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive) 
-endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+endif(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 # These options are used to force every object to be included even if it's unused.


### PR DESCRIPTION
Thanks to Jan Vorlicek for finding the source of the first linker error. Those
linker options need to be passed to the linker on FreeBSD too.
The second linker error is caused by the fact that FreeBSD has no libdl, the
functionality is instead implemented in libc. Thus do not add the -ldl option
to the linker on FreeBSD. Fixes #739

This is fixes the build on FreeBSD completely. With this applied we can successfully build CoreCLR on FreeBSD!