### PR TITLE
Added an ifdef _DEBUG to fix the release build on Linux.

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -627,7 +627,9 @@ void GcInfoEncoder::Build()
      m_DbgEncoder.Build();
 #endif    
 
+#if _DEBUG
     _ASSERTE(m_IsSlotTableFrozen || m_NumSlots == 0);
+#endif
 
     _ASSERTE((1 << NUM_NORM_CODE_OFFSETS_PER_CHUNK_LOG2) == NUM_NORM_CODE_OFFSETS_PER_CHUNK);
 


### PR DESCRIPTION
Inside gcinfoencoder.h, the member variable m_IsSlotTableFrozen is compiled out in release, but referenced in release at gcinfoencoder.cpp:630 added a ifdef to avoid that.

Please note this is my first contribution to this project, if there is anything I have done wrong or would prefer to be done a different way please tell me so that I can learn for the future.