### PR TITLE
Removes some string-related allocations from StackTrace and StackFrame

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Stackframe.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stackframe.cs
@@ -255,13 +255,13 @@ namespace System.Diagnostics {
                 {
                     Type[] typars = ((MethodInfo)method).GetGenericArguments();
 
-                    sb.Append("<");
+                    sb.Append('<');
                     int k = 0;
                     bool fFirstTyParam = true;
                     while (k < typars.Length)
                     {
                         if (fFirstTyParam == false)
-                            sb.Append(",");
+                            sb.Append(',');
                         else
                             fFirstTyParam = false;
 
@@ -269,7 +269,7 @@ namespace System.Diagnostics {
                         k++;
                     }
 
-                    sb.Append(">");
+                    sb.Append('>');
                 }
 
                 sb.Append(" at offset ");
@@ -304,9 +304,9 @@ namespace System.Diagnostics {
                     sb.Append("<filename unknown>");
                 else
                     sb.Append(strFileName);
-                sb.Append(":");
+                sb.Append(':');
                 sb.Append(iLineNumber);
-                sb.Append(":");
+                sb.Append(':');
                 sb.Append(iColumnNumber);
             }
             else

--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -527,9 +527,14 @@ namespace System.Diagnostics {
                     Type t = mb.DeclaringType;
                      // if there is a type (non global method) print it
                     if (t != null)
-                    {                                   
-                        sb.Append(t.FullName.Replace('+', '.'));
-                        sb.Append(".");
+                    {
+                        // Append t.FullName, replacing '+' with '.'
+                        for (int i = 0; i < t.FullName.Length; i++)
+                        {
+                            char ch = t.FullName[i];
+                            sb.Append(ch == '+' ? '.' : ch);
+                        }
+                        sb.Append('.');
                     }
                     sb.Append(mb.Name);
 
@@ -537,24 +542,24 @@ namespace System.Diagnostics {
                     if (mb is MethodInfo && ((MethodInfo)mb).IsGenericMethod)
                     {
                         Type[] typars = ((MethodInfo)mb).GetGenericArguments();
-                        sb.Append("[");
+                        sb.Append('[');
                         int k=0;
                         bool fFirstTyParam = true;
                         while (k < typars.Length)
                         {
                             if (fFirstTyParam == false)
-                                sb.Append(",");
+                                sb.Append(',');
                             else
                                 fFirstTyParam = false;
 
                             sb.Append(typars[k].Name);             
                             k++;
                         }   
-                        sb.Append("]");    
+                        sb.Append(']');    
                     }
 
                     // arguments printing
-                    sb.Append("(");
+                    sb.Append('(');
                     ParameterInfo[] pi = mb.GetParameters();
                     bool fFirstParam = true;
                     for (int j = 0; j < pi.Length; j++)
@@ -567,9 +572,11 @@ namespace System.Diagnostics {
                         String typeName = "<UnknownType>";
                         if (pi[j].ParameterType != null)
                             typeName = pi[j].ParameterType.Name;
-                        sb.Append(typeName + " " + pi[j].Name);             
+                        sb.Append(typeName);
+                        sb.Append(' ');
+                        sb.Append(pi[j].Name);
                     }   
-                    sb.Append(")");
+                    sb.Append(')');
 
                     // source location printing
                     if (displayFilenames && (sf.GetILOffset() != -1))


### PR DESCRIPTION
I noticed some string allocations that can be trivially avoided in StackTrace and StackFrame.