### PR TITLE
Fix the ECMA standard link

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -6,7 +6,7 @@ This repo includes several documents that explain both high-level and low-level 
 Intro to .NET Core
 ==================
 
-.NET Core is a self-contained .NET runtime and framework that implements [ECMA 335](dotnet-standards.md). It can be (and has been) ported to multiple architectures and platforms. It support a variety of installation options, having no specific deployment requirements itself.
+.NET Core is a self-contained .NET runtime and framework that implements [ECMA 335](project-docs/dotnet-standards.md). It can be (and has been) ported to multiple architectures and platforms. It support a variety of installation options, having no specific deployment requirements itself.
 
 Learn about .NET Core
 ====================


### PR DESCRIPTION
On README.md, the intro to .NET Core had a wrong link.
Missing the directory portion.

/cc @richlander 