### PR TITLE
Fix SIGINT and SIGQUIT handling on Linux / FreeBSD

### DIFF
--- a/src/pal/src/exception/console.cpp
+++ b/src/pal/src/exception/console.cpp
@@ -253,8 +253,9 @@ Parameters :
 
 Notes :
     Handlers are called on a last-installed, first called basis, until a
-    handler returns TRUE. If no handler returns TRUE (or no hanlder is
-    installed), the default behavior is to call TerminateProcess
+    handler returns TRUE. If no handler returns TRUE (or no handler is
+    installed), the default behavior is to call the default handler of
+    the corresponding signal.
 --*/
 void SEHHandleControlEvent(DWORD event, LPVOID eip)
 {
@@ -369,17 +370,28 @@ done:
 #endif
     if(!fHandled)
     {
+        int signalCode;
+
         if(CTRL_C_EVENT == event)
         {
             TRACE("Control-C not handled; terminating.\n");
+            signalCode = SIGINT;
         }
         else
         {
             TRACE("Control-Break not handled; terminating.\n");
+            signalCode = SIGQUIT;
         }
-        /* tested in Win32 : this is the exit code when ^C and ^Break are not 
-           handled */
-        TerminateProcess(GetCurrentProcess(),CONTROL_C_EXIT);
+        
+        // The proper behavior for unhandled SIGINT/SIGQUIT is to set the signal handler to the default one
+        // and then send the SIGINT/SIGQUIT to self and let the default handler do its work.
+        struct sigaction action;
+        action.sa_handler = SIG_DFL;
+        action.sa_flags = 0;
+        sigemptyset(&action.sa_mask);
+        sigaction(signalCode, &action, NULL);
+
+        kill(getpid(), signalCode);    
     }
 }
 

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -105,7 +105,12 @@ SEHInitialize (CPalThread *pthrCurrent, DWORD flags)
     }
 
 #if !HAVE_MACH_EXCEPTIONS
-    SEHInitializeSignals();
+    if (!SEHInitializeSignals())
+    {
+        ERROR("SEHInitializeSignals failed!\n");
+        SEHCleanup();
+        goto SEHInitializeExit;
+    }
 
     if (flags & PAL_INITIALIZE_SIGNAL_THREAD)
     {

--- a/src/pal/src/exception/signal.hpp
+++ b/src/pal/src/exception/signal.hpp
@@ -32,9 +32,10 @@ Function :
 Parameters :
     None
 
-    (no return value)
+Return :
+    TRUE in case of a success, FALSE otherwise
 --*/
-void SEHInitializeSignals();
+BOOL SEHInitializeSignals();
 
 /*++
 Function :

--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -1299,8 +1299,6 @@ CThreadSuspensionInfo::InitializeSignalSets()
     // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a 
     // significant reduction in performance.
     sigaddset(&smDefaultmask, SIGHUP);  
-    sigaddset(&smDefaultmask, SIGINT);
-    sigaddset(&smDefaultmask, SIGQUIT); 
     sigaddset(&smDefaultmask, SIGABRT); 
 #ifdef SIGEMT
     sigaddset(&smDefaultmask, SIGEMT); 


### PR DESCRIPTION
This change changes the way the SIGINT and SIGQUIT are handled. First, it
makes sure that when the signal is not handled, we call the default signal
handler that takes care of the proper default behavior.
And second, it makes debugging experience better. Before, in the external events
handler thread we were waiting for these signals and then spawning a console event
handling thread. That caused the signals to be detected in that thread even when
running under the debugger, effectively making ctrl-c break-in unusable, since
an attempt to continue after the ctrl-c caused the process to exit.
I have modified it so that the SIGINT and SIGQUIT are now handled by regular signal
handlers and use pipe to notify the external events handler thread about the
events. That way, the debugger has a chance to swallow the SIGINT signal and work
as expected.