### PR TITLE
Fix unused-private-field warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,6 @@ add_compile_options(-ferror-limit=4096)
 add_compile_options(-Werror)
 
 # Disabled warnings
-add_compile_options(-Wno-unused-private-field)
 add_compile_options(-Wno-implicit-exception-spec-mismatch)
 # A derived class defines a virtual method with the same name as its base
 # class, but different set of parameters.

--- a/dac.cmake
+++ b/dac.cmake
@@ -6,4 +6,9 @@ if(WIN32)
     remove_definitions(-DPROFILING_SUPPORTED)
     add_definitions(-DPROFILING_SUPPORTED_DATA)
     add_definitions(-MT)
+else()
+	# In DAC builds, a lot of the private fields of structs and classes is not
+	# accessed. So we disable the warning here, real unused fields are detected
+	# during the non-DAC build.
+	add_compile_options(-Wno-unused-private-field)
 endif(WIN32)

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -5480,7 +5480,9 @@ CachedString Output::BuildManagedVarValue(__in_z LPCWSTR expansionName, ULONG fr
 }
 
 EnableDMLHolder::EnableDMLHolder(BOOL enable)
+#ifndef FEATURE_PAL
     : mEnable(enable)
+#endif // FEATURE_PAL
 {
 #ifndef FEATURE_PAL
     // If the user has not requested that we use DML, it's still possible that

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -152,7 +152,7 @@ const int nMaxHeapSegmentCount = 1000;
 
 class BaseObject
 {
-    MethodTable    *m_pMethTab;
+    MethodTable    *m_pMethTab UNUSED_ATTR;
 };
 
 
@@ -414,7 +414,9 @@ public:
     ~EnableDMLHolder();
 
 private:
+#ifndef FEATURE_PAL
     BOOL mEnable;
+#endif    
 };
 
 size_t CountHexCharacters(CLRDATA_ADDRESS val);
@@ -2847,7 +2849,7 @@ private:
     ULONG mPageSize, mCurrPageSize;
     BYTE *mPage;
     
-    int mMisses, mReads, mMisaligned;
+    int mMisses UNUSED_ATTR, mReads UNUSED_ATTR, mMisaligned;
 };
 
 

--- a/src/binder/inc/fusionassemblyname.hpp
+++ b/src/binder/inc/fusionassemblyname.hpp
@@ -53,7 +53,7 @@ private:
     LPWSTR       _pwzTextualIdentity;
     LPWSTR       _pwzTextualIdentityILFull;
 
-    DWORD _dw;
+    DWORD _dw UNUSED_ATTR;
 
 public:
     // IUnknown methods

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -5960,7 +5960,7 @@ private:
     //-----------------------------------------------------------
 private:
     // offset of the beginning of the last sequence point in the sequence point map
-    SIZE_T                   m_lastIL;
+    SIZE_T                   m_lastIL UNUSED_ATTR;
 
     // start address(es) and size(s) of hot and cold regions
     TargetBuffer             m_rgCodeRegions[MAX_REGIONS];

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -313,7 +313,7 @@ class TypeHandleDummyPtr
 {
 private:
     TypeHandleDummyPtr() { }; // should never actually create this.
-    void * data;
+    void * data UNUSED_ATTR;
 };
 
 // Convert: VMPTR_TYPEHANDLE --> TypeHandle

--- a/src/debug/inc/dbgtransportsession.h
+++ b/src/debug/inc/dbgtransportsession.h
@@ -613,7 +613,7 @@ private:
     // Some flags used to record how far we got in Init() (used for cleanup in Shutdown()).
     bool m_fInitStateLock;
 #ifndef RIGHT_SIDE_COMPILE
-    bool m_fInitWSA;
+    bool m_fInitWSA UNUSED_ATTR;
 #endif // !RIGHT_SIDE_COMPILE
 
     // Protocol version. This consists of two parts. The major version is incremented on incompatible protocol

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -963,7 +963,7 @@ class exclusive_sync
     
     int spin_count;
 
-    BYTE cache_separator[HS_CACHE_LINE_SIZE - sizeof (int) - sizeof (LONG)];
+    BYTE cache_separator[HS_CACHE_LINE_SIZE - sizeof (int) - sizeof (LONG)] UNUSED_ATTR;
 
     // TODO - perhaps each object should be on its own cache line...
     VOLATILE(BYTE*) alloc_objects[max_pending_allocs];

