### PR TITLE
Export OpenSemaphoreW from PAL

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1547,6 +1547,14 @@ CreateSemaphoreExW(
         IN /*_Reserved_*/  DWORD dwFlags,
         IN DWORD dwDesiredAccess);
 
+PALIMPORT
+HANDLE
+PALAPI
+OpenSemaphoreW(
+    IN DWORD dwDesiredAccess,
+    IN BOOL bInheritHandle,
+    IN LPCWSTR lpName);
+
 #ifdef UNICODE
 #define CreateSemaphore CreateSemaphoreW
 #define CreateSemaphoreEx CreateSemaphoreExW


### PR DESCRIPTION
Semaphore.OpenExisting uses OpenSemaphoreW from the PAL, but it's not being exported, resulting in EntryPointNotFoundExceptions.