### PR TITLE
Add JIT/Regression/CLR-x86-JIT/V1-M09 test cases for JIT

### DIFF
--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/b13170.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/b13170.cs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+/**
+ * A simple Com+ application.
+ */
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class SafeCStep
+    {
+        /**
+         * The main entry point for the application.
+         *
+         * @param args Array of parameters passed to the application
+         * via the command line.
+         */
+        public static int Main(String[] args)
+        {
+            int i = 10;
+            int j = i - 5;              // j = 5
+            int sum = 0;
+
+            sum = Add(i, j);            // sum = 15
+            sum = Add(sum, i);          // sum = 25
+            sum = Add(j, sum);          // sum = 30
+
+            i = 10;
+            j = sum / i;                // j = 3
+            sum = Add(40, j);  // sum = 43
+
+            x();
+            return 100;
+        }
+
+        public static int Add(int a, int b)
+        {
+            int c = a + b;
+
+            return c;
+        }
+
+        public static void x()
+        {
+            int foo;
+
+            foo
+               =
+               1;
+
+            foo =
+               2;
+
+            foo = 3;
+
+            if (y() && z())
+            {
+                w();
+                w();
+                w();
+            }
+
+            if (y() && z())
+            {
+                w();
+                w();
+                w();
+            }
+        }
+
+        public static bool y()
+        {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int f = a +
+                    b +
+                    c +
+                    d +
+                    e;
+
+            return (true);
+        }
+
+        public static bool z()
+        {
+            for (int i = 0; i < 10; i++)
+                w();
+
+            return (true);
+        }
+
+        public static void w()
+        {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int dummy = a + b + c + d + e;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/b13170.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/b13170.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13170/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/b13178.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/b13178.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+    using System.IO;
+    using System.Reflection;
+
+    public class Ternary3b
+    {
+        public static int Main(String[] argv)
+        {
+            Ternary3b hmm = new Ternary3b();
+            hmm.Problem();
+            return 100;
+        }
+
+        // If these field members are in the Problem() function, the problem does Not repro!!
+        internal int m_rr = -1;
+        internal int m_cc = 2;
+
+        public virtual void Problem()
+        {
+            int uu = 20;
+            int oo = 12;
+            int pp = 34;
+            ///
+
+
+            oo = (m_rr != -1) ? m_rr : ((uu + m_cc - 1) / m_cc);
+            Console.WriteLine("Ternary Logic A1: == " + oo);
+
+
+            if (m_rr != -1)
+            {
+                pp = m_rr;
+            }
+            else
+            {
+                pp = ((uu + m_cc - 1) / m_cc);
+            }
+            Console.WriteLine("IfElse Logic A1: == " + pp);
+
+
+            if (oo == pp)
+            {
+                Console.WriteLine("Good, 1738huy");
+            }
+            else
+            {
+                Console.WriteLine("FAIL!, 2738hub");
+            }
+        }
+    }
+
+
+    /**  RESULTS PASTED IN FROM CMD.EXE SCREEN... Show error only when JIT ON...
+
+    C:\Junk> jvc.exe -C Ternary3b.java
+    Microsoft (R) Visual J++ Compiler Version 7.00.8474
+    Copyright (C) Microsoft Corp 1996-1998. All rights reserved.
+
+
+    C:\Junk> echo JIT is ON
+    JIT is ON
+
+    C:\Junk> Ternary3b.exe
+    Ternary Logic A1: == 0
+    IfElse Logic A1: == 10
+    FAIL!, 2738hub
+
+    C:\Junk> echo Now JIT is OFF
+    Now JIT is OFF
+
+    C:\Junk> Ternary3b.exe
+    Ternary Logic A1: == 10
+    IfElse Logic A1: == 10
+    Good, 1738huy
+
+    C:\Junk>
+    **/
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/b13178.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/b13178.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13178/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/b13647.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/b13647.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class Bug
+    {
+        public static int Main(String[] args)
+        {
+            //Console.WriteLine (DateTime.GetNow().ToString());
+            Console.WriteLine(DateTime.Now.ToString());
+            return 100;
+        }
+    }
+
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/b13647.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/b13647.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13647/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/b14057.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/b14057.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+public class test
+{
+    static byte by = 13;
+    public static int Main(string[] args)
+    {
+        byte by1 = (byte)(by >> 1);
+        byte by2 = (byte)(by >> 1);
+
+        Console.WriteLine(by1);
+        Console.WriteLine(by2);
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/b14057.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/b14057.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14057/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/b14059.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/b14059.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+public class test
+{
+    static byte by = 13;
+    public static int Main(string[] args)
+    {
+        byte by1 = (byte)(-by);
+
+        Console.WriteLine(by1);
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/b14059.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/b14059.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14059/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/b14277.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/b14277.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class Bug
+    {
+        public virtual void runTest()
+        {
+            Decimal dcml1;
+            dcml1 = (new Decimal(6) - new Decimal(2)) / new Decimal(4);
+            if (dcml1 == 1)
+                Console.WriteLine("Test paSsed");
+            else
+                Console.WriteLine("Test FAiLED");
+
+        }
+
+        public static int Main(String[] args)
+        {
+            Bug b = new Bug();
+            b.runTest();
+            return 100;
+        }
+    }
+    ///// EOF
+
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/b14277.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/b14277.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14277/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/b14314.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/b14314.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    internal struct ValueCls1
+    {
+        //internal ValueCls1() {}
+
+    }
+
+
+    internal class Class1
+    {
+        public ValueCls1[] valCls1Array = new ValueCls1[1];
+
+        public virtual void Method()
+        {
+            valCls1Array[0] = new ValueCls1();
+        }
+
+    }
+
+    internal class Finalize
+    {
+        public static int Main(String[] args)
+        {
+            Class1 Cls = new Class1();
+            Cls.Method();
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/b14314.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/b14314.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14314/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/b14367.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/b14367.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    internal interface IV2
+    { }
+
+    internal struct V2 : IV2
+    {
+        //public V2() {} 		ANDREIS: commented due compiler error SC0568
+        public override bool Equals(Object o) { return false; }
+        public override int GetHashCode() { return 0; }
+    }
+
+    // The legendary 37-byte value class.
+    /*
+    value class V3 
+    {
+    	long a;
+    	long b;
+    	long c;
+    	long d;
+    	int e;
+    	short f;
+    	ubyte g;
+    	
+    	public V3() {
+    		a = 1;
+    		b = -2;
+    		c = 3;
+    		d = -4;
+    		e = 5;
+    		f = (short)-6;
+    		g = 7;
+    	}
+    	
+    	public boolean Validate()
+    	{
+    		return a==1 && b==-2 && c==3 && d==-4 && e==5 && f==-6 && g==7;
+    	}
+    	
+    	public boolean Equals(Object o) { return false; }
+    	public int GetHashCode() { return 0; }
+    }
+    */
+
+    public class jitAssert
+    {
+        internal const int Length = 3;
+
+        internal static V2[] V2Array = new V2[Length];
+        //	static V3[] V3Array = new V3[Length];
+
+        public static int Main(String[] args)
+        {
+            for (int i = 0; i < Length; i++)
+            {
+                V2Array[i] = new V2();
+                //			V3Array[i] = new V3();
+            }
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/b14367.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/b14367.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14367/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/b14396.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/b14396.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class Bug
+    {
+        public static int Main(String[] args)
+        {
+
+            byte x = 0xFF;		//	ANDREIS: Added cast operator due compiler error SC0031
+            byte tmp = 255;
+            if (tmp == (byte)x)
+            {
+                Console.WriteLine("Pass");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("Fail");
+                return 1;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/b14396.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/b14396.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14396/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/b14422.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/b14422.cs
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+/**
+ * A simple Com+ application.
+ */
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class SafeCStep
+    {
+        /**
+         * The main entry point for the application.
+         *
+         * @param args Array of parameters passed to the application
+         * via the command line.
+         */
+        public static int Main(String[] args)
+        {
+            int i = 10;
+            int j = i - 5;              // j = 5
+            int sum = 0;
+
+            sum = Add(i, j);            // sum = 15
+            sum = Add(sum, i);          // sum = 25
+            sum = Add(j, sum);          // sum = 30
+
+            i = 10;
+            j = sum / i;                // j = 3
+            sum = Add(40, j);  // sum = 43
+
+            x();
+            return 100;
+        }
+
+        public static int Add(int a, int b)
+        {
+            int c = a + b;
+
+            return c;
+        }
+
+        public static void x()
+        {
+            int foo;
+
+            foo
+               =
+               1;
+
+            foo =
+               2;
+
+            foo = 3;
+
+            if (y() && z())
+            {
+                w();
+                w();
+                w();
+            }
+
+            if (y() && z())
+            {
+                w();
+                w();
+                w();
+            }
+        }
+
+        public static bool y()
+        {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+            int f = a +
+                    b +
+                    c +
+                    d +
+                    e;
+
+            return (true);
+        }
+
+        public static bool z()
+        {
+            for (int i = 0; i < 10; i++)
+                w();
+
+            return (true);
+        }
+
+        public static void w()
+        {
+            int a = 1;
+            int b = 2;
+            int c = 3;
+            int d = 4;
+            int e = 5;
+
+            int dummy = a + b + c + d + e;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/b14422.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/b14422.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14422/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/b14428.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/b14428.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class DateTimeCompare
+    {
+
+        public static int Main(String[] args)
+        {
+            Object v1 = new DateTime(1952, 2, 19);
+            Object v2 = new DateTime(1968, 12, 8);
+            Console.WriteLine(DateTime.Compare((DateTime)v1, (DateTime)v2));
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/b14428.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/b14428.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14428/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/b14443.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/b14443.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    using System;
+
+    public class Bug4
+    {
+        public static int Main(String[] args)
+        {
+            Decimal cy1;
+            Decimal cy2;
+            Decimal dm3;
+            //
+
+            dm3 = new Decimal(-2.34);
+
+            cy1 = new Decimal(2.34);
+            cy2 = -dm3;
+
+            Console.WriteLine("cy1 ,cy2 ,dm3: " + cy1 + " ," + cy2 + " ," + dm3);
+
+            if (cy1 != cy2)
+            {
+                Console.WriteLine("FAIL! (72c)");
+                return 1;
+            }
+            else
+            {
+                Console.WriteLine("Good. (73g)");
+                return 100;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/b14443.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/b14443.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14443/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/b14616.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/b14616.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class jitAssert
+    {
+        public static bool MultiDim_ArgCheck_Fail()
+        {
+            if (true)
+            {
+                Console.WriteLine("\n\tMultiDim Array arg check disabled for now - can't create 2D array!\n");
+                return true;
+            }
+
+            try
+            {
+            }
+            catch (RankException)
+            {
+            }
+
+            return true;
+        }
+
+        public static int Main(String[] args)
+        {
+            MultiDim_ArgCheck_Fail();
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/b14616.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/b14616.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14616/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/b14624.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/b14624.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+// The legendary 37-byte value class.
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    internal struct V3
+    {
+        internal long a;
+        internal long b;
+        internal long c;
+        internal long d;
+        internal int e;
+        internal short f;
+        internal byte g;
+
+        public V3(int unused_param)
+        {
+            a = 1;
+            b = -2;
+            c = 3;
+            d = -4;
+            e = 5;
+            f = (short)-6;
+            g = 7;
+        }
+
+        public bool Validate()
+        {
+            return a == 1 && b == -2 && c == 3 && d == -4 && e == 5 && f == -6 && g == 7;
+        }
+
+        public override bool Equals(Object o) { return false; }
+        public override int GetHashCode() { return 0; }
+    }
+
+    public class jitBug
+    {
+        public static int Main(String[] args)
+        {
+            V3[] V3Array = new V3[5];
+            for (int i = 0; i < V3Array.Length; i++)
+                V3Array[i] = new V3();
+
+            /*
+            V3[] clone = null;
+    		
+            clone = (V3[]) V3Array.Clone();
+    		
+            if (clone.length != V3Array.length)
+                throw new Exception("V3[] length mismatch!  cloned length: "+clone.length);
+            for(int i=0; i<V3Array.length; i++) {
+                clone[i].Validate();
+            }
+            Console.WriteLine("V3 array test worked");
+            /* */
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/b14624.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/b14624.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14624/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/b14640.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/b14640.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    internal class repro
+    {
+        public static int Main(String[] args)
+        {
+            char b = 'B';
+
+            Char.IsWhiteSpace(b);
+
+            //Console.Write( "Y"+    "Y" );  // This line causes no bug.
+            Console.Write("Y" + b + "Y");  // This line causes the bug!  JIT InLiner problem.
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/b14640.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/b14640.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14640/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/b14673.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/b14673.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    using System;
+
+    public class Bug
+    {
+        public void runTest(Object var2)
+        {
+            int iTemp = 5;
+            Object VarResult = (iTemp);
+
+            if ((int)VarResult == 5)
+                Console.WriteLine("Test paSsed");
+            else
+                Console.WriteLine("Test FAiLED");
+        }
+        public static int Main(String[] args)
+        {
+            Bug oCbTest = new Bug();
+            oCbTest.runTest((3));
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/b14673.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/b14673.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14673/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/b15155.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/b15155.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    struct V3
+    {
+        long a;
+        long b;
+        long c;
+        long d;
+        int e;
+        short f;
+        byte g;
+
+        public V3(short bar)
+        {
+            a = 1;
+            b = -2;
+            c = 3;
+            d = -4;
+            e = 5;
+            f = (short)-6;
+            g = 7;
+        }
+
+        public Boolean Validate()
+        {
+            return (a == 1 && b == -2 && c == 3 && d == -4 && e == 5 && f == -6 && g == 7);
+        }
+
+
+        //	public override Boolean Equals(Object o) { return (o instanceof V3); }
+        //	public override int GetHashCode() { return 0; }
+    }
+
+
+    public class bug
+    {
+        public static int Main(String[] args)
+        {
+
+            int size = 32;
+            V3[] tmpV3Array = new V3[size];
+            Object[] VarArray = new Object[size];
+            for (int i = 0; i < size; i++)
+                VarArray[i] = (new V3(1));
+            Array.Copy(VarArray, tmpV3Array, size);
+            for (int i = 0; i < size; i++)
+                if (!tmpV3Array[i].Validate())
+                    throw new Exception("tmpV3Array[" + i + "] didn't validate correctly!  got: " + tmpV3Array[i] + "  expected: " + VarArray[i]);
+
+            return 100;
+
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/b15155.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/b15155.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15155/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/b15468.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/b15468.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    class unsignedNegative
+    {
+        public static int Main(String[] args)
+        {
+            Int16 testUI = (-1);
+
+            Console.WriteLine(testUI);
+            Console.WriteLine((-1).ToString("d"));
+
+            testUI = Int16.Parse("32535");
+            Console.WriteLine(testUI);
+            if (testUI < 0) Console.WriteLine("Fail (testUI < 0)");
+            if (testUI < (Int16)0) Console.WriteLine("Fail (testUI < (ushort)0)");
+            else Console.WriteLine("cast to unsigned short worked");
+
+            testUI = Int16.Parse((-1).ToString("d"));
+            Console.WriteLine(testUI);
+            return testUI + 101;
+
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/b15468.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/b15468.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15468/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/b15526.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/b15526.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class Bug
+    {
+        public virtual void runTest()
+        {
+            int iVal1 = 2;
+            int iVal2 = 3;
+            Console.WriteLine(Math.Min(iVal1, iVal2));
+        }
+        public static int Main(String[] args)
+        {
+            Bug oCbTest = new Bug();
+            oCbTest.runTest();
+            return 100;
+        }
+    }
+    ///// EOF}
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/b15526.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/b15526.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15526/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/b15783.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/b15783.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    using System;
+    public class jitbug
+    {
+        public static UInt16 f()
+        {
+            return UInt16.MaxValue;
+        }
+
+        public static int Main(String[] args)
+        {
+            Object v = ((UInt16)65535);
+            Console.WriteLine("v.ToUInt16: " + v);
+            Console.WriteLine("UInt16.MaxValue: " + UInt16.MaxValue);
+
+            // This worked...  I couldn't simplify it.
+            if (f() != UInt16.MaxValue)
+                Console.WriteLine("Ack!  f() didn't return the correct value!");
+            else
+                Console.WriteLine("ushort comparison looked good...");
+
+            if (((UInt16)v) != UInt16.MaxValue)
+                throw new Exception("UInt16.MaxValue from Object as UInt16 wasn't right!  " + (UInt16)v);
+            Console.WriteLine("pass");
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/b15783.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/b15783.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15783/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/b15786.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/b15786.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class jitcast
+    {
+        public static UInt16 f()
+        {
+            int i = (Int32)UInt16.MaxValue;
+            return (UInt16)i;
+        }
+
+        public static int Main(String[] args)
+        {
+            // Looks like what's happening is the JIT sees I'm casting an int
+            // to an unsigned short then back to an int and it messes up by
+            // sticking in sign extension.
+            int a = (Int32)f();
+            Console.WriteLine("a was: " + a);
+            if (a == -1)
+                Console.WriteLine("\n\tBug #1: a shouldn't be -1!  Widened from a unsigned short to an int shouldn't give a negative!\n");
+            else
+            {
+                Console.WriteLine("pass");
+                return 100;
+            }
+            return 1;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/b15786.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/b15786.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15786/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/b15797.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/b15797.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+// Compute distance light travels using long variables.
+using System;
+class Light
+{
+
+    public static int Main(String[] args)
+    {
+        int lightspeed;
+        long days;
+        long seconds1, seconds2, seconds3, seconds4, seconds5;
+        long distance;
+
+        // approximate speed of light in miles per second
+        lightspeed = 86000;
+
+        days = 1000;
+        seconds1 = days * 24 * 60 * 60; //this is one of the problems, more than 2 multiplication produce the error
+        //seconds = days * 24;  // if we calculate "seconds" like follows it works
+        //seconds *=60;	    
+        // seconds *=60;
+        seconds2 = (days * 24) * (60 * 60);
+        seconds3 = days * (24 * 60) * 60;
+        seconds4 = days * 24 * (60 * 60);
+        seconds5 = (days * 24) * 60 * 60;
+        if (seconds1 != seconds2 ||
+             seconds1 != seconds3 ||
+             seconds1 != seconds4 ||
+             seconds1 != seconds5)
+        {
+            Console.WriteLine("Test failed.");
+            return 1;
+        }
+
+        distance = lightspeed * seconds1;
+        Console.WriteLine("in  {0} days light will travel about  {1} miles.", days, distance);//crash here but if we replace 
+        //the variable days by "seconds" it works (same type) !!!!!!!!!!
+        //by removing this line or casting to integer it works.
+        // if we change the type of days to int it works !!
+
+        seconds1 /= 60 * 60;
+        seconds1 /= days;
+        if (seconds1 / 24 != 1)
+        {
+            Console.WriteLine("Test failed.");
+            return 1;
+        }
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/b15797.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/b15797.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15797/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/b15864.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/b15864.cs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    using System.Security;
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    class TestClass
+    {
+        public static int iExitCode;
+
+        protected void TestMain()
+        {
+            int caught = 0;
+            //int fincount = 0;
+
+            try
+            {
+                throw new ArgumentException();
+            }
+            catch (ArgumentException /*e1*/)
+            {
+                caught++;
+                try
+                {
+                    throw new SecurityException();
+                }
+                catch (SecurityException /*e2*/)
+                {
+                }
+                finally
+                {
+                    try
+                    {
+                        throw new NullReferenceException();
+                    }
+                    catch (Exception /*e3*/)
+                    {
+                    }
+
+                }
+
+            }
+
+
+        }
+
+        public static int Main(String[] args)
+        {
+            (new TestClass()).TestMain();
+            Console.WriteLine("Passed.");
+            return 100;
+        }
+
+    };
+};
+

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/b15864.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/b15864.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b15864/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/app.config
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/b16294.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/b16294.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+namespace DefaultNamespace
+{
+    //@BEGINRENAME; Verify this renames
+    //@ENDRENAME; Verify this renames
+    using System;
+
+    public class Bug
+    {
+        public virtual void runTest()
+        {
+            Random rand = new Random((int)DateTime.Now.Ticks);
+            Object o = ((UInt64)rand.Next((int)UInt64.MinValue, Int32.MaxValue));
+        }
+
+        public static int Main(String[] args)
+        {
+            new Bug().runTest();
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/b16294.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/b16294.csproj
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <Target Name="Build">
+    <ItemGroup>
+      <AllSourceFiles Include="$(MSBuildProjectDirectory)\*.cs" />
+    </ItemGroup>
+    <PropertyGroup>
+      <GenerateRunScript>false</GenerateRunScript>
+    </PropertyGroup>
+    <MSBuild Projects="cs_template.proj" Properties="AssemblyName1=%(AllSourceFiles.FileName);AllowUnsafeBlocks=True;IntermediateOutputPath=$(IntermediateOutputPath)\%(AllSourceFiles.FileName)\" />
+  </Target>
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/cs_template.proj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/cs_template.proj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(AssemblyName1)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="$(AssemblyName1).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/packages.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16294/packages.config
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+    <package id="System.Console" version="4.0.0-beta-22405" />
+    <package id="System.Runtime" version="4.0.20-beta-22405" />
+    <package id="System.Runtime.Extensions" version="4.0.10-beta-22412" />
+    <package id="System.Threading" version="4.0.0-beta-22412" />
+    <package id="System.Threading.Thread" version="4.0.0-beta-22512" />
+</packages>


### PR DESCRIPTION
Add JIT/Regression/CLR-x86-JIT/V1-M09 test cases for JIT. Related proj, config files added.
AllTestProjects.sln update delayed for a batch adding. Passed build, buildtest, runtest.