### PR TITLE
mscorlib: Use Array.Empty where possible

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -1018,7 +1018,7 @@ namespace System.Diagnostics.Tracing
         {
             if (m_eventSourceEnabled)
             {
-                if (arg1 == null) arg1 = new byte[0];
+                if (arg1 == null) arg1 = Array.Empty<byte>();
                 int blobSize = arg1.Length;
                 fixed (byte* blob = &arg1[0])
                 {
@@ -1038,7 +1038,7 @@ namespace System.Diagnostics.Tracing
         {
             if (m_eventSourceEnabled)
             {
-                if (arg2 == null) arg2 = new byte[0];
+                if (arg2 == null) arg2 = Array.Empty<byte>();
                 int blobSize = arg2.Length;
                 fixed (byte* blob = &arg2[0])
                 {
@@ -5854,7 +5854,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.channelTab == null)
             {
-                return new ulong[0];
+                return Array.Empty<ulong>();
             }
 
             // We create an array indexed by the channel id for fast look up.

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -434,7 +434,7 @@ namespace System.Reflection
             m_typedCtorArgs = Array.AsReadOnly(new CustomAttributeTypedArgument[] {
                 new CustomAttributeTypedArgument(fieldOffset.Value)
             });
-            m_namedArgs = Array.AsReadOnly(new CustomAttributeNamedArgument[0]);
+            m_namedArgs = Array.AsReadOnly(Array.Empty<CustomAttributeNamedArgument>());
         }
         private void Init(MarshalAsAttribute marshalAs)
         {
@@ -484,14 +484,14 @@ namespace System.Reflection
             typedArgs[0] = new CustomAttributeTypedArgument(typeof(Type), forwardedTo.Destination);
             m_typedCtorArgs = Array.AsReadOnly(typedArgs);
 
-            CustomAttributeNamedArgument[] namedArgs = new CustomAttributeNamedArgument[0];
+            CustomAttributeNamedArgument[] namedArgs = Array.Empty<CustomAttributeNamedArgument>();
             m_namedArgs = Array.AsReadOnly(namedArgs);
         }
         private void Init(object pca)
         {
             m_ctor = pca.GetType().GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];
-            m_typedCtorArgs = Array.AsReadOnly(new CustomAttributeTypedArgument[0]);
-            m_namedArgs = Array.AsReadOnly(new CustomAttributeNamedArgument[0]);
+            m_typedCtorArgs = Array.AsReadOnly(Array.Empty<CustomAttributeTypedArgument>());
+            m_namedArgs = Array.AsReadOnly(Array.Empty<CustomAttributeNamedArgument>());
         }
         #endregion
 
@@ -2174,7 +2174,7 @@ namespace System.Reflection
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
             if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
-                return new Attribute[0];
+                return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
             Attribute pca = null;
@@ -2247,7 +2247,7 @@ namespace System.Reflection
 
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
             if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
-                return new Attribute[0];
+                return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
             Attribute pca = null;
@@ -2375,7 +2375,7 @@ namespace System.Reflection
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
             if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
-                return new Attribute[0];
+                return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
             if (includeSecCa && (all || IsSecurityAttribute(caType)))
@@ -2486,7 +2486,7 @@ namespace System.Reflection
             bool all = caType == (RuntimeType)typeof(object) || caType == (RuntimeType)typeof(Attribute);
 
             if (!all && s_pca.GetValueOrDefault(caType) == null && !IsSecurityAttribute(caType))
-                return new Attribute[0];
+                return Array.Empty<Attribute>();
 
             List<Attribute> pcas = new List<Attribute>();
 

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -363,7 +363,7 @@ namespace System.Reflection.Emit
                 }
             }
             else {
-                m_parameterTypes = new RuntimeType[0];
+                m_parameterTypes = Array.Empty<RuntimeType>();
             }
             
             // check and store the return value

--- a/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/mscorlib/src/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -78,8 +78,8 @@ namespace System.Runtime.CompilerServices
         [System.Security.SecuritySafeCritical]
         public ConditionalWeakTable()
         {
-            _buckets = new int[0];
-            _entries = new Entry[0];
+            _buckets = Array.Empty<int>();
+            _entries = Array.Empty<Entry>();
             _freeList = -1;
             _lock = new Object();
 

--- a/src/mscorlib/src/System/Runtime/InteropServices/RegistrationServices.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/RegistrationServices.cs
@@ -352,7 +352,7 @@ namespace System.Runtime.InteropServices {
 
             // If the does not have a public default constructor then is not creatable from COM so 
             // it does not require registration unless it is a value class.
-            if (!type.IsValueType && type.GetConstructor(BindingFlags.Instance | BindingFlags.Public,null,new Type[0],null) == null)
+            if (!type.IsValueType && type.GetConstructor(BindingFlags.Instance | BindingFlags.Public,null,Array.Empty<Type>(),null) == null)
                 return false;
 
             // All other conditions are met so check to see if the type is visible from COM.

--- a/src/mscorlib/src/System/Runtime/InteropServices/TCEAdapterGen/EventProviderWriter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/TCEAdapterGen/EventProviderWriter.cs
@@ -102,7 +102,7 @@ namespace System.Runtime.InteropServices.TCEAdapterGen {
             Contract.Assert(CookieField != null, "Unable to find the field m_dwCookie on the sink helper");
             
             // Retrieve the sink helper's constructor.
-            ConstructorInfo SinkHelperCons = SinkHelperClass.GetConstructor(EventProviderWriter.DefaultLookup | BindingFlags.NonPublic, null, new Type[0], null );    
+            ConstructorInfo SinkHelperCons = SinkHelperClass.GetConstructor(EventProviderWriter.DefaultLookup | BindingFlags.NonPublic, null, Array.Empty<Type>(), null );    
             Contract.Assert(SinkHelperCons != null, "Unable to find the constructor for the sink helper");
             
             // Retrieve the IConnectionPoint.Advise method.
@@ -461,7 +461,7 @@ namespace System.Runtime.InteropServices.TCEAdapterGen {
         private MethodBuilder DefineInitSrcItfMethod( TypeBuilder OutputTypeBuilder, Type SourceInterface, FieldBuilder fbSinkHelperArray, FieldBuilder fbEventCP, FieldBuilder fbCPC )
         {
             // Retrieve the constructor info for the array list's default constructor.
-            ConstructorInfo DefaultArrayListCons = typeof(ArrayList).GetConstructor(EventProviderWriter.DefaultLookup, null, new Type[0], null );
+            ConstructorInfo DefaultArrayListCons = typeof(ArrayList).GetConstructor(EventProviderWriter.DefaultLookup, null, Array.Empty<Type>(), null );
             Contract.Assert(DefaultArrayListCons != null, "Unable to find the constructor for class ArrayList");    
             
             // Temp byte array for Guid
@@ -551,7 +551,7 @@ namespace System.Runtime.InteropServices.TCEAdapterGen {
         private void DefineConstructor( TypeBuilder OutputTypeBuilder, FieldBuilder fbCPC )
         {
             // Retrieve the constructor info for the base class's constructor.
-            ConstructorInfo DefaultBaseClsCons = typeof(Object).GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, new Type[0], null );
+            ConstructorInfo DefaultBaseClsCons = typeof(Object).GetConstructor(BindingFlags.Instance | BindingFlags.Public, null, Array.Empty<Type>(), null );
             Contract.Assert(DefaultBaseClsCons != null, "Unable to find the object's public default constructor");
             
             // Define the default constructor.

--- a/src/mscorlib/src/System/Runtime/InteropServices/TCEAdapterGen/EventSinkHelperWriter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/TCEAdapterGen/EventSinkHelperWriter.cs
@@ -252,7 +252,7 @@ namespace System.Runtime.InteropServices.TCEAdapterGen {
         private void DefineConstructor( TypeBuilder OutputTypeBuilder, FieldBuilder fbCookie, FieldBuilder[] afbDelegates )
         {
             // Retrieve the constructor info for the base classe's constructor.
-            ConstructorInfo DefaultBaseClsCons = typeof(Object).GetConstructor(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, new Type[0], null );
+            ConstructorInfo DefaultBaseClsCons = typeof(Object).GetConstructor(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public, null, Array.Empty<Type>(), null );
             Contract.Assert(DefaultBaseClsCons != null, "Unable to find the constructor for class " + m_InputType.Name);    
         
             // Define the default constructor.


### PR DESCRIPTION
I decided to do what I did for [corefx](https://github.com/dotnet/corefx/pull/2344) back a few days ago, and replace most of the `new T[0]` expressions in mscorlib with `Array.Empty<T>()`. The only ones I left alone were `EmptyArray<T>` (which `Array.Empty` references) and some code in `String.cs`, where there were explicit comments stating that the code should be left alone for compat issues.

Are my changes OK?