### PR TITLE
Fix register used in method fixup stubs

### DIFF
--- a/src/vm/amd64/externalmethodfixupthunk.S
+++ b/src/vm/amd64/externalmethodfixupthunk.S
@@ -13,7 +13,7 @@
 
 NESTED_ENTRY ExternalMethodFixupStub, _TEXT, NoHandler
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, 8, rdx, 0, 0
+        PROLOG_WITH_TRANSITION_BLOCK 0, 8, rsi, 0, 0
 
         lea             rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
         sub             rsi, 5                              // pThunk
@@ -34,7 +34,7 @@ NESTED_END ExternalMethodFixupStub, _TEXT
 
 NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, 8, rdx, 0, 0
+        PROLOG_WITH_TRANSITION_BLOCK 0, 8, rsi, 0, 0
 
         lea             rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
         sub             rsi, 5                              // pThunk


### PR DESCRIPTION
On x64, Linux uses rsi instead of rdx to pass the second parameter.