### PR TITLE
Initialize signal-handling thread in PAL initialization

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -442,8 +442,8 @@ typedef long time_t;
 #define PAL_INITIALIZE_SYNC_THREAD     0x01
 #define PAL_INITIALIZE_SIGNAL_THREAD   0x02
 
-// PAL_Initialize() flags - do not initialize signal thread (used for ctrl-c handling) for now
-#define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD     
+// PAL_Initialize() flags
+#define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD | PAL_INITIALIZE_SIGNAL_THREAD
 
 // PAL_InitializeDLL() flags - don't start any of the helper threads
 #define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE       


### PR DESCRIPTION
Without this, ctrl-C will not interrupt a program, nor will Console.CancelKeyPress in corefx work.

Fixes #1094 