### PR TITLE
Add support for mscorlib.dll build on Unix.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ __resgenpackageversion="1.0.0"
 __resgenpath=$__packageroot/$__resgenpackageid.$__resgenpackageversion/tools/resgen.exe
 
 if [ $(uname) == "Linux" ]; then
-    __monoroot=/devel
+    __monoroot=/usr
 elif [ $(uname) == "FreeBSD" ]; then
     __monoroot=/usr/local
 else

--- a/dir.props
+++ b/dir.props
@@ -1,4 +1,4 @@
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" InitialTargets="CheckRoslyn" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!--
     $(OS) is set to Unix/Windows_NT. This comes from an environment variable on Windows and MSBuild on Unix.
@@ -112,13 +112,146 @@
     <NuSpecs Condition="'$(Configuration)'=='Debug'" Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.Debug.Development.nuspec" />
   </ItemGroup>
 
-  <!-- Setup common target properties that we use to conditionally include sources -->
+
+
+  <!--
+    Set up Roslyn predefines
+  -->
   <PropertyGroup>
-    <TargetsFreeBSD Condition="'$(BuildOS)' == 'FreeBSD'">true</TargetsFreeBSD>
-    <TargetsLinux Condition="'$(BuildOS)' == 'Linux'">true</TargetsLinux>
-    <TargetsOSX Condition="'$(BuildOS)' == 'OSX'">true</TargetsOSX>
-    <TargetsWindows Condition="'$(BuildOS)' == 'Windows_NT'">true</TargetsWindows>
-    
-    <TargetsUnix Condition="'$(TargetsFreeBSD)' == 'true' or '$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true'">true</TargetsUnix>
+    <RoslynPackageDir>$(PackagesDir)/$(RoslynPackageName).$(RoslynVersion)/</RoslynPackageDir>
+    <RoslynPropsFile>$(RoslynPackageDir)build/Microsoft.Net.ToolsetCompilers.props</RoslynPropsFile>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(OsEnvironment)'=='Unix' and '$(UseRoslynCompiler)'=='true'">
+    <!--
+      PDB support isn't implemented yet. https://github.com/dotnet/roslyn/issues/2449
+      Note that both DebugSymbols and DebugType need set or project references will assume they need to copy pdbs and fail.
+    -->
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+    <!--
+      Delay signing with the ECMA key currently doesn't work.
+      https://github.com/dotnet/roslyn/issues/2444
+    -->
+    <UseECMAKey>false</UseECMAKey>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(OsEnvironment)'=='Unix' and '$(UseRoslynCompiler)'=='true'">
+    <!--
+      System.Diagnostics.Debug.Tests currently fails trying to resolve types against System.Runtime
+      https://github.com/dotnet/corefx/issues/1609
+    -->
+    <ExcludeProjects Include="System.Diagnostics.Debug/tests/System.Diagnostics.Debug.Tests.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(OsEnvironment)'=='Unix'">
+    <!--
+      Mono currently doesn't include VB targets for portable, notably /lib/mono/xbuild/Microsoft/Portable/v4.5/Microsoft.Portable.VisualBasic.targets.
+      Fixed in https://github.com/mono/mono/pull/1726.
+    -->
+    <IncludeVbProjects>false</IncludeVbProjects>
+    <!--
+      Building packages fails for two reasons.
+      First, nuget doesn't like the paths in the nuspec having backslashes as directory separators.
+      Second, we aren't yet building pdbs, which the nuspecs specify.
+    -->
+    <SkipBuildPackages>true</SkipBuildPackages>
+  </PropertyGroup>
+
+  <!-- 
+  Projects that have no OS-specific implementations just use Debug and Release for $(Configuration).
+  Projects that do have OS-specific implementations use OS_Debug and OS_Release, for all OS's we support even
+  if the code is the same between some OS's (so if you have some project that just calls POSIX APIs, we still have
+  OSX_[Debug|Release] and Linux_[Debug|Release] configurations.  We do this so that we place all the output under
+  a single binary folder and can have a similar experience between the command line and Visual Studio.
+  
+  Since now have multiple *Debug and *Release configurations, ConfigurationGroup is set to Debug for any of the
+  debug configurations, and to Release for any of the release configurations.
+  -->
+
+  <!-- Set default Configuration and Platform -->
+  <PropertyGroup>
+    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
+
+    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
+    <ConfigurationGroup Condition="$(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
+    <ConfigurationGroup Condition="$(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">$(Configuration)</ConfigurationGroup>
+
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Windows'))">Windows_NT</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
+    <OSGroup Condition="'$(OSGroup)'==''">Windows_NT</OSGroup>
+  </PropertyGroup>
+
+  <!-- Set up Default symbol and optimization for Configuration -->
+  <PropertyGroup Condition="'$(ConfigurationGroup)' == 'Debug'">
+    <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+    <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
+    <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
+    <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(ConfigurationGroup)' == 'Release'">
+    <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+    <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
+    <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+    <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <!-- Disable some standard properties for building our projects -->
+  <PropertyGroup>
+    <NoStdLib>true</NoStdLib>
+    <NoExplicitReferenceToStdLib>true</NoExplicitReferenceToStdLib>
+    <AddAdditionalExplicitAssemblyReferences>false</AddAdditionalExplicitAssemblyReferences>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
+  </PropertyGroup>
+
+  <!-- Set up handling of build warnings -->
+  <PropertyGroup>
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <!-- Set up some common paths -->
+  <PropertyGroup>
+    <CommonPath>$(SourceDir)Common\src</CommonPath>
+    <CommonTestPath>$(SourceDir)Common\tests</CommonTestPath>
+  </PropertyGroup>
+
+  <!-- Set up the default output and intermediate paths -->
+  <PropertyGroup>
+    <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
+
+    <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)\$(MSBuildProjectName)\</OutputPath>
+
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
+    <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\</IntermediateOutputPath>
+
+    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)\</TestPath>
+
+    <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
+  </PropertyGroup>
+
+  <!-- Set up common target properties that we use to conditionally include sources -->
+  <PropertyGroup>
+    <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>
+    <TargetsLinux Condition="'$(OSGroup)' == 'Linux'">true</TargetsLinux>
+    <TargetsOSX Condition="'$(OSGroup)' == 'OSX'">true</TargetsOSX>
+    <TargetsFreeBSD Condition="'$(OSGroup)' == 'FreeBSD'">true</TargetsFreeBSD>
+
+    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true'">true</TargetsUnix>
+  </PropertyGroup>
+
+
+
+  <Import Project="$(RoslynPropsFile)"
+          Condition="'$(UseRoslynCompiler)'=='true' and Exists('$(RoslynPropsFile)')" />
+
+  <!-- Building the build.proj should restore successfully, so ignore in that case -->
+  <Target Name="CheckRoslyn" Condition="'$(UseRoslynCompiler)'=='true' and '$(MSBuildProjectFile)'!='build.proj'">
+    <Warning Condition="!Exists('$(RoslynPropsFile)')"
+             Text="The Roslyn targets do not exist- Roslyn will not be used for this build, but the package should be restored if you build again." />
+  </Target>
+
 </Project>

