### PR TITLE
Add simple JIT test for typed references.

### DIFF
--- a/tests/src/AllTestProjects.sln
+++ b/tests/src/AllTestProjects.sln
@@ -169,6 +169,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NaN", "NaN", "{06633516-0C7
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NaN", "JIT\Methodical\NaN\NaN.csproj", "{5FEB6365-EB6C-4D4D-9DAA-E5E2EEA5A1FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TypedReference", "JIT\Directed\TypedReference\TypedReference.csproj", "{47849C79-F7B8-47C6-BBA7-8E6FCE66B9F1}"
+EndProject
+
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/tests/src/JIT/Directed/TypedReference/TypedReference.cs
+++ b/tests/src/JIT/Directed/TypedReference/TypedReference.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+
+public class BringUpTest
+{
+    const int Pass = 100;
+    const int Fail = -1;
+    const string Apple = "apple";
+    const string Orange = "orange";
+
+    public static int Main()
+    {
+        int i = Fail;
+        F(__makeref(i));
+
+        if (i != Pass) return Fail;
+
+        string j = Apple;
+        G(__makeref(j));
+        
+        if (j != Orange) return Fail;
+
+        return Pass;
+    }
+
+    static void F(System.TypedReference t)
+    {
+        __refvalue(t, int) = Pass;
+    }
+
+    static void G(System.TypedReference t)
+    {
+        __refvalue(t, string) = Orange;
+    }
+
+}    

--- a/tests/src/JIT/Directed/TypedReference/TypedReference.csproj
+++ b/tests/src/JIT/Directed/TypedReference/TypedReference.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>TypedReference</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{47849C79-F7B8-47C6-BBA7-8E6FCE66B9F1}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <LinkLocalMscorlib>true</LinkLocalMscorlib>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TypedReference.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/JIT/Directed/TypedReference/app.config
+++ b/tests/src/JIT/Directed/TypedReference/app.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Directed/TypedReference/packages.config
+++ b/tests/src/JIT/Directed/TypedReference/packages.config
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+</packages>


### PR DESCRIPTION
This compiles directly against mscorlib since TypedReference is not part of any contract assembly.