### PR TITLE
Add back setting locale for gettext

### DIFF
--- a/src/pal/src/include/pal/locale.h
+++ b/src/pal/src/include/pal/locale.h
@@ -38,6 +38,8 @@ extern "C"
 #define ISO_NAME(region, encoding, part)  region ".ISO" encoding "-" part
 #endif
 
+void InitializeStringResources(void);
+
 #if HAVE_COREFOUNDATION
 #define CF_EXCLUDE_CSTD_HEADERS
 #include <CoreFoundation/CoreFoundation.h>

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -669,7 +669,9 @@ PAL_InitializeCoreCLR(
     {
         return ERROR_DLL_INIT_FAILED;
     }
-    
+
+    InitializeStringResources();
+
     if (!fStayInPAL)
     {
         PAL_Leave(PAL_BoundaryTop);

--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -951,6 +951,22 @@ EXIT:
     return retval;
 }
 
+/*++
+ Function :
+ InitializeStringResources -
+
+     Initialize the the native resources string support
+ --*/
+void InitializeStringResources(void)
+{
+#ifndef __APPLE__
+    // Set the locale for string resources to en_US
+    // UNIXTODO: After we add localized resources, change this to check the current
+    // locale and set it to en_US only if we don't have resources for the current locale.
+    setlocale(LC_MESSAGES, "en_US.UTF-8");
+#endif // __APPLE__
+}
+
 extern char g_szCoreCLRPath[MAX_PATH];
 
 /*++


### PR DESCRIPTION
Add back setting locale for gettext that was accidentally removed by change #736. I have just made it friendly to the app using coreclr / PAL so that it sets the LC_MESSAGE locale category only for the gettext API call and reverts it back after the call.