### PR TITLE
Fix GC of other thread during native frames unwinding

### DIFF
--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -298,6 +298,13 @@ public:
         return m_pInitialExplicitFrame;
     }
 
+    // Reset the range of explicit frames that covers already unwound frames.
+    void ResetUnwoundExplicitFramesRange()
+    {
+        m_pInitialExplicitFrame = NULL;
+        m_pLimitFrame = NULL;
+    }
+
     // Determines if we have unwound to the specified parent method frame.
     // Currently this is only used for funclet skipping.
     static bool IsUnwoundToTargetParentFrame(CrawlFrame * pCF, StackFrame sfParent);


### PR DESCRIPTION
This change fixes a problem when the GC is attempting to scan a stack
of another thread that have just performed the native stack segment
unwind, but didn't have a chance to update the exception tracker
to reflect the fact that the stack range from m_pInitialExplicitFrame
and m_pLimitFrame is in the reclaimed part of the stack and is waiting
for the GC to complete (it uses the GCX_COOP).
The GC then attempts to scan explicit frames in the already reclaimed
part of the stack in the `ExceptionTracker::HasFrameBeenUnwoundByAnyActiveException` method and crashes due to the stack being already overwritten.
Besides fixing the issue, I have noticed that we are missing GCX_COOP
to enter the cooperative mode when unwinding frame chain in the
UnwindManagedExceptionPass1. I have also found that we don't have the
GCX_COOP in the HandleHardwareException properly scoped.
So I have fixed those as well.