### PR TITLE
Extend the Unix hosting API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ function(generate_exports_file inputFilename outputFilename)
   add_custom_command(
     OUTPUT ${outputFilename}
     COMMAND ${AWK} -f ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT} ${inputFilename} >${outputFilename}
-    DEPENDS ${inputFilename}
+    DEPENDS ${inputFilename} ${CMAKE_SOURCE_DIR}/${AWK_SCRIPT}
     COMMENT "Generating exports file ${outputFilename}"
   )
   set_source_files_properties(${outputFilename}

--- a/generateexportedsymbols.awk
+++ b/generateexportedsymbols.awk
@@ -2,5 +2,10 @@
 	# Remove the CR character in case the sources are mapped from
 	# a Windows share and contain CRLF line endings
 	gsub(/\r/,"", $0);
-	print "_"  $0;
+
+	# Skip empty lines and comment lines starting with semicolon
+	if (NF && !match($0, /^[:space:]*;/))
+	{
+		print "_"  $0;
+	}
 } 

--- a/generateversionscript.awk
+++ b/generateversionscript.awk
@@ -6,7 +6,12 @@ BEGIN {
 	# Remove the CR character in case the sources are mapped from
 	# a Windows share and contain CRLF line endings
 	gsub(/\r/,"", $0);
-	print "        "  $0 ";";
+	
+	# Skip empty lines and comment lines starting with semicolon
+	if (NF && !match($0, /^[:space:]*;/))
+	{
+		print "        "  $0 ";";
+	}
 } 
 END {
 	print "    local: *;"

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -24,29 +24,31 @@ static const char * const coreClrDll = "libcoreclr.dylib";
 static const char * const coreClrDll = "libcoreclr.so";
 #endif
 
-// Windows types used by the ExecuteAssembly function
-typedef unsigned int DWORD;
-typedef const char16_t* LPCWSTR;
-typedef const char* LPCSTR;
-typedef int32_t HRESULT;
+#define SUCCEEDED(Status) ((Status) >= 0)
 
-#define SUCCEEDED(Status) ((HRESULT)(Status) >= 0)
+// Prototype of the coreclr_initialize function from the libcoreclr.so
+typedef int (*InitializeCoreCLRFunction)(
+            const char* exePath,
+            const char* appDomainFriendlyName,
+            int propertyCount,
+            const char** propertyKeys,
+            const char** propertyValues,
+            void** hostHandle,
+            unsigned int* domainId);
 
-// Prototype of the ExecuteAssembly function from the libcoreclr.do
-typedef HRESULT (*ExecuteAssemblyFunction)(
-                    LPCSTR exePath,
-                    LPCSTR coreClrPath,
-                    LPCSTR appDomainFriendlyName,
-                    int propertyCount,
-                    LPCSTR* propertyKeys,
-                    LPCSTR* propertyValues,
-                    int argc,
-                    LPCSTR* argv,
-                    LPCSTR managedAssemblyPath,
-                    LPCSTR entryPointAssemblyName,
-                    LPCSTR entryPointTypeName,
-                    LPCSTR entryPointMethodsName,
-                    DWORD* exitCode);
+// Prototype of the coreclr_shutdown function from the libcoreclr.so
+typedef int (*ShutdownCoreCLRFunction)(
+            void* hostHandle,
+            unsigned int domainId);
+
+// Prototype of the coreclr_execute_assembly function from the libcoreclr.so
+typedef int (*ExecuteAssemblyFunction)(
+            void* hostHandle,
+            unsigned int domainId,
+            int argc,
+            const char** argv,
+            const char* managedAssemblyPath,
+            unsigned int* exitCode);
 
 bool GetAbsolutePath(const char* path, std::string& absolutePath)
 {
@@ -233,8 +235,23 @@ int ExecuteManagedAssembly(
     void* coreclrLib = dlopen(coreClrDllPath.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (coreclrLib != nullptr)
     {
-        ExecuteAssemblyFunction executeAssembly = (ExecuteAssemblyFunction)dlsym(coreclrLib, "ExecuteAssembly");
-        if (executeAssembly != nullptr)
+        InitializeCoreCLRFunction initializeCoreCLR = (InitializeCoreCLRFunction)dlsym(coreclrLib, "coreclr_initialize");
+        ExecuteAssemblyFunction executeAssembly = (ExecuteAssemblyFunction)dlsym(coreclrLib, "coreclr_execute_assembly");
+        ShutdownCoreCLRFunction shutdownCoreCLR = (ShutdownCoreCLRFunction)dlsym(coreclrLib, "coreclr_shutdown");
+
+        if (initializeCoreCLR == nullptr)
+        {
+            fprintf(stderr, "Function coreclr_initialize not found in the libcoreclr.so\n");
+        }
+        else if (executeAssembly == nullptr)
+        {
+            fprintf(stderr, "Function coreclr_execute_assembly not found in the libcoreclr.so\n");
+        }
+        else if (shutdownCoreCLR == nullptr)
+        {
+            fprintf(stderr, "Function coreclr_shutdown not found in the libcoreclr.so\n");
+        }
+        else
         {
             // Allowed property names:
             // APPBASE
@@ -272,30 +289,46 @@ int ExecuteManagedAssembly(
                 "UseLatestBehaviorWhenTFMNotSpecified"
             };
 
-            HRESULT st = executeAssembly(
-                            currentExeAbsolutePath,
-                            coreClrDllPath.c_str(),
-                            "unixcorerun",
-                            sizeof(propertyKeys) / sizeof(propertyKeys[0]),
-                            propertyKeys,
-                            propertyValues,
-                            managedAssemblyArgc,
-                            managedAssemblyArgv,
-                            managedAssemblyAbsolutePath,
-                            NULL,
-                            NULL,
-                            NULL,
-                            (DWORD*)&exitCode);
+            void* hostHandle;
+            unsigned int domainId;
+
+            int st = initializeCoreCLR(
+                        currentExeAbsolutePath, 
+                        "unixcorerun", 
+                        sizeof(propertyKeys) / sizeof(propertyKeys[0]), 
+                        propertyKeys, 
+                        propertyValues, 
+                        &hostHandle, 
+                        &domainId);
 
             if (!SUCCEEDED(st))
             {
-                fprintf(stderr, "ExecuteAssembly failed - status: 0x%08x\n", st);
+                fprintf(stderr, "coreclr_initialize failed - status: 0x%08x\n", st);
                 exitCode = -1;
             }
-        }
-        else
-        {
-            fprintf(stderr, "Function ExecuteAssembly not found in the libcoreclr.so\n");
+            else 
+            {
+                st = executeAssembly(
+                        hostHandle,
+                        domainId,
+                        managedAssemblyArgc,
+                        managedAssemblyArgv,
+                        managedAssemblyAbsolutePath,
+                        (unsigned int*)&exitCode);
+
+                if (!SUCCEEDED(st))
+                {
+                    fprintf(stderr, "coreclr_execute_assembly failed - status: 0x%08x\n", st);
+                    exitCode = -1;
+                }
+
+                st = shutdownCoreCLR(hostHandle, domainId);
+                if (!SUCCEEDED(st))
+                {
+                    fprintf(stderr, "coreclr_shutdown failed - status: 0x%08x\n", st);
+                    exitCode = -1;
+                }
+            }
         }
 
         if (dlclose(coreclrLib) != 0)

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -1,7 +1,30 @@
+; Unix hosting API
+coreclr_create_delegate
+coreclr_execute_assembly
+coreclr_initialize
+coreclr_shutdown
+
+; Obsolete Unix hosting API, to be removed
+ExecuteAssembly
+
+; PAL initialization and module registration
+PAL_InitializeCoreCLR 
+PAL_RegisterModule
+PAL_UnregisterModule
+
+; Functions exported by the coreclr
+CoreDllMain
+DllMain
+GetCLRRuntimeHost
+
+; Functions used by CoreFX
+EnsureOpenSslInitialized
+ForkAndExecProcess
+
+; Win32 API and other PAL functions used by the mscorlib
 CloseHandle
 CoCreateGuid
 CopyFileW
-CoreDllMain
 CoTaskMemAlloc
 CoTaskMemFree
 CreateDirectoryW
@@ -10,19 +33,14 @@ CreateFileW
 CreateMutexW
 CreateSemaphoreW
 DeleteFileW
-DllMain
 DuplicateHandle
-EnsureOpenSslInitialized
-ExecuteAssembly
 FindClose
 FindFirstFileW
 FindNextFileW
 FlushFileBuffers
-ForkAndExecProcess
 FormatMessageW
 FreeEnvironmentStringsW
 GetACP
-GetCLRRuntimeHost
 GetConsoleCP
 GetConsoleOutputCP
 GetCurrentDirectoryW
@@ -53,10 +71,7 @@ MultiByteToWideChar
 OpenEventW
 OpenMutexW
 OpenSemaphoreW
-PAL_InitializeCoreCLR 
 PAL_Random
-PAL_RegisterModule
-PAL_UnregisterModule
 QueryPerformanceCounter  
 QueryPerformanceFrequency
 RaiseException

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -88,6 +88,205 @@ static LPCWSTR* StringArrayToUnicode(int argc, LPCSTR* argv)
 }
 
 //
+// Initialize the CoreCLR. Creates and starts CoreCLR host and creates an app domain
+//
+// Parameters:
+//  exePath                 - Absolute path of the executable that invoked the ExecuteAssembly
+//  appDomainFriendlyName   - Friendly name of the app domain that will be created to execute the assembly
+//  propertyCount           - Number of properties (elements of the following two arguments)
+//  propertyKeys            - Keys of properties of the app domain
+//  propertyValues          - Values of properties of the app domain
+//  hostHandle              - Output parameter, handle of the created host
+//  domainId                - Output parameter, id of the created app domain 
+//
+// Returns:
+//  HRESULT indicating status of the operation. S_OK if the assembly was successfully executed
+//
+extern "C"
+int coreclr_initialize(
+            const char* exePath,
+            const char* appDomainFriendlyName,
+            int propertyCount,
+            const char** propertyKeys,
+            const char** propertyValues,
+            void** hostHandle,
+            unsigned int* domainId)
+{
+    DWORD error = PAL_InitializeCoreCLR(exePath);
+    HRESULT hr = HRESULT_FROM_WIN32(error);
+
+    // If PAL initialization failed, then we should return right away and avoid
+    // calling any other APIs because they can end up calling into the PAL layer again.
+    if (FAILED(hr))
+    {
+        return hr;
+    }
+
+    ReleaseHolder<ICLRRuntimeHost2> host;
+
+    hr = CorHost2::CreateObject(IID_ICLRRuntimeHost2, (void**)&host);
+    IfFailRet(hr);
+
+    hr = host->SetStartupFlags((STARTUP_FLAGS)
+                               (STARTUP_FLAGS::STARTUP_LOADER_OPTIMIZATION_SINGLE_DOMAIN |
+                                STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN));
+    IfFailRet(hr);
+
+    hr = host->Start();
+    IfFailRet(hr);
+    
+    ConstWStringHolder appDomainFriendlyNameW = StringToUnicode(appDomainFriendlyName);
+    
+    ConstWStringArrayHolder propertyKeysW;
+    propertyKeysW.Set(StringArrayToUnicode(propertyCount, propertyKeys), propertyCount);
+    
+    ConstWStringArrayHolder propertyValuesW;
+    propertyValuesW.Set(StringArrayToUnicode(propertyCount, propertyValues), propertyCount);
+
+    hr = host->CreateAppDomainWithManager(
+        appDomainFriendlyNameW,
+        // Flags:
+        // APPDOMAIN_ENABLE_PLATFORM_SPECIFIC_APPS
+        // - By default CoreCLR only allows platform neutral assembly to be run. To allow
+        //   assemblies marked as platform specific, include this flag
+        //
+        // APPDOMAIN_ENABLE_PINVOKE_AND_CLASSIC_COMINTEROP
+        // - Allows sandboxed applications to make P/Invoke calls and use COM interop
+        //
+        // APPDOMAIN_SECURITY_SANDBOXED
+        // - Enables sandboxing. If not set, the app is considered full trust
+        //
+        // APPDOMAIN_IGNORE_UNHANDLED_EXCEPTION
+        // - Prevents the application from being torn down if a managed exception is unhandled
+        //
+        APPDOMAIN_ENABLE_PLATFORM_SPECIFIC_APPS |
+        APPDOMAIN_ENABLE_PINVOKE_AND_CLASSIC_COMINTEROP |
+        APPDOMAIN_DISABLE_TRANSPARENCY_ENFORCEMENT,
+        NULL,                    // Name of the assembly that contains the AppDomainManager implementation
+        NULL,                    // The AppDomainManager implementation type name
+        propertyCount,
+        propertyKeysW,
+        propertyValuesW,
+        domainId);
+
+    if (SUCCEEDED(hr))
+    {
+        host.SuppressRelease();
+        *hostHandle = host;
+    }
+
+    return hr;
+}
+
+//
+// Shutdown CoreCLR. It unloads the app domain and stops the CoreCLR host.
+//
+// Parameters:
+//  hostHandle              - Handle of the host
+//  domainId                - Id of the domain 
+//
+// Returns:
+//  HRESULT indicating status of the operation. S_OK if the assembly was successfully executed
+//
+extern "C"
+int coreclr_shutdown(
+            void* hostHandle,
+            unsigned int domainId)
+{
+    ReleaseHolder<ICLRRuntimeHost2> host(reinterpret_cast<ICLRRuntimeHost2*>(hostHandle));
+    HRESULT hr = host->UnloadAppDomain(domainId,
+                                       true); // Wait until done
+    IfFailRet(hr);
+
+    hr = host->Stop();
+
+    // The PAL_Terminate is not called here since it would terminate the current process.
+
+    return hr;
+}
+
+//
+// Create a native callable delegate for a managed method.
+//
+// Parameters:
+//  hostHandle              - Handle of the host
+//  domainId                - Id of the domain 
+//  entryPointAssemblyName  - Name of the assembly which holds the custom entry point
+//  entryPointTypeName      - Name of the type which holds the custom entry point
+//  entryPointMethodName    - Name of the method which is the custom entry point
+//  delegate                - Output parameter, the function stores a pointer to the delegate at the specified address
+//
+// Returns:
+//  HRESULT indicating status of the operation. S_OK if the assembly was successfully executed
+//
+extern "C"
+int coreclr_create_delegate(
+            void* hostHandle,
+            unsigned int domainId,
+            const char* entryPointAssemblyName,
+            const char* entryPointTypeName,
+            const char* entryPointMethodName,
+            void** delegate)
+{
+    ICLRRuntimeHost2* host = reinterpret_cast<ICLRRuntimeHost2*>(hostHandle);
+
+    ConstWStringHolder entryPointAssemblyNameW = StringToUnicode(entryPointAssemblyName);
+    ConstWStringHolder entryPointTypeNameW = StringToUnicode(entryPointTypeName);
+    ConstWStringHolder entryPointMethodNameW = StringToUnicode(entryPointMethodName);
+
+    HRESULT hr = host->CreateDelegate(
+                            domainId,
+                            entryPointAssemblyNameW,
+                            entryPointTypeNameW,
+                            entryPointMethodNameW,
+                            (INT_PTR*)delegate);
+    
+    return hr;
+}
+
+//
+// Execute a managed assembly with given arguments
+//
+// Parameters:
+//  hostHandle              - Handle of the host
+//  domainId                - Id of the domain 
+//  argc                    - Number of arguments passed to the executed assembly
+//  argv                    - Array of arguments passed to the executed assembly
+//  managedAssemblyPath     - Path of the managed assembly to execute (or NULL if using a custom entrypoint).
+//  exitCode                - Exit code returned by the executed assembly
+//
+// Returns:
+//  HRESULT indicating status of the operation. S_OK if the assembly was successfully executed
+//
+extern "C"
+int coreclr_execute_assembly(
+            void* hostHandle,
+            unsigned int domainId,
+            int argc,
+            const char** argv,
+            const char* managedAssemblyPath,
+            unsigned int* exitCode)
+{
+    if (exitCode == NULL)
+    {
+        return HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER);
+    }
+    *exitCode = -1;
+
+    ICLRRuntimeHost2* host = reinterpret_cast<ICLRRuntimeHost2*>(hostHandle);
+
+    ConstWStringArrayHolder argvW;
+    argvW.Set(StringArrayToUnicode(argc, argv), argc);
+    
+    ConstWStringHolder managedAssemblyPathW = StringToUnicode(managedAssemblyPath);
+
+    HRESULT hr = host->ExecuteAssembly(domainId, managedAssemblyPathW, argc, argvW, exitCode);
+    IfFailRet(hr);
+
+    return hr;
+}
+
+//
 // Execute a managed assembly with given arguments
 //
 // Parameters:
@@ -130,64 +329,10 @@ HRESULT ExecuteAssembly(
     }
     *exitCode = -1;
 
-    DWORD error = PAL_InitializeCoreCLR(exePath);
-    HRESULT hr = HRESULT_FROM_WIN32(error);
-
-    // If PAL initialization failed, then we should return right away and avoid
-    // calling any other APIs because they can end up calling into the PAL layer again.
-    if (FAILED(hr))
-    {
-        return hr;
-    }
-
-    ReleaseHolder<ICLRRuntimeHost2> host;
-
-    hr = CorHost2::CreateObject(IID_ICLRRuntimeHost2, (void**)&host);
-    IfFailRet(hr);
-
-    hr = host->SetStartupFlags((STARTUP_FLAGS)
-                               (STARTUP_FLAGS::STARTUP_LOADER_OPTIMIZATION_SINGLE_DOMAIN |
-                                STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN));
-    IfFailRet(hr);
-
-    hr = host->Start();
-    IfFailRet(hr);
-    
-    ConstWStringHolder appDomainFriendlyNameW = StringToUnicode(appDomainFriendlyName);
-    
-    ConstWStringArrayHolder propertyKeysW;
-    propertyKeysW.Set(StringArrayToUnicode(propertyCount, propertyKeys), propertyCount);
-    
-    ConstWStringArrayHolder propertyValuesW;
-    propertyValuesW.Set(StringArrayToUnicode(propertyCount, propertyValues), propertyCount);
-
+    ReleaseHolder<ICLRRuntimeHost2> host; //(reinterpret_cast<ICLRRuntimeHost2*>(hostHandle));
     DWORD domainId;
 
-    hr = host->CreateAppDomainWithManager(
-        appDomainFriendlyNameW,
-        // Flags:
-        // APPDOMAIN_ENABLE_PLATFORM_SPECIFIC_APPS
-        // - By default CoreCLR only allows platform neutral assembly to be run. To allow
-        //   assemblies marked as platform specific, include this flag
-        //
-        // APPDOMAIN_ENABLE_PINVOKE_AND_CLASSIC_COMINTEROP
-        // - Allows sandboxed applications to make P/Invoke calls and use COM interop
-        //
-        // APPDOMAIN_SECURITY_SANDBOXED
-        // - Enables sandboxing. If not set, the app is considered full trust
-        //
-        // APPDOMAIN_IGNORE_UNHANDLED_EXCEPTION
-        // - Prevents the application from being torn down if a managed exception is unhandled
-        //
-        APPDOMAIN_ENABLE_PLATFORM_SPECIFIC_APPS |
-        APPDOMAIN_ENABLE_PINVOKE_AND_CLASSIC_COMINTEROP |
-        APPDOMAIN_DISABLE_TRANSPARENCY_ENFORCEMENT,
-        NULL,                    // Name of the assembly that contains the AppDomainManager implementation
-        NULL,                    // The AppDomainManager implementation type name
-        propertyCount,
-        propertyKeysW,
-        propertyValuesW,
-        &domainId);
+    HRESULT hr = coreclr_initialize(exePath, appDomainFriendlyName, propertyCount, propertyKeys, propertyValues, &host, &domainId);
     IfFailRet(hr);
 
     ConstWStringArrayHolder argvW;
@@ -219,14 +364,8 @@ HRESULT ExecuteAssembly(
 
         *exitCode = pHostMain(argc, argvW);
     }
-    
-    hr = host->UnloadAppDomain(domainId,
-                               true); // Wait until done
-    IfFailRet(hr);
 
-    hr = host->Stop();
-
-    // The PAL_Terminate is not called here since it would terminate the current process.
+    hr = coreclr_shutdown(host, domainId);
 
     return hr;
 }

--- a/src/dlls/mscorrc/CMakeLists.txt
+++ b/src/dlls/mscorrc/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
             COMMAND ${CMAKE_CXX_COMPILER} -E -P ${PREPROCESS_DEFINITIONS} ${INCLUDE_DIRECTORIES} -o ${PREPROCESSED_SOURCE} -x c ${SOURCE}
             # Convert the preprocessed .rc file to a C++ file which will be used to make a static lib.
             COMMAND ${AWK} -f ${RC_TO_CPP} -f ${PROCESS_RC} ${PREPROCESSED_SOURCE} >${RESOURCE_ENTRY_ARRAY_CPP}
-            DEPENDS ${SOURCE}
+            DEPENDS ${SOURCE} ${RC_TO_CPP} ${PROCESS_RC}
         )
 
         include_directories(${RESOURCE_STRING_HEADER_DIR})


### PR DESCRIPTION
This change modifies the Unix hosting API so that the hosting app can create
as many managed delegates as it needs and execute them as many times it wants.
The new API contains separate functions to initialize and shutdown CoreCLR
and a function to create a delegate.
The current ExecuteAssembly function behavior stays unmodified for now to
ensure that dnx that uses that API and that pulls the binary libcoreclr
is not broken.
After the dnx is updated to use the new CreateDelegate API, I'll change
the ExecuteAssembly and the corerun / coreconsole too.