### PR TITLE
Only clean previous output for the selected configuration.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -51,6 +51,7 @@ set "__IntermediatesDir=%__RootBinDir%\obj\%__BuildOS%.%__BuildArch%.%__BuildTyp
 set "__PackagesBinDir=%__BinDir%\.nuget"
 set "__ToolsDir=%__RootBinDir%\tools"
 set "__TestBinDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__TestIntermediatesDir=%__RootBinDir%\tests\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
 
 :: Generate path to be set for CMAKE_INSTALL_PREFIX to contain forward slash
 set "__CMakeBinDir=%__BinDir%"
@@ -64,8 +65,14 @@ echo.
 :: MSBuild projects would need a rebuild
 set __MSBCleanBuildArgs=/t:rebuild
 
-:: Cleanup the binaries drop folder
-if exist "%__RootBinDir%" rd /s /q "%__RootBinDir%"
+:: Cleanup the previous output for the selected configuration
+if exist "%__BinDir%" rd /s /q "%__BinDir%"
+if exist "%__IntermediatesDir%" rd /s /q "%__IntermediatesDir%"
+
+if exist "%__TestBinDir%" rd /s /q "%__TestBinDir%"
+if exist "%__TestIntermediatesDir%" rd /s /q "%__TestIntermediatesDir%"
+
+if exist "%__LogsDir%" del /f /q "%__LogsDir%\*_%__BuildOS%__%__BuildArch%__%__BuildType%.*"
 
 :MakeDirectories
 if not exist "%__BinDir%" md "%__BinDir%"

--- a/build.sh
+++ b/build.sh
@@ -26,8 +26,14 @@ setup_dirs()
 
 clean()
 {
-    echo Cleaning binaries directory
-    rm -rf "$__RootBinDir"
+    echo Cleaning previous output for the selected configuration
+    rm -rf "$__BinDir"
+    rm -rf "$__IntermediatesDir"
+	
+    rm -rf "$__TestWorkingDir"
+    rm -rf "$__TestIntermediatesDir"
+	
+    rm -rf "$__LogsDir/*_$__BuildOS__$__BuildArch__$__BuildType.*"
 }
 
 # Check the system to ensure the right pre-reqs are in place
@@ -187,6 +193,7 @@ __PackagesBinDir="$__BinDir/.nuget"
 __ToolsDir="$__RootBinDir/tools"
 __TestWorkingDir="$__RootBinDir/tests/$__BuildOS.$__BuildArch.$__BuildType"
 __IntermediatesDir="$__RootBinDir/obj/$__BuildOS.$__BuildArch.$__BuildType"
+__TestIntermediatesDir="$__RootBinDir/tests/obj/$__BuildOS.$__BuildArch.$__BuildType"
 
 # Specify path to be set for CMAKE_INSTALL_PREFIX.
 # This is where all built CoreClr libraries will copied to.

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -57,8 +57,9 @@ echo.
 :: MSBuild projects would need a rebuild
 set __MSBCleanBuildArgs=/t:rebuild
 
-:: Cleanup the binaries drop folder
-if exist "%__TestBinDir%" rmdir /S /Q "%__TestBinDir%"
+:: Cleanup the binaries drop folder for the current configuration
+if exist "%__TestBinDir%" rd /s /q "%__TestBinDir%"
+if exist "%__NativeTestIntermediatesDir%" rd /s /q "%__NativeTestIntermediatesDir%"
 
 :MakeDirectories
 if not exist "%__TestBinDir%" md "%__TestBinDir%"

--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -77,8 +77,8 @@ if not exist %__LogsDir%           md  %__LogsDir%
 :SkipDefaultCoreRootSetup
 set __XunitWrapperBuildLog=%__LogsDir%\Tests_XunitWrapper_%__BuildOS%__%__BuildArch%__%__BuildType%.log
 set __TestRunBuildLog=%__LogsDir%\TestRunResults_%__BuildOS%__%__BuildArch%__%__BuildType%.log
-set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%_%__BuildType%.html
-set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%_%__BuildType%.xml
+set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.html
+set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.xml
 
 echo "Core_Root that will be used is : %Core_Root%"
 echo "Starting The Test Run .. "


### PR DESCRIPTION
This modifies the `build.cmd`, `build.sh`, and `buildtest.cmd` to only
remove previous output (binaries, intermediates, and logs) for the
selected configuration when the `clean` argument is specified.

This also modifies `runtest.cmd` to output log files in the same format
as `build.cmd`, `build.sh`, and `buildtest.cmd` do currently.

This fixes Issue #901.