### PR TITLE
StreamReader: Use a cached byte[] preamble for Encoding.UTF8

### DIFF
--- a/src/mscorlib/src/System/IO/StreamReader.cs
+++ b/src/mscorlib/src/System/IO/StreamReader.cs
@@ -35,6 +35,13 @@ namespace System.IO
         // StreamReader.Null is threadsafe.
         public new static readonly StreamReader Null = new NullStreamReader();
 
+        // Encoding.GetPreamble() always allocates and returns a new byte[] array for
+        // encodings that have a preamble.
+        // We can avoid repeated allocations for the default and commonly used Encoding.UTF8
+        // encoding by using our own private cached instance of the UTF8 preamble.
+        // This is lazily allocated the first time it is used.
+        private static byte[] s_utf8Preamble;
+
         // Using a 1K byte buffer and a 4K FileStream buffer works out pretty well
         // perf-wise.  On even a 40 MB text file, any perf loss by using a 4K
         // buffer is negated by the win of allocating a smaller byte[], which 
@@ -237,7 +244,20 @@ namespace System.IO
             byteLen = 0;
             bytePos = 0;
             _detectEncoding = detectEncodingFromByteOrderMarks;
-            _preamble = encoding.GetPreamble();
+
+            // Encoding.GetPreamble() always allocates and returns a new byte[] array for
+            // encodings that have a preamble.
+            // We can avoid repeated allocations for the default and commonly used Encoding.UTF8
+            // encoding by using our own private cached instance of the UTF8 preamble.
+            // We specifically look for Encoding.UTF8 because we know it has a preamble,
+            // whereas other instances of UTF8Encoding may not have a preamble enabled, and
+            // there's no public way to tell if the preamble is enabled for an instance other
+            // than calling GetPreamble(), which we're trying to avoid.
+            // This means that other instances of UTF8Encoding are excluded from this optimization.
+            _preamble = object.ReferenceEquals(encoding, Encoding.UTF8) ?
+                (s_utf8Preamble ?? (s_utf8Preamble = encoding.GetPreamble())) :
+                encoding.GetPreamble();
+
             _checkPreamble = (_preamble.Length > 0);
             _isBlocked = false;
             _closable = !leaveOpen;


### PR DESCRIPTION
Avoids allocations associated with `Encoding.GetPreamble()` for the default and commonly used `Encoding.UTF8` encoding.

The same optimization can be applied for other encodings that have BOMs like `Encoding.Unicode`, `Encoding.BigEndianUnicode`, `Encoding.UTF32`, etc., but I kept it scoped to just `UTF8` for now since it is the default encoding for `StreamReader` and is the most commonly used encoding in the code base. I can add the optimization for these other encodings, if desirable. Let me know.

I considered implementing this by adding some internal encoding APIs (e.g. `internal int PreambleLength { get; }`, which would be nice to add publicly in the future, BTW), but figured `StreamReader` might be moving out of mscorlib.dll in the near future, at which point it would only have access to public encoding APIs.