### PR TITLE
Parse Guid correctly

### DIFF
--- a/src/mscorlib/src/System/Guid.cs
+++ b/src/mscorlib/src/System/Guid.cs
@@ -642,7 +642,7 @@ namespace System {
             startPos += 4;
             currentPos = startPos;
 
-            if (!StringToLong(guidString, ref currentPos, startPos /*flags*/, out templ, ref result))
+            if (!StringToLong(guidString, ref currentPos, ParseNumbers.NoSpace, out templ, ref result))
                 return false;
 
             if (currentPos - startPos!=12) {


### PR DESCRIPTION
startPos was used instead of ParseNumbers.NoSpace like in the other occurence of this function.

fix #182

Same as https://github.com/dotnet/coreclr/blob/0fe17e9cfe627abfd860ff53772768608da3a08d/src/mscorlib/src/System/Guid.cs#L724