### PR TITLE
Fix ARM64 compile break

### DIFF
--- a/src/vm/interpreter.h
+++ b/src/vm/interpreter.h
@@ -798,7 +798,7 @@ public:
           m_retBufArg(NULL),  // Initialize to NULL so we can safely declare protected.
 #endif // USE_CHECKED_OBJECTREFS
           m_genericsCtxtArg(NULL),
-          m_securityObject(TADDR(NULL)),
+          m_securityObject((Object*)NULL),
           m_args(NULL),
           m_argsSize(0),
           m_callThisArg(NULL), 


### PR DESCRIPTION
This fixes a small compile issue on the ARM64 release build. Assumidly @kangaroo didn't catch it as he was doing debug builds but I have built arm and arm64 as debug and release through the new cross compilation support and caught this issue. The other configurations build successfully though.