### PR TITLE
StreamReader: Use the static cached Encoding instances

### DIFF
--- a/src/mscorlib/src/System/IO/StreamReader.cs
+++ b/src/mscorlib/src/System/IO/StreamReader.cs
@@ -451,7 +451,7 @@ namespace System.IO
             if (byteBuffer[0]==0xFE && byteBuffer[1]==0xFF) {
                 // Big Endian Unicode
 
-                encoding = new UnicodeEncoding(true, true);
+                encoding = Encoding.BigEndianUnicode;
                 CompressBuffer(2);
                 changedEncoding = true;
             }
@@ -459,13 +459,13 @@ namespace System.IO
             else if (byteBuffer[0]==0xFF && byteBuffer[1]==0xFE) {
                 // Little Endian Unicode, or possibly little endian UTF32
                 if (byteLen < 4 || byteBuffer[2] != 0 || byteBuffer[3] != 0) {
-                    encoding = new UnicodeEncoding(false, true);
+                    encoding = Encoding.Unicode;
                     CompressBuffer(2);
                     changedEncoding = true;
                 }
 #if FEATURE_UTF32   
                 else {
-                    encoding = new UTF32Encoding(false, true);
+                    encoding = Encoding.UTF32;
                     CompressBuffer(4);
                 changedEncoding = true;
             }


### PR DESCRIPTION
The static cached `Encoding` instances can be used instead of creating new instances when detecting the encoding. The [same](https://github.com/dotnet/coreclr/blob/564b1ca107c67dc50106efd823cc157acfe504fe/src/mscorlib/src/System/Text/Encoding.cs#L1505-L1558) constructor arguments are used.