### PR TITLE
Handle threads in side-by-side statically linked PALs

### DIFF
--- a/src/pal/src/include/pal/dbgmsg.h
+++ b/src/pal/src/include/pal/dbgmsg.h
@@ -257,7 +257,6 @@ extern Volatile<BOOL> dbg_master_switch ;
 #define ERROR     NOTRACE
 #define ERROR_(x) NOTRACE
 
-#define CHECK_PAL_THREAD
 #define CHECK_STACK_ALIGN
 
 #else /* _NO_DEBUG_MESSAGES_ */
@@ -274,13 +273,6 @@ extern Volatile<BOOL> dbg_master_switch ;
 #define WARN_(x) \
     DBG_PRINTF(DLI_WARN,DCI_##x,TRUE)
 
-#if _DEBUG && defined(FEATURE_PAL_SXS)
-void CheckPalThread();
-#define CHECK_PAL_THREAD CheckPalThread();
-#else // _DEBUG && FEATURE_PAL_SXS
-#define CHECK_PAL_THREAD
-#endif // _DEBUG && FEATURE_PAL_SXS
-
 #if _DEBUG && defined(__APPLE__)
 bool DBG_ShouldCheckStackAlignment();
 #define CHECK_STACK_ALIGN   if (DBG_ShouldCheckStackAlignment()) DBG_CheckStackAlignment()
@@ -293,12 +285,10 @@ bool DBG_ShouldCheckStackAlignment();
     DBG_PRINTF(DLI_ENTRY, defdbgchan,TRUE)
 
 #define ENTRY \
-    CHECK_PAL_THREAD; \
     CHECK_STACK_ALIGN; \
     DBG_PRINTF(DLI_ENTRY, defdbgchan,TRUE)
 
 #define ENTRY_(x) \
-    CHECK_PAL_THREAD; \
     CHECK_STACK_ALIGN; \
     DBG_PRINTF(DLI_ENTRY, DCI_##x,TRUE)
 

--- a/src/pal/src/include/pal/seh.hpp
+++ b/src/pal/src/include/pal/seh.hpp
@@ -72,7 +72,6 @@ Parameters:
 Return value:
     Does not return
 --*/
-PAL_NORETURN
 VOID 
 SEHProcessException(PEXCEPTION_POINTERS pointers);
 

--- a/src/pal/src/include/pal/threadsusp.hpp
+++ b/src/pal/src/include/pal/threadsusp.hpp
@@ -406,12 +406,14 @@ namespace CorUnix
             };
 
 #if USE_SIGNALS_FOR_THREAD_SUSPENSION
-            VOID
+            bool
             HandleSuspendSignal(
                 CPalThread *pthrTarget
             );
 
-            VOID HandleResumeSignal();
+            bool 
+            HandleResumeSignal(
+            );
 #else // USE_SIGNALS_FOR_THREAD_SUSPENSION
             static
             BOOL 

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4949,6 +4949,7 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
     {
         return;
     }
+
     if (ex->ExceptionRecord.ExceptionCode != STATUS_BREAKPOINT && ex->ExceptionRecord.ExceptionCode != STATUS_SINGLE_STEP)
     {
         // A hardware exception is handled only if it happened in a jitted code or 


### PR DESCRIPTION
Create CPalThread object on the fly in InternalGetCurrentThread. SIGUSR1/SIGUSR2 are needed by the PAL thread suspend/resume logic. Enable them for PAL_InitializeDLL. Added an assert and ExitProcess to the on the fly CPalThread data allocation failure path.

Fixed a problem introduced in #807. HandleSuspendSignal and HandleResumeSignal needed to indicate whether to chain or continue the SIGUSR1/2 signal.

Issue #749.