### PR TITLE
Implement FlushProcessWriteBuffers using the page protection mechanism

### DIFF
--- a/src/pal/src/include/pal/process.h
+++ b/src/pal/src/include/pal/process.h
@@ -152,6 +152,17 @@ Function:
 --*/
 void PROCCleanupProcess(BOOL bTerminateUnconditionally);
 
+/*++
+Function:
+  InitializeFlushProcessWriteBuffers
+
+Abstract
+  This function initializes data structures needed for the FlushProcessWriteBuffers
+Return
+  TRUE if it succeeded, FALSE otherwise
+--*/
+BOOL InitializeFlushProcessWriteBuffers();
+
 #if HAVE_MACH_EXCEPTIONS
 /*++
 Function:

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -670,6 +670,11 @@ PAL_InitializeCoreCLR(
         return ERROR_DLL_INIT_FAILED;
     }
 
+    if (!InitializeFlushProcessWriteBuffers())
+    {
+        return ERROR_GEN_FAILURE;
+    }
+
     if (!fStayInPAL)
     {
         PAL_Leave(PAL_BoundaryTop);


### PR DESCRIPTION
Changing a helper memory page protection from read / write to no access
causes the OS to issue IPI to flush TLBs on all processors. This also
results in flushing the processor buffers.