### PR TITLE
Change order in which P/Invoke names are checked

### DIFF
--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1348,15 +1348,15 @@ static HMODULE LOADLoadLibrary(LPCSTR shortAsciiName, BOOL fDynamic)
         // We try to dlopen with such variations on the original.
         const char* const formatStrings[4] = // used with args: PAL_SHLIB_PREFIX, shortAsciiName, PAL_SHLIB_SUFFIX
         {
+            "%.0s%s%.0s", //        name        (checked first so that the dev has more control if needed)
             "%s%s%s",     // prefix+name+suffix
-            "%.0s%s%.0s", // name
-            "%.0s%s%s",   // name+suffix
+            "%.0s%s%s",   //        name+suffix
             "%s%s%.0s",   // prefix+name
         };
         const int skipPrefixing = strchr(shortAsciiName, '/') != NULL; // skip prefixing if the name is actually a path
         for (int i = 0; i < 4; i++)
         {
-           if (skipPrefixing && (i == 0 || i == 3)) // 0th and 3rd strings include prefixes
+           if (skipPrefixing && (i == 1 || i == 3)) // 1st and 3rd strings include prefixes
                continue;
            
             if (!dl_handle &&


### PR DESCRIPTION
In #1248 we added support for automatically prepending a prefix onto a DllImport name, in addition to the existing support for automatically appending a suffix.  This leads to four combinations that are checked: name, prefix+name, name+suffix, and prefix+name+suffix.  The current code as of #1248 first checks for prefix+name+suffix, under the assumption that it'll be the most common case, and thus we optimize for it, e.g. a developer writes "sqlite3" such that it'll become "sqlite3.dll" on Windows, "libsqlite3.so" on Linux, "libsqlite3.dylib" on OS X, etc.

However, there is a debate about whether we should actually check first for exactly what the developer wrote, checking for just name before checking for prefix+name+suffix.  Whereas the argument for prefix+name+suffix is performance, the argument for name is safety, in that by always checking first for what the developer explicitly typed, the developer has more control over ensuring that another library isn't injected into the search order ahead of it.

This commit swaps the order of the checks for prefix+name+suffix and name, making the check for name first.

We can either choose to merge the PR if we want this revised behavior of checking for name first, or close the PR if we decide we want the behavior of prefix+name+suffix first.