### PR TITLE
Fix #1186: wrong Contract.Assert in Lazy<>::Value getter.

### DIFF
--- a/src/mscorlib/src/System/Lazy.cs
+++ b/src/mscorlib/src/System/Lazy.cs
@@ -322,7 +322,7 @@ namespace System
                     }
 
                     LazyInternalExceptionHolder exc = m_boxed as LazyInternalExceptionHolder;
-                    Contract.Assert(m_boxed != null);
+                    Contract.Assert(exc != null);
                     exc.m_edi.Throw();
                 }
 


### PR DESCRIPTION
Fixed issue #1186: a wrong Contract.Assert in a Value property getter of a class Lazy<>.