### PR TITLE
Improve .gitignore-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ node_modules/
 *.metaproj.tmp
 .atom-build.json
 tags
+TAGS
 
 # RIA/Silverlight projects
 Generated_Code/
@@ -222,6 +223,7 @@ $RECYCLE.BIN/
 ### Linux ###
 
 *~
+\#*\#
 
 # KDE directory preferences
 .directory
@@ -266,3 +268,4 @@ Vagrantfile
 CMakeFiles/
 cmake_install.cmake
 CMakeCache.txt
+Makefile


### PR DESCRIPTION
Currently all emacs-temp files are tracked.
TAGS is for emacs' etags used to track symbols in code-files.
Generated Makefiles from the build-process should also be ignored.