### PR TITLE
Add missing contracts to some destructors

### DIFF
--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -183,7 +183,10 @@ typedef  SHash<ZapperLoaderModuleTableTraits> ZapperLoaderModuleTable;
 class CEECompileInfo : public ICorCompileInfo
 {
   public:
-    virtual ~CEECompileInfo() {}
+    virtual ~CEECompileInfo()
+    {
+        WRAPPER_NO_CONTRACT;
+    }
     
     HRESULT Startup(     BOOL                     fForceDebug, 
                          BOOL                     fForceProfiling,

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -186,7 +186,10 @@ public:
 
     virtual void FinishEmit(MethodDesc* pMD) = 0;
 
-    virtual ~StubState() {}
+    virtual ~StubState()
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
 };
 
 class ILStubState : public StubState

--- a/src/vm/hash.h
+++ b/src/vm/hash.h
@@ -139,7 +139,10 @@ public:
         m_ptr = ptr;
     }
 
-    virtual ~Compare() {}
+    virtual ~Compare()
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
 
     virtual UPTR CompareHelper(UPTR val1, UPTR storedval)
     {

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -235,7 +235,10 @@ public:
     {
     }
 
-    virtual ~ILMarshaler() {}
+    virtual ~ILMarshaler()
+    {
+        LIMITED_METHOD_CONTRACT;
+    }
 
     void SetNDirectStubLinker(NDirectStubLinker* pslNDirect)
     {

--- a/src/vm/ilmarshalers.h
+++ b/src/vm/ilmarshalers.h
@@ -1949,6 +1949,7 @@ public:
 
     ILWSTRMarshaler()
     {
+        LIMITED_METHOD_CONTRACT;
         m_fCoMemoryAllocated = false;
     }
 #endif // _DEBUG
@@ -2447,6 +2448,7 @@ public:
         m_dwCCHLocal(-1)
        ,m_dwLocalBuffer(-1)
     {
+        LIMITED_METHOD_CONTRACT;
     }
 
     virtual bool SupportsArgumentMarshal(DWORD dwMarshalFlags, UINT* pErrorResID);
@@ -2478,6 +2480,7 @@ public:
     ILVBByValStrMarshaler() :
         m_dwCCHLocal(-1)
     {
+        LIMITED_METHOD_CONTRACT;
     }
 
     virtual bool SupportsArgumentMarshal(DWORD dwMarshalFlags, UINT* pErrorResID);
@@ -2719,6 +2722,7 @@ public:
         m_dwOffsetLocalNum(-1),
         m_dwPinnedLocalNum(-1)
     {
+        LIMITED_METHOD_CONTRACT;
     }
 
 protected:
@@ -2748,6 +2752,7 @@ public:
     ILAsAnyMarshalerBase() :
         m_dwMarshalerLocalNum(-1)
     {
+        LIMITED_METHOD_CONTRACT;
     }
 
 protected:
@@ -2821,6 +2826,7 @@ public:
         m_idClearNativeContents(clearNatContents),
         m_idClearManaged(clearMan)
     {
+        LIMITED_METHOD_CONTRACT;
     }
     
 protected:    


### PR DESCRIPTION
This change adds missing contract annotation to several destructors that
were missing it.