### PR TITLE
Declare locals in correct order.

### DIFF
--- a/src/utilcode/util.cpp
+++ b/src/utilcode/util.cpp
@@ -263,8 +263,8 @@ HRESULT FakeCoCreateInstanceEx(REFCLSID       rclsid,
     HRESULT hr = S_OK;
 
     // Call the function to get a class factory for the rclsid passed in.
-    ReleaseHolder<IClassFactory> classFactory;
     HModuleHolder hDll;
+    ReleaseHolder<IClassFactory> classFactory;
     IfFailRet(FakeCoCallDllGetClassObject(rclsid, wszDllPath, _IID_IClassFactory, (void**)&classFactory, &hDll));
 
     // Ask the class factory to create an instance of the


### PR DESCRIPTION
The order of declaration doesn't matter when the call to CreateInstance
succeeds because the call to unload the DLL is suppressed. However, if
CreateInstance fails, we do unload the DLL, and this needs to happen after the
call to Release on the class factory.