### PR TITLE
Fix LLDB header related build error on FreeBSD

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/debugclient.cpp
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.cpp
@@ -3,14 +3,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 //
 
+#include <cstdarg>
+#include <cstdlib>
 #include "sosplugin.h"
 #include <string.h>
 #include <dbgtargetcontext.h>
 #include <string>
-#if defined(__FreeBSD__)
-#include <stdarg.h>
-#include <stdlib.h>
-#endif
 
 DebugClient::DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject) :
     m_debugger(debugger),

--- a/src/ToolBox/SOS/lldbplugin/debugclient.cpp
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.cpp
@@ -7,6 +7,10 @@
 #include <string.h>
 #include <dbgtargetcontext.h>
 #include <string>
+#if defined(__FreeBSD__)
+#include <stdarg.h>
+#include <stdlib.h>
+#endif
 
 DebugClient::DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject) :
     m_debugger(debugger),


### PR DESCRIPTION
Fixed lldb header related build errors on FreeBSD (this timearound with no platform specific includes)