### PR TITLE
Fix links that are now in /coding-guidelines

### DIFF
--- a/Documentation/project-docs/contributing.md
+++ b/Documentation/project-docs/contributing.md
@@ -40,7 +40,7 @@ Most managed code changes should be made in the [CoreFX](https://github.com/dotn
 - The type exists in CoreCLR only -> choose CoreCLR.
 - In doubt -> choose CoreFX.
 
-Please see [Breaking Changes](https://github.com/dotnet/corefx/blob/master/Documentation/breaking-changes.md) to understand our requirements on changes that could impact compatibility. Please pay the most attention to changes that affect the [Public Contract](https://github.com/dotnet/corefx/blob/master/Documentation/breaking-changes.md#bucket-1-public-contract). We will not accept changes that break compatibility.
+Please see [Breaking Changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-changes.md) to understand our requirements on changes that could impact compatibility. Please pay the most attention to changes that affect the [Public Contract](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-changes.md#bucket-1-public-contract). We will not accept changes that break compatibility.
 
 General Contribution Guidance
 =============================
@@ -49,7 +49,7 @@ There are several issues to keep in mind when making a change.
 
 Managed Code Compatibility
 --------------------------
-Please review [Breaking Changes](https://github.com/dotnet/corefx/blob/master/Documentation/breaking-changes.md) before making changes to managed code. Please pay the most attention to changes that affect the [Public Contract](https://github.com/dotnet/corefx/blob/master/Documentation/breaking-changes.md#bucket-1-public-contract).
+Please review [Breaking Changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-changes.md) before making changes to managed code. Please pay the most attention to changes that affect the [Public Contract](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-changes.md#bucket-1-public-contract).
 
 Typos
 -----
@@ -82,7 +82,7 @@ the PR.
 DOs and DON'Ts
 ==============
 
-* **DO** follow our [coding style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-style.md) (C# code-specific)
+* **DO** follow our [coding style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md) (C# code-specific)
 * **DO** give priority to the current style of the project or file you're changing even if it diverges from the general guidelines.
 * **DO** include tests when adding new features. When fixing bugs, start with
   adding a test that highlights how the current behavior is broken.
@@ -96,7 +96,7 @@ DOs and DON'Ts
   of time.
 * **DON'T** commit code that you didn't write. If you find code that you think is a good fit to add to .NET Core, file an issue and start a discussion before proceeding.
 * **DON'T** submit PRs that alter licensing related files or headers. If you believe there's a problem with them, file an issue and we'll be happy to discuss it.
-* **DON'T** add API additions without filing an issue and discussing with us first. See [API Review Process](https://github.com/dotnet/corefx/blob/master/Documentation/api-review-process.md).
+* **DON'T** add API additions without filing an issue and discussing with us first. See [API Review Process](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/api-review-process.md).
 
 Contributor License Agreement
 =============================


### PR DESCRIPTION
Just a few link fixes as I read through the documentation.