### PR TITLE
Temporarily change invariant currency symbol on Unix for demo purposes

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
@@ -162,7 +162,7 @@ namespace System.Globalization
                 case LocaleStringData.Digits:
                     return "3;0";
                 case LocaleStringData.MonetarySymbol:
-                    return "\u00A4";
+                    return "$"; // TODO: CoreFX #846 Restore to the original value "\x00a4"
                 case LocaleStringData.Iso4217MonetarySymbol:
                     return "XDR";
                 case LocaleStringData.MonetaryDecimalSeparator:

--- a/src/mscorlib/corefx/System/Globalization/CultureData.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureData.cs
@@ -450,7 +450,8 @@ namespace System.Globalization
                     invariant.sPerMille = "\x2030";               // PerMille(‰) symbol
 
                     // Currency
-                    invariant.sCurrency = "\x00a4";                // local monetary symbol "¤: for international monetary symbol
+                    // TODO: CoreFX #846 Put sCurrency back to its correct Invariant value.
+                    invariant.sCurrency = "$"; // "\x00a4";         // local monetary symbol "¤: for international monetary symbol
                     invariant.sIntlMonetarySymbol = "XDR";                  // international monetary symbol (RegionInfo)
                     invariant.iCurrencyDigits = 2;                      // # local monetary fractional digits
                     invariant.iCurrency = 0;                      // positive currency format

--- a/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/NumberFormatInfo.cs
@@ -59,7 +59,7 @@ namespace System.Globalization
         internal String numberGroupSeparator = ",";
         internal String currencyGroupSeparator = ",";
         internal String currencyDecimalSeparator = ".";
-        internal String currencySymbol = "\x00a4";  // U+00a4 is the symbol for International Monetary Fund.
+        internal String currencySymbol = "$"; // TODO: CoreFX #846 Restore to the original value "\x00a4";  // U+00a4 is the symbol for International Monetary Fund.
         internal String nanSymbol = "NaN";
         internal String positiveInfinitySymbol = "Infinity";
         internal String negativeInfinitySymbol = "-Infinity";


### PR DESCRIPTION
mscorlib's globalization stack on Unix is a temporary implementation, good enough just to help unblock getting the rest of the system up and running and for some basic demos.  However, such demos are hindered slightly by the use of the international monetary symbol "\x00a4" when rendering currency.  This commit just makes a temporary tweak to instead use "$".