### PR TITLE
Clarify that the final mscorlib.dll is in bin\Product

### DIFF
--- a/Documentation/linux-instructions.md
+++ b/Documentation/linux-instructions.md
@@ -78,7 +78,7 @@ You will build `mscorlib.dll` out of the coreclr repository and the rest of the 
 D:\git\coreclr> build.cmd linuxmscorlib
 ```
 
-The output is placed in `bin\obj\Linux.x64.Debug\mscorlib.dll`.  You'll want to copy this to the runtime folder on your Linux machine. (e.g. `~/coreclr-demo/runtime`)
+The output is placed in `bin\Product\Linux.x64.Debug\mscorlib.dll`.  You'll want to copy this to the runtime folder on your Linux machine. (e.g. `~/coreclr-demo/runtime`)
 
 For the rest of the framework, you need to pass some special parameters to build.cmd when building out of the CoreFX repository.
 

--- a/src/mscorlib/Tools/PostProcessingTools.targets
+++ b/src/mscorlib/Tools/PostProcessingTools.targets
@@ -18,6 +18,7 @@
     
     <!-- Copy to the final output location -->
     <Copy Retries="3" SourceFiles="@(RewrittenAssembly)" DestinationFiles="$(FinalOutputPath)\%(RewrittenAssembly.FileName)%(RewrittenAssembly.Extension)"/>
+    <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(FinalOutputPath)\%(RewrittenAssembly.FileName)%(RewrittenAssembly.Extension)" />
     <Copy Retries="3" SourceFiles="$(CurrentAssemblyPdb)" DestinationFiles="$(FinalOutputPath)\$(TargetName).pdb"/>
   </Target>
 


### PR DESCRIPTION
Currently, when running "build.cmd linuxmscorlib", the last line of output shows that mscorlib has been created in bin\obj. This is misleading, making it sounds like that the user should copy mscorlib.dll form there, and even the instruction said so. But that's not correct. The mscorlib.dll in bin\obj is only an intermediate version. It is then processed by BCL rewriter, and the final version is placed in bin\Product, which is the right location for the user to copy mscorlib from.

Using mscorlib from bin\obj works fine in most cases, but it causes crossgen to assert, since it contains methods that shouldn't be there.

This PR adds a message in the post-processing step to make it clear that the final mscorlib is in bin\Product, and also fixes the documentation.