### PR TITLE
Fix new set of warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,6 +270,9 @@ add_definitions(-DDISABLE_CONTRACTS)
 # after hitting just about 20 errors.
 add_compile_options(-ferror-limit=4096)
 
+# All warnings that are not explicitly disabled are reported as errors
+add_compile_options(-Werror)
+
 # Disabled warnings
 add_compile_options(-Wno-unused-private-field)
 add_compile_options(-Wno-implicit-exception-spec-mismatch)

--- a/src/inc/debugmacros.h
+++ b/src/inc/debugmacros.h
@@ -68,7 +68,7 @@ extern int _DbgBreakCount;
 
 #define _ASSERTE(expr) ((void)0)
 #define _ASSERTE_MSG(expr, msg) ((void)0)
-#define VERIFY(stmt) (stmt)
+#define VERIFY(stmt) (void)(stmt)
 
 void __FreeBuildDebugBreak();
 void DECLSPEC_NORETURN __FreeBuildAssertFail(const char *szFile, int iLine, const char *szExpr);

--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -213,7 +213,7 @@ void BasicBlock::dspBlockILRange()
     }
     else
     {
-        printf("[???..");
+        printf("[???" "..");
     }
 
     if (bbCodeOffsEnd != BAD_IL_OFFSET)
@@ -224,7 +224,7 @@ void BasicBlock::dspBlockILRange()
     else
     {
         // brace-matching editor workaround for following line: (
-        printf("???)");
+        printf("???" ")");
     }
 }
 

--- a/src/jit/dll/CMakeLists.txt
+++ b/src/jit/dll/CMakeLists.txt
@@ -2,7 +2,6 @@ project(ClrJit)
 
 # Disable the following for UNIX altjit on Windows
 if(CLR_CMAKE_PLATFORM_UNIX)
-    add_compile_options(-Wno-trigraphs)
     add_compile_options(-fPIC)
     add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18038,11 +18038,12 @@ void                Compiler::fgSetTreeSeqHelper(GenTreePtr tree)
         fgSetTreeSeqHelper(tree->gtBoundsChk.gtIndex);
         break;
 
-#ifdef DEBUG
     default:
+#ifdef DEBUG
         gtDispTree(tree);
         noway_assert(!"unexpected operator");
 #endif // DEBUG
+        break;
     }
 
     fgSetTreeSeqFinish(tree);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6912,7 +6912,7 @@ void                Compiler::gtDispNode(GenTreePtr     tree,
         }
         else
         {
-            printf("(???,???) "); // This probably indicates a bug: the node has a sequence number, but not costs.
+            printf("(???" ",???" ") "); // This probably indicates a bug: the node has a sequence number, but not costs.
         }
     }
     else
@@ -9296,10 +9296,9 @@ CHK_OVF:
                         d1 = (double) INT32(i1);
                     goto CNS_DOUBLE;
 
-#ifdef  DEBUG
                 default:
                     assert(!"BAD_TYP");
-#endif
+                    break;
                 }
                 return tree;
 
@@ -9390,10 +9389,9 @@ CHK_OVF:
                         d1 = f1;
                     }
                     goto CNS_DOUBLE;
-#ifdef  DEBUG
                 default:
                     assert(!"BAD_TYP");
-#endif
+                    break;
                 }
                 return tree;
 
@@ -9531,10 +9529,9 @@ CHK_OVF:
                         d1 = forceCastToFloat(d1); // truncate precision
                     goto CNS_DOUBLE; // redundant cast
 
-#ifdef  DEBUG
                 default:
                     assert(!"BAD_TYP");
-#endif
+                    break;
                 }
                 return tree;
 

--- a/src/pal/src/file/path.cpp
+++ b/src/pal/src/file/path.cpp
@@ -1519,7 +1519,7 @@ PathFindFileNameW(
             ret++;
         }
     }
-done:
+
     LOGEXIT("PathFindFileNameW returns %S\n", ret);
     PERF_EXIT(PathFindFileNameW);
     return ret;

--- a/src/pal/src/init/sxs.cpp
+++ b/src/pal/src/init/sxs.cpp
@@ -91,7 +91,6 @@ PAL_Enter(PAL_Boundary boundary)
         }
     }
 
-EXIT:
     LOGEXIT("PAL_Enter returns %d\n", palError);
     return palError;
 }

--- a/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.c
+++ b/src/pal/tests/palsuite/threading/WaitForSingleObject/WFSOExThreadTest/WFSOExThreadTest.c
@@ -27,7 +27,7 @@ VOID PALAPI APCFunc(ULONG_PTR dwParam);
 DWORD PALAPI WaiterProc(LPVOID lpParameter);
 void WorkerThread(void);
 
-DWORD ThreadWaitDelta;
+int ThreadWaitDelta;
 
 int __cdecl main( int argc, char **argv ) 
 {
@@ -185,7 +185,7 @@ satisfying any threads that were waiting on the object.
         NewTickCount  = 0xFFFFFFFF;
     }
 
-    ThreadWaitDelta = NewTickCount - OldTickCount;
+    ThreadWaitDelta = (int)(NewTickCount - OldTickCount);
 
     ret = CloseHandle(hWaitThread);
     if (!ret)

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -7294,7 +7294,7 @@ extern "C" IExecutionEngine * __stdcall IEE()
         // Create a local copy on the stack and then copy it over to the static instance.
         // This avoids race conditions caused by multiple initializations of vtable in the constructor
        CExecutionEngine local;
-       memcpy(&g_CEEInstance, &local, sizeof(CExecutionEngine));
+       memcpy(&g_CEEInstance, (void*)&local, sizeof(CExecutionEngine));
 
        g_pCEE = (IExecutionEngine*)(CExecutionEngine*)&g_CEEInstance;
     }

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -827,14 +827,6 @@ public:
     virtual void Save(ZapWriter * pZapWriter);
 };
 
-#ifndef BINDER // Binder sees a body in vm\util.hpp
-static BOOL FitsInU2(unsigned __int64 val)
-{
-    LIMITED_METHOD_CONTRACT;
-    return val == (unsigned __int64)(unsigned __int16)val;
-}
-#endif
-
 void ZapVirtualMethodThunk::Save(ZapWriter * pZapWriter)
 {
     ZapImage * pImage = ZapImage::GetImage(pZapWriter);
@@ -845,7 +837,7 @@ void ZapVirtualMethodThunk::Save(ZapWriter * pZapWriter)
     // On ARM, the helper would already have the thumb-bit set. Refer to
     // GetHelperThunk implementation.
     ZapNode *  helper  = pImage->GetHelperThunk(CORINFO_HELP_EE_VTABLE_FIXUP);
-    _ASSERTE(FitsInU2((SIZE_T)GetHandle2() - 1));
+    _ASSERTE(FitsIn<UINT16>((SIZE_T)GetHandle2() - 1));
     USHORT     slotNum = (USHORT)((SIZE_T)GetHandle2() - 1);
 
 #if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1337,6 +1337,8 @@ COUNT_T ZapImage::MethodCodeTraits::Hash(key_t k)
             case ZapNodeType_Import_MethodHandle:
                 hash = ((hash << 5) + hash) ^ (COUNT_T)(pTarget);
                 break;
+            default:
+                break;
             }
 
             pRelocs++;


### PR DESCRIPTION
This change fixes a new bunch of warnings that were recently introduced
unnoticed to the coreclr / pal. Also, I've discovered that in release build,
there are some additional warnings, so I've fixed them as well.

I have also added a compiler switch to treat warnings as errors so that
we catch a new issue right away next time.