### PR TITLE
Add missing EnsureOpenSslInitialized to the export list of coreclr

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -12,6 +12,7 @@ CreateSemaphoreW
 DeleteFileW
 DllMain
 DuplicateHandle
+EnsureOpenSslInitialized
 ExecuteAssembly
 FindClose
 FindFirstFileW


### PR DESCRIPTION
Hotfix to an issue discovered after the list of export was added