### PR TITLE
Fixed lldb header related build errors on FreeBSD

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/debugclient.cpp
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.cpp
@@ -3,6 +3,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 //
 
+#include <cstdarg>
+#include <cstdlib>
 #include "sosplugin.h"
 #include <string.h>
 #include <dbgtargetcontext.h>


### PR DESCRIPTION
... no platform specific ifdefs)