### PR TITLE
Implemented hardware exception chaining.

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -59,7 +59,9 @@ include_directories(${CLR_DIR}/src/inc)
 set(SOURCES
     sosplugin.cpp
     soscommand.cpp
+    coreruncommand.cpp
     debugclient.cpp
+    ${CLR_DIR}/src/coreclr/hosts/unixcorerun/corerun.cpp
 )
 
 add_library(sosplugin SHARED ${SOURCES})

--- a/src/ToolBox/SOS/lldbplugin/coreruncommand.cpp
+++ b/src/ToolBox/SOS/lldbplugin/coreruncommand.cpp
@@ -1,0 +1,48 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
+#include "sosplugin.h"
+#include <dlfcn.h>
+#include <string>
+
+extern int corerun(const int argc, const char* argv[]);
+
+class corerunCommand : public lldb::SBCommandPluginInterface
+{
+public:
+    corerunCommand()
+    {
+    }
+
+    virtual bool
+    DoExecute (lldb::SBDebugger debugger,
+               char** arguments,
+               lldb::SBCommandReturnObject &result)
+    {
+        if (arguments)
+        {
+            int argc = 0;
+            char **argv = arguments;
+            for (const char* arg = *arguments; arg; arg = *(++arguments))
+            {
+                ++argc;
+            }
+            int exitcode = corerun((const int)argc, (const char**)argv);
+            if (exitcode != 0)
+            {
+                result.SetError("corerun failed");
+            }
+        }
+        return result.Succeeded();
+    }
+};
+
+bool
+corerunCommandInitialize(lldb::SBDebugger debugger)
+{
+    lldb::SBCommandInterpreter interpreter = debugger.GetCommandInterpreter();
+    interpreter.AddCommand("corerun", new corerunCommand(), "run a managed app inside the debugger");
+    return true;
+}

--- a/src/ToolBox/SOS/lldbplugin/sosplugin.cpp
+++ b/src/ToolBox/SOS/lldbplugin/sosplugin.cpp
@@ -12,5 +12,7 @@ namespace lldb {
 bool
 lldb::PluginInitialize (lldb::SBDebugger debugger)
 {
-    return sosCommandInitialize(debugger);
+    corerunCommandInitialize(debugger);
+    sosCommandInitialize(debugger);
+    return true;
 }

--- a/src/ToolBox/SOS/lldbplugin/sosplugin.h
+++ b/src/ToolBox/SOS/lldbplugin/sosplugin.h
@@ -12,3 +12,6 @@ typedef HRESULT (*CommandFunc)(PDEBUG_CLIENT client, const char *args);
 
 bool 
 sosCommandInitialize(lldb::SBDebugger debugger);
+
+bool
+corerunCommandInitialize(lldb::SBDebugger debugger);

--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -321,7 +321,7 @@ int ExecuteManagedAssembly(
         return -1;
     }
     
-    void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (coreclrLib != nullptr)
     {
         ExecuteAssemblyFunction executeAssembly = (ExecuteAssemblyFunction)dlsym(coreclrLib, "ExecuteAssembly");
@@ -402,7 +402,7 @@ int ExecuteManagedAssembly(
     return exitCode;
 }
 
-int main(const int argc, const char* argv[])
+int corerun(const int argc, const char* argv[])
 {
     const char* clrFilesPath;
     const char* managedAssemblyPath;
@@ -483,4 +483,9 @@ int main(const int argc, const char* argv[])
                             managedAssemblyArgc,
                             managedAssemblyArgv);
     return exitCode;
+}
+
+int main(const int argc, const char* argv[])
+{
+    return corerun(argc, argv);
 }

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -100,12 +100,12 @@ SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
     if (!SEHInitializeConsole())
     {
         ERROR("SEHInitializeConsole failed!\n");
-        SEHCleanup(flags);
+        SEHCleanup();
         goto SEHInitializeExit;
     }
 
 #if !HAVE_MACH_EXCEPTIONS
-    SEHInitializeSignals(flags);
+    SEHInitializeSignals();
 
     if (flags & PAL_INITIALIZE_SIGNAL_THREAD)
     {
@@ -113,7 +113,7 @@ SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
         if (NO_ERROR != palError)
         {
             ERROR("StartExternalSignalHandlerThread returned %d\n", palError);
-            SEHCleanup(flags);
+            SEHCleanup();
             goto SEHInitializeExit;
         }
     }
@@ -131,20 +131,20 @@ Function :
     Undo work done by SEHInitialize
 
 Parameters :
-    PAL initialize flags
+    None
 
     (no return value)
     
 --*/
 VOID 
-SEHCleanup(DWORD flags)
+SEHCleanup()
 {
     TRACE("Cleaning up SEH\n");
 
 #if HAVE_MACH_EXCEPTIONS
     SEHCleanupExceptionPort();
 #else
-    SEHCleanupSignals(flags);
+    SEHCleanupSignals();
 #endif
 }
 
@@ -179,9 +179,8 @@ Parameters:
     PEXCEPTION_POINTERS pointers
 
 Return value:
-    Does not return
+    Returns only if the exception is unhandled
 --*/
-PAL_NORETURN
 VOID
 SEHProcessException(PEXCEPTION_POINTERS pointers)
 {
@@ -197,9 +196,7 @@ SEHProcessException(PEXCEPTION_POINTERS pointers)
         throw exception;
     }
 
-    ASSERT("Unhandled hardware exception %08x\n", pointers->ExceptionRecord->ExceptionCode);
-
-    ExitProcess(pointers->ExceptionRecord->ExceptionCode);
+    TRACE("Unhandled hardware exception %08x\n", pointers->ExceptionRecord->ExceptionCode);
 }
 
 /*++

--- a/src/pal/src/exception/signal.hpp
+++ b/src/pal/src/exception/signal.hpp
@@ -30,11 +30,11 @@ Function :
     Set-up signal handlers to catch signals and translate them to exceptions
 
 Parameters :
-    PAL initialize flags
+    None
 
     (no return value)
 --*/
