### PR TITLE
build,freebsd: Adds freebsdmscorlib to build.cmd

### DIFF
--- a/Documentation/freebsd-instructions.md
+++ b/Documentation/freebsd-instructions.md
@@ -95,10 +95,10 @@ We don't _yet_ have support for building managed code on FreeBSD, so you'll need
 You will build `mscorlib.dll` out of the coreclr repository and the rest of the framework that out of the corefx repository.  For mscorlib (from a regular command prompt window) run:
 
 ```
-D:\git\coreclr> build.cmd linuxmscorlib
+D:\git\coreclr> build.cmd freebsdmscorlib
 ```
 
-The output is placed in `bin\Product\Linux.x64.Debug\mscorlib.dll`.  You'll want to copy this to the runtime folder on your FreeBSD machine. (e.g. `~/coreclr-demo/runtime`)
+The output is placed in `bin\Product\FreeBSD.x64.Debug\mscorlib.dll`.  You'll want to copy this to the runtime folder on your FreeBSD machine. (e.g. `~/coreclr-demo/runtime`)
 
 For the rest of the framework, you need to pass some special parameters to build.cmd when building out of the CoreFX repository.
 

--- a/build.cmd
+++ b/build.cmd
@@ -31,9 +31,10 @@ if /i "%1" == "release"   (set __BuildType=Release&shift&goto Arg_Loop)
 
 if /i "%1" == "clean"   (set __CleanBuild=1&shift&goto Arg_Loop)
 
-if /i "%1" == "windowsmscorlib" (set __MscorlibOnly=1&set __BuildOS=Windows_NT&shift&goto Arg_Loop)
+if /i "%1" == "freebsdmscorlib" (set __MscorlibOnly=1&set __BuildOS=FreeBSD&shift&goto Arg_Loop)
 if /i "%1" == "linuxmscorlib" (set __MscorlibOnly=1&set __BuildOS=Linux&shift&goto Arg_Loop)
 if /i "%1" == "osxmscorlib" (set __MscorlibOnly=1&set __BuildOS=OSX&shift&goto Arg_Loop)
+if /i "%1" == "windowsmscorlib" (set __MscorlibOnly=1&set __BuildOS=Windows_NT&shift&goto Arg_Loop)
 
 if /i "%1" == "vs2013" (set __VSVersion=%1&set __VSProductVersion=120&shift&goto Arg_Loop)
 if /i "%1" == "vs2015" (set __VSVersion=%1&set __VSProductVersion=140&shift&goto Arg_Loop)

--- a/dir.props
+++ b/dir.props
@@ -58,11 +58,12 @@
 
   <!-- Setup common target properties that we use to conditionally include sources -->
   <PropertyGroup>
-    <TargetsWindows Condition="'$(BuildOS)' == 'Windows_NT'">true</TargetsWindows>
+    <TargetsFreeBSD Condition="'$(BuildOS)' == 'FreeBSD'">true</TargetsFreeBSD>
     <TargetsLinux Condition="'$(BuildOS)' == 'Linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(BuildOS)' == 'OSX'">true</TargetsOSX>
-
-    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true'">true</TargetsUnix>
+    <TargetsWindows Condition="'$(BuildOS)' == 'Windows_NT'">true</TargetsWindows>
+    
+    <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true'">true</TargetsUnix>
   </PropertyGroup>
   
   <!-- Common NuGet properties -->


### PR DESCRIPTION
FreeBSD is yet to be supported by CoreFX build system. 
However in CoreCLR, FreeBSD support is (almost) on a par with that of Linux, OSX and Windows.
This commit updates the build script and associated docs.

FYI @josteink, @saper