### PR TITLE
Fix the implicit-exception-spec-mismatch warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,7 +279,6 @@ add_compile_options(-Werror)
 
 # Disabled warnings
 add_compile_options(-Wno-unused-private-field)
-add_compile_options(-Wno-implicit-exception-spec-mismatch)
 # A derived class defines a virtual method with the same name as its base
 # class, but different set of parameters.
 add_compile_options(-Wno-overloaded-virtual)

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -189,6 +189,12 @@ typedef LPSTR   LPUTF8;
 #define sizeofmember(c,m) (sizeof(((c*)0)->m))
 #endif
 
+#if defined(_MSC_VER) && _MSC_VER < 1900
+#define NOEXCEPT
+#else
+#define NOEXCEPT noexcept
+#endif
+
 //=--------------------------------------------------------------------------=
 // Prefast helpers.
 //
@@ -506,10 +512,10 @@ _Ret_bytecap_(_Size) void * __cdecl
 operator new[](size_t n);
 
 void __cdecl
-operator delete(void *p);
+operator delete(void *p) NOEXCEPT;
 
 void __cdecl
-operator delete[](void *p);
+operator delete[](void *p) NOEXCEPT;
 
 #ifdef _DEBUG_IMPL
 HRESULT _OutOfMemory(LPCSTR szFile, int iLine);

--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -471,7 +471,7 @@ void * __cdecl operator new[](size_t n, const NoThrow&)
 __attribute__((visibility("hidden")))
 #endif
 void __cdecl
-operator delete(void *p)
+operator delete(void *p) NOEXCEPT
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -487,7 +487,7 @@ operator delete(void *p)
 __attribute__((visibility("hidden")))
 #endif
 void __cdecl
-operator delete[](void *p)
+operator delete[](void *p) NOEXCEPT
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;


### PR DESCRIPTION
Fix the warning. Since VC++ doesn't support the noexcept keyword,
define a NOEXCEPT macro as empty for VC++ and as noexcept for others.