### PR TITLE
Fix GC stack unwinding issue

### DIFF
--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -3529,6 +3529,7 @@ void ExceptionTracker::PartialTrackerState::Save(const ExceptionTracker* pSource
     m_EHClauseInfo = pSourceTracker->m_EHClauseInfo;
     m_EnclosingClauseInfo = pSourceTracker->m_EnclosingClauseInfo;
     m_EnclosingClauseInfoForGCReporting = pSourceTracker->m_EnclosingClauseInfoForGCReporting;
+    m_fFixupCallerSPForGCReporting = pSourceTracker->m_fFixupCallerSPForGCReporting;
 }
 
 // Restore the state into the target exception tracker
@@ -3542,6 +3543,7 @@ void ExceptionTracker::PartialTrackerState::Restore(ExceptionTracker* pTargetTra
     pTargetTracker->m_EHClauseInfo = m_EHClauseInfo;
     pTargetTracker->m_EnclosingClauseInfo = m_EnclosingClauseInfo;
     pTargetTracker->m_EnclosingClauseInfoForGCReporting = m_EnclosingClauseInfoForGCReporting;
+    pTargetTracker->m_fFixupCallerSPForGCReporting = m_fFixupCallerSPForGCReporting;
 }
 
 //
@@ -6090,6 +6092,8 @@ bool ExceptionTracker::IsInStackRegionUnwoundByCurrentException(CrawlFrame * pCF
     PTR_ExceptionTracker pCurrentTracker = pThread->GetExceptionState()->GetCurrentExceptionTracker();
     return ExceptionTracker::IsInStackRegionUnwoundBySpecifiedException(pCF, pCurrentTracker);
 }
+
+
 
 // Returns a bool indicating if the specified CrawlFrame has been unwound by any active (e.g. nested) exceptions.
 // 

--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -677,6 +677,7 @@ private: ;
         EHClauseInfo m_EHClauseInfo;
         EnclosingClauseInfo m_EnclosingClauseInfo;
         EnclosingClauseInfo m_EnclosingClauseInfoForGCReporting;
+        bool m_fFixupCallerSPForGCReporting;
 
     public:
         // Save the state of the source exception tracker


### PR DESCRIPTION
This change fixes a GC stack unwinding issue when a GC is
triggered in a catch handler that caught a rethrown
exception.
The problem was that we need to propagate the m_fFixupCallerSPForGCReporting
to the new exception tracker created when interleaved exception handling
starts processing a block of managed frames after processing another
block of managed frames followed by a block of native frames.
Without this flag, the m_EnclosingClauseInfoForGCReporting's
caller SP is not updated when the target unwind frame is found and
such an update is needed.