### PR TITLE
Add a test that triggers stack probing.

### DIFF
--- a/tests/src/JIT/CodeGenBringUpTests/LocallocLarge.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/LocallocLarge.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Threading;
+
+public class ThreadData
+{
+    public AutoResetEvent autoEvent;
+    public int initialAllocation;
+    public int result;
+
+    public unsafe void Run()
+    {
+        autoEvent.WaitOne();
+        int* buffer = stackalloc int[initialAllocation];
+        int last = initialAllocation - 1;
+        buffer[0] = 100;
+        buffer[last] = 200;
+
+        for (int i = 2; i < 1026; i++)
+        {
+            result += AllocateMore(i);
+        }
+
+        result += buffer[last] - buffer[0];
+    }
+
+    public unsafe int AllocateMore(int n)
+    {
+        int* buffer = stackalloc int[n];
+        int last = n - 1;
+        buffer[0] = n + 1;
+        buffer[last] = n - 1;
+        return buffer[last] - buffer[0] + 2;
+    }
+}
+
+public class BringUpTest
+{
+    const int Pass = 100;
+    const int Fail = -1;
+
+    public static bool RunTest(int n)
+    {
+        ThreadData data = new ThreadData();
+        data.autoEvent = new AutoResetEvent(false);
+        data.initialAllocation = n;
+
+        Thread t = new Thread(data.Run);
+        t.Start();
+        if (!t.IsAlive)
+        {
+            return false;
+        }
+        data.autoEvent.Set();
+        t.Join();
+        bool ok = data.result == 100;
+        return ok;
+    }
+
+    public static int Main()
+    {
+        for (int j = 2; j < 1024 * 100; j += 33)
+        {
+            bool b = RunTest(j);
+            if (!b) return Fail;
+        }
+        return Pass;
+    }
+}

--- a/tests/src/JIT/CodeGenBringUpTests/packages.config
+++ b/tests/src/JIT/CodeGenBringUpTests/packages.config
@@ -3,4 +3,6 @@
     <package id="System.Console" version="4.0.0-beta-22405" />
     <package id="System.Runtime" version="4.0.20-beta-22405" />
     <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
 </packages>


### PR DESCRIPTION
This test exercises the JIT's ability to probe the stack on windows for dynamic allocation. It uses multiple threads and a two-stage allocation pattern to try and hit various boundary cases.