### PR TITLE
Fix crash when using OpenCover with mscorlib

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1859,7 +1859,7 @@ AssemblySpecBindingCache::AssemblyBinding* AssemblySpecBindingCache::GetAssembly
         // It is possible that the AssemblySpec corresponds to a TPA assembly, so try the lookup
         // against the TPABinder context.
         ICLRPrivBinder* pTPABinderContext = pSpecDomain->GetTPABinderContext();
-        if (!AreSameBinderInstance(pTPABinderContext, pBinderContextForLookup))
+        if ((pTPABinderContext != NULL) && !AreSameBinderInstance(pTPABinderContext, pBinderContextForLookup))
         {
             UINT_PTR tpaBinderID = 0;
             HRESULT hr = pTPABinderContext->GetBinderID(&tpaBinderID);


### PR DESCRIPTION
OpenCover injects self referencing assembly refs to mscorlib. The fix avoids crash when the assembly loader tries to resolve them early during startup.

Fix #1340.