### PR TITLE
Build, Windows: Use Config instead of Build Type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,9 +254,7 @@ add_compile_options(/wd4960 /wd4961 /wd4603 /wd4627 /wd4838 /wd4456 /wd4457 /wd4
 add_compile_options(/O1) # minimize space
 add_compile_options(/Zi) # enable debugging information
 
-if (CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL Relwithdebinfo)
-  add_compile_options(/GL) # enable WholeProgramOptimization
-endif ()
+add_compile_options($<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/GL>)
 
 if (IS_64BIT_BUILD EQUAL 1)
 # The generator expression in the following command means that the /homeparams option is added only for debug builds

--- a/build.cmd
+++ b/build.cmd
@@ -147,7 +147,7 @@ exit /b 1
 :GenVSSolution
 :: Regenerate the VS solution
 pushd "%__IntermediatesDir%"
-call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion% %__BuildType%
+call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion%
 popd
 
 :BuildComponents

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -68,17 +68,11 @@ if(WIN32)
     # mscordac.def should be generated before mscordaccore.dll is built
     add_dependencies(mscordaccore mscordaccore_def)
 
-    set(LTCG_FLAG "")
-    if (CMAKE_BUILD_TYPE STREQUAL Release OR CMAKE_BUILD_TYPE STREQUAL Relwithdebinfo)
-        set(LTCG_FLAG "/LTCG")
-    endif()
-
     # Generate export file
     add_custom_command(TARGET mscordaccore
         PRE_LINK
-        COMMAND lib.exe ${LTCG_FLAG} /OUT:${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.lib /DEF:${CMAKE_CURRENT_BINARY_DIR}/mscordac.def $<TARGET_FILE:daccess> ${STATIC_LIBRARY_FLAGS} ${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.dir/$<CONFIG>/mscordac.obj
+        COMMAND lib.exe /OUT:"${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.lib" /DEF:"${CMAKE_CURRENT_BINARY_DIR}/mscordac.def" "$<TARGET_FILE:daccess>" $<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/LTCG> ${STATIC_LIBRARY_FLAGS} "${CMAKE_CURRENT_BINARY_DIR}/mscordaccore.dir/$<CONFIG>/mscordac.obj"
         COMMENT "Generating mscordaccore.exp export file"
-        VERBATIM
     )
 
     set(COREDAC_LIBRARIES

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==3 GOTO :USAGE
+if NOT %argC%==2 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -24,13 +24,13 @@ if defined CMakePath goto DoGen
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& .\probe-win.ps1"') do %%a
 
 :DoGen
-"%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" "-DCMAKE_BUILD_TYPE=%3" -G "Visual Studio %__VSString% Win64" %1
+"%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" -G "Visual Studio %__VSString% Win64" %1
 endlocal
 GOTO :DONE
 
 :USAGE
   echo "Usage..."
-  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion> <BuildType>"
+  echo "gen-buildsys-win.bat <path to top level CMakeLists.txt> <VSVersion>"
   echo "Specify the path to the top level CMake file - <ProjectK>/src/NDP"
   echo "Specify the VSVersion to be used - VS2013 or VS2015"
   EXIT /B 1

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -118,7 +118,7 @@ exit /b 1
 :GenVSSolution
 :: Regenerate the VS solution
 pushd "%__NativeTestIntermediatesDir%"
-call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectFilesDir%\" %__VSVersion% %__BuildType%
+call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectFilesDir%\" %__VSVersion%
 popd
 
 :BuildComponents


### PR DESCRIPTION
CMAKE_BUILD_TYPE should not be used with multi-configuration toolsets like Visual Studio. This commit removes the dependence of the Windows build on CMAKE_BUILD_TYPE.

See [this](https://github.com/dotnet/coreclr/pull/1111#commitcomment-11562822) for more information.