### PR TITLE
Expose Unix hosting API on Windows

### DIFF
--- a/src/dlls/mscoree/CMakeLists.txt
+++ b/src/dlls/mscoree/CMakeLists.txt
@@ -2,6 +2,7 @@ include_directories("../../inc")
 
 set(CLR_SOURCES
     mscoree.cpp
+    unixinterface.cpp
 )
 
 if(WIN32)
@@ -15,10 +16,6 @@ set (DEF_SOURCES
   mscorwks_ntdef.src
 )
 else()
-list(APPEND CLR_SOURCES
-    unixinterface.cpp
-)
-
 set (DEF_SOURCES
   mscorwks_unixexports.src
 )

--- a/src/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/dlls/mscoree/mscorwks_ntdef.src
@@ -17,6 +17,12 @@ EXPORTS
         ; This cannot change, or else CoreCLR debugging will not work.
         ; See clr\src\DLLS\dbgshim\dbgshim.cpp.
         g_CLREngineMetrics                                  @2 data
+        
+        ; Unix hosting API
+        coreclr_create_delegate
+        coreclr_execute_assembly
+        coreclr_initialize
+        coreclr_shutdown
 
 #ifdef FEATURE_PREJIT
         ; MetaDataGetDispenser is needed for nidump. We want nidump to work on non-debug

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -112,8 +112,10 @@ int coreclr_initialize(
             void** hostHandle,
             unsigned int* domainId)
 {
+    HRESULT hr;
+#ifdef FEATURE_PAL
     DWORD error = PAL_InitializeCoreCLR(exePath);
-    HRESULT hr = HRESULT_FROM_WIN32(error);
+    hr = HRESULT_FROM_WIN32(error);
 
     // If PAL initialization failed, then we should return right away and avoid
     // calling any other APIs because they can end up calling into the PAL layer again.
@@ -121,6 +123,7 @@ int coreclr_initialize(
     {
         return hr;
     }
+#endif
 
     ReleaseHolder<ICLRRuntimeHost2> host;
 
@@ -167,7 +170,7 @@ int coreclr_initialize(
         propertyCount,
         propertyKeysW,
         propertyValuesW,
-        domainId);
+        (DWORD *)domainId);
 
     if (SUCCEEDED(hr))
     {
@@ -280,12 +283,13 @@ int coreclr_execute_assembly(
     
     ConstWStringHolder managedAssemblyPathW = StringToUnicode(managedAssemblyPath);
 
-    HRESULT hr = host->ExecuteAssembly(domainId, managedAssemblyPathW, argc, argvW, exitCode);
+    HRESULT hr = host->ExecuteAssembly(domainId, managedAssemblyPathW, argc, argvW, (DWORD *)exitCode);
     IfFailRet(hr);
 
     return hr;
 }
 
+#ifdef PLATFORM_UNIX
 //
 // Execute a managed assembly with given arguments
 //
@@ -369,3 +373,4 @@ HRESULT ExecuteAssembly(
 
     return hr;
 }
+#endif


### PR DESCRIPTION
This fixes #1256 by exposing the new Unix hosting API on Windows. I have not exposed the old hosting API as it only exists on the Unix side for compatibility with dnx. @janvorli 