### PR TITLE
FreeBSD build-instructions: Remove unneeded Linux-reference.

### DIFF
--- a/Documentation/freebsd-instructions.md
+++ b/Documentation/freebsd-instructions.md
@@ -189,7 +189,7 @@ janhenke@freebsd-frankfurt:~/coreclr-demo/runtime % mcs /nostdlib /noconfig /r:.
 Run your App
 ============
 
-You're ready to run Hello World!  To do that, run corerun, passing the path to the managed exe, plus any arguments.  The HelloWorld from corefxlab will print Tux if you pass "linux" as an argument, so:
+You're ready to run Hello World!  To do that, run corerun, passing the path to the managed exe, plus any arguments.  The HelloWorld from corefxlab will print a daemon if you pass "freebsd" as an argument, so:
 
 ```
 janhenke@freebsd-frankfurt:~/coreclr-demo/runtime % ./corerun HelloWorld.exe freebsd


### PR DESCRIPTION
@jkotas Good catch in the former PR. I guess I was quite excited about the news, and just wanted something up.

Good now? :)