### PR TITLE
Ensure FEATURE_MANAGED_ETW isn't set for TargetsUnix

### DIFF
--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -79,7 +79,7 @@
     <!-- The rejit feature is available only on supported architectures (x86 & x64) -->
     <FeatureReJIT Condition="('$(TargetArch)' == 'i386') or ('$(TargetArch)' == 'amd64')">true</FeatureReJIT>
     <FeatureWindowsPhone>true</FeatureWindowsPhone>
-    <FeatureManagedEtw Condition="'$(OS)' == 'Windows_NT'">true</FeatureManagedEtw>
+    <FeatureManagedEtw>true</FeatureManagedEtw>
     <FeatureManagedEtwChannels>true</FeatureManagedEtwChannels>
     <FeatureHostedBinder>true</FeatureHostedBinder>
     <BinderDebugLog Condition="'$(_BuildType)'=='dbg'">true</BinderDebugLog>
@@ -112,6 +112,7 @@
     <FeatureCominterop>false</FeatureCominterop>
     <FeatureCominteropUnmanagedActivation>false</FeatureCominteropUnmanagedActivation>
     <FeatureCominteropWinRTManagedActivation>false</FeatureCominteropWinRTManagedActivation>
+    <FeatureManagedEtw>false</FeatureManagedEtw>
 
     <!-- Features implemented by fxcore -->
     <FeatureLegacySurface>false</FeatureLegacySurface>


### PR DESCRIPTION
Updated buildtools were brought in to coreclr, and the props file was
still using the $(OS) variable to control whether FEATURE_MANAGED_ETW was
set, but whereas that used to be used to mean what platform we were
targeting, updated buildtools use it to mean what platform we're building
on, with $(OSGroup) meaning what is the target platform.