### PR TITLE
Changes for building using VS2015

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,6 @@ set(CMAKE_CXX_STANDARD_LIBRARIES "") # do not link against standard win32 libs i
 # Linker flags
 #
 # Disable the following line for UNIX altjit on Windows
-set(CMAKE_SHARED_LINKER_FLAGS "/NODEFAULTLIB") #do not use default libraries when resolving external references
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /MANIFEST:NO") #Do not create Side-by-Side Assembly Manifest
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /SUBSYSTEM:WINDOWS,6.00") #windows subsystem
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LARGEADDRESSAWARE") # can handle addresses larger than 2 gigabytes

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -4801,7 +4801,7 @@ typedef enum
 DacpGcHeapData *g_pHeapData = NULL;
 DacpGcHeapData g_HeapData;
 
-inline BOOL InitializeHeapData()
+BOOL InitializeHeapData()
 {
     if (g_pHeapData == NULL)
     {        

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -19820,7 +19820,9 @@ void gc_heap::realloc_plan_generation_start (generation* gen, generation* consin
     }
 
     dprintf (1, ("plan re-alloc gen%d start at %Ix (ptr: %Ix, limit: %Ix)", gen->gen_num, 
-        generation_allocation_pointer (consing_gen), generation_allocation_limit (consing_gen))); 
+        generation_plan_allocation_start (consing_gen),
+        generation_allocation_pointer (consing_gen), 
+        generation_allocation_limit (consing_gen))); 
 }
 
 void gc_heap::plan_generation_starts (generation*& consing_gen)
@@ -28476,7 +28478,7 @@ void gc_heap::realloc_plug (size_t last_plug_size, BYTE*& last_plug,
             }
 #endif //SHORT_PLUGS
 
-            dprintf (3, ("ra plug %Ix was shortened, adjusting plug size to %Ix", last_plug_size))
+            dprintf (3, ("ra plug %Ix was shortened, adjusting plug size to %Ix", last_plug, last_plug_size))
         }
 
 #ifdef SHORT_PLUGS
