### PR TITLE
Fix warning no-overloaded-virtual

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -279,9 +279,6 @@ add_compile_options(-Werror)
 
 # Disabled warnings
 add_compile_options(-Wno-unused-private-field)
-# A derived class defines a virtual method with the same name as its base
-# class, but different set of parameters.
-add_compile_options(-Wno-overloaded-virtual)
 add_compile_options(-Wno-unused-variable)
 # Explicit constructor calls are not supported by clang (this->ClassName::ClassName())
 add_compile_options(-Wno-microsoft)

--- a/src/debug/daccess/dacdbiimpl.h
+++ b/src/debug/daccess/dacdbiimpl.h
@@ -642,6 +642,9 @@ public:
 // CordbAssembly, CordbModule
 // ============================================================================
  
+    using ClrDataAccess::GetModuleData;
+    using ClrDataAccess::GetAddressType;
+
 public:
     // Get the full path and file name to the assembly's manifest module.
     BOOL GetAssemblyPath(VMPTR_Assembly  vmAssembly, 

--- a/src/inc/metadata.h
+++ b/src/inc/metadata.h
@@ -1110,6 +1110,9 @@ EXTERN_GUID(IID_IMDInternalImportENC, 0xe03d7730, 0xd7e3, 0x11d2, 0x8c, 0xd, 0x0
 #define INTERFACE IMDInternalImportENC
 DECLARE_INTERFACE_(IMDInternalImportENC, IMDInternalImport)
 {
+private:
+    using IMDInternalImport::ApplyEditAndContinue;    
+public:
     // ENC only methods here.
     STDMETHOD(ApplyEditAndContinue)(        // S_OK or error.
         MDInternalRW *pDelta) PURE;         // Interface to MD with the ENC delta.

--- a/src/inc/stgpool.h
+++ b/src/inc/stgpool.h
@@ -1094,6 +1094,10 @@ private:
 class StgBlobPool : public StgPool
 {
     friend class VerifyLayoutsMD;
+
+    using StgPool::InitNew;
+    using StgPool::InitOnMem;
+    
 public:
     StgBlobPool(ULONG ulGrowInc=DFT_BLOB_HEAP_SIZE) :
         StgPool(ulGrowInc),

--- a/src/md/compiler/regmeta.h
+++ b/src/md/compiler/regmeta.h
@@ -109,6 +109,13 @@ struct CCustAttrHashKey
 class CCustAttrHash : public CClosedHashEx<CCustAttrHashKey, CCustAttrHash>
 {
     typedef CCustAttrHashKey T;
+
+    using CClosedHashEx<CCustAttrHashKey, CCustAttrHash>::Hash;
+    using CClosedHashEx<CCustAttrHashKey, CCustAttrHash>::Compare;
+    using CClosedHashEx<CCustAttrHashKey, CCustAttrHash>::Status;
+    using CClosedHashEx<CCustAttrHashKey, CCustAttrHash>::SetStatus;
+    using CClosedHashEx<CCustAttrHashKey, CCustAttrHash>::GetKey;
+    
 public:
     CCustAttrHash(int iBuckets=37) : CClosedHashEx<CCustAttrHashKey,CCustAttrHash>(iBuckets) {}
     unsigned int Hash(const T *pData);

--- a/src/md/inc/recordpool.h
+++ b/src/md/inc/recordpool.h
@@ -25,6 +25,10 @@
 class RecordPool : public StgPool
 {
     friend class VerifyLayoutsMD;
+
+    using StgPool::InitNew;
+    using StgPool::InitOnMem;
+
 public:
     RecordPool() :
         StgPool(1024, 1)


### PR DESCRIPTION
This warning is issued when a derived class defines a virtual method with the
same name as its base class, but different set of parameters. The base class
virtual method is hidden in that case. Clang issues a warning here.
To fix the warning, I have added "using Base::Method" to the private section
of all the derived classes. While it makes the Base::Method visible to the code of the derived 
class, it doesn't have any other side effects and it seems cleaner than trying to rename the methods in the derived class to some artificial names.