### PR TITLE
Documentation: Inline source should use single backticks

### DIFF
--- a/Documentation/freebsd-instructions.md
+++ b/Documentation/freebsd-instructions.md
@@ -28,14 +28,14 @@ Note: LLDB is not yet available in the pkg repository on FreeBSD. The LLDB plugi
 
 To install the packages you need:
 
-```janhenke@freebsd-frankfurt:~ % sudo pkg install bash cmake clang35 libunwind gettext```
+`janhenke@freebsd-frankfurt:~ % sudo pkg install bash cmake clang35 libunwind gettext`
 
 You now have all the required components.
 
 Git Setup
 ---------
 
-This guide assumes that you've cloned the coreclr repository into ```~/git/coreclr``` on your FreeBSD machine and the corefx and coreclr repositories into ```D:\git\corefx``` and ```D:\git\coreclr``` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the FreeBSD and Windows machine.
+This guide assumes that you've cloned the coreclr repository into `~/git/coreclr` on your FreeBSD machine and the corefx and coreclr repositories into `D:\git\corefx` and `D:\git\coreclr` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the FreeBSD and Windows machine.
 
 Build the Runtime
 =================
@@ -48,11 +48,11 @@ janhenke@freebsd-frankfurt:~/git/coreclr % ./build.sh
 
 Note: FreeBSD 10.1-RELEASE system's Clang/LLVM is 3.4, the minimum version to compile CoreCLR runtime is 3.5. You may need to specify `./build.sh clang3.5` to find Clang 3.5.
 
-After the build is completed, there should some files placed in ```bin/Product/FreeBSD.x64.Debug```.  The ones we are interested in are:
+After the build is completed, there should some files placed in `bin/Product/FreeBSD.x64.Debug`.  The ones we are interested in are:
 
-* ```corerun```: The command line host.  This program loads and starts the CoreCLR runtime and passes the managed program you want to run to it.
-* ```libcoreclr.so```: The CoreCLR runtime itself.
-* ```libcoreclrpal.so```: The platform abstraction library for the CoreCLR runtime. This library is temporary and the functionality will be merged back into `libcoreclr.so`
+* `corerun`: The command line host.  This program loads and starts the CoreCLR runtime and passes the managed program you want to run to it.
+* `libcoreclr.so`: The CoreCLR runtime itself.
+* `libcoreclrpal.so`: The platform abstraction library for the CoreCLR runtime. This library is temporary and the functionality will be merged back into `libcoreclr.so`
 
 In order to keep everything tidy, let's create a new directory for the runtime and copy the runtime and corerun into it.
 
@@ -67,13 +67,13 @@ Build the Framework
 
 We don't _yet_ have support for building managed code on FreeBSD, so you'll need a Windows machine with clones of both the CoreCLR and CoreFX projects.
 
-You will build ```mscorlib.dll``` out of the coreclr repository and the rest of the framework that out of the corefx repository.  For mscorlib (from a regular command prompt window) run:
+You will build `mscorlib.dll` out of the coreclr repository and the rest of the framework that out of the corefx repository.  For mscorlib (from a regular command prompt window) run:
 
 ```
 D:\git\coreclr> build.cmd linuxmscorlib
 ```
 
-The output is placed in ```bin\Product\Linux.x64.Debug\mscorlib.dll```.  You'll want to copy this to the runtime folder on your FreeBSD machine. (e.g. ```~/coreclr-demo/runtime```)
+The output is placed in `bin\Product\Linux.x64.Debug\mscorlib.dll`.  You'll want to copy this to the runtime folder on your FreeBSD machine. (e.g. `~/coreclr-demo/runtime`)
 
 For the rest of the framework, you need to pass some special parameters to build.cmd when building out of the CoreFX repository.
 
@@ -83,9 +83,9 @@ D:\git\corefx> build.cmd /p:OSGroup=Linux /p:SkipTests=true
 
 Note: We are using the Linux build currently, as CoreFX does not yet know about FreeBSD.
 
-It's also possible to add ```/t:rebuild``` to the build.cmd to force it to delete the previously built assemblies.
+It's also possible to add `/t:rebuild` to the build.cmd to force it to delete the previously built assemblies.
 
-For the purposes of Hello World, you need to copy over both ```bin\Linux.AnyCPU.Debug\System.Console\System.Console.dll``` and ```bin\Linux.AnyCPU.Debug\System.Diagnostics.Debug\System.Diagnostics.Debug.dll```  into the runtime folder on FreeBSD. (e.g ```~/coreclr-demo/runtime```).
+For the purposes of Hello World, you need to copy over both `bin\Linux.AnyCPU.Debug\System.Console\System.Console.dll` and `bin\Linux.AnyCPU.Debug\System.Diagnostics.Debug\System.Diagnostics.Debug.dll`  into the runtime folder on FreeBSD. (e.g `~/coreclr-demo/runtime`).
 
 After you've done these steps, the runtime directory on FreeBSD should look like this:
 
