### PR TITLE
Fix PAL signal count upper limit issues.

### DIFF
--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -602,25 +602,25 @@ namespace CorUnix
         virtual
         PAL_ERROR
         GetSignalCount(
-            DWORD *pdwSignalCount
+            LONG *plSignalCount
             ) = 0;
 
         virtual
         PAL_ERROR
         SetSignalCount(
-            DWORD dwNewCount
+            LONG lNewCount
             ) = 0;
 
         virtual
         PAL_ERROR
         IncrementSignalCount(
-            DWORD dwAmountToIncrement
+            LONG lAmountToIncrement
             ) = 0;
 
         virtual
         PAL_ERROR
         DecrementSignalCount(
-            DWORD dwAmountToDecrement
+            LONG lAmountToDecrement
             ) = 0;
 
         //

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -269,15 +269,19 @@ namespace CorUnix
 
         // Object signal count accessor methods
         LONG GetSignalCount(void) 
-        { 
+        {
+            _ASSERTE(m_lSignalCount >= 0);
             return m_lSignalCount; 
         }
         void SetSignalCount(LONG lSignalCount) 
         { 
+            _ASSERTE(m_lSignalCount >= 0);
+            _ASSERTE(lSignalCount >= 0);
             m_lSignalCount = lSignalCount; 
         }
         LONG DecrementSignalCount(void) 
-        { 
+        {
+            _ASSERTE(m_lSignalCount > 0);
             return --m_lSignalCount; 
         }
 
@@ -481,10 +485,10 @@ namespace CorUnix
         //
         // ISynchStateController methods
         //
-        virtual PAL_ERROR GetSignalCount(DWORD *pdwSignalCount);
-        virtual PAL_ERROR SetSignalCount(DWORD dwNewCount);
-        virtual PAL_ERROR IncrementSignalCount(DWORD dwAmountToIncrement);
-        virtual PAL_ERROR DecrementSignalCount(DWORD dwAmountToDecrement);
+        virtual PAL_ERROR GetSignalCount(LONG *plSignalCount);
+        virtual PAL_ERROR SetSignalCount(LONG lNewCount);
+        virtual PAL_ERROR IncrementSignalCount(LONG lAmountToIncrement);
+        virtual PAL_ERROR DecrementSignalCount(LONG lAmountToDecrement);
         virtual PAL_ERROR SetOwner(CPalThread *pNewOwningThread);
         virtual PAL_ERROR DecrementOwnershipCount(void);
         virtual void ReleaseController(void);

--- a/src/pal/src/synchobj/semaphore.cpp
+++ b/src/pal/src/synchobj/semaphore.cpp
@@ -469,7 +469,6 @@ CorUnix::InternalReleaseSemaphore(
     IPalObject *pobjSemaphore = NULL;
     ISynchStateController *pssc = NULL;
     SemaphoreImmutableData *pSemaphoreData;
-    DWORD dwOldCount;
     LONG lOldCount;
 
     _ASSERTE(NULL != pthr);
@@ -521,7 +520,7 @@ CorUnix::InternalReleaseSemaphore(
         goto InternalReleaseSemaphoreExit;
     }
 
-    palError = pssc->GetSignalCount(&dwOldCount);
+    palError = pssc->GetSignalCount(&lOldCount);
 
     if (NO_ERROR != palError)
     {
@@ -529,9 +528,8 @@ CorUnix::InternalReleaseSemaphore(
         goto InternalReleaseSemaphoreExit;
     }
 
-    lOldCount = dwOldCount;
-
-    if (lOldCount + lReleaseCount > pSemaphoreData->lMaximumCount)
+    _ASSERTE(lOldCount <= pSemaphoreData->lMaximumCount);
+    if (lReleaseCount > pSemaphoreData->lMaximumCount - lOldCount)
     {
         palError = ERROR_INVALID_PARAMETER;
         goto InternalReleaseSemaphoreExit;

--- a/src/pal/tests/palsuite/threading/CreateSemaphoreA_ReleaseSemaphore/test3/createsemaphore.c
+++ b/src/pal/tests/palsuite/threading/CreateSemaphoreA_ReleaseSemaphore/test3/createsemaphore.c
@@ -38,7 +38,9 @@ struct testcase testCases[] =
     {NULL, -1, -1, NULL, TRUE},
     {NULL, 2, 1, NULL, TRUE},
     {NULL, 1, 2, NULL, FALSE},
-    {NULL, 0, 10, NULL, FALSE}
+    {NULL, 0, 10, NULL, FALSE},
+    {NULL, INT_MAX - 1, INT_MAX, NULL, FALSE},
+    {NULL, INT_MAX, INT_MAX, NULL, FALSE}
 };
 
 HANDLE hSemaphore[sizeof(testCases)/sizeof(struct testcase)];
@@ -96,8 +98,9 @@ int __cdecl main (int argc, char **argv)
                 continue;
             }
         }
-        /* incriment semaphore count to lMaximumCount */
-        for (j = testCases[i].lInitialCount; j <= testCases[i].lMaximumCount; 
+
+        /* increment semaphore count to lMaximumCount */
+        for (j = testCases[i].lInitialCount; (ULONG)j <= (ULONG)testCases[i].lMaximumCount; 
              j++)    
         {
             if (testCases[i].lMaximumCount == j)
@@ -144,6 +147,13 @@ int __cdecl main (int argc, char **argv)
                 }
             }
         }
+
+        // Skip exhaustive decrement tests for too large an initial count
+        if(testCases[i].lInitialCount >= INT_MAX - 1)
+        {
+            continue;
+        }
+
         /* decrement semaphore count to 0 */
         for (j = testCases[i].lMaximumCount; j >= 0; j--)    
         {

--- a/src/pal/tests/palsuite/threading/CreateSemaphoreW_ReleaseSemaphore/test3/createsemaphore.c
+++ b/src/pal/tests/palsuite/threading/CreateSemaphoreW_ReleaseSemaphore/test3/createsemaphore.c
@@ -38,7 +38,9 @@ struct testcase testCases[] =
     {NULL, -1, -1, NULL, TRUE},
     {NULL, 2, 1, NULL, TRUE},
     {NULL, 1, 2, NULL, FALSE},
-    {NULL, 0, 10, NULL, FALSE}
+    {NULL, 0, 10, NULL, FALSE},
+    {NULL, INT_MAX - 1, INT_MAX, NULL, FALSE},
+    {NULL, INT_MAX, INT_MAX, NULL, FALSE}
 };
 
 HANDLE hSemaphore[sizeof(testCases)/sizeof(struct testcase)];
@@ -96,8 +98,9 @@ int __cdecl main (int argc, char **argv)
                 continue;
             }
         }
-        /* incriment semaphore count to lMaximumCount */
-        for (j = testCases[i].lInitialCount; j <= testCases[i].lMaximumCount; 
+
+        /* increment semaphore count to lMaximumCount */
+        for (j = testCases[i].lInitialCount; (ULONG)j <= (ULONG)testCases[i].lMaximumCount; 
              j++)    
         {
             if (testCases[i].lMaximumCount == j)
@@ -144,6 +147,13 @@ int __cdecl main (int argc, char **argv)
                 }
             }
         }
+
+        // Skip exhaustive decrement tests for too large an initial count
+        if(testCases[i].lInitialCount >= INT_MAX - 1)
+        {
+            continue;
+        }
+
         /* decrement semaphore count to 0 */
         for (j = testCases[i].lMaximumCount; j >= 0; j--)    
         {


### PR DESCRIPTION
- Fix assert in SetSignalCount to allow int32 max as a valid value.
- Change ISynchStateController signal count functions to use LONG
  instead of DWORD to match the storage type for consistency.
- In ReleaseSemaphoreInternal, handle overflow of (oldCount +
  releaseCount) to return failure. Updated PAL semaphore tests to catch
  this case.

Fix #1318