--- a/roslyn.xplat.targets
+++ b/roslyn.xplat.targets
@@ -1,0 +1,14 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Overrides for Roslyn on Unix
+  -->
+
+  <PropertyGroup>
+    <!-- PDB support isn't implemented yet. -->
+    <!-- Some .csproj files override the settings coming from dir.props so we have to set again here to trump them. -->
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
+
+  <!-- This target in the build tools partialfacades.targets assumes that a pdb exists. -->
+  <Target Name="FillPartialFacade" />
+</Project>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -3,4 +3,7 @@
   <package id="Microsoft.DotNet.BuildTools.CoreCLR" version="1.0.2-prerelease" />
   <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00056" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
+  <package id="dnx-mono" version="1.0.0-beta5-12101" />
+  <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc2-20150421-01" />
+  <package id="Mono.Tools.ResgenModified" version="1.0.0" />
 </packages>

--- a/src/build.proj
+++ b/src/build.proj
@@ -21,15 +21,15 @@
   <Target Name="BuildNuGetPackages" AfterTargets="MovePDB" Condition="'$(BuildNugetPackage)' != 'false'">
     <MakeDir Directories="$(PackagesBinDir)" Condition="!Exists('$(PackagesBinDir)')" />
     <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(PackagesBinDir)" />
-    <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" />
+    <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" Condition="'$(OS)'!='Unix'"/>
   </Target>
 
   <ItemGroup>
-    <PDBSToMove Include="$(BinDir)mscorlib.pdb"/>
+    <PDBSToMove Condition="'$(OS)'!='Unix'" Include="$(BinDir)mscorlib.pdb"/>
   </ItemGroup>
 
   <PropertyGroup>
-    <MscorlibPDBPath>$(BinDir)mscorlib.pdb</MscorlibPDBPath>
+    <MscorlibPDBPath Condition="'$(OS)'!='Unix'">$(BinDir)mscorlib.pdb</MscorlibPDBPath>
   </PropertyGroup>
 
   <Target Name="MovePDB" AfterTargets="Build">

--- a/src/mscorlib/GenerateCompilerResponseFile.targets
+++ b/src/mscorlib/GenerateCompilerResponseFile.targets
@@ -7,10 +7,16 @@
   <Target Name="GenerateCompilerResponseFile">
     <Message Text="Generating module name response file: $(IntermediateOutputPath)\moduleName.rsp" />
 
-    <!-- When Roslyn is NOT enabled, we need to set the module name for mscorlib -->
-    <WriteLinesToFile Condition="'$(UseRoslynCompiler)'!='true'"
+    <!-- When Roslyn is NOT enabled, we need to set the module name for mscorlib 
+    ... but it is not enabled on mcs either, so skip it. -->
+    <WriteLinesToFile Condition="'$(UseRoslynCompiler)'!='true' and '$(OS)'!='Unix'"
                       File="$(IntermediateOutputPath)\moduleName.rsp"
                       Lines="/test:moduleName=CommonLanguageRuntimeLibrary"
