### PR TITLE
Go back to a statically linked PAL (issue #728).

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -89,11 +89,11 @@ else(WIN32)
   )
 
   set(SOS_LIBRARY
-    coreclrpal
     corguids
     debugshim
     dbgutil
-    palrt
+    # share the PAL in the dac module
+    mscordaccore
   )
 endif(WIN32)
 

--- a/src/coreclr/hosts/unixcorerun/corerun.cpp
+++ b/src/coreclr/hosts/unixcorerun/corerun.cpp
@@ -18,10 +18,8 @@
 
 // The name of the CoreCLR native runtime DLL.
 #if defined(__APPLE__)
-static const char * const coreClrPal = "libcoreclrpal.dylib";
 static const char * const coreClrDll = "libcoreclr.dylib";
 #else
-static const char * const coreClrPal = "libcoreclrpal.so";
 static const char * const coreClrDll = "libcoreclr.so";
 #endif
 
@@ -282,20 +280,10 @@ int ExecuteManagedAssembly(
     // Indicates failure
     int exitCode = -1;
     
-    std::string coreClrPalPath(clrFilesAbsolutePath);
-    coreClrPalPath.append("/");
-    coreClrPalPath.append(coreClrPal);
-
     std::string coreClrDllPath(clrFilesAbsolutePath);
     coreClrDllPath.append("/");
     coreClrDllPath.append(coreClrDll);
     
-    if (coreClrPalPath.length() >= PATH_MAX)
-    {
-        fprintf(stderr, "Absolute path to libcoreclrpal.so too long\n");
-        return -1;
-    }
-
     if (coreClrDllPath.length() >= PATH_MAX)
     {
         fprintf(stderr, "Absolute path to libcoreclr.so too long\n");
@@ -313,14 +301,6 @@ int ExecuteManagedAssembly(
     std::string tpaList;
     AddFilesFromDirectoryToTpaList(clrFilesAbsolutePath, tpaList);
 
-    void* coreclrPal = dlopen(coreClrPalPath.c_str(), RTLD_NOW | RTLD_GLOBAL);
-    if (coreclrPal == nullptr)
-    {
-        char* error = dlerror();
-        fprintf(stderr, "dlopen failed to open the libcoreclrpal.so with error %s\n", error);
-        return -1;
-    }
-    
     void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (coreclrLib != nullptr)
     {

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -57,8 +57,8 @@ if(WIN32)
 elseif(CLR_CMAKE_PLATFORM_UNIX)
     list(APPEND COREDBI_LIBRARIES
         mdhotdata_full
-        coreclrpal
-        palrt
+        # share the PAL in the dac module
+        mscordaccore
     )
 
     # COREDBI_LIBRARIES is mentioned twice because ld is one pass linker and will not find symbols

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -94,7 +94,9 @@ if(WIN32)
     )
 else()
     list(APPEND CORECLR_LIBRARIES
+        ${START_WHOLE_ARCHIVE} # force all PAL objects to be included so all exports are available  
         coreclrpal
+        ${END_WHOLE_ARCHIVE} 
         palrt
     )
 endif(WIN32)
@@ -120,13 +122,6 @@ if(WIN32)
         COMMENT Add dactable & debug resources to coreclr
     )
 endif(WIN32)
-
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    # add @loader_path to the rpath so that the loader can find libcoreclrpal which is
-    # sxs with libcoreclr
-    set_target_properties(coreclr PROPERTIES INSTALL_RPATH "@loader_path")
-endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-
 
 # add the install targets
 install (TARGETS coreclr DESTINATION .)

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -697,10 +697,9 @@ namespace Microsoft.Win32 {
         internal const String USER32   = "user32.dll";
         internal const String OLE32    = "ole32.dll";
 #else //FEATURE_PAL
-        internal const String KERNEL32 = "libcoreclrpal";
-        internal const String USER32   = "libcoreclrpal";
-        internal const String OLE32    = "libcoreclrpal";
-        internal const String LIBCORECLR = "libcoreclr";
+        internal const String KERNEL32 = "libcoreclr";
+        internal const String USER32   = "libcoreclr";
+        internal const String OLE32    = "libcoreclr";
 #endif //FEATURE_PAL         
         internal const String ADVAPI32 = "advapi32.dll";
         internal const String OLEAUT32 = "oleaut32.dll";
@@ -1373,25 +1372,13 @@ namespace Microsoft.Win32 {
         [DllImport(KERNEL32, CharSet=CharSet.Auto, BestFitMapping=false)]
         internal extern static int GetComputerName([Out]StringBuilder nameBuffer, ref int bufferSize);
 
-#if !FEATURE_PAL
         [DllImport(OLE32)]
-#else
-        [DllImport(LIBCORECLR)]
-#endif
         internal extern static int CoCreateGuid(out Guid guid);
 
-#if !FEATURE_PAL
         [DllImport(OLE32)]
-#else
-        [DllImport(LIBCORECLR)]
-#endif
         internal static extern IntPtr CoTaskMemAlloc(UIntPtr cb);
 
-#if !FEATURE_PAL
         [DllImport(OLE32)]
-#else
-        [DllImport(LIBCORECLR)]
-#endif
         internal static extern void CoTaskMemFree(IntPtr ptr);
 
         [DllImport(OLE32)]

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -438,11 +438,15 @@ typedef long time_t;
 #define DLL_THREAD_DETACH  3
 #define DLL_PROCESS_DETACH 0
 
+#define PAL_INITIALIZE_NONE            0x00
 #define PAL_INITIALIZE_SYNC_THREAD     0x01
 #define PAL_INITIALIZE_SIGNAL_THREAD   0x02
-#define PAL_INITIALIZE_ALL_SIGNALS     0x04
-#define PAL_INITIALIZE_ALL             0xff
-#define PAL_INITIALIZE_DLL             0x00
+
+// PAL_Initialize() flags - do not initialize signal thread (used for ctrl-c handling) for now
+#define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD     
+
+// PAL_InitializeDLL() flags - don't start any of the helper threads
+#define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE       
 
 typedef DWORD (PALAPI *PTHREAD_START_ROUTINE)(LPVOID lpThreadParameter);
 typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -157,7 +157,7 @@ set(SOURCES
 )
 
 add_library(coreclrpal
-  SHARED
+  STATIC
   ${SOURCES}
   ${PLATFORM_SOURCES}
 )
@@ -197,4 +197,3 @@ endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 add_subdirectory(examples)
 
-install(TARGETS coreclrpal DESTINATION .)

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -140,7 +140,7 @@ PAL_Initialize(
     int argc,
     const char *const argv[])
 {
-    return Initialize(argc, argv, PAL_INITIALIZE_ALL);
+    return Initialize(argc, argv, PAL_INITIALIZE);
 }
 
 /*++


### PR DESCRIPTION
These changes undo's all the build and runtime changes to go back to statically linked PALs in coreclr, dbi/dac/sos (these modules share a pal in the dac), and dbgshim.

Also a little cleanup signal handling. Make sure the default signal action will happen if no previous handler by restore the signal and returning from the handler restarting the h/w exception.