### PR TITLE
Complete FreeBSD bringup

### DIFF
--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -22,6 +22,13 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     )
 endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
+# FreeBSD requires pthread to be loaded by the executable process
+if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    target_link_libraries(corerun
+        pthread
+    )
+endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+
 add_dependencies(corerun
     coreclr
 )

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -2433,6 +2433,9 @@ PAL_GetStackBase()
     
     pthread_t thread = pthread_self();
     
+    status = pthread_attr_init(&attr);
+    _ASSERT_MSG(status == 0, "pthread_attr_init call failed");
+
 #if HAVE_PTHREAD_ATTR_GET_NP
     status = pthread_attr_get_np(thread, &attr);
 #elif HAVE_PTHREAD_GETATTR_NP
@@ -2465,6 +2468,9 @@ PAL_GetStackLimit()
     
     pthread_t thread = pthread_self();
     
+    status = pthread_attr_init(&attr);
+    _ASSERT_MSG(status == 0, "pthread_attr_init call failed");
+
 #if HAVE_PTHREAD_ATTR_GET_NP
     status = pthread_attr_get_np(thread, &attr);
 #elif HAVE_PTHREAD_GETATTR_NP


### PR DESCRIPTION
Fixes issue #801 which was caused by the CoreCLR and PAL being
dlopened, but pthread not being initialized by the runtime linker yet.
FreeBSD requires that the main executable load pthread, rather than a
downstream dependency.  Also fixed a few missing calls to pthread_attr_init
which was causing asserts() on FBSD.