### PR TITLE
runpaltests.sh outputs a XUnit compatible result file for Jenkins.

### DIFF
--- a/src/pal/tests/palsuite/runpaltests.sh
+++ b/src/pal/tests/palsuite/runpaltests.sh
@@ -137,8 +137,8 @@ XUNIT_PREFIX+="<assemblies>\n"
 XUNIT_PREFIX+="<assembly name=\"PAL\" total=\"$NUMBER_OF_TESTS\" passed=\"$NUMBER_OF_PASSED_TESTS\" failed=\"$NUMBER_OF_FAILED_TESTS\" skipped=\"0\">\n"
 XUNIT_PREFIX+="<collection total=\"$NUMBER_OF_TESTS\" passed=\"$NUMBER_OF_PASSED_TESTS\" failed=\"$NUMBER_OF_FAILED_TESTS\" skipped=\"0\" name=\"palsuite\">"
 
-echo -e $XUNIT_SUFFIX >> $PAL_XUNIT_TEST_LIST_TMP
-echo -e $XUNIT_PREFIX | cat - $PAL_XUNIT_TEST_LIST_TMP > $PAL_XUNIT_TEST_LIST
+printf "$XUNIT_SUFFIX" >> $PAL_XUNIT_TEST_LIST_TMP
+printf "$XUNIT_PREFIX" | cat - $PAL_XUNIT_TEST_LIST_TMP > $PAL_XUNIT_TEST_LIST
 
 # If there were tests failures then print the list of failed tests
 if [ $NUMBER_OF_FAILED_TESTS -gt "0" ]; then


### PR DESCRIPTION
This makes runpaltests.sh output a pal_tests.xml file that can be used with Jenkins as an XUnit test report. The location of this output may need to be changed if any other test reports need to be used, as the only way (from my limited Googling) of using multiple test reports is to have some wildcard matching all files.This will produce a file such as https://gist.github.com/benpye/50772556da8c77b23750 which Jenkins displays as https://goo.gl/9F99SN . The failures there are due to the fact I ran it on my ARM build, not that it is broken.