### PR TITLE
Fix SHR operand diassembly in RyuJIT

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -7024,7 +7024,7 @@ PRINT_CONSTANT:
         break;
 
     case IF_RRW_SHF:
-        printf("%s", emitRegName(id->idReg1()));
+        printf("%s", emitRegName(id->idReg1(), attr));
         emitDispShift(ins, (BYTE)emitGetInsSC(id));
         break;
 


### PR DESCRIPTION
Pass `attr` to `emitRegName` so the correct register is displayed. In the absence of the `attr` argument `EA_PTRSIZE` is used and a 64 bit register is displayed in cases where a 32 bit register is used. For example, `C1E802 shr rax, 2` is displayed instead of `C1E802 shr eax, 2` (note the lack of a REX prefix).