@@ -128,7 +128,7 @@ Download NuGet Packages
 
 With Mono and NuGet in hand, you can use NuGet to get the required dependencies.
 
-Make a ```packages.config``` file with the following text. These are the required dependencies of this particular app. Different apps will have different dependencies and require a different ```packages.config``` - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
+Make a `packages.config` file with the following text. These are the required dependencies of this particular app. Different apps will have different dependencies and require a different `packages.config` - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
 
 ```
 <?xml version="1.0" encoding="utf-8"?>
@@ -182,7 +182,7 @@ janhenke@freebsd-frankfurt:~/coreclr-demo/packages % cd ~/coreclr-demo/runtime
 janhenke@freebsd-frankfurt:~/coreclr-demo/runtime % curl -O https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs
 ```
 
-Then you just need to build it, with ```mcs```, the Mono C# compiler. FYI: The Roslyn C# compiler will soon be available on FreeBSD.  Because you need to compile the app against the .NET Core surface area, you need to pass references to the contract assemblies you restored using NuGet:
+Then you just need to build it, with `mcs`, the Mono C# compiler. FYI: The Roslyn C# compiler will soon be available on FreeBSD.  Because you need to compile the app against the .NET Core surface area, you need to pass references to the contract assemblies you restored using NuGet:
 
 ```
 janhenke@freebsd-frankfurt:~/coreclr-demo/runtime % mcs /nostdlib /noconfig /r:../packages/System.Console.4.0.0-beta-22703/lib/contract/System.Console.dll /r:../packages/System.Runtime.4.0.20-beta-22703/lib/contract/System.Runtime.dll HelloWorld.cs

--- a/Documentation/get-dotnetcore-dnx-windows.md
+++ b/Documentation/get-dotnetcore-dnx-windows.md
@@ -25,7 +25,7 @@ You can see the currently installed DNX versions with `dnvm list`, which will di
 Installing a .NET Core DNX
 ==========================
 
-It's easy to install the latest .NET Core-based DNX, using the ```dnvm install``` command. 
+It's easy to install the latest .NET Core-based DNX, using the `dnvm install` command. 
 
 	C:\coreclr-demo> dnvm install -r coreclr latest -u
 
@@ -73,7 +73,7 @@ public class Program
 } 
 ```
 
-Some people on the .NET Core team are partial to a demo console app on corefxlab repo which will print a picture for you. Download the [corefxlab demo](https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs) to ```C:\coreclr-demo```.
+Some people on the .NET Core team are partial to a demo console app on corefxlab repo which will print a picture for you. Download the [corefxlab demo](https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs) to `C:\coreclr-demo`.
 
 You need a `project.json` that matches your app. Use this one. It will work for both of the apps provided/referenced above. Save the project.json beside your app.
 

