### PR TITLE
Remove the InitializeStringResources function

### DIFF
--- a/src/pal/src/include/pal/locale.h
+++ b/src/pal/src/include/pal/locale.h
@@ -38,8 +38,6 @@ extern "C"
 #define ISO_NAME(region, encoding, part)  region ".ISO" encoding "-" part
 #endif
 
-void InitializeStringResources(void);
-
 #if HAVE_COREFOUNDATION
 #define CF_EXCLUDE_CSTD_HEADERS
 #include <CoreFoundation/CoreFoundation.h>

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -670,8 +670,6 @@ PAL_InitializeCoreCLR(
         return ERROR_DLL_INIT_FAILED;
     }
 
-    InitializeStringResources();
-
     if (!fStayInPAL)
     {
         PAL_Leave(PAL_BoundaryTop);

--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -951,22 +951,6 @@ EXIT:
     return retval;
 }
 
-/*++
- Function :
- InitializeStringResources -
-
-     Initialize the the native resources string support
- --*/
-void InitializeStringResources(void)
-{
-#ifndef __APPLE__
-    // Set the locale for string resources to en_US
-    // UNIXTODO: After we add localized resources, change this to check the current
-    // locale and set it to en_US only if we don't have resources for the current locale.
-    setlocale(LC_MESSAGES, "en_US.UTF-8");
-#endif // __APPLE__
-}
-
 extern char g_szCoreCLRPath[MAX_PATH];
 
 /*++


### PR DESCRIPTION
Now that the default string resources are embedded in the libcoreclr, it is no longer necessary to
set the LC_MESSAGES locale to en_US in the PAL.