### PR TITLE
Add String.Split overloads that take a single char and string separator

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6336,10 +6336,16 @@
       <Member Name="Remove(System.Int32,System.Int32)" />
       <Member Name="Replace(System.Char,System.Char)" />
       <Member Name="Replace(System.String,System.String)" />
+      <Member Name="Split(System.Char)" />
+      <Member Name="Split(System.Char,System.Int32,System.StringSplitOptions)" />
+      <Member Name="Split(System.Char,System.StringSplitOptions)"/>
       <Member Name="Split(System.Char[])" />
       <Member Name="Split(System.Char[],System.Int32)" />
       <Member Name="Split(System.Char[],System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.Char[],System.StringSplitOptions)"/>
+      <Member Name="Split(System.String)" />
+      <Member Name="Split(System.String,System.Int32,System.StringSplitOptions)" />
+      <Member Name="Split(System.String,System.StringSplitOptions)"/>
       <Member Name="Split(System.String[],System.Int32,System.StringSplitOptions)" />
       <Member Name="Split(System.String[],System.StringSplitOptions)"/>
       <Member Name="StartsWith(System.String)" />


### PR DESCRIPTION
Fixes dotnet/corefx/issues/1513

Notes:

 - Tests are here: dotnet/corefx/pull/1600, although, the tests in corefx won't exercise these new overloads until the new methods are exposed in System.Runtime.dll (the tests are written in a way to "light up" once the methods are available). In the meantime, I ran the `Split` tests manually in a one-off app compiled against a CoreCLR mscorlib.dll with the added methods (on Windows).

 - I made the changes as "surgical" as possible to minimize churn. There are some opportunities for stylistic code formatting improvements, but I held off on those for this PR.

/cc @ellismg