--- a/Documentation/get-dotnetcore-windows.md
+++ b/Documentation/get-dotnetcore-windows.md
@@ -12,7 +12,7 @@ The preferred approach to acquire .NET Core is via the [.NET Core DNX SDK](get-d
 NuGet Restore Packages
 ======================
 
-Given that NuGet is the .NET Core distribution mechanism, you need a packages.config to restore the packages. The following packages.config is the most minimal one you can have for console apps. You will need to add packages if your app needs it Save this XML to ```c:\coreclr-demo\packages\packages.config```.
+Given that NuGet is the .NET Core distribution mechanism, you need a packages.config to restore the packages. The following packages.config is the most minimal one you can have for console apps. You will need to add packages if your app needs it Save this XML to `c:\coreclr-demo\packages\packages.config`.
 
 ```
 <?xml version="1.0" encoding="utf-8"?>
@@ -39,9 +39,9 @@ Given that NuGet is the .NET Core distribution mechanism, you need a packages.co
 </packages>
 ```
 
-You will need to update the version numbers to acquire later versions of the NuGet packages. If you do, you'll need to update the copy commands later in the instructions to accomodate. NuGet supports wildcard versions, such as ```version="4.0.0-beta-*"```, which can be helpful.
+You will need to update the version numbers to acquire later versions of the NuGet packages. If you do, you'll need to update the copy commands later in the instructions to accomodate. NuGet supports wildcard versions, such as `version="4.0.0-beta-*"`, which can be helpful.
 
-Download the [NuGet client](https://nuget.org/nuget.exe) if you don't already have it in your path. You can grab it from: https://nuget.org/nuget.exe. Save it to ```c:\coreclr-demo```.
+Download the [NuGet client](https://nuget.org/nuget.exe) if you don't already have it in your path. You can grab it from: https://nuget.org/nuget.exe. Save it to `c:\coreclr-demo`.
 
 You need to restore the packages to the packages directory.
 
@@ -65,7 +65,7 @@ public class Program
 } 
 ```
 
-Some people on the .NET Core team are partial to a demo console app on corefxlab repo which will print a picture for you. Download the [corefxlab demo](https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs) to ```C:\coreclr-demo```.
+Some people on the .NET Core team are partial to a demo console app on corefxlab repo which will print a picture for you. Download the [corefxlab demo](https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs) to `C:\coreclr-demo`.
 
 Compile your App
 ================
@@ -89,9 +89,9 @@ You need to copy the NuGet package assemblies over to the app folder. You need t
 
 	C:\coreclr-demo> copy packages\Microsoft.NETCore.Runtime.CoreCLR.ConsoleHost-x64.1.0.0-beta-22819\native\win\x64\CoreConsole.exe app\HelloWorld.exe
 
-This last step might be a bit surprising, copying ```CoreConsole.exe``` to MyApp.exe, in this case ```HelloWorld.exe```. This is closedly related to compiling the app, in the instructions above, to MyApp.dll, in this case to ```HelloWorld.dll```. 
+This last step might be a bit surprising, copying `CoreConsole.exe` to MyApp.exe, in this case `HelloWorld.exe`. This is closedly related to compiling the app, in the instructions above, to MyApp.dll, in this case to `HelloWorld.dll`. 
 
-We've grown very fond of creating and using managed EXEs that don't require a separate launcher with the .NET Framework on Windows. We wanted the same experience for .NET Core. To enable the experience, we created a launcher that expects a managed assembly of the same name, compiled with a static main method. As a case in point, if you run ```CoreConsole.exe``` without renaming it, it will expect a ```CoreConsole.dll```. The renaming step, which you see above, needs to match the main assembly, compiled as a DLL, and you get an experience that feels launcher-less.
+We've grown very fond of creating and using managed EXEs that don't require a separate launcher with the .NET Framework on Windows. We wanted the same experience for .NET Core. To enable the experience, we created a launcher that expects a managed assembly of the same name, compiled with a static main method. As a case in point, if you run `CoreConsole.exe` without renaming it, it will expect a `CoreConsole.dll`. The renaming step, which you see above, needs to match the main assembly, compiled as a DLL, and you get an experience that feels launcher-less.
 
 Run the demo
 ============

--- a/Documentation/linux-instructions.md
+++ b/Documentation/linux-instructions.md
@@ -8,7 +8,7 @@ Environment
 
 These instructions are written assuming the Ubuntu 14.04 LTS, since that's the distro the team uses. Pull Requests are welcome to address other environments as long as they don't break the ability to use Ubuntu 14.04 LTS.
 
-There have been reports of issues when using other distros or versions of Ubuntu (e.g. [Issue 95](https://github.com/dotnet/coreclr/issues/95)). If you're on another distribution, consider using docker's ```ubuntu:14.04``` image.
+There have been reports of issues when using other distros or versions of Ubuntu (e.g. [Issue 95](https://github.com/dotnet/coreclr/issues/95)). If you're on another distribution, consider using docker's `ubuntu:14.04` image.
 
 Minimum RAM required to build is 1GB. The build is known to fail on 512 MB VMs ([Issue 536](https://github.com/dotnet/coreclr/issues/536)).
 
@@ -36,14 +36,14 @@ ellismg@linux:~$ sudo apt-get update
 
 Then install the packages you need:
 
-```ellismg@linux:~$ sudo apt-get install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev libunwind8 libunwind8-dev gettext```  
+`ellismg@linux:~$ sudo apt-get install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev libunwind8 libunwind8-dev gettext`
 
 You now have all the required components.
 
 Git Setup
 ---------
 
-This guide assumes that you've cloned the coreclr repository into ```~/git/coreclr``` on your Linux machine and the corefx and coreclr repositories into ```D:\git\corefx``` and ```D:\git\coreclr``` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the Linux and Windows machine.
+This guide assumes that you've cloned the coreclr repository into `~/git/coreclr` on your Linux machine and the corefx and coreclr repositories into `D:\git\corefx` and `D:\git\coreclr` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the Linux and Windows machine.
 
 Build the Runtime
 =================
@@ -54,10 +54,10 @@ To build the runtime on Linux, run build.sh from the root of the coreclr reposit
 ellismg@linux:~/git/coreclr$ ./build.sh
 ```
 
-After the build is completed, there should some files placed in ```bin/Product/Linux.x64.Debug```.  The ones we are interested in are:
+After the build is completed, there should some files placed in `bin/Product/Linux.x64.Debug`.  The ones we are interested in are:
 
-* ```corerun```: The command line host.  This program loads and starts the CoreCLR runtime and passes the managed program you want to run to it.
-* ```libcoreclr.so```: The CoreCLR runtime itself.
+* `corerun`: The command line host.  This program loads and starts the CoreCLR runtime and passes the managed program you want to run to it.
+* `libcoreclr.so`: The CoreCLR runtime itself.
 
 In order to keep everything tidy, let's create a new directory for the runtime and copy the runtime and corerun into it.
 
@@ -72,13 +72,13 @@ Build the Framework
 
 We don't _yet_ have support for building managed code on Linux, so you'll need a Windows machine with clones of both the CoreCLR and CoreFX projects.
 
-You will build ```mscorlib.dll``` out of the coreclr repository and the rest of the framework that out of the corefx repository.  For mscorlib (from a regular command prompt window) run:
+You will build `mscorlib.dll` out of the coreclr repository and the rest of the framework that out of the corefx repository.  For mscorlib (from a regular command prompt window) run:
 
 ```
 D:\git\coreclr> build.cmd linuxmscorlib
 ```
 
-The output is placed in ```bin\obj\Linux.x64.Debug\mscorlib.dll```.  You'll want to copy this to the runtime folder on your Linux machine. (e.g. ```~/coreclr-demo/runtime```)
+The output is placed in `bin\obj\Linux.x64.Debug\mscorlib.dll`.  You'll want to copy this to the runtime folder on your Linux machine. (e.g. `~/coreclr-demo/runtime`)
 
 For the rest of the framework, you need to pass some special parameters to build.cmd when building out of the CoreFX repository.
 
@@ -86,9 +86,9 @@ For the rest of the framework, you need to pass some special parameters to build
 D:\git\corefx> build.cmd /p:OSGroup=Linux /p:SkipTests=true
 ```
 
-It's also possible to add ```/t:rebuild``` to the build.cmd to force it to delete the previously built assemblies.
+It's also possible to add `/t:rebuild` to the build.cmd to force it to delete the previously built assemblies.
 
-For the purposes of Hello World, you need to copy over both ```bin\Linux.AnyCPU.Debug\System.Console\System.Console.dll``` and ```bin\Linux.AnyCPU.Debug\System.Diagnostics.Debug\System.Diagnostics.Debug.dll```  into the runtime folder on Linux. (e.g ```~/coreclr-demo/runtime```).
+For the purposes of Hello World, you need to copy over both `bin\Linux.AnyCPU.Debug\System.Console\System.Console.dll` and `bin\Linux.AnyCPU.Debug\System.Diagnostics.Debug\System.Diagnostics.Debug.dll`  into the runtime folder on Linux. (e.g `~/coreclr-demo/runtime`).
 
 After you've done these steps, the runtime directory on Linux should look like this:
 
@@ -134,7 +134,7 @@ ellismg@linux:~$ mkdir ~/coreclr-demo/packages
 ellismg@linux:~$ cd ~/coreclr-demo/packages
 ```
 
-Make a ```packages.config``` file with the following text. These are the required dependencies of this particular app. Different apps will have different dependencies and require a different ```packages.config``` - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
+Make a `packages.config` file with the following text. These are the required dependencies of this particular app. Different apps will have different dependencies and require a different `packages.config` - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
 
 ```
 <?xml version="1.0" encoding="utf-8"?>
@@ -184,7 +184,7 @@ ellismg@linux:~$ cd ~/coreclr-demo/runtime
 ellismg@linux:~/coreclr-demo/runtime$ curl -O https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs
 ```
 
-Then you just need to build it, with ```mcs```, the Mono C# compiler. FYI: The Roslyn C# compiler will soon be available on Linux.  Because you need to compile the app against the .NET Core surface area, you need to pass references to the contract assemblies you restored using NuGet:
+Then you just need to build it, with `mcs`, the Mono C# compiler. FYI: The Roslyn C# compiler will soon be available on Linux.  Because you need to compile the app against the .NET Core surface area, you need to pass references to the contract assemblies you restored using NuGet:
 
 ```
 ellismg@linux:~/coreclr-demo/runtime$ mcs /nostdlib /noconfig /r:../packages/System.Console.4.0.0-beta-22703/lib/contract/System.Console.dll /r:../packages/System.Runtime.4.0.20-beta-22703/lib/contract/System.Runtime.dll HelloWorld.cs


### PR DESCRIPTION
Triple backticks are for multiline, but inline could break depending markdown implementation / highlighter.

``get-dotnetcore-dnx-{osx,linux}.md``, ``windows-instructions.md`` and ``osx-instructions.md`` were ok