### PR TITLE
Enable building linuxmscorlib / osxmscorlib with VS2015

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -106,8 +106,12 @@ goto :eof
 if /i "%__VSVersion%" =="vs2015" goto MSBuild14
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-:MSBuild14
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+goto :CheckMSBuild14
+:MSBuild14
+set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+set UseRoslynCompiler=true
+:CheckMSBuild14
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/coreclr/wiki/Developer%%20Guide for build instructions. && exit /b 1
 

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -35,8 +35,12 @@ goto :eof
 if /i "%__VSVersion%" =="vs2015" goto MSBuild14
 set _msbuildexe="%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\12.0\Bin\MSBuild.exe"
-:MSBuild14
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+goto :CheckMSBuild14
+:MSBuild14
+set _msbuildexe="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
+set UseRoslynCompiler=true
+:CheckMSBuild14
 if not exist %_msbuildexe% set _msbuildexe="%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe"
 if not exist %_msbuildexe% echo Error: Could not find MSBuild.exe.  Please see https://github.com/dotnet/corefx/wiki/Developer%%20Guide for build instructions. && exit /b 1
 


### PR DESCRIPTION
Trying to do "build linuxmscorlib vs2015" was resulting in an error due to the script trying to read %_msbuildexe% when _msbuildexe hadn't been defined.  When that was addressed, mscorlib was then also failing to compile due to the csc compiler not understanding a flag that was being set in the response file based on UseRoslynCompiler not being set.  This commit addresses both issues.