--- a/src/inc/clrhost.h
+++ b/src/inc/clrhost.h
@@ -601,7 +601,6 @@ extern void DecCantAllocCount();
 
 class CantAllocHolder
 {
-    BOOL m_bUseTLSCount;
 public:
     CantAllocHolder ()
     {

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -531,7 +531,7 @@ private:
 
 #ifdef _DEBUG
     GcInfoDecoderFlags m_Flags;
-    PTR_CBYTE m_GcInfoAddress;
+    PTR_CBYTE m_GcInfoAddress UNUSED_ATTR;
 #endif
 
 #ifdef VERIFY_GCINFO

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -598,6 +598,12 @@
 #define MAKEDLLNAME(x) MAKEDLLNAME_A(x)
 #endif
 
+#ifdef __GNUC__
+#define UNUSED_ATTR __attribute__((unused))
+#else  // __GNUC__
+#define UNUSED_ATTR
+#endif // __GNUC__
+
 #endif	// __PALCLR_H__
 
 #include "palclr_win.h"

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -4939,9 +4939,9 @@ public:
     }
 
 private:
-    TlsThreadTypeFlag m_flag;
-    BOOL m_fPreviouslySet;
-    INDEBUG(size_t m_nPreviousFlagGroup);
+    TlsThreadTypeFlag m_flag UNUSED_ATTR;
+    BOOL m_fPreviouslySet UNUSED_ATTR;
+    INDEBUG(size_t m_nPreviousFlagGroup UNUSED_ATTR);
 };
 
 class ClrFlsValueSwitch

--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -3993,7 +3993,7 @@ private:
     EXPSET_TP* mJumpDestOut;
     EXPSET_TP* mJumpDestGen;
 
-    Compiler* m_pCompiler;
+    Compiler* m_pCompiler UNUSED_ATTR; // TODO: remove it completely?
 
 public:
     AssertionPropFlowCallback(Compiler* pCompiler, EXPSET_TP* jumpDestOut, EXPSET_TP* jumpDestGen)

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -1225,6 +1225,12 @@ template< class T >
 typename std::remove_reference<T>::type&& move( T&& t );
 #endif // __cplusplus
 
+#ifdef __GNUC__
+#define UNUSED_ATTR __attribute__((unused))
+#else  // __GNUC__
+#define UNUSED_ATTR
+#endif // __GNUC__
+
 #define __RPC__out
 #define __RPC__in
 #define __RPC__deref_out_opt

--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -793,7 +793,7 @@ public:
 
 private:
     ThreadStaticHandleBucket *m_pNext;
-    int m_ArraySize;
+    int m_ArraySize UNUSED_ATTR;
     OBJECTHANDLE m_hndHandleArray;
 };
 

--- a/src/vm/constrainedexecutionregion.h
+++ b/src/vm/constrainedexecutionregion.h
@@ -422,10 +422,10 @@ class MethodCallGraphPreparer
     DWORD               m_cEHClauses;           // Number of elements in above array
     CerPrepInfo        *m_pCerPrepInfo;         // Context recording how much preparation this region has had
     MethodContextStack  m_sPersist;             // MethodContexts we need to keep around past the 'prepare' phase of preparation
-#ifdef FEATURE_PREJIT
+#if defined(FEATURE_PREJIT) && defined(FEATURE_NATIVE_IMAGE_GENERATION)
     bool                m_fNgen;                // True when being called as part of an ngen
     MethodContextStack  m_sRootMethods;         // Methods containing a sub-CER (excludes the real root)
-#endif
+#endif // FEATURE_PREJIT && FEATURE_NATIVE_IMAGE_GENERATION
     Thread             *m_pThread;              // Cached managed thread pointer (for allocations and the like)
     bool                m_fPartialPreparation;  // True if we have unbound type vars at the CER root and can only prep one instantiation at a time
 

--- a/src/vm/dllimport.h
+++ b/src/vm/dllimport.h
@@ -773,7 +773,6 @@ private:
     MethodDesc*                      m_pTargetMD;
     NDirectStubParameters*           m_pParams;
     NewArrayHolder<ILStubHashBlob>   m_pHashParams;
