### PR TITLE
Allow coreconsole to be called without extension

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -595,15 +595,27 @@ void showHelp() {
 
 int __cdecl wmain(const int argc, const wchar_t* argv[])
 {
-	auto programPath = _wcsdup(argv[0]);
-	auto extension = wcsrchr(programPath, '.') + 1;
-	if (wcscmp(extension, L"exe") != 0) {
-		::wprintf(W("This executable needs to have 'exe' extension"));
-		return -1;
-	}
-	extension[0] = 'd';
-	extension[1] = 'l';
-	extension[2] = 'l';
+    auto programPath = _wcsdup(argv[0]);
+    auto extension = wcsrchr(programPath, '.');
+    if (extension == NULL) {
+        // We were called without the extension so need a bigger buffer
+        size_t pathLen = wcslen(programPath);
+        size_t bufLen = pathLen + 5;
+        wchar_t *newPath = new wchar_t[bufLen];
+        wcscpy_s(newPath, bufLen, programPath);
+        wcscat_s(newPath, bufLen, W(".dll"));
+        programPath = newPath;
+    }
+    else {
+        extension += 1;
+        if (wcscmp(extension, L"exe") != 0) {
+            ::wprintf(W("This executable needs to have 'exe' extension"));
+            return -1;
+        }
+        extension[0] = 'd';
+        extension[1] = 'l';
+        extension[2] = 'l';
+    }
 
     // Parse the options from the command line
     bool verbose = false;


### PR DESCRIPTION
This fixes #1253 . It handles the case where coreconsole is run from the command line without giving the extension. If called without an extension then `newPath` will be allocated but not freed, but this shouldn't matter since it is needed for the duration of the application anyway.

Minor issue for a future PR perhaps, this file is mixed spaces and tabs indentation.