### PR TITLE
Modify conservative GC code for unaligned InlinedCallFrames

### DIFF
--- a/src/vm/gcenv.cpp
+++ b/src/vm/gcenv.cpp
@@ -511,7 +511,14 @@ VOID GCToEEInterface::ScanStackRoots(Thread * pThread, promote_func* fn, ScanCon
         // Since we report every thing as pinned, we don't need to run following code for relocation phase.
         if (sc->promotion)
         {
-            Object ** topStack = (Object **)pThread->GetFrame();
+            Frame* pTopFrame = pThread->GetFrame();
+            Object ** topStack = (Object **)pTopFrame;
+            if ((pTopFrame != ((Frame*)-1)) 
+                && (pTopFrame->GetVTablePtr() == InlinedCallFrame::GetMethodFrameVPtr())) {
+                // It is an InlinedCallFrame. Get SP from it.
+                InlinedCallFrame* pInlinedFrame = (InlinedCallFrame*)pTopFrame;
+                topStack = (Object **)pInlinedFrame->GetCallSiteSP();
+            } 
             Object ** bottomStack = (Object **) pThread->GetCachedStackBase();
             Object ** walk;
             for (walk = topStack; walk < bottomStack; walk ++)


### PR DESCRIPTION
When making pinvoke calls the JITs allocate InlinedCallFrames
within their stack frames to record the location
of the managed stack frame.  These were being used
as the topStack in src/vm/gcenv.cpp, in the method
GCToEEInterface::ScanStackRoots. But they are not
really the top of the stack, but they can be used to find
the real top of the stack.

This change checks to see if a frame is an InlinedCallFrame.
If so then its GetCallSiteSP method is used to
get the real top of stack. 
