### PR TITLE
Perf: List<T>.Reverse changed to not use non-generic Array.Reverse

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -918,9 +918,6 @@ namespace System.Collections.Generic {
         // which was previously located at index i will now be located at
         // index index + (index + count - i - 1).
         // 
-        // This method uses the Array.Reverse method to reverse the
-        // elements.
-        // 
         public void Reverse(int index, int count) {
             if (index < 0) {
                 ThrowHelper.ThrowArgumentOutOfRangeException(ExceptionArgument.index, ExceptionResource.ArgumentOutOfRange_NeedNonNegNum);
@@ -933,7 +930,23 @@ namespace System.Collections.Generic {
             if (_size - index < count)
                 ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_InvalidOffLen);
             Contract.EndContractBlock();
-            Array.Reverse(_items, index, count);
+
+            // The non-generic Array.Reverse is not used because it does not perform
+            // well for non-primitive value types.
+            // If/when a generic Array.Reverse<T> becomes available, the below code
+            // can be deleted and replaced with a call to Array.Reverse<T>.
+            int i = index;
+            int j = index + count - 1;
+            T[] array = _items;
+            while (i < j)
+            {
+                T temp = array[i];
+                array[i] = array[j];
+                array[j] = temp;
+                i++;
+                j--;
+            }
+
             _version++;
         }
         


### PR DESCRIPTION
`List<T>.Reverse` is currently implemented in terms of the non-generic [`Array.Reverse`](https://github.com/dotnet/coreclr/blob/ef1e2ab328087c61a6878c1e84f4fc5d710aebce/src/mscorlib/src/System/Array.cs#L1570-L1606). `Array.Reverse` includes a fast path for a known set of primitive types via a call into the runtime (see [`TrySZReverse`](https://github.com/dotnet/coreclr/blob/4cf8a6b082d9bb1789facd996d8265d3908757b2/src/classlibnative/bcltype/arrayhelpers.cpp#L390-L424)). Otherwise, it falls back to slower code paths that involve boxing for non-primitive value types.

This commit changes `List<T>.Reverse` to use a generic implementation of reverse that does not have the performance issue for non-primitive value types.

`List<PathPair>.Reverse` is ~22x faster after the change (via 1,000 iteration benchmark reversing a 100,000 length list, where `PathPair` is a custom struct with two `string` fields).

CoreFX `System.Collections` tests pass.

It would be worth considering exposing `Array.Reverse<T>` publicly in the future when new public APIs can be added to `Array`.

(This came up in a [discussion](https://github.com/dotnet/corefx/pull/2319#discussion_r34417098) regarding `System.IO` file system enumeration improvements in CoreFX).