### PR TITLE
Remove the dependency on LD_LIBRARY_PATH in the sos code (issue #820)

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/debugclient.cpp
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.cpp
@@ -10,9 +10,10 @@
 #include <dbgtargetcontext.h>
 #include <string>
 
-DebugClient::DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject) :
+DebugClient::DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject, char *coreclrDirectory) :
     m_debugger(debugger),
-    m_returnObject(returnObject)
+    m_returnObject(returnObject),
+    m_coreclrDirectory(coreclrDirectory)
 {
 }
 
@@ -859,6 +860,12 @@ DebugClient::GetFrameOffset(
 //----------------------------------------------------------------------------
 // IDebugClient
 //----------------------------------------------------------------------------
+
+PCSTR
+DebugClient::GetCoreClrDirectory()
+{
+    return m_coreclrDirectory;
+}
 
 DWORD_PTR
 DebugClient::GetExpression(

--- a/src/ToolBox/SOS/lldbplugin/debugclient.h
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.h
@@ -8,6 +8,7 @@ class DebugClient : public IDebugClient
 private:
     lldb::SBDebugger &m_debugger;
     lldb::SBCommandReturnObject &m_returnObject;
+    char *m_coreclrDirectory;
 
     void OutputString(ULONG mask, PCSTR str);
     lldb::SBProcess GetCurrentProcess();
@@ -18,7 +19,7 @@ private:
     DWORD_PTR GetRegister(lldb::SBFrame frame, const char *name);
 
 public:
-    DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject);
+    DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject, char *coreclrDirectory);
     ~DebugClient();
 
     //----------------------------------------------------------------------------
@@ -165,6 +166,8 @@ public:
     //----------------------------------------------------------------------------
     // IDebugClient
     //----------------------------------------------------------------------------
+
+    PCSTR GetCoreClrDirectory();
 
     DWORD_PTR GetExpression(
         PCSTR exp);

--- a/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
@@ -347,6 +347,11 @@ typedef class IDebugRegister* PDEBUG_REGISTERS;
 class IDebugClient : IDebugControl2, IDebugDataSpaces, IDebugSymbols, IDebugSystemObjects, IDebugRegister
 {
 public:
+    // Returns the coreclr module directory found by lldb plugin 
+    // in the target process.
+    virtual PCSTR GetCoreClrDirectory() = 0;
+
+    // Evaluates a lldb expression into a value.
     virtual DWORD_PTR GetExpression(
         /* [in] */ PCSTR exp) = 0;
 };

--- a/src/ToolBox/SOS/lldbplugin/mstypes.h
+++ b/src/ToolBox/SOS/lldbplugin/mstypes.h
@@ -51,6 +51,8 @@ typedef int HRESULT;
 #define E_NOTIMPL                        (HRESULT)0x80004001
 #define E_FAIL                           (HRESULT)0x80004005
 
+#define MAX_PATH                         260 
+
 #if defined(_MSC_VER) || defined(__llvm__)
 #define DECLSPEC_ALIGN(x)   __declspec(align(x))
 #else

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -53,6 +53,8 @@ OpenEventW
 OpenMutexW
 OpenSemaphoreW
 PAL_Random
+PAL_RegisterModule
+PAL_UnregisterModule
 QueryPerformanceCounter  
 QueryPerformanceFrequency
 RaiseException

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -515,6 +515,18 @@ PAL_InitializeDebug(
     void);
 
 PALIMPORT
+HINSTANCE
+PALAPI
+PAL_RegisterModule(
+    IN LPCSTR lpLibFileName);
+
+PALIMPORT
+VOID 
+PALAPI
+PAL_UnregisterModule(
+    IN HINSTANCE hInstance);
+
+PALIMPORT
 HMODULE
 PALAPI
 PAL_RegisterLibraryW(

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -56,12 +56,15 @@ extern "C"
 #define PAL_SHLIB_SUFFIX ".so"
 #endif
 
-typedef BOOL (__stdcall *PDLLMAIN)(HINSTANCE,DWORD,LPVOID); /* entry point of module */
+typedef BOOL (__stdcall *PDLLMAIN)(HINSTANCE, DWORD, LPVOID);   /* entry point of module */
+typedef HINSTANCE (PALAPI *PREGISTER_MODULE)(LPCSTR);           /* used to create the HINSTANCE for above DLLMain entry point */
+typedef VOID (PALAPI *PUNREGISTER_MODULE)(HINSTANCE);           /* used to cleanup the HINSTANCE for above DLLMain entry point */
 
 typedef struct _MODSTRUCT
 {
     HMODULE self;         /* circular reference to this module */
     void *dl_handle;      /* handle returned by dlopen() */
+    HINSTANCE hinstance;  /* handle returned by PAL_RegisterLibrary */
 #if defined(CORECLR) && defined(__APPLE__)
     CORECLRHANDLE sys_module; /* System modules can be loaded via mechanisms other than dlopen() under
                                * CoreCLR/Mac */


### PR DESCRIPTION
Uses the coreclr path found by the lldb sos plugin when loading the sos module.

Preload the DAC module in the lldb sos plugin so SOS and DBI can still use DAC's PAL.

Fix the HMODULE handle passed to DLLMain to be a handle in the target module's PAL context (issue #931).