### PR TITLE
Adding TimeZoneInfo.Local and FindSystemTimeZoneById support on Linux.

### DIFF
--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -2327,11 +2327,13 @@ ArgumentOutOfRange_Week = The Week parameter must be in the range 1 through 5.
 ; begin System.TimeZoneInfo InvalidTimeZoneException's
 ;
 InvalidTimeZone_InvalidRegistryData = The time zone ID '{0}' was found on the local computer, but the registry information was corrupt.
+InvalidTimeZone_InvalidFileData = The time zone ID '{0}' was found on the local computer, but the file at '{1}' was corrupt.
 InvalidTimeZone_InvalidWin32APIData = The Local time zone was found on the local computer, but the data was corrupt.
 ;
 ; begin System.TimeZoneInfo SecurityException's
 ;
 Security_CannotReadRegistryData = The time zone ID '{0}' was found on the local computer, but the application does not have permission to read the registry information.
+Security_CannotReadFileData = The time zone ID '{0}' was found on the local computer, but the application does not have permission to read the file.
 ;
 ; begin System.TimeZoneInfo SerializationException's
 ;
@@ -2340,7 +2342,7 @@ Serialization_InvalidEscapeSequence = The serialized data contained an invalid e
 ;
 ; begin System.TimeZoneInfo TimeZoneNotFoundException's
 ;
-TimeZoneNotFound_MissingRegistryData = The time zone ID '{0}' was not found on the local computer.
+TimeZoneNotFound_MissingData = The time zone ID '{0}' was not found on the local computer.
 ;
 ; end System.TimeZoneInfo
 ;


### PR DESCRIPTION
The local time zone is found by using the TZ environment variable or the "localtime" files on the system.  I needed to add some code that searched through the zoneinfo directory to get the correct Id of the local time zone, since this information is only stored in the file name, and not in the file itself.

FindSystemTimeZoneById uses the id as a file path to find the correct tzfile on the system.

Also added a few #ifs of dead code on Linux.

@ellismg @joshfree 