### PR TITLE
Add an option to request 16 bytes alignment for read-only data.

### DIFF
--- a/src/inc/corjit.h
+++ b/src/inc/corjit.h
@@ -300,7 +300,13 @@ enum CorJitAllocMemFlag
 {
     CORJIT_ALLOCMEM_DEFAULT_CODE_ALIGN = 0x00000000, // The code will be use the normal alignment
     CORJIT_ALLOCMEM_FLG_16BYTE_ALIGN   = 0x00000001, // The code will be 16-byte aligned
+    CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN = 0x00000002, // The read-only data will be 16-byte aligned
 };
+
+inline CorJitAllocMemFlag operator |(CorJitAllocMemFlag a, CorJitAllocMemFlag b)
+{
+    return static_cast<CorJitAllocMemFlag>(static_cast<int>(a) | static_cast<int>(b));
+}
 
 enum CorJitFuncKind
 {

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -1768,8 +1768,19 @@ void ZapInfo::allocMem(
 
     if (roDataSize > 0)
     {
-        m_pROData = ZapBlobWithRelocs::NewAlignedBlob(m_pImage, NULL, roDataSize,
-            optForSize || (roDataSize < 8) ? sizeof(TADDR) : 8);
+        if (flag & CORJIT_ALLOCMEM_FLG_RODATA_16BYTE_ALIGN)
+        {
+            align = 16;
+        }
+        else if (optForSize || (roDataSize < 8))
+        {
+            align = sizeof(TADDR);
+        }
+        else
+        {
+            align = 8;
+        }
+        m_pROData = ZapBlobWithRelocs::NewAlignedBlob(m_pImage, NULL, roDataSize, align);
         *roDataBlock = m_pROData->GetData();
     }
 


### PR DESCRIPTION
llilc jit needs this to support LLVM floating-point constant pools.