### PR TITLE
Added VS2013 "Update 3 or later" requirement to windows-instructions.md

### DIFF
--- a/Documentation/windows-instructions.md
+++ b/Documentation/windows-instructions.md
@@ -14,7 +14,7 @@ Visual Studio
 Visual Studio must be installed. Supported versions:
 
 - [Visual Studio Community 2013](http://go.microsoft.com/fwlink/?LinkId=517284) - **Free** for Open Source development!
-- [Visual Studio 2013](http://www.visualstudio.com/downloads/download-visual-studio-vs) (Pro, Premium, Ultimate)
+- [Visual Studio 2013 Update 3](http://www.visualstudio.com/downloads/download-visual-studio-vs) or later (Pro, Premium, Ultimate)
 
 Visual Studio Express is not supported. Visual Studio 2015 isn't supported yet (see [issue #30](https://github.com/dotnet/coreclr/issues/30)).
 


### PR DESCRIPTION
I had Visual Studio 2013 Update 1 installed and was getting errors building CoreFx. Some of the projects in that repo reference .netportable v4.5 profile259, which wasn't added until Update 3. I've updated the windows build instructions to note this.