### PR TITLE
Fixed PAL thread allocation stack overflow.

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SOURCES
     coreruncommand.cpp
     debugclient.cpp
     ${CLR_DIR}/src/coreclr/hosts/unixcorerun/corerun.cpp
+    ${CLR_DIR}/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
 )
 
 add_library(sosplugin SHARED ${SOURCES})

--- a/src/debug/debug-pal/CMakeLists.txt
+++ b/src/debug/debug-pal/CMakeLists.txt
@@ -29,5 +29,3 @@ if(CLR_CMAKE_PLATFORM_UNIX)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_library(debug-pal STATIC ${TWO_WAY_PIPE_SOURCES})
-
-install (TARGETS debug-pal DESTINATION .)

--- a/src/dlls/dbgshim/CMakeLists.txt
+++ b/src/dlls/dbgshim/CMakeLists.txt
@@ -25,7 +25,7 @@ endif(CLR_CMAKE_PLATFORM_UNIX)
 if(CLR_CMAKE_PLATFORM_LINUX)
     # This option is necessary to ensure that the overloaded delete operator defined inside
     # of the utilcode will be used instead of the standard library delete operator.
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
 endif(CLR_CMAKE_PLATFORM_LINUX)
 
 add_library(dbgshim SHARED ${DBGSHIM_SOURCES})

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -33,7 +33,7 @@ else(WIN32)
     if(CLR_CMAKE_PLATFORM_LINUX)
         # This option is necessary to ensure that the overloaded delete operator defined inside
         # of the utilcode will be used instead of the standard library delete operator.
-        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
 
         # The following linked options can be inserted into the linker libraries list to 
         # ensure proper resolving of circular references between a subset of the libraries.

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -68,7 +68,7 @@ elseif(CLR_CMAKE_PLATFORM_UNIX)
 
     # This option is necessary to ensure that the overloaded new/delete operators defined inside
     # of the utilcode will be used instead of the standard library delete operator.
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")    
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")    
 
     add_dependencies(mscordbi mscordaccore)
     

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -1,38 +1,37 @@
 if (WIN32)
-preprocess_def_file(${DEF_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/coreclr.def)
+    preprocess_def_file(${DEF_SOURCES} ${CMAKE_CURRENT_BINARY_DIR}/coreclr.def)
 
-list(APPEND CLR_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/coreclr.def)
+    list(APPEND CLR_SOURCES ${CMAKE_CURRENT_BINARY_DIR}/coreclr.def)
 
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /ENTRY:CoreDllMain")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /ENTRY:CoreDllMain")
 
-# No library groups for Win32
-set(START_LIBRARY_GROUP)
-set(END_LIBRARY_GROUP)
+    # No library groups for Win32
+    set(START_LIBRARY_GROUP)
+    set(END_LIBRARY_GROUP)
 
 else()
+    add_definitions(-DNO_CRT_INIT)
 
-add_definitions(-DNO_CRT_INIT)
+    if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+        # This option is necessary to ensure that the overloaded delete operator defined inside
+        # of the utilcode will be used instead of the standard library delete operator.
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-# This option is necessary to ensure that the overloaded delete operator defined inside
-# of the utilcode will be used instead of the standard library delete operator.
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic-functions")
+        # The following linked options can be inserted into the linker libraries list to 
+        # ensure proper resolving of circular references between a subset of the libraries.
+        set(START_LIBRARY_GROUP -Wl,--start-group)
+        set(END_LIBRARY_GROUP -Wl,--end-group)
 
-# The following linked options can be inserted into the linker libraries list to 
-# ensure proper resolving of circular references between a subset of the libraries.
-    set(START_LIBRARY_GROUP -Wl,--start-group)
-    set(END_LIBRARY_GROUP -Wl,--end-group)
+        # These options are used to force every object to be included even if it's unused.
+        set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
+        set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive) 
+    endif(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
-# These options are used to force every object to be included even if it's unused.
-    set(START_WHOLE_ARCHIVE -Wl,--whole-archive)
-    set(END_WHOLE_ARCHIVE -Wl,--no-whole-archive) 
-endif(CMAKE_SYSTEM_NAME STREQUAL Linux OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-
-if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-# These options are used to force every object to be included even if it's unused.
-    set(START_WHOLE_ARCHIVE -force_load)
-    set(END_WHOLE_ARCHIVE )
-endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        # These options are used to force every object to be included even if it's unused.
+        set(START_WHOLE_ARCHIVE -force_load)
+        set(END_WHOLE_ARCHIVE )
+    endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 endif (WIN32)
 
@@ -44,7 +43,7 @@ add_library(coreclr
 )
 
 if (CLR_CMAKE_PLATFORM_UNIX)
-set(LIB_UNWINDER unwinder_wks)
+    set(LIB_UNWINDER unwinder_wks)
 endif (CLR_CMAKE_PLATFORM_UNIX)
 
 # IMPORTANT! Please do not rearrange the order of the libraries. The linker on Linux is

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -198,3 +198,5 @@ endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 add_subdirectory(examples)
 
+# Install the static PAL library for VS
+install (TARGETS coreclrpal DESTINATION lib)

--- a/src/pal/src/sync/cs.cpp
+++ b/src/pal/src/sync/cs.cpp
@@ -371,7 +371,7 @@ VOID InternalDeleteCriticalSection(
 
 #ifdef _DEBUG
     CPalThread * pThread = 
-        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
+        (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
 
     if (0 != pPalCriticalSection->LockCount)
     {
@@ -510,7 +510,7 @@ which has no knowledge of CPalThread, classes and namespaces.
 VOID PALCEnterCriticalSection(CRITICAL_SECTION * pcs)
 {
     CPalThread * pThread = 
-        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
+        (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
     CorUnix::InternalEnterCriticalSection(pThread, pcs);
 }
 
@@ -524,7 +524,7 @@ which has no knowledge of CPalThread, classes and namespaces.
 VOID PALCLeaveCriticalSection(CRITICAL_SECTION * pcs)
 {
     CPalThread * pThread = 
-        (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
+        (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
     CorUnix::InternalLeaveCriticalSection(pThread, pcs);    
 }
 
@@ -642,7 +642,7 @@ namespace CorUnix
 
 #ifdef _DEBUG
         CPalThread * pThread = 
-            (PALIsThreadDataInitialized() ? InternalGetCurrentThread() : NULL);
+            (PALIsThreadDataInitialized() ? GetCurrentPalThread() : NULL);
 
         pPalCriticalSection->DebugInfo = InternalNew<CRITICAL_SECTION_DEBUG_INFO>(pThread);
         _ASSERT_MSG(NULL != pPalCriticalSection->DebugInfo, 

--- a/src/palrt/CMakeLists.txt
+++ b/src/palrt/CMakeLists.txt
@@ -22,3 +22,6 @@ add_library(palrt
     STATIC
     ${PALRT_SOURCES}
 )
+
+# Install the static PAL library for VS
+install (TARGETS palrt DESTINATION lib)


### PR DESCRIPTION
Fix a stack overflow when a PAL thread object is created for a foreign thread.

Add -Bsymbolic linker option to prevent static variables from being shared across PAL instances

Install coreclrpal and palrt libraries so VS has easy access to link against them.