### PR TITLE
Conservatively mark variable as killed if there is an embedded comma …

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5302,10 +5302,14 @@ public:
     typedef ArrayStack<GenTreePtr> GenTreePtrStack;
     typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, GenTreePtrStack*, DefaultSimplerHashBehavior> LclNumToGenTreePtrStack;
 
+    // Kill set to track variables with intervening definitions.
+    VARSET_TP optCopyPropKillSet;
+
     // Copy propagation functions.
     void optCopyProp(BasicBlock* block, GenTreePtr stmt, GenTreePtr tree, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyPropPopStacks(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
     void optBlockCopyProp(BasicBlock* block, LclNumToGenTreePtrStack* curSsaName);
+    bool optIsSsaLocal(GenTreePtr tree);
     int optCopyProp_LclVarScore(LclVarDsc* lclVarDsc, LclVarDsc* copyVarDsc, bool preferOp2);
     void optVnCopyProp();
 


### PR DESCRIPTION
…assignment

GitHub Issue: Another RyuJIT optimization bug #1299
https://github.com/dotnet/coreclr/issues/1299

The underlying problem is there are two loops:

The first loop does copy prop
The second loop updates the stack of live definitions in the currently
traversed CFG path.

This approach works fine only if assignments are atomic statements, but
when there is an assignment embedded using a comma in a statement:
The first loop does nothing about this and continues to propagate
copies, i.e., without updating the liveness stack. This leads to using a
stale VN for comparison rather than using an updated VN due to this
definition.

Only when the second loop runs, this live definition is added to the
stack.

The right fix is to merge the two loops into a single loop that does
copy prop on the tree and at the same time updates the liveness on the
stack right after the call. But this is causing a lot of ASM diffs which
would affect stability.

I am making a conservative fix of temporarily marking the variables that
have embedded intervening defs as "killed", until the second loop runs
to update liveness.

There are no SuperASM diffs with this change.