### PR TITLE
[WIP] Initial commit of libcorefx_io with stat shims

### DIFF
--- a/src/corefx/CMakeLists.txt
+++ b/src/corefx/CMakeLists.txt
@@ -13,4 +13,5 @@
 
 if(CLR_CMAKE_PLATFORM_UNIX)
   add_subdirectory(System.Security.Cryptography.Native)
+  add_subdirectory(io)
 endif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/corefx/io/CMakeLists.txt
+++ b/src/corefx/io/CMakeLists.txt
@@ -1,0 +1,18 @@
+
+project(corefx_io)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+add_compile_options(-fPIC)
+
+set(NATIVEIO_SOURCES
+    corefx_io.cpp
+)
+
+add_library(corefx_io
+    SHARED
+    ${NATIVEIO_SOURCES}
+)
+
+install (TARGETS corefx_io DESTINATION .)
+ 

--- a/src/corefx/io/corefx_io.cpp
+++ b/src/corefx/io/corefx_io.cpp
@@ -1,0 +1,61 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include "corefx_io.h"
+#include <sys/stat.h>
+
+#if HAVE_STAT64 && !(defined(__APPLE__) && defined(_AMD64_))
+#    define stat_ stat64
+#    define fstat_ fstat64
+#else
+#   define stat_ stat
+#   define fstat_ fstat
+#endif
+
+static void ConvertFileStats(const struct stat_& src, FileStats* dst)
+{
+    dst->Flags = FILESTATS_FLAGS_NONE;
+    dst->Mode = src.st_mode;
+    dst->Uid = src.st_uid;
+    dst->Gid = src.st_gid;
+    dst->Size = src.st_size;
+    dst->AccessTime = src.st_atime;
+    dst->ModificationTime = src.st_mtime;
+    dst->StatusChangeTime = src.st_ctime;
+
+#if HAVE_STAT_BIRTHTIME
+    dst->BirthTime = src->st_birthtime;
+    dst->Flags |= FILESTATS_FLAGS_HAS_CREATION_TIME;
+#endif
+}
+
+extern "C"
+{
+    int32_t GetFileStatsFromPath(const char* path, struct FileStats* output)
+    {
+        struct stat_ result;
+        int ret = stat_(path, &result);
+
+        if (ret == 0)
+        {
+            ConvertFileStats(result, output);
+        }
+
+        return ret;
+    }
+
+    int32_t GetFileStatsFromDescriptor(int32_t fileDescriptor, FileStats* output)
+    {
+        struct stat_ result;
+        int ret = fstat_(fileDescriptor, &result);
+
+        if (ret == 0)
+        {
+            ConvertFileStats(result, output);
+        }
+
+        return ret;
+    }
+}

--- a/src/corefx/io/corefx_io.h
+++ b/src/corefx/io/corefx_io.h
@@ -1,0 +1,45 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#pragma once
+
+#include <stdint.h>
+
+extern "C"
+{
+    struct FileStats
+    {
+        int32_t Flags;            // flags for testing if some members are present (see values below)
+        int32_t Mode;             // protection
+        int32_t Uid;              // user ID of owner
+        int32_t Gid;              // group ID of owner
+        int64_t Size;             // total size, in bytes
+        int64_t AccessTime;       // time of last access (atime)
+        int64_t ModificationTime; // time of last modification (mtime)
+        int64_t StatusChangeTime; // time of last status change (ctime)
+        int64_t CreationTime;     // time the file was created (birthtime)
+    };
+
+    enum
+    {
+        FILESTATS_FLAGS_NONE = 0,
+        FILESTATS_FLAGS_HAS_CREATION_TIME = 1,
+    };
+
+    /**
+     * Get file stats from a decriptor. Implemented as shim to fstat(2).
+     *
+     * Returns 0 for success, -1 for failure. Sets errno on failure.
+     */
+    int32_t GetFileStatsFromDescriptor(int32_t fileDescriptor, FileStats* output);
+
+    /**
+     * Get file stats from a full path. Implemented as shim to stat(2).
+     *
+     * Returns 0 for success, -1 for failure. Sets errno on failure.
+     */
+    int32_t GetFileStatsFromPath(const char* path, FileStats* output);
+}
+


### PR DESCRIPTION
# WIP

Using this as a sample of my current thinking on dotnet/corefx#2137 and to get early feedback.

Some notes on departures of from earlier offline discussion:

### Library names

I dislike the <managed namespace>.Native.so pattern without lib prefix. It just feels out of place in native code. I propose libcorefx_io, libcorefx_crypto, etc. instead. Also, depending on where we land for how these are distributed/versioned, etc. we might opt to merge them all together or split along different, fewer lines...

### API names
I propose using our own PascalCased and spelled out names, and not names that are 1:1 with the native API they wrap. My reasoning is that we can't always be 1:1...

Even in this simple stat example:
   - we have to introduce something unique (Flags). 
  -  we leave some things out (not worth wasting dev cycles deciding how to surface unused types with stable ABI or CPU cycles copying them).

And looking at crypto:
    - being 1:1 with libcrypto would be completely impractical with all of that pointer indirection. We can't copy whole graphs to a stable layout and then only use a small part of it!

So, in the end, I think giving these libraries their own style in which to express themselves will make them more self-consistent and easier to evolve. The guideline is still to keep them as "thin" as possible/practical.