### PR TITLE
Fix System.Progress`1 in model.xml

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3526,7 +3526,7 @@
       <Member Name="EndInvoke(System.IAsyncResult)" />
       <Member Name="Invoke(T)" />
     </Type>
-    <Type Name="System.Progress&lt;T&gt;" Condition="FEATURE_COMINTEROP">
+    <Type Name="System.Progress&lt;T&gt;">
       <Member Name="#ctor" />
       <Member Name="#ctor(System.Action&lt;T&gt;)" />
       <Member MemberType="Event" Name="ProgressChanged" />


### PR DESCRIPTION
The BCL rewriter is stripping System.Progress`1 out of mscorlib when compiling for Linux and OSX, because the model.xml has it conditionally included based on FEATURE_COMINTEROP.  Code trying to use System.Progress`1 type forwarded from System.Runtime.Extensions.dll then blows up at run time, since the type isn't available.  As far as I can tell, there's no reason for that condition; this just removes it.