-    AllocMemTracker*                 m_pAmTracker;
     MethodDesc*                      m_pStubMD;
     AllocMemTracker                  m_amTracker;
     bool                             m_bILStubCreator;     // Only the creator can remove the ILStub from the Cache

--- a/src/vm/fieldmarshaler.h
+++ b/src/vm/fieldmarshaler.h
@@ -169,7 +169,7 @@ struct LayoutRawFieldInfo
     struct
     {
         private:
-            char m_space[MAXFIELDMARSHALERSIZE];
+            char m_space[MAXFIELDMARSHALERSIZE] UNUSED_ATTR;
     } m_FieldMarshaler;
 };
 

--- a/src/vm/gcstress.h
+++ b/src/vm/gcstress.h
@@ -59,12 +59,6 @@ namespace GCStressPolicy
 
 #ifdef STRESS_HEAP
 
-#ifdef __GNUC__
-#define UNUSED_ATTR __attribute__ ((unused))
-#else  // __GNUC__
-#define UNUSED_ATTR
-#endif // __GNUC__
-
 #ifndef __UNUSED
 #define __UNUSED(x) ((void)(x))
 #endif // __UNUSED

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -2358,7 +2358,7 @@ class FCallMethodDesc : public MethodDesc
 
     DWORD   m_dwECallID;
 #ifdef _WIN64 
-    DWORD   m_padding;
+    DWORD   m_padding UNUSED_ATTR;
 #endif
 
 public:

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -157,7 +157,7 @@ class MethodDataCache
     UINT32 m_iLastTouched;
 
 #ifdef _WIN64
-    UINT32 pad;      // insures that we are a multiple of 8-bytes
+    UINT32 pad UNUSED_ATTR;      // insures that we are a multiple of 8-bytes
 #endif
 };  // class MethodDataCache
 

--- a/src/vm/mlinfo.h
+++ b/src/vm/mlinfo.h
@@ -799,7 +799,9 @@ private:
     BOOL            m_fAnsi;
     BOOL            m_fDispItf;
     BOOL            m_fInspItf;
+#ifdef FEATURE_COMINTEROP
     BOOL            m_fErrorNativeType;
+#endif // FEATURE_COMINTEROP
 
     // Information used by NT_CUSTOMMARSHALER.
     CustomMarshalerHelper* m_pCMHelper;

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -1844,21 +1844,21 @@ class CultureInfoBaseObject : public Object
     friend class MscorlibBinder;
 
 private:
-    OBJECTREF compareInfo;
-    OBJECTREF textInfo;
+    OBJECTREF compareInfo UNUSED_ATTR;
+    OBJECTREF textInfo UNUSED_ATTR;
 #ifndef FEATURE_CORECLR
     OBJECTREF regionInfo;
 #endif // !FEATURE_CORECLR
-    OBJECTREF numInfo;
-    OBJECTREF dateTimeInfo;
-    OBJECTREF calendar;
-    OBJECTREF m_cultureData;
+    OBJECTREF numInfo UNUSED_ATTR;
+    OBJECTREF dateTimeInfo UNUSED_ATTR;
+    OBJECTREF calendar UNUSED_ATTR;
+    OBJECTREF m_cultureData UNUSED_ATTR;
 #ifndef FEATURE_CORECLR
     OBJECTREF m_consoleFallbackCulture;
 #endif // !FEATURE_CORECLR
     STRINGREF m_name;                       // "real" name - en-US, de-DE_phoneb or fj-FJ
-    STRINGREF m_nonSortName;                // name w/o sort info (de-DE for de-DE_phoneb)
-    STRINGREF m_sortName;                   // Sort only name (de-DE_phoneb, en-us for fj-fj (w/us sort)
+    STRINGREF m_nonSortName UNUSED_ATTR;    // name w/o sort info (de-DE for de-DE_phoneb)
+    STRINGREF m_sortName UNUSED_ATTR;       // Sort only name (de-DE_phoneb, en-us for fj-fj (w/us sort)
     CULTUREINFOBASEREF m_parent;
 #if !FEATURE_CORECLR
     INT32    iDataItem;                     // NEVER USED, DO NOT USE THIS! (Serialized in Whidbey/Everett)
@@ -1867,8 +1867,8 @@ private:
 #ifdef FEATURE_LEAK_CULTURE_INFO
     INT32 m_createdDomainID;
 #endif // FEATURE_LEAK_CULTURE_INFO
