### PR TITLE
Add support for IL tests.

### DIFF
--- a/tests/src/IL.targets
+++ b/tests/src/IL.targets
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Required by Microsoft.Common.targets -->
+  <Target Name="CreateManifestResourceNames" Condition="'@(EmbeddedResource)' != ''" />
+
+  <Target Name="CoreCompile"
+          Inputs="$(MSBuildAllProjects);
+                  @(Compile)"
+          Outputs="@(IntermediateAssembly);"
+          Returns=""
+          DependsOnTargets="$(CoreCompileDependsOn)">
+    <PropertyGroup>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">/DLL</_OutputTypeArgument>
+      <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">/EXE</_OutputTypeArgument>
+
+      <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">/KEY=$(KeyOriginatorFile)</_KeyFileArgument>
+    </PropertyGroup>
+
+    <Exec Command="ilasm /QUIET $(_OutputTypeArgument) /OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile)">
+      <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
+    </Exec>
+    <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />
+  </Target>
+
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" />
+
+</Project>

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -40,7 +40,16 @@
     </ItemGroup>
   </Target>
 
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- Project language -->
+  <PropertyGroup Condition="'$(ProjectLanguage)' == ''">
+    <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.ilproj' OR '$(Language)' == 'IL'">IL</ProjectLanguage>
+    <ProjectLanguage Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#' OR '$(ProjectLanguage)'==''">CSharp</ProjectLanguage>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" Condition="'$(ProjectLanguage)' == 'CSharp'" />
+
+  <!-- TODO (#1122): import this from the ToolsDir once it becomes available -->
+  <Import Project="$(ProjectDir)IL.targets" Condition="'$(ProjectLanguage)' == 'IL'" />
 
   <Import Project="$(ToolsDir)packageresolve.targets" Condition="Exists('$(ToolsDir)packageresolve.targets')" />
 


### PR DESCRIPTION
This change is comprised of two parts:
- A new property in dir.targets, ProjectLanguage, that allows test
  projects to specify the language in which they are written. If unset,
  this property is inferred from the extension, defaulting to C# if all
  else fails. The only lanugages currently supported are C# and IL, but
  it should be easy to support others (e.g. Visual Basic) if necessary.
- A copy of IL.targets from Microsoft.DotNet.BuildTools. This should be
  removed once CoreCLR has been moved to a version of the build tools
  package that contains IL.targets; this work is tracked by
  https://github.com/dotnet/coreclr/issues/1122.

This work is necessary to support a large number of JIT tests that are
written in IL and have yet to be ported.