### PR TITLE
Fix markdown of the "Testing with CoreFX" documentation so it renders correctly on GitHub

### DIFF
--- a/Documentation/building/testing-with-corefx.md
+++ b/Documentation/building/testing-with-corefx.md
@@ -6,16 +6,18 @@ It may be valuable to use CoreFX tests to validate your changes to CoreCLR or ms
 In order to do this you need to create a file called `localpublish.props` under the `<repo root>\packages` folder.
 The contents of the file should look like this (make sure to update the version to the current version of the CoreCLR package used by CoreFx):
 
-  <Project ToolsVersion="12.0" DefaultTargets="Build" 
-         xmlns="http://schemas.microsoft.com/developer/msbuilding/2003">
-      <ItemGroup>
-      <LocalPackages Include="$(PackagesBinDir)">
-          <PackageName>Microsoft.DotNet.CoreCLR</PackageName>
-          <PackageVersion>1.0.2-prerelease</PackageVersion>
-          <InstallLocation><corefx repo root>\packages</InstallLocation>
-        </LocalPackages>
-      </ItemGroup>
-    </Project>
+```xml
+<Project ToolsVersion="12.0" DefaultTargets="Build" 
+     xmlns="http://schemas.microsoft.com/developer/msbuilding/2003">
+  <ItemGroup>
+  <LocalPackages Include="$(PackagesBinDir)">
+      <PackageName>Microsoft.DotNet.CoreCLR</PackageName>
+      <PackageVersion>1.0.2-prerelease</PackageVersion>
+      <InstallLocation><corefx repo root>\packages</InstallLocation>
+    </LocalPackages>
+  </ItemGroup>
+</Project>
+```
 
 Once this file is there, subsequent builds of the CoreCLR repo will install the CoreCLR package into the location specified by `InstallLocation`.
 


### PR DESCRIPTION
The document wasn't rendering correctly on GitHub.

## Before

![before](https://cloud.githubusercontent.com/assets/710598/8469831/349a1d68-2036-11e5-9beb-2ad6bd526820.png)

## After

![after](https://cloud.githubusercontent.com/assets/710598/8469834/38b95db4-2036-11e5-9b8a-7197ec391595.png)

/cc @richlander