### PR TITLE
Fix exitCode from ExecuteAssembly

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -290,6 +290,7 @@ int ExecuteManagedAssembly(
             if (!SUCCEEDED(st))
             {
                 fprintf(stderr, "ExecuteAssembly failed - status: 0x%08x\n", st);
+                exitCode = -1;
             }
         }
         else

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -124,7 +124,11 @@ HRESULT ExecuteAssembly(
             LPCSTR entryPointMethodName,
             DWORD* exitCode)
 {
-    *exitCode = 0;
+    if (exitCode == NULL)
+    {
+        return HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER);
+    }
+    *exitCode = -1;
 
     DWORD error = PAL_InitializeCoreCLR(exePath, coreClrPath, true);
     HRESULT hr = HRESULT_FROM_WIN32(error);


### PR DESCRIPTION
ExecuteAssembly is initializing exitCode to 0 on entrance to the function.  If it then fails prior to exitCode being set when invoking the entry point, the exitCode remains 0 even though there was a failure, and corerun ends up returning a successful exit code.

This was causing problems in the corefx CI builds, where it was masking another issue that was causing the build to break.