### PR TITLE
Fix SIGINT and SIGQUIT handling on Linux / FreeBSD

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -449,10 +449,9 @@ typedef long time_t;
 
 #define PAL_INITIALIZE_NONE            0x00
 #define PAL_INITIALIZE_SYNC_THREAD     0x01
-#define PAL_INITIALIZE_SIGNAL_THREAD   0x02
 
 // PAL_Initialize() flags
-#define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD | PAL_INITIALIZE_SIGNAL_THREAD
+#define PAL_INITIALIZE                 PAL_INITIALIZE_SYNC_THREAD
 
 // PAL_InitializeDLL() flags - don't start any of the helper threads
 #define PAL_INITIALIZE_DLL             PAL_INITIALIZE_NONE       

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -70,12 +70,6 @@ int t_holderCount = 0;
 
 BOOL SEHInitializeConsole();
 
-#if !HAVE_MACH_EXCEPTIONS
-PAL_ERROR
-StartExternalSignalHandlerThread(
-    CPalThread *pthr);
-#endif // !HAVE_MACH_EXCEPTIONS
-
 /* Internal function definitions **********************************************/
 
 /*++
@@ -106,17 +100,6 @@ SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
 
 #if !HAVE_MACH_EXCEPTIONS
     SEHInitializeSignals();
-
-    if (flags & PAL_INITIALIZE_SIGNAL_THREAD)
-    {
-        PAL_ERROR palError = StartExternalSignalHandlerThread(pthrCurrent);
-        if (NO_ERROR != palError)
-        {
-            ERROR("StartExternalSignalHandlerThread returned %d\n", palError);
-            SEHCleanup();
-            goto SEHInitializeExit;
-        }
-    }
 #endif
     bRet = TRUE;
 

--- a/src/pal/src/include/pal/seh.hpp
+++ b/src/pal/src/include/pal/seh.hpp
@@ -25,9 +25,6 @@ Abstract:
 #include "pal/palinternal.h"
 #include "pal/corunix.hpp"
 
-// Uncomment this define to turn off the signal handling thread.
-// #define DO_NOT_USE_SIGNAL_HANDLING_THREAD
-
 /*++
 Function :
     SEHInitialize

--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -1293,14 +1293,11 @@ CThreadSuspensionInfo::InitializeSignalSets()
 #if !HAVE_MACH_EXCEPTIONS
     sigemptyset(&smDefaultmask);
     
-#ifndef DO_NOT_USE_SIGNAL_HANDLING_THREAD
     // The default signal mask masks all common signals except those that represent 
     // synchronous exceptions in the PAL or are used by the system (e.g. SIGPROF on BSD).
     // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a 
     // significant reduction in performance.
     sigaddset(&smDefaultmask, SIGHUP);  
-    sigaddset(&smDefaultmask, SIGINT);
-    sigaddset(&smDefaultmask, SIGQUIT); 
     sigaddset(&smDefaultmask, SIGABRT); 
 #ifdef SIGEMT
     sigaddset(&smDefaultmask, SIGEMT); 
@@ -1332,20 +1329,9 @@ CThreadSuspensionInfo::InitializeSignalSets()
         sigaddset(&smDefaultmask, SIGUSR1);
     }
     #endif // !USE_SIGNALS_FOR_THREAD_SUSPENSION
-#endif // DO_NOT_USE_SIGNAL_HANDLING_THREAD
 #endif // !HAVE_MACH_EXCEPTIONS
 
 #if USE_SIGNALS_FOR_THREAD_SUSPENSION
-#if !HAVE_MACH_EXCEPTIONS
-    #ifdef DO_NOT_USE_SIGNAL_HANDLING_THREAD
-    {
-        // If the SWT is turned on, SIGUSR2 was already added to the mask. 
-        // Otherwise, add it to the mask now.
-        sigaddset(&smDefaultmask, SIGUSR2);
-    }
-    #endif
-#endif // !HAVE_MACH_EXCEPTIONS
-
     // smContmask is used to allow a thread to accept a SIGUSR1 when in sigsuspend, 
     // after a pending suspension
     sigfillset(&smContmask);


### PR DESCRIPTION
This change changes the way the SIGINT and SIGQUIT are handled. First, it
makes sure that when the signal is not handled, we call the default signal
handler that takes care of the proper default behavior.
And second, it makes debugging experience better. Before, we had a thread
that was waiting for these signals and then spawning a console event handling
thread. That caused the signals to be detected in that thread even when
running under the debugger, effectively making ctrl-c break-in unusable, since
an attempt to continue after the ctrl-c caused the process to exit.
I've changed it so that the SIGINT and SIGQUIT call signal handlers and those
handlers then spawn a helper thread to handle the console event.
This enables the debugger to take over the signal handling properly.
I had to use a plain pthread insted of creating a PAL thread to make sure
there is no danger of a deadlock in case the original thread was interrupted
while holding a lock that the PAL thread creation use.