### PR TITLE
Adding instructions to clone both corefx and coreclr in the Git Setup…

### DIFF
--- a/Documentation/building/freebsd-instructions.md
+++ b/Documentation/building/freebsd-instructions.md
@@ -60,7 +60,7 @@ You now have all the required components to debug CoreCLR installed.
 Git Setup
 ---------
 
-This guide assumes that you've cloned the coreclr repository into `~/git/coreclr` on your FreeBSD machine and the corefx and coreclr repositories into `D:\git\corefx` and `D:\git\coreclr` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the FreeBSD and Windows machine.
+This guide assumes that you've cloned the corefx and coreclr repositories into `~/git/corefx` and `~/git/coreclr` on your FreeBSD machine and the corefx and coreclr repositories into `D:\git\corefx` and `D:\git\coreclr` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the FreeBSD and Windows machine.
 
 Build the Runtime
 =================

--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -43,7 +43,7 @@ You now have all the required components.
 Git Setup
 ---------
 
-This guide assumes that you've cloned the coreclr repository into `~/git/coreclr` on your Linux machine and the corefx and coreclr repositories into `D:\git\corefx` and `D:\git\coreclr` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the Linux and Windows machine.
+This guide assumes that you've cloned the corefx and coreclr repositories into `~/git/corefx` and `~/git/coreclr` on your Linux machine and the corefx and coreclr repositories into `D:\git\corefx` and `D:\git\coreclr` on Windows. If your setup is different, you'll need to pay careful attention to the commands you run. In this guide, I'll always show what directory I'm in on both the Linux and Windows machine.
 
 Build the Runtime
 =================


### PR DESCRIPTION
Added instructions to clone both corefx and coreclr in the Git Setup section for Linux and FreeBSD. The corefx clone is needed on Linux/FreeBSD to build the native components. 

Previously, as per the instructions only the coreclr needed to be cloned on Linux/FreeBSD. 

Ref: #1313 