### PR TITLE
Report a reasonable name for types without metadata.

### DIFF
--- a/src/vm/typestring.cpp
+++ b/src/vm/typestring.cpp
@@ -979,17 +979,22 @@ void TypeString::AppendType(TypeNameBuilder& tnb, TypeHandle ty, Instantiation t
         // Get the TypeDef token and attributes
         IMDInternalImport *pImport = ty.GetMethodTable()->GetMDImport();
         mdTypeDef td = ty.GetCl();
-        _ASSERTE(!IsNilToken(td));
-
-#ifdef _DEBUG
-        if (format & FormatDebug)
-        {
-            WCHAR wzAddress[128];
-            _snwprintf_s(wzAddress, 128, _TRUNCATE, W("(%p)"), dac_cast<TADDR>(ty.AsPtr()));
-            tnb.AddName(wzAddress);
+        if (IsNilToken(td)) {
+            // This type does not exist in metadata. Simply append "dynamicClass".
+            tnb.AddName(W("(dynamicClass)"));
         }
+        else
+        {
+#ifdef _DEBUG
+            if (format & FormatDebug)
+            {
+                WCHAR wzAddress[128];
+                _snwprintf_s(wzAddress, 128, _TRUNCATE, W("(%p)"), dac_cast<TADDR>(ty.AsPtr()));
+                tnb.AddName(wzAddress);
+            }
 #endif
-        AppendNestedTypeDef(tnb, pImport, td, format);
+            AppendNestedTypeDef(tnb, pImport, td, format);
+        }
 
         // Append the instantiation
         if ((format & (FormatNamespace|FormatAssembly)) && ty.HasInstantiation() && (!ty.IsGenericTypeDefinition() || bToString))


### PR DESCRIPTION
TypeString::AppendType currently asserts that any plain type def must
have a definition in metadata in order for its name to appended. This
blocks LLILC when jitting unboxing stubs, which are instance methods
that are hung off of a class that does not exist in metadata.

An alternative solution might be to provide some way to detect that a
particular type has no definition in metadata (or that a particular method
is a member of such a type) via the JIT interface and defer handling this
case to the client JIT.