### PR TITLE
Use Frame list context when GetThreadContext is unavailable

### DIFF
--- a/src/debug/di/shimremotedatatarget.cpp
+++ b/src/debug/di/shimremotedatatarget.cpp
@@ -286,7 +286,6 @@ ShimRemoteDataTarget::GetThreadContext(
 {
     ReturnFailureIfStateNotOk();
         
-#ifdef FEATURE_DBGIPC_TRANSPORT_DI
     // GetThreadContext() is currently not implemented in ShimRemoteDataTarget, which is used with our pipe transport 
     // (FEATURE_DBGIPC_TRANSPORT_DI). Pipe transport is used on POSIX system, but occasionally we can turn it on for Windows for testing,
     // and then we'd like to have same behavior as on POSIX system (zero context).
@@ -297,15 +296,8 @@ ShimRemoteDataTarget::GetThreadContext(
     // Instead, we just zero out the seed CONTEXT for the stackwalk.  This tells the stackwalker to
     // start the stackwalk with the first explicit frame.  This won't work when we do native debugging, 
     // but that won't happen on the POSIX systems since they don't support native debugging.
-    ZeroMemory(pContext, contextSize);        
-    return S_OK;
-#else
-    // ICorDebugDataTarget::GetThreadContext() and ICorDebugDataTarget::SetThreadContext() are currently only 
-    // required for interop-debugging and inspection of floating point registers, both of which are not 
-    // implemented on Mac.
-    _ASSERTE(!"The remote data target doesn't know how to get a thread's CONTEXT.");
+    ZeroMemory(pContext, contextSize);
     return E_NOTIMPL;
-#endif  // DFEATURE_DBGIPC_TRANSPORT_DI
 }
 
 // impl of interface method ICorDebugMutableDataTarget::SetThreadContext

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -531,6 +531,12 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
   #define FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END    DEBUG_OK_TO_RETURN_END(LAZYMACHSTATE)
 #endif
 
+#ifdef FEATURE_PAL
+#define PAL_ONLY(x) x
+#else
+#define PAL_ONLY(x)
+#endif
+
 // BEGIN: before gcpoll
 //FCallGCCanTriggerNoDtor __fcallGcCanTrigger;        
 //__fcallGcCanTrigger.Enter();                        
@@ -551,6 +557,7 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
             helperFrame;                                        \
             FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_BEGIN;          \
             FORLAZYMACHSTATE(CAPTURE_STATE(__helperframe.MachineState(), ret);) \
+            PAL_ONLY(FORLAZYMACHSTATE(__helperframe.InsureInit(false, NULL);))  \
             FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END;            \
             INDEBUG(__helperframe.SetAddrOfHaveCheckedRestoreState(&__haveCheckedRestoreState)); \
             DEBUG_ASSURE_NO_RETURN_BEGIN(HELPER_METHOD_FRAME);  \

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1657,8 +1657,6 @@ void HelperMethodFrame::Push()
     _ASSERTE(GetGSCookiePtr() == (((GSCookie *)(this)) - 1));
     *(((GSCookie *)(this)) - 1) = GetProcessGSCookie();
 
-    _ASSERTE(!m_MachState.isValid());
-
     Thread * pThread = ::GetThread();
     m_pThread = pThread;
 


### PR DESCRIPTION
When DAC tries to obtain thread context for debugee thread on the system without working GetThreadContext, it uses filter context
and if it is NULL, it goes through thread Frame list looking for a Frame that can provide meaningful CONTEXT to start the stackwalk.
Filter context can be NULL if the thread is currently running native code, or manage exception just has been thrown (first chance).
Before this change DBI stackwalker would file to provide stack trace in such cases.