@@ -30549,7 +30551,7 @@ void gc_heap::should_check_bgc_mark (heap_segment* seg,
         // FALSE if the address is the same as reserved.
         if ((seg->flags & heap_segment_flags_swept) || (current_sweep_pos == heap_segment_reserved (seg)))
         {
-            dprintf (3, ("seg %Ix is already swept by bgc"));
+            dprintf (3, ("seg %Ix is already swept by bgc", seg));
         }
         else
         {

--- a/src/inc/msodw.h
+++ b/src/inc/msodw.h
@@ -188,7 +188,7 @@
 
 // shared reg values between DW and DW COM EXE
 #define DEFAULT_SUBPATH L"Microsoft\\PCHealth\\ErrorReporting\\DW"
-#define QUEUE_REG_SUBPATH  L"Software\\"DEFAULT_SUBPATH
+#define QUEUE_REG_SUBPATH  L"Software\\" DEFAULT_SUBPATH
 #define QUEUE_REG_OKTOREPORT_VALUE L"OkToReportFromTheseQueues"
 #define WATSON_INSTALLED_REG_SUBPATH QUEUE_REG_SUBPATH L"\\Installed"
 #define WATSON_INSTALLED_REG_SUBPATH_IA64 L"Software\\Wow6432Node\\"DEFAULT_SUBPATH L"\\Installed"

--- a/src/inc/warningcontrol.h
+++ b/src/inc/warningcontrol.h
@@ -42,6 +42,9 @@
 #pragma warning(3               :4212)   // function declaration used ellipsis
 #pragma warning(error           :4259)   // pure virtual function was not defined
 #pragma warning(disable         :4291)   // delete not defined for new, c++ exception may cause leak
+#pragma warning(disable         :4302)   // truncation from '%$S' to '%$S'
+#pragma warning(disable         :4311)   // pointer truncation from '%$S' to '%$S'
+#pragma warning(disable         :4312)   // '<function-style-cast>' : conversion from '%$S' to '%$S' of greater size
 #pragma warning(disable :4334)   // result of 32-bit shift implicitly converted to 64 bits
 #pragma warning(disable :4345)   // behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized
 #pragma warning(disable :4430)   // missing type specifier: C++ doesn't support default-int

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1952,7 +1952,7 @@ float ValueNumStore::EvalOpIntegral<float>(VNFunc vnf, float v0, float v1, Value
     switch (oper)
     {
     case GT_MOD:
-        return fmod(v0, v1);
+        return fmodf(v0, v1);
     default:
         // For any other values of 'oper', we will assert and return 0.0f
         break;

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -5472,9 +5472,11 @@ PALIMPORT double __cdecl cosh(double);
 PALIMPORT double __cdecl sinh(double);
 PALIMPORT double __cdecl tanh(double);
 PALIMPORT double __cdecl fmod(double, double);
+PALIMPORT float __cdecl fmodf(float, float);
 PALIMPORT double __cdecl floor(double);
 PALIMPORT double __cdecl ceil(double);
 PALIMPORT double __cdecl fabs(double);
+PALIMPORT float __cdecl fabsf(float);
 PALIMPORT double __cdecl modf(double, double *);
 PALIMPORT float __cdecl modff(float, float *);
 
@@ -5484,10 +5486,6 @@ PALIMPORT double __cdecl _copysign(double, double);
 
 #ifdef __cplusplus
 extern "C++" {
-inline float fabsf(float _X)
-{
-    return ((float)fabs((double)_X));
-}
 
 #ifdef BIT64
 inline __int64 abs(__int64 _X) {

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -208,12 +208,13 @@ function_name() to call the system's implementation
 #define tanh DUMMY_tanh
 #define modf DUMMY_modf
 #define fmod DUMMY_fmod
+#define fmodf DUMMY_fmodf
 #define sqrt DUMMY_sqrt
 #define ceil DUMMY_ceil
 #define fabs DUMMY_fabs
+#define fabsf DUMMY_fabsf
 #define floor DUMMY_floor
 #define modff DUMMY_modff
-#define fabsf DUMMY_fabsf
 
 /* RAND_MAX needed to be renamed to avoid duplicate definition when including 
    stdlib.h header files. PAL_RAND_MAX should have the same value as RAND_MAX 
@@ -455,12 +456,13 @@ function_name() to call the system's implementation
 #undef tanh
 #undef modf
 #undef fmod
+#undef fmodf
 #undef sqrt
 #undef ceil
 #undef fabs
+#undef fabsf
 #undef floor
 #undef modff
-#undef fabsf
 
 #undef wchar_t
 #undef ptrdiff_t

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(../../pal/prebuilt/corerror)
 set(crossgen_SOURCES crossgen.cpp ../util/consoleargs.cpp)
 if(WIN32)
     set(crossgen_RESOURCES Native.rc)
+    add_definitions(-D_CRT_NON_CONFORMING_WCSTOK)
 endif()
 
 add_definitions(-DFX_VER_INTERNALNAME_STR=crossgen.exe)

--- a/src/utilcode/jitperf.cpp
+++ b/src/utilcode/jitperf.cpp
@@ -8,6 +8,7 @@
 #include "perflog.h"
 #include "clrhost.h"
 #include "contract.h"
+#include "utilcode.h"
 
 //=============================================================================
 // ALL THE JIT PERF STATS GATHERING CODE IS COMPILED ONLY IF THE ENABLE_JIT_PERF WAS DEFINED.

--- a/src/vm/amd64/InstantiatingStub.asm
+++ b/src/vm/amd64/InstantiatingStub.asm
@@ -12,9 +12,7 @@
 include <AsmMacros.inc>
 include AsmConstants.inc
 
-SHF_GETMETHODFRAMEVPTR              equ ?GetMethodFrameVPtr@StubHelperFrame@@SA_KXZ
-
-extern SHF_GETMETHODFRAMEVPTR:proc
+extern s_pStubHelperFrameVPtr:qword
 extern JIT_FailFast:proc
 extern s_gsCookie:qword
 
@@ -84,7 +82,7 @@ NESTED_ENTRY InstantiatingMethodStubWorker, _TEXT
         ;
         ; fully initialize the StubHelperFrame
         ;
-        call    SHF_GETMETHODFRAMEVPTR
+        mov     rax, s_pStubHelperFrameVPtr
         mov     [rbp + OFFSETOF_FRAME], rax
 
         mov     rax, s_gsCookie

--- a/src/vm/amd64/UMThunkStub.asm
+++ b/src/vm/amd64/UMThunkStub.asm
@@ -30,8 +30,10 @@ extern g_TrapReturningThreads:dword
 extern UM2MDoADCallBack:proc
 extern ReverseEnterRuntimeHelper:proc
 extern ReverseLeaveRuntimeHelper:proc
+ifdef FEATURE_INCLUDE_ALL_INTERFACES
 extern gfHostConfig:dword
 extern NDirect__IsHostHookEnabled:proc
+endif
 extern UMThunkStubRareDisableWorker:proc
 
 

--- a/src/vm/amd64/cgenamd64.cpp
+++ b/src/vm/amd64/cgenamd64.cpp
@@ -79,6 +79,9 @@ void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
 
 #ifndef DACCESS_COMPILE
 
+extern "C" TADDR s_pStubHelperFrameVPtr;
+TADDR s_pStubHelperFrameVPtr = StubHelperFrame::GetMethodFrameVPtr();
+
 void TailCallFrame::InitFromContext(T_CONTEXT * pContext)
 {
     WRAPPER_NO_CONTRACT;

--- a/src/vm/rcwwalker.cpp
+++ b/src/vm/rcwwalker.cpp
@@ -25,6 +25,7 @@
 #include "cominterfacemarshaler.h"
 #include "excep.h"
 #include "finalizerthread.h"
+#include "interoputil.inl"
 
 const IID IID_ICLRServices = __uuidof(ICLRServices);
 


### PR DESCRIPTION
Assorted set of changes to make build produce coreclr.dll using VS2015 successfully. Fixes #824.

More fixes are needed in the managed part of the build to make build work end to end on VS2015.