### PR TITLE
Remove incorrectly duplicated comment

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2357,7 +2357,6 @@ namespace System {
             return LastIndexOfAny(anyOf,this.Length-1,this.Length);
         }
     
-        //ForceInline ... Jit can't recognize String.get_Length to determine that this is "fluff"
         [Pure]
         public int LastIndexOfAny(char [] anyOf, int startIndex) {
             return LastIndexOfAny(anyOf,startIndex,startIndex + 1);


### PR DESCRIPTION
I just happened to see this comment. It's applicable to the overload directly above but not to this overload. It was presumably accidentally duplicated.