+                      Overwrite="true" />
+
+    <WriteLinesToFile Condition="'$(UseRoslynCompiler)'!='true' and '$(OS)'=='Unix'"
+                      File="$(IntermediateOutputPath)\moduleName.rsp"
+                      Lines="  "
                       Overwrite="true" />
 
     <!-- When Roslyn is enabled we need to set the runtimemetadataversion -->

--- a/src/mscorlib/GenerateSplitStringResources.targets
+++ b/src/mscorlib/GenerateSplitStringResources.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ResGenCommand Condition="'$(ResGenCommand)'==''">$(SDK40ToolsPath)ResGen.exe</ResGenCommand>
+    <ResGenCommand Condition="'$(ResGenCommand)'==''">$(SDK40ToolsPath)resgen.exe</ResGenCommand>
     <PrepareResourcesDependsOn>GenerateSplitStringResources;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
   </PropertyGroup>
     

--- a/src/mscorlib/Tools/PostProcessingTools.targets
+++ b/src/mscorlib/Tools/PostProcessingTools.targets
@@ -8,10 +8,22 @@
     <Clean Include="$(FinalOutputPath)\$(TargetName).pdb" />
   </ItemGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(OS)'!='Unix'">
     <CurrentAssemblyPdb>$(IntermediateOutputPath)$(TargetName).pdb</CurrentAssemblyPdb>
     <PostProcessingTargets>RewriteWithBclRewriter</PostProcessingTargets>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)'=='Unix'">
+    <PostProcessingTargets>PlaceCopyAsDummyRewrite</PostProcessingTargets>
+  </PropertyGroup>
+
+  <Target Name="PlaceCopyAsDummyRewrite"
+          Inputs="$(IntermediateOutputPath)$(TargetName).dll"
+          Outputs="@(RewrittenAssembly)">
+    <Copy
+      SourceFiles="$(IntermediateOutputPath)$(TargetName).dll"
+      DestinationFiles="@(RewrittenAssembly)" />
+  </Target>
 
   <Target Name="AfterBuild" DependsOnTargets="$(PostProcessingTargets)"
           Inputs="@(RewrittenAssembly)" Outputs="$(FinalOutputPath)\%(RewrittenAssembly.FileName)%(RewrittenAssembly.Extension)">
@@ -19,7 +31,7 @@
     <!-- Copy to the final output location -->
     <Copy Retries="3" SourceFiles="@(RewrittenAssembly)" DestinationFiles="$(FinalOutputPath)\%(RewrittenAssembly.FileName)%(RewrittenAssembly.Extension)"/>
     <Message Importance="High" Text="$(MSBuildProjectName) -&gt; $(FinalOutputPath)\%(RewrittenAssembly.FileName)%(RewrittenAssembly.Extension)" />
-    <Copy Retries="3" SourceFiles="$(CurrentAssemblyPdb)" DestinationFiles="$(FinalOutputPath)\$(TargetName).pdb"/>
+    <Copy Condition="'$(OS)'!='Unix'" Retries="3" SourceFiles="$(CurrentAssemblyPdb)" DestinationFiles="$(FinalOutputPath)\$(TargetName).pdb"/>
   </Target>
 
 </Project>

--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -67,13 +67,13 @@
   
   <!-- Configuration specific properties -->
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols Condition="'$(OS)'!='Unix'">true</DebugSymbols>
     <DebugType>full</DebugType>
     <DefineConstants>DBG;_DEBUG;_LOGGING;DEBUG;TRACE;$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(Platform)' == 'x86' or '$(Platform)' == 'amd64'">CODE_ANALYSIS;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols Condition="'$(OS)'!='Unix'">true</DebugSymbols>
     <DebugType>pdbOnly</DebugType>
     <DefineConstants>TRACE;$(DefineConstants)</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Rationale: mscorlib.dll does not build outside Windows yet.
https://github.com/dotnet/coreclr/blob/8d3936b/Documentation/building/linux-instructions.md#build-the-framework-

This change removes the limitation.

Basically it does what corefx does on Unix. It pulls MSBuild package
from myget and use it to build mscorlib.dll.

Some additional notes:

- Mono (as of 4.0/4.2) does not support resgen -d option. So I created
  a patched version that supports it.
- Then I have created NuGet package for that resgen.exe so that we don't
  have to wait for Mono bugfix for above. Just like the custom MSBuild
  that corefx uses, it now uses the packaged resgen.exe.
  (src/mscorlib/GenerateSplitStringResources.targets takes ResGenCommand
  custom build property, so I pass it to msbuild run.)
- BclRewriter.exe does not work outside Windows yet, so there are some
  build targets file hacks that makes it conditional to non-Unix OS.
- Similarly, there is call to rc.exe. It could be disabled by passing
  /p:GenerateNativeVersionInfo=false to msbuild.
- Pdb generation is not working on Unix (PdbWriter depends on COM stuff)
  so I disabled any relevant parts by adding MSBuild condition.
- NuGet packaging fails due to incomplete set of files (e.g. pdb), so
  it is also skipped by MSBuild condition.