### PR TITLE
Replace hash_map/set with unordered_map/set

### DIFF
--- a/src/ToolBox/SOS/Strike/eeheap.cpp
+++ b/src/ToolBox/SOS/Strike/eeheap.cpp
@@ -678,7 +678,7 @@ BOOL GCObjInHeap(TADDR taddrObj, const DacpGcHeapDetails &heap,
 
 #ifndef FEATURE_PAL
 // this function updates genUsage to reflect statistics from the range defined by [start, end)
-void GCGenUsageStats(TADDR start, TADDR end, const std::hash_set<TADDR> &liveObjs, 
+void GCGenUsageStats(TADDR start, TADDR end, const std::unordered_set<TADDR> &liveObjs,
     const DacpGcHeapDetails &heap, BOOL bLarge, const AllocInfo *pAllocInfo, GenUsageStat *genUsage)
 {
     // if this is an empty segment or generation return
@@ -787,7 +787,7 @@ BOOL GCHeapUsageStats(const DacpGcHeapDetails& heap, BOOL bIncUnreachable, HeapU
 #ifndef FEATURE_PAL
     // this will create the bitmap of rooted objects only if bIncUnreachable is true
     GCRootImpl gcroot;
-    const std::hash_set<TADDR> &liveObjs = gcroot.GetLiveObjects();
+    const std::unordered_set<TADDR> &liveObjs = gcroot.GetLiveObjects();
     
     // 1a. enumerate all non-ephemeral segments
     while (taddrSeg != (TADDR)heap.generation_table[0].start_segment)

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -4010,7 +4010,7 @@ private:
 private:
 #if !defined(FEATURE_PAL)
     // Windows only
-    std::hash_set<TADDR> mLiveness;
+    std::unordered_set<TADDR> mLiveness;
     typedef std::list<sos::FragmentationBlock> FragmentationList;
     FragmentationList mFrag;
 

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -146,7 +146,7 @@ namespace com_activation
         { return memcmp(&_Key1, &_Key2, sizeof(GUID)) == -1; }
     };
 
-    static std::hash_map<GUID, HMODULE, hash_compareGUID> *g_pClsidHmodMap = NULL;
+    static std::unordered_map<GUID, HMODULE, hash_compareGUID> *g_pClsidHmodMap = NULL;
 
 
 
@@ -393,7 +393,7 @@ Error:
 *                                                                      *
 * Note:                                                                *
 *                                                                      *
-* It uses a hash_map to cache the mapping between a CLSID and the      *
+* It uses a unordered_map to cache the mapping between a CLSID and the      *
 * HMODULE that is successfully used to activate the CLSID from. When   *
 * SOS is unloaded (in DebugExtensionUninitialize()) we call            *
 * FreeLibrary() for all cached HMODULEs.                               *
@@ -411,7 +411,7 @@ HRESULT CreateInstanceFromPath(
 
     if (g_pClsidHmodMap == NULL)
     {
-        g_pClsidHmodMap = new std::hash_map<GUID, HMODULE, hash_compareGUID>();
+        g_pClsidHmodMap = new std::unordered_map<GUID, HMODULE, hash_compareGUID>();
         OnUnloadTask::Register(CleanupClsidHmodMap);
     }
 

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -2857,8 +2857,8 @@ private:
 //
 
 #ifndef FEATURE_PAL
-#include <hash_map>
-#include <hash_set>
+#include <unordered_map>
+#include <unordered_set>
 #include <list>
 #endif
 
@@ -2877,7 +2877,7 @@ private:
     LinearReadCache mCache;
     
 #ifndef FEATURE_PAL
-    std::hash_map<TADDR, std::list<TADDR>> mDependentHandleMap;
+    std::unordered_map<TADDR, std::list<TADDR>> mDependentHandleMap;
 #endif
     
 public:           
@@ -3031,7 +3031,7 @@ private:
     };
 
 public:
-    static void GetDependentHandleMap(std::hash_map<TADDR, std::list<TADDR>> &map);
+    static void GetDependentHandleMap(std::unordered_map<TADDR, std::list<TADDR>> &map);
 
 public:
     // Finds all objects which root "target" and prints the path from the root
@@ -3050,7 +3050,7 @@ public:
     void ObjSize();
 
     // Returns the set of all live objects in the process.
-    const std::hash_set<TADDR> &GetLiveObjects(bool excludeFQ = false);
+    const std::unordered_set<TADDR> &GetLiveObjects(bool excludeFQ = false);
 
     // See !FindRoots.
     int FindRoots(int gen, TADDR target);
@@ -3108,12 +3108,12 @@ private:
     std::list<RootNode*> mCleanupList;  // A list of RootNode's we've newed up.  This is only used to delete all of them later.
     std::list<RootNode*> mRootNewList;  // A list of unused RootNodes that are free to use instead of having to "new" up more.
     
-    std::hash_map<TADDR, MTInfo*> mMTs;     // The MethodTable cache which maps from MT -> MethodTable data (size, gcdesc, string typename)
-    std::hash_map<TADDR, RootNode*> mTargets;   // The objects that we are searching for.
-    std::hash_set<TADDR> mConsidered;       // A hashtable of objects we've already visited.
-    std::hash_map<TADDR, size_t> mSizes;   // A mapping from object address to total size of data the object roots.
+    std::unordered_map<TADDR, MTInfo*> mMTs;     // The MethodTable cache which maps from MT -> MethodTable data (size, gcdesc, string typename)
+    std::unordered_map<TADDR, RootNode*> mTargets;   // The objects that we are searching for.
+    std::unordered_set<TADDR> mConsidered;       // A hashtable of objects we've already visited.
+    std::unordered_map<TADDR, size_t> mSizes;   // A mapping from object address to total size of data the object roots.
     
-    std::hash_map<TADDR, std::list<TADDR>> mDependentHandleMap;
+    std::unordered_map<TADDR, std::list<TADDR>> mDependentHandleMap;
     
     LinearReadCache mCache;     // A linear cache which stops us from having to read from the target process more than 1-2 times per object.
 };

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -18,7 +18,7 @@
 #if defined(_TARGET_ARM_) || defined(FEATURE_CORESYSTEM) // @ARMTODO: STL breaks the build with current VC headers
 //---------------------------------------------------------------------------------------
 // Setting DAC_HASHTABLE tells the DAC to use the hand rolled hashtable for
-// storing code:DAC_INSTANCE .  Otherwise, the DAC uses the STL hash_map to.
+// storing code:DAC_INSTANCE .  Otherwise, the DAC uses the STL unordered_map to.
 
 #define DAC_HASHTABLE
 #endif // _TARGET_ARM_|| FEATURE_CORESYSTEM
@@ -26,7 +26,7 @@
 #ifndef DAC_HASHTABLE
 #pragma push_macro("return")
 #undef return
-#include <hash_map>
+#include <unordered_map>
 #pragma pop_macro("return")
 #endif //DAC_HASHTABLE
 extern CRITICAL_SECTION g_dacCritSec;
@@ -784,7 +784,7 @@ private:
     HashInstanceKeyBlock* m_hash[DAC_INSTANCE_HASH_SIZE];
 #else //DAC_HASHTABLE
 
-    // We're going to use the STL hash_map for our instance hash.  
+    // We're going to use the STL unordered_map for our instance hash.  
     // This has the benefit of scaling to different workloads appropriately (as opposed to having a 
     // fixed number of buckets).
 
@@ -829,7 +829,7 @@ private:
 #endif
 
     };
-    typedef stdext::hash_map<TADDR, DAC_INSTANCE*, DacHashCompare > DacInstanceHash;
+    typedef stdext::unordered_map<TADDR, DAC_INSTANCE*, DacHashCompare > DacInstanceHash;
     typedef DacInstanceHash::value_type DacInstanceHashValue;
     typedef DacInstanceHash::iterator DacInstanceHashIterator;
     DacInstanceHash m_hash;


### PR DESCRIPTION
hash_map/hash_set are deprecated in VS 2015

Haven't found time to fix my issues with building mscorlib on VS2013 so I did not run the tests (jup, i know pretty bad but at least I'm honest about it :-) ).

I did however build on Fedora and VS2015 (but with failures because of the other issues but I could see the hash_map/set issues are now gone).

fixes #821

Let me know if something is wrong and I might be able to fix it :) Thanks!