-void SEHInitializeSignals(DWORD flags);
+void SEHInitializeSignals();
 
 /*++
 Function :
@@ -44,7 +44,7 @@ Function :
 
     (no parameters, no return value)
 --*/
-void SEHCleanupSignals(DWORD flags);
+void SEHCleanupSignals();
 
 #if (__GNUC__ > 3 ||                                            \
      (__GNUC__ == 3 && __GNUC_MINOR__ > 2))

--- a/src/pal/src/include/pal/seh.hpp
+++ b/src/pal/src/include/pal/seh.hpp
@@ -53,12 +53,12 @@ Function :
     Clean up SEH-related stuff(signals, etc)
 
 Parameters:
-    flags : PAL initialize flags
+    None
 
     (no return value)
 --*/
 VOID 
-SEHCleanup(DWORD flags);
+SEHCleanup();
 
 /*++
 Function:

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -534,7 +534,7 @@ CLEANUP10:
 CLEANUP8:
     MAPCleanup();
 CLEANUP6:
-    SEHCleanup(flags);
+    SEHCleanup();
 CLEANUP5:
     PROCCleanupInitialProcess();
 CLEANUP4:
@@ -847,7 +847,7 @@ PALCommonCleanup(PALCLEANUP_STEP step, BOOL full_cleanup)
                    LOADFreeModules requires SEH to be functional when calling DllMain.
                    Therefore SEHCleanup must go between LOADFreeModules and
                    PROCCleanupInitialProcess */
-                SEHCleanup(PAL_INITIALIZE_ALL);
+                SEHCleanup();
                 PROCCleanupInitialProcess();
             }
 

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -1945,8 +1945,10 @@ HRESULT CorHost2::SetStartupFlags(STARTUP_FLAGS flag)
     }
     CONTRACTL_END;
 
-    if(g_fEEStarted)
+    if (m_fStarted)
+    {
         return HOST_E_INVALIDOPERATION;
+    }
 
     if (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_gcServer) != 0)
     {

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4945,6 +4945,10 @@ bool IsDivByZeroAnIntegerOverflow(PCONTEXT pContext)
 
 VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
 {
+    if (!g_fEEStarted)
+    {
+        return;
+    }
     if (ex->ExceptionRecord.ExceptionCode != STATUS_BREAKPOINT && ex->ExceptionRecord.ExceptionCode != STATUS_SINGLE_STEP)
     {
         // A hardware exception is handled only if it happened in a jitted code or 
@@ -4989,13 +4993,13 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             UNREACHABLE();
         }
     }
-    else 
+    else
     {
         // This is a breakpoint or single step stop, we report it to the debugger.
-        Thread *pThread = GetThread(); 
+        Thread *pThread = GetThread();
         if (pThread != NULL && g_pDebugInterface != NULL)
         {
-            if (ex->ExceptionRecord.ExceptionCode == STATUS_BREAKPOINT)   
+            if (ex->ExceptionRecord.ExceptionCode == STATUS_BREAKPOINT)
             {
                 // If this is breakpoint context, it is set up to point to an instruction after the break instruction.
                 // But debugger expects to see context that points to the break instruction, that's why we correct it.
@@ -5004,13 +5008,13 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             }
 
             if (g_pDebugInterface->FirstChanceNativeException(&ex->ExceptionRecord,
-                                                          &ex->ContextRecord,
-                                                          ex->ExceptionRecord.ExceptionCode,
-                                                          pThread))
+                &ex->ContextRecord,
+                ex->ExceptionRecord.ExceptionCode,
+                pThread))
             {
                 RtlRestoreContext(&ex->ContextRecord, &ex->ExceptionRecord);
-            } 
-            else 
+            }
+            else
             {
                 _ASSERTE(!"Looks like a random breakpoint/trap that was not prepared by the EE debugger");
             }


### PR DESCRIPTION
Test CLR hosting under a debugger (lldb). In order to test the debugger modules and coreclr running together in the same process, add the test command "corerun" to the lldb plugin that uses the CLR hosting apis to run managed code in the lldb process.

Fixed a problem where the dac module was picking up an constructor in the coreclr module instead of using the dac version. This is because the corerun code was dlopen'ing coreclr with RTLD_GLOBAL which exposed all the symbols to the reset of the dynamic modules loaded.  Changing it to RTLD_LOCAL (the default) fixes this problem.

Changed from an ASSERT to an ERROR in the hardware exception handler because ASSERT does an SIGTRAP (DebugBreak) that keeps recursively being hit.

Removed all signals that installed a fatal_signal_handler especially SIGINT which was interfering with lldb's. The rest of the signals, the default action should be good enough.

Checked if the EE was started in the VM's hardware exception handler just to make sure everything is ready before the managed exception chain is called.

Cleanup signal thread masking. Only wait for SIGINT/SIGQUIT explicitly instead of trying to mask all the signals we don't want to wait on.