### PR TITLE
Fix recursive asserts in coreclr.

### DIFF
--- a/src/inc/debugmacros.h
+++ b/src/inc/debugmacros.h
@@ -28,7 +28,7 @@ class SString;
 bool GetStackTraceAtContext(SString & s, struct _CONTEXT * pContext);
 
 void _cdecl DbgWriteEx(LPCTSTR szFmt, ...);
-int _DbgBreakCheck(LPCSTR szFile, int iLine, LPCSTR szExpr, BOOL fConstrained = FALSE);
+bool _DbgBreakCheck(LPCSTR szFile, int iLine, LPCSTR szExpr, BOOL fConstrained = FALSE);
 
 extern VOID DbgAssertDialog(const char *szFile, int iLine, const char *szExpr);
 

--- a/src/inc/winwrap.h
+++ b/src/inc/winwrap.h
@@ -943,7 +943,9 @@ inline void DbgWPrintf(const LPCWSTR wszFormat, ...)
     va_end(args);
 
     if (IsDebuggerPresent())
+    {
         OutputDebugStringW(wszBuffer);
+    }
     else
     {
         fwprintf(stdout, W("%s"), wszBuffer);

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -415,8 +415,9 @@ static void sigtrap_handler(int code, siginfo_t *siginfo, void *context)
     }
     else
     {
-        // Restore the original or default handler and restart h/w exception
-        restore_signal(code, &g_previous_sigtrap);
+        // We abort instead of restore the original or default handler and returning
+        // because returning from a SIGTRAP handler continues execution past the trap.
+        abort();
     }
 }
 

--- a/src/utilcode/debug.cpp
+++ b/src/utilcode/debug.cpp
@@ -339,7 +339,7 @@ static const char * szLowMemoryAssertMessage = "Assert failure (unable to format
 //*****************************************************************************
 // This function will handle ignore codes and tell the user what is happening.
 //*****************************************************************************
-int _DbgBreakCheck(
+bool _DbgBreakCheck(
     LPCSTR      szFile,
     int         iLine,
     LPCSTR      szExpr, 
@@ -547,7 +547,7 @@ int _DbgBreakCheck(
     return false;
 }
 
-int _DbgBreakCheckNoThrow(
+bool _DbgBreakCheckNoThrow(
     LPCSTR      szFile,
     int         iLine,
     LPCSTR      szExpr, 
@@ -565,8 +565,8 @@ int _DbgBreakCheckNoThrow(
         DebugBreak();
     }
 
-    int failed = false;
-    int result = false;
+    bool failed = false;
+    bool result = false;
     EX_TRY
     {
         result = _DbgBreakCheck(szFile, iLine, szExpr, fConstrained);

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -5061,10 +5061,6 @@ VOID PALAPI HandleHardwareException(PAL_SEHException* ex)
             {
                 RtlRestoreContext(&ex->ContextRecord, &ex->ExceptionRecord);
             }
-            else
-            {
-                _ASSERTE(!"Looks like a random breakpoint/trap that was not prepared by the EE debugger");
-            }
         }
     }
 }


### PR DESCRIPTION
Remove assert in VM break handler to prevent recursive asserts. Fixed problem where the DebugBreak wasn't terminating the app on an assert causing double assert messages.  Restoring the SIGTRAP handler and returning was continuing the DebugBreak not terminating. Replaced this with an abort().

Cleanup the assert message formatting.