### PR TITLE
Implement ILGenerator on Unix to use System.Console.dll

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
@@ -1174,6 +1174,17 @@ namespace System.Reflection.Emit
             this.Emit(OpCodes.Throw);
         }
 
+        private static Type GetConsoleType()
+        {
+#if FEATURE_LEGACYSURFACE
+            return typeof(Console);
+#else
+            return Type.GetType(
+                "System.Console, System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=" + AssemblyRef.MicrosoftPublicKeyToken, 
+                throwOnError: true);
+#endif
+        }
+
         public virtual void EmitWriteLine(String value)
         {
             // Emits the IL to call Console.WriteLine with a string.
@@ -1181,7 +1192,7 @@ namespace System.Reflection.Emit
             Emit(OpCodes.Ldstr, value);
             Type[] parameterTypes = new Type[1];
             parameterTypes[0] = typeof(String);
-            MethodInfo mi = typeof(Console).GetMethod("WriteLine", parameterTypes);
+            MethodInfo mi = GetConsoleType().GetMethod("WriteLine", parameterTypes);
             Emit(OpCodes.Call, mi);
         }
 
@@ -1198,7 +1209,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(Environment.GetResourceString("InvalidOperation_BadILGeneratorUsage"));
             }
 
-            MethodInfo prop = typeof(Console).GetMethod("get_Out");
+            MethodInfo prop = GetConsoleType().GetMethod("get_Out");
             Emit(OpCodes.Call, prop);
             Emit(OpCodes.Ldloc, localBuilder);
             Type[] parameterTypes = new Type[1];
@@ -1230,7 +1241,7 @@ namespace System.Reflection.Emit
             }
             Contract.EndContractBlock();
             
-            MethodInfo prop = typeof(Console).GetMethod("get_Out");
+            MethodInfo prop = GetConsoleType().GetMethod("get_Out");
             Emit(OpCodes.Call, prop);
 
             if ((fld.Attributes & FieldAttributes.Static)!=0) {


### PR DESCRIPTION
The System.Console type in mscorlib on Unix is internal and lacks any ability to actually write out.  As such, System.Reflection.Emit.ILGenerator.EmitWriteLine on Unix is currently broken, as it attempts to use Console in mscorlib via reflection.

This is a fix for https://github.com/dotnet/corefx/issues/1915.  It's a hack, using reflection to find and use the System.Console from the System.Console.dll assembly, but short of this the only two other solutions I'm aware of are re-implementing Console in mscorlib (which we don't want to do) or just always throwing PlatformNotSupportedException.