### PR TITLE
Cache Type.FullName in StackTrace

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -529,9 +529,10 @@ namespace System.Diagnostics {
                     if (t != null)
                     {
                         // Append t.FullName, replacing '+' with '.'
-                        for (int i = 0; i < t.FullName.Length; i++)
+                        string fullName = t.FullName;
+                        for (int i = 0; i < fullName.Length; i++)
                         {
-                            char ch = t.FullName[i];
+                            char ch = fullName[i];
                             sb.Append(ch == '+' ? '.' : ch);
                         }
                         sb.Append('.');


### PR DESCRIPTION
Type.FullName is not cheap: virtual property with non-trivial implementation. Cache its value to avoid computing it multiple times.