-    CLR_BOOL m_isReadOnly;
-    CLR_BOOL m_isInherited;
+    CLR_BOOL m_isReadOnly UNUSED_ATTR;
+    CLR_BOOL m_isInherited UNUSED_ATTR;
 #ifdef FEATURE_LEAK_CULTURE_INFO
     CLR_BOOL m_isSafeCrossDomain;
 #endif // FEATURE_LEAK_CULTURE_INFO
@@ -2291,22 +2291,22 @@ class ContextBaseObject : public Object
     // Modifying the order or fields of this object may require other changes to the
     //  classlib class definition of this object.
 
-    OBJECTREF m_ctxProps;   // array of name-value pairs of properties
-    OBJECTREF m_dphCtx;     // dynamic property holder
-    OBJECTREF m_localDataStore; // context local store
-    OBJECTREF m_serverContextChain; // server context sink chain
-    OBJECTREF m_clientContextChain; // client context sink chain
-    OBJECTREF m_exposedAppDomain;       //appDomain ??
-    PTRARRAYREF m_ctxStatics; // holder for context relative statics
+    OBJECTREF m_ctxProps UNUSED_ATTR;           // array of name-value pairs of properties
+    OBJECTREF m_dphCtx UNUSED_ATTR;             // dynamic property holder
+    OBJECTREF m_localDataStore UNUSED_ATTR;     // context local store
+    OBJECTREF m_serverContextChain UNUSED_ATTR; // server context sink chain
+    OBJECTREF m_clientContextChain UNUSED_ATTR; // client context sink chain
+    OBJECTREF m_exposedAppDomain;               //appDomain ??
+    PTRARRAYREF m_ctxStatics;                   // holder for context relative statics
     
-    Context*  m_internalContext;            // Pointer to the VM context
+    Context*  m_internalContext;                // Pointer to the VM context
 
-    INT32 _ctxID;
-    INT32 _ctxFlags;
-    INT32 _numCtxProps;     // current count of properties
+    INT32 _ctxID UNUSED_ATTR;
+    INT32 _ctxFlags UNUSED_ATTR;
+    INT32 _numCtxProps UNUSED_ATTR;             // current count of properties
 
-    INT32 _ctxStaticsCurrentBucket;
-    INT32 _ctxStaticsFreeIndex;
+    INT32 _ctxStaticsCurrentBucket UNUSED_ATTR;
+    INT32 _ctxStaticsFreeIndex UNUSED_ATTR;
 
   protected:
     ContextBaseObject() { LIMITED_METHOD_CONTRACT; }
@@ -3132,12 +3132,12 @@ protected:
 
 private:
     OBJECTREF       _tp;
-    OBJECTREF       _identity;
-    OBJECTREF       _serverObject;
-    DWORD           _flags;
+    OBJECTREF       _identity UNUSED_ATTR;
+    OBJECTREF       _serverObject UNUSED_ATTR;
+    DWORD           _flags UNUSED_ATTR;
     DWORD           _optFlags;
     DWORD           _domainID;
-    OBJECTHANDLE    _srvIdentity;
+    OBJECTHANDLE    _srvIdentity UNUSED_ATTR;
 };
 
 #ifdef USE_CHECKED_OBJECTREFS
@@ -3674,7 +3674,7 @@ class ReflectClassBaseObject;
 class SafeBuffer : SafeHandle
 {
   private:
-    size_t m_numBytes;
+    size_t m_numBytes UNUSED_ATTR;
 
   public:
     static FCDECL1(UINT, SizeOfType, ReflectClassBaseObject* typeUNSAFE);
@@ -3730,20 +3730,20 @@ public:
     // If you modify the order of these fields, make sure to update the definition in 
     // BCL for this object.
 private:
-    OBJECTREF _userCallback;
-    OBJECTREF _userStateObject;
+    OBJECTREF _userCallback UNUSED_ATTR;
+    OBJECTREF _userStateObject UNUSED_ATTR;
 
     WAITHANDLEREF _waitHandle;
-    SAFEHANDLEREF _fileHandle;     // For cancellation.
-    LPOVERLAPPED  _overlapped;
-    int _EndXxxCalled;             // Whether we've called EndXxx already.
-    int _numBytes;                 // number of bytes read OR written
+    SAFEHANDLEREF _fileHandle UNUSED_ATTR;      // For cancellation.
+    LPOVERLAPPED  _overlapped UNUSED_ATTR;
+    int _EndXxxCalled UNUSED_ATTR;              // Whether we've called EndXxx already.
+    int _numBytes;                              // number of bytes read OR written
     int _errorCode;
-    int _numBufferedBytes;
+    int _numBufferedBytes UNUSED_ATTR;
 
-    CLR_BOOL _isWrite;                 // Whether this is a read or a write
+    CLR_BOOL _isWrite UNUSED_ATTR;              // Whether this is a read or a write
     CLR_BOOL _isComplete;
-    CLR_BOOL _completedSynchronously;  // Which thread called callback
+    CLR_BOOL _completedSynchronously;           // Which thread called callback
 };
 
 #ifdef USE_CHECKED_OBJECTREFS
