### PR TITLE
GcInfo: Add support for Standalone build

### DIFF
--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
@@ -40,6 +40,9 @@
     <file src="..\inc\corinfo.h" target="inc\corinfo.h" />
     <file src="..\inc\corjit.h" target="inc\corjit.h" />
     <file src="..\inc\opcode.def" target="inc\opcode.def" />
-    <file src="..\inc\openum.h" target="inc\openum.h" />
+    <file src="..\inc\openum.h" target="inc\openum.h" />	
+    <file src="..\inc\gcinfoencoder.h" target="inc\gcinfoencoder.h" />
+    <file src="..\inc\gcinfotypes.h" target="inc\gcinfotypes.h" />
+    <file src="..\gcinfo\gcinfoencoder.cpp" target="gcinfo\gcinfoencoder.cpp" />
   </files>
 </package>

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
@@ -41,5 +41,8 @@
     <file src="..\inc\corjit.h" target="inc\corjit.h" />
     <file src="..\inc\opcode.def" target="inc\opcode.def" />
     <file src="..\inc\openum.h" target="inc\openum.h" />
+    <file src="..\inc\gcinfoencoder.h" target="inc\gcinfoencoder.h" />
+    <file src="..\inc\gcinfotypes.h" target="inc\gcinfotypes.h" />
+    <file src="..\.\gcinfo\gcinfoencoder.cpp" target="gcinfo\gcinfoencoder.cpp" />	
   </files>
 </package>

--- a/src/gcinfo/CMakeLists.txt
+++ b/src/gcinfo/CMakeLists.txt
@@ -14,3 +14,6 @@ endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(lib)
 add_subdirectory(crossgen)
+
+install (FILES gcinfoencoder.cpp
+               DESTINATION gcinfo)

--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -20,8 +20,11 @@
         #define LOGGING
     #endif
 #endif
+
+#ifndef STANDALONE_BUILD
 #include "log.h"
 #include "simplerhash.h"
+#endif
 
 #ifdef MDIL
 #define MUST_CALL_JITALLOCATOR_FREE 1
@@ -84,7 +87,7 @@ void GcInfoSize::Log(DWORD level, const char * header)
 
 #endif
 
-
+#ifndef DISABLE_EH_VECTORS
 inline BOOL IsEssential(EE_ILEXCEPTION_CLAUSE *pClause)
 {
     _ASSERTE(pClause->TryEndPC >= pClause->TryStartPC);
@@ -93,6 +96,7 @@ inline BOOL IsEssential(EE_ILEXCEPTION_CLAUSE *pClause)
 
      return TRUE;
 }
+#endif
 
 GcInfoEncoder::GcInfoEncoder(
             ICorJitInfo*                pCorJitInfo,

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -74,4 +74,6 @@ install (FILES cor.h
                corjit.h
                opcode.def
                openum.h
+               gcinfoencoder.h
+               gcinfotypes.h
                DESTINATION inc)

--- a/src/inc/gcinfoencoder.h
+++ b/src/inc/gcinfoencoder.h
@@ -41,28 +41,54 @@
  7. Chunk pointers
  8. Chunk encodings
  
+
+ STANDALONE_BUILD
+
+ The STANDALONE_BUILD switch can be used to build the GcInfoEncoder library 
+ independently by clients outside the CoreClr tree.
+
+ The GcInfo library uses some custom data-structures (ex: ArrayList, SimplerHashTable)
+ and includes some utility libraries (ex: UtilCode) which pull in several other 
+ headers with considerable unrelated content. Rather than porting all the 
+ utility code to suite other clients, the  STANDALONE_BUILD switch can be used 
+ to include only the minimal set of headers specific to GcInfo encodings.
+
+ Clients of STANDALONE_BUILD will likely use standard library
+ implementations of data-structures like ArrayList, HashMap etc., in place
+ of the custom implementation currently used by GcInfoEncoder.
+
+ Rather than spew the GcInfoEnoder code with
+ #ifdef STANDALONE_BUILD ... #else .. #endif blocks, we include a special
+ header GcInfoUtil.h in STANDALONE_BUILD mode.  GcInfoUtil.h is expected to 
+ supply the interface/implementation for the data-structures and utilities 
+ used by GcInfoEncoder. This header should be provided by the clients doing 
+ the standalone build in their source tree.
+
 *****************************************************************/
 
 
 #ifndef __GCINFOENCODER_H__
 #define __GCINFOENCODER_H__
 
-
-#include <windows.h>
-
+#ifdef STANDALONE_BUILD
 #include <wchar.h>
 #include <stdio.h>
-
+#include "GcInfoUtil.h"  
+#include "corjit.h"
+#else
+#include <windows.h>
+#include <wchar.h>
+#include <stdio.h>
 #include "utilcode.h"
 #include "corjit.h"
 #include "slist.h"     // for SList
 #include "arraylist.h"
 #include "iallocator.h"
-
 #include "stdmacros.h"
-#include "gcinfotypes.h"
 #include "eexcp.h"
+#endif
 
+#include "gcinfotypes.h"
 
 #ifdef VERIFY_GCINFO
 #include "dbggcinfoencoder.h"

--- a/src/inc/gcinfotypes.h
+++ b/src/inc/gcinfotypes.h
@@ -62,7 +62,6 @@
 //--------------------------------------------------------------------------------
 __forceinline size_t SAFE_SHIFT_LEFT(size_t x, size_t count)
 {
-    LIMITED_METHOD_DAC_CONTRACT;
     _ASSERTE(count <= BITS_PER_SIZE_T);
     return (x << 1) << (count-1);
 }


### PR DESCRIPTION
 The STANDALONE_BUILD switch can be used to build the GcInfoEncoder library
 independently by clients outside the CoreClr tree.

 The GcInfo library uses some custom data-structures (ex: ArrayList)
 and includes some utility libraries (ex: UtilCode) which pull in several other
 headers with considerable unrelated content. Rather than porting all the
 utility code to suite other clients, the  STANDALONE_BUILD switch can be used
 to include only the minimal set of headers specific to GcInfo encodings.

 Clients of STANDALONE_BUILD will likely use standard library
 implementations of data-structures like ArrayList, HashMap etc., in place
 of the custom implementation currently used by GcInfoEncoder.

 Rather than spew the GcInfoEnoder code with
 #ifdef STANDALONE_BUILD ... #else .. #endif blocks, we include a special
 header GcInfoUtil.h in STANDALONE_BUILD mode.  GcInfoUtil.h is expected to
 supply the interface/implementation for the data-structures and utilities
 used by GcInfoEncoder. This header should be provided by the clients doing
 the standalone build in their source tree.

The following additional files are exported to the build directory:
1) GcInfoEncoder.h and GcInfoTypes.h, as part of extended EE interface.
2) The GcInfoEncoder.cpp -- so that clients can build the library in their tree.