### PR TITLE
Allow building with VS2015 installed

### DIFF
--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==1 GOTO :USAGE
+if NOT %argC%==2 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -15,20 +15,24 @@ set "basePath=%basePath:"=%"
 :: remove trailing slash
 if %basePath:~-1%==\ set "basePath=%basePath:~0,-1%"
 
+set __VSString=12 2013
+if /i "%2" == "vs2015" (set __VSString=14 2015)
+
 if defined CMakePath goto DoGen
 
 :: Eval the output from probe-win1.ps1
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& .\probe-win.ps1"') do %%a
 
 :DoGen
-"%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" -G "Visual Studio 12 2013 Win64" %1
+"%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" -G "Visual Studio %__VSString% Win64" %1
 endlocal
 GOTO :DONE
 
 :USAGE
   echo "Usage..."
-  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt>"
+  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion>"
   echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
+  echo "Specify the VSVersion to be used - VS2013 or VS2015"
   EXIT /B 1
 
 :DONE


### PR DESCRIPTION
Previous it was required to have VS2013 but now VS2015 can also be used. The default is still 2013 though.
On a machine with both version installed it is possible to force VS2013/VS2015 with a parameter.

Note: Still some work has to be done to make compilation successfull on VS2015.

There are some warnings which are now on by default (I think) and some new warnings which are an issue with `TreatWarningAsError`. The errors I'm talking about:

* `4302` The compiler detected a conversion from a larger type to a smaller type. Information may be lost
* `4311`This warning detects 64-bit pointer truncation issues. For example, if code is compiled for a 64-bit architecture, the value of a pointer (64 bits) will be truncated if it is assigned to an int (32 bits)
* `4312`  This warning detects an attempt to assign a 32-bit value to a 64-bit pointer type, for example, casting a 32-bit int or long to a 64-bit pointer

`hash_map`/`hash_set` are deprecated causing the build to fail #821

So this pull request adds effectively nothing because VS2015 still doesn't work but I just wanted to throw this out here for review. If this isn't the right way feel free to close :)