### PR TITLE
Fix VM total space issue

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -6846,6 +6846,14 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
             MEMORYSTATUSEX st;
             GetProcessMemoryLoad (&st);
             BYTE* top = (BYTE*)0 + Align ((size_t)(st.ullTotalVirtual));
+            // On non-Windows systems, we get only an approximate ullTotalVirtual
+            // value that can possibly be slightly lower than the saved_g_highest_address.
+            // In such case, we set the top to the saved_g_highest_address so that the
+            // card and brick tables always cover the whole new range.
+            if (top < saved_g_highest_address)
+            {
+                top = saved_g_highest_address;
+            }
             size_t ps = ha-la;
 #ifdef _WIN64
             if (ps > (ULONGLONG)200*1024*1024*1024)

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -289,8 +289,12 @@ GlobalMemoryStatusEx(
 #endif // __APPLE__
     }
 
-    // TODO: figure out a way to get the real values for the total / available virtual
-    lpBuffer->ullTotalVirtual = lpBuffer->ullTotalPhys;
+    // There is no API to get the total virtual address space size on 
+    // Unix, so we use a constant value representing 128TB, which is 
+    // the approximate size of total user virtual address space on
+    // the currently supported Unix systems.
+    static const UINT64 _128TB = (1ull << 47); 
+    lpBuffer->ullTotalVirtual = _128TB;
     lpBuffer->ullAvailVirtual = lpBuffer->ullAvailPhys;
 
     LOGEXIT("GlobalMemoryStatusEx returns %d\n", fRetVal);


### PR DESCRIPTION
This change fixes an issue that caused brick table corruption due to
an incorrectly reported VM total space and the gc_heap::grow_brick_card_tables
not being resilient against that.
This change updates the GlobalMemoryStatusEx PAL function to return appropriate
VM user space size value and also modifies the gc_heap::grow_brick_card_tables
so that in case an end address of a new GC heap segment is larger than the
approximate maximum obtained using the GlobalMemoryStatusEx, we don't
clip down the range that the new card_table / brick_table will cover.
Otherwise an object allocated above that range would cause indexing into the
card_table to overrun the end of the table.