@@ -3854,17 +3854,17 @@ private:
     // to access the fields directly from unmanaged code given an OBJECTREF. 
     // Please keep them in sync when you make changes to the fields. 
     OBJECTREF _permSet;
-    STRINGREF _serializedPermissionSet;
-    OBJECTREF _permSetSaved;
-    OBJECTREF _unrestrictedPermSet;
-    OBJECTREF _normalPermSet;
+    STRINGREF _serializedPermissionSet UNUSED_ATTR;
+    OBJECTREF _permSetSaved UNUSED_ATTR;
+    OBJECTREF _unrestrictedPermSet UNUSED_ATTR;
+    OBJECTREF _normalPermSet UNUSED_ATTR;
     CLR_BOOL _Unrestricted;
     CLR_BOOL _allPermissionsDecoded;
-    CLR_BOOL _ignoreTypeLoadFailures;
+    CLR_BOOL _ignoreTypeLoadFailures UNUSED_ATTR;
     CLR_BOOL _CheckedForNonCas;
     CLR_BOOL _ContainsCas;
     CLR_BOOL _ContainsNonCas;
-    CLR_BOOL _Readable;
+    CLR_BOOL _Readable UNUSED_ATTR;
 #ifdef FEATURE_CAS_POLICY
     CLR_BOOL _canUnrestrictedOverride;
 #endif // FEATURE_CAS_POLICY
@@ -3893,13 +3893,13 @@ public:
 private:
     // If you modify the order of these fields, make sure
     // to update the definition in BCL for this object.
-    OBJECTREF _objSet;
+    OBJECTREF _objSet UNUSED_ATTR;
     OBJECTREF _Obj;
-    OBJECTREF _Set;
-    INT32 _initSize;
-    INT32 _increment;
+    OBJECTREF _Set UNUSED_ATTR;
+    INT32 _initSize UNUSED_ATTR;
+    INT32 _increment UNUSED_ATTR;
     INT32 _cElt;
-    INT32 _maxIndex;
+    INT32 _maxIndex UNUSED_ATTR;
 };
 
 #ifdef USE_CHECKED_OBJECTREFS
@@ -3917,7 +3917,7 @@ private:
 #ifdef FEATURE_CAS_POLICY
     OBJECTREF _dependentEvidence;
 #endif // FEATURE_CAS_POLICY
-    INT32 _attributes;
+    INT32 _attributes UNUSED_ATTR;
 
 public:
     PERMISSIONSETREF GetPermissionSet()
@@ -3943,7 +3943,7 @@ private:
     OBJECTREF _elExtraInfo;
 #endif // FEATURE_CLICKONCE
     POLICYSTATEMENTREF _psDefaultGrant;
-    OBJECTREF _fullTrustAssemblies;
+    OBJECTREF _fullTrustAssemblies UNUSED_ATTR;
     DWORD _grantSetSpecialFlags;
 #ifdef FEATURE_CLICKONCE
     CLR_BOOL _appTrustedToRun;
@@ -4517,8 +4517,8 @@ public:
 private:
     // keep these in sync with ndp/clr/src/bcl/system/diagnostics/contracts/contractsbcl.cs
     IN_WIN64(INT32 _Kind;)
-    STRINGREF _UserMessage;
-    STRINGREF _Condition;
+    STRINGREF _UserMessage UNUSED_ATTR;
+    STRINGREF _Condition UNUSED_ATTR;
     IN_WIN32(INT32 _Kind;)
 };
 #include "poppack.h"

--- a/src/vm/securitydescriptor.h
+++ b/src/vm/securitydescriptor.h
@@ -91,8 +91,10 @@ protected:
     LoaderAllocator *m_pLoaderAllocator;
 
 private:
+#ifndef CROSSGEN_COMPILE
     LOADERHANDLE m_hGrantedPermissionSet;   // Granted Permission
     LOADERHANDLE m_hGrantDeniedPermissionSet;// Specifically Denied Permissions
+#endif // CROSSGEN_COMPILE
 	
 public:
     BOOL IsFullyTrusted();

--- a/src/vm/securitydescriptor.inl
+++ b/src/vm/securitydescriptor.inl
@@ -50,9 +50,11 @@ inline SecurityDescriptor::SecurityDescriptor(AppDomain *pAppDomain,
     m_fEvidenceComputed(FALSE),
 #endif // FEATURE_CAS_POLICY
     m_dwSpecialFlags(0),
-    m_pLoaderAllocator(pLoaderAllocator),
-    m_hGrantedPermissionSet(NULL),
+    m_pLoaderAllocator(pLoaderAllocator)
+#ifndef CROSSGEN_COMPILE
+    , m_hGrantedPermissionSet(NULL),
     m_hGrantDeniedPermissionSet(NULL)
+#endif // CROSSGEN_COMPILE
 {
     LIMITED_METHOD_CONTRACT;
 }

--- a/src/vm/stackwalk.h
+++ b/src/vm/stackwalk.h
@@ -680,7 +680,6 @@ private:
     // the following fields are used to cache information about a managed stack frame 
     // when we need to stop for skipped explicit frames
     EECodeInfo     m_cachedCodeInfo;
-    PTR_VOID       m_pCachedGCInfo;
 
     GSCookie *     m_pCachedGSCookie;
 

--- a/src/vm/win32threadpool.h
+++ b/src/vm/win32threadpool.h
@@ -126,7 +126,7 @@ class ThreadpoolMgr
     private:
 
         // padding to ensure we get our own cache line
-        BYTE padding1[64];
+        BYTE padding1[64] UNUSED_ATTR;
 
         //
         // We track everything we care about in a single 64-bit struct to allow us to 
@@ -150,7 +150,7 @@ class ThreadpoolMgr
         CLRSemaphore m_sem;  //waiters wait on this
 
         // padding to ensure we get our own cache line
-        BYTE padding2[64];
+        BYTE padding2[64] UNUSED_ATTR;
 
         INDEBUG(int m_maxCount;)
 
@@ -1003,11 +1003,11 @@ public:
     //
     class RecycledListsWrapper
     {
-        DWORD                        CacheGuardPre[64/sizeof(DWORD)];
+        DWORD                        CacheGuardPre[64/sizeof(DWORD)] UNUSED_ATTR;
         
         RecycledListInfo            (*pRecycledListPerProcessor)[MEMTYPE_COUNT];  // RecycledListInfo [numProc][MEMTYPE_COUNT]
 
-        DWORD                        CacheGuardPost[64/sizeof(DWORD)];
+        DWORD                        CacheGuardPost[64/sizeof(DWORD)] UNUSED_ATTR;
 
     public:
         void Initialize( unsigned int numProcs );

--- a/src/zap/zapcode.h
+++ b/src/zap/zapcode.h
@@ -228,7 +228,7 @@ public:
         BOOL GetNext(CORINFO_METHOD_HANDLE *pHnd);
 
     private:
-        ZapMethodHeader* m_pMethod;
+        ZapMethodHeader* m_pMethod UNUSED_ATTR;
         ZapReloc* m_pCurReloc;
     };
 
@@ -927,7 +927,7 @@ private:
 //
 class ZapProfileData : public ZapNode
 {
-    ZapMethodHeader *          m_pMethod;
+    ZapMethodHeader *          m_pMethod UNUSED_ATTR;
     ZapProfileData *           m_pNext;
 
 public:


### PR DESCRIPTION
The warning is fixed mostly by adding __attribute__((unused)) to the
unused private fields. In most cases, these fields are either paddings or
members of structs / classes that have a managed counterpart and
need to match its layout or seems to serve for debugging purposes.
Several places are fixed by conditionally ifdefing-out the members.

For DAC build though, the warning is left disabled since a large
amount of classes have their members unused in the DAC build, which
is ok.