### PR TITLE
Run code under long paths on Unix

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -175,8 +175,8 @@ namespace BINDER_SPACE
             else
             {
                 PathString fullAssemblyPath;
-                WCHAR *pwzFullAssemblyPath = fullAssemblyPath.OpenUnicodeBuffer(MAX_PATH);
-                DWORD dwCCFullAssemblyPath = MAX_PATH + 1; // SString allocates extra byte for null.
+                WCHAR *pwzFullAssemblyPath = fullAssemblyPath.OpenUnicodeBuffer(MAX_LONGPATH);
+                DWORD dwCCFullAssemblyPath = MAX_LONGPATH + 1; // SString allocates extra byte for null.
 
                 MutateUrlToPath(assemblyPath);
 
@@ -186,7 +186,7 @@ namespace BINDER_SPACE
                                                           NULL);
                 fullAssemblyPath.CloseBuffer(dwCCFullAssemblyPath);
 
-                if ((dwCCFullAssemblyPath == 0) || (dwCCFullAssemblyPath > (MAX_PATH + 1)))
+                if ((dwCCFullAssemblyPath == 0) || (dwCCFullAssemblyPath > (MAX_LONGPATH + 1)))
                 {
                     hr = HRESULT_FROM_GetLastError();
                 }

--- a/src/binder/utils.cpp
+++ b/src/binder/utils.cpp
@@ -267,7 +267,7 @@ namespace BINDER_SPACE
 
         if (!path.IsEmpty())
         {
-            WCHAR wszCanonicalPath[MAX_PATH];
+            WCHAR wszCanonicalPath[MAX_LONGPATH];
             PlatformPath(path);
 
             // This is also defined in rotor pal
@@ -300,7 +300,7 @@ namespace BINDER_SPACE
         BINDER_LOG_STRING(W("path A"), pathA);
         BINDER_LOG_STRING(W("path B"), pathB);
 
-        WCHAR tempResultPath[MAX_PATH];
+        WCHAR tempResultPath[MAX_LONGPATH];
         if (PathCombineW(tempResultPath, pathA, pathB))
         {
             combinedPath.Set(tempResultPath);

--- a/src/classlibnative/bcltype/system.cpp
+++ b/src/classlibnative/bcltype/system.cpp
@@ -288,7 +288,7 @@ FCIMPL0(StringObject*, SystemNative::_GetModuleFileName)
 {
     FCALL_CONTRACT;
 
-    WCHAR wszFile[MAX_PATH];
+    WCHAR wszFile[MAX_LONGPATH];
     STRINGREF   refRetVal   = NULL;
     LPCWSTR pFileName = NULL;
     DWORD lgth = 0;
@@ -301,7 +301,7 @@ FCIMPL0(StringObject*, SystemNative::_GetModuleFileName)
     else
     {
         HELPER_METHOD_FRAME_BEGIN_RET_1(refRetVal);
-        lgth = WszGetModuleFileName(NULL, wszFile, MAX_PATH);
+        lgth = WszGetModuleFileName(NULL, wszFile, MAX_LONGPATH);
         if (!lgth)
         {
             COMPlusThrowWin32();
@@ -310,9 +310,9 @@ FCIMPL0(StringObject*, SystemNative::_GetModuleFileName)
         pFileName = wszFile;
     }
 
-    if(lgth) 
+    if(lgth)
     {
-        HELPER_METHOD_FRAME_BEGIN_RET_1(refRetVal);       
+        HELPER_METHOD_FRAME_BEGIN_RET_1(refRetVal);
         refRetVal = StringObject::NewString(pFileName, lgth);
         HELPER_METHOD_FRAME_END();
     }

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -15135,7 +15135,7 @@ HRESULT Debugger::InitAppDomainIPC(void)
     } hEnsureCleanup(this);
 
     DWORD dwStrLen = 0;
-    WCHAR szExeName[MAX_PATH];
+    WCHAR szExeName[MAX_LONGPATH];
     int i;
 
     // all fields in the object can be zero initialized.
@@ -15185,7 +15185,7 @@ HRESULT Debugger::InitAppDomainIPC(void)
     // also initialize the process name
     dwStrLen = WszGetModuleFileName(NULL,
                                     szExeName,
-                                    MAX_PATH);
+                                    MAX_LONGPATH);
 
     // If we couldn't get the name, then use a nice default.
     if (dwStrLen == 0)

--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -1137,13 +1137,13 @@ STDAPI LoadLibraryShimInternal(LPCWSTR szDllName, LPCWSTR szVersion, LPVOID pvRe
     
     BEGIN_ENTRYPOINT_NOTHROW;
 
-    WCHAR szDllPath[_MAX_PATH+1];
+    WCHAR szDllPath[MAX_LONGPATH+1];
 
-    if (!PAL_GetPALDirectoryW(szDllPath, _MAX_PATH)) {
+    if (!PAL_GetPALDirectoryW(szDllPath, MAX_LONGPATH)) {
         IfFailGo(HRESULT_FROM_GetLastError());
     }
-    wcsncat_s(szDllPath, _MAX_PATH+1, szDllName, _MAX_PATH - wcslen(szDllPath));
-    
+    wcsncat_s(szDllPath, MAX_LONGPATH+1, szDllName, MAX_LONGPATH - wcslen(szDllPath));
+
     if ((*phModDll = WszLoadLibrary(szDllPath)) == NULL)
         IfFailGo(HRESULT_FROM_GetLastError());
 
@@ -1196,7 +1196,7 @@ ErrExit:
 #endif // CROSSGEN_COMPILE
 
 static DWORD g_dwSystemDirectory = 0;
-static WCHAR g_pSystemDirectory[_MAX_PATH + 1];
+static WCHAR g_pSystemDirectory[MAX_LONGPATH + 1];
 
 HRESULT GetInternalSystemDirectory(__out_ecount_part_opt(*pdwLength,*pdwLength) LPWSTR buffer, __inout DWORD* pdwLength)
 {

--- a/src/inc/palclr.h
+++ b/src/inc/palclr.h
@@ -598,7 +598,14 @@
 #define MAKEDLLNAME(x) MAKEDLLNAME_A(x)
 #endif
 
-#endif	// __PALCLR_H__
+#if !defined(MAX_LONGPATH)
+#define MAX_LONGPATH   260 /* max. length of full pathname */
+#endif
+#if !defined(MAX_PATH_FNAME)
+#define MAX_PATH_FNAME   MAX_PATH /* max. length of full pathname */
+#endif
+
+#endif // __PALCLR_H__
 
 #include "palclr_win.h"
 

--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -379,9 +379,9 @@ namespace System {
             [System.Security.SecuritySafeCritical]  // auto-generated
 #endif
             get {
-                StringBuilder sb = new StringBuilder(Path.MAX_PATH);
-                int r = Win32Native.GetSystemDirectory(sb, Path.MAX_PATH);
-                Contract.Assert(r < Path.MAX_PATH, "r < Path.MAX_PATH");
+                StringBuilder sb = new StringBuilder(Path.MaxPath);
+                int r = Win32Native.GetSystemDirectory(sb, Path.MaxPath);
+                Contract.Assert(r < Path.MaxPath, "r < Path.MaxPath");
                 if (r==0) __Error.WinIOError();
                 String path = sb.ToString();
                 
@@ -399,9 +399,9 @@ namespace System {
         internal static String InternalWindowsDirectory {
             [System.Security.SecurityCritical]  // auto-generated
             get {
-                StringBuilder sb = new StringBuilder(Path.MAX_PATH);
-                int r = Win32Native.GetWindowsDirectory(sb, Path.MAX_PATH);
-                Contract.Assert(r < Path.MAX_PATH, "r < Path.MAX_PATH");
+                StringBuilder sb = new StringBuilder(Path.MaxPath);
+                int r = Win32Native.GetWindowsDirectory(sb, Path.MaxPath);
+                Contract.Assert(r < Path.MaxPath, "r < Path.MaxPath");
                 if (r==0) __Error.WinIOError();
                 String path = sb.ToString();
                 
@@ -1458,7 +1458,7 @@ namespace System {
             }
 #endif
 
-            StringBuilder sb = new StringBuilder(Path.MAX_PATH);
+            StringBuilder sb = new StringBuilder(Path.MaxPath);
             int hresult = Win32Native.SHGetFolderPath(IntPtr.Zero,                    /* hwndOwner: [in] Reserved */
                                                       ((int)folder | (int)option),    /* nFolder:   [in] CSIDL    */
                                                       IntPtr.Zero,                    /* hToken:    [in] access token */

--- a/src/mscorlib/src/System/IO/Directory.cs
+++ b/src/mscorlib/src/System/IO/Directory.cs
@@ -967,7 +967,7 @@ namespace System.IO {
         [System.Security.SecurityCritical]
         private static String InternalGetCurrentDirectory(bool checkHost)
         {
-            StringBuilder sb = StringBuilderCache.Acquire(Path.MAX_PATH + 1);
+            StringBuilder sb = StringBuilderCache.Acquire(Path.MaxPath + 1);
             if (Win32Native.GetCurrentDirectory(sb.Capacity, sb) == 0)
                 __Error.WinIOError();
             String currentDirectory = sb.ToString();
@@ -976,9 +976,9 @@ namespace System.IO {
             // this will return a short file name.
             if (currentDirectory.IndexOf('~') >= 0) {
                 int r = Win32Native.GetLongPathName(currentDirectory, sb, sb.Capacity);
-                if (r == 0 || r >= Path.MAX_PATH) {                    
+                if (r == 0 || r >= Path.MaxPath) {                    
                     int errorCode = Marshal.GetLastWin32Error();
-                    if (r >= Path.MAX_PATH)
+                    if (r >= Path.MaxPath)
                         errorCode = Win32Native.ERROR_FILENAME_EXCED_RANGE;
                     if (errorCode != Win32Native.ERROR_FILE_NOT_FOUND &&
                         errorCode != Win32Native.ERROR_PATH_NOT_FOUND &&
@@ -1017,7 +1017,7 @@ namespace System.IO {
             if (path.Length==0)
                 throw new ArgumentException(Environment.GetResourceString("Argument_PathEmpty"));
             Contract.EndContractBlock();
-            if (path.Length >= Path.MAX_PATH)
+            if (path.Length >= Path.MaxPath)
                 throw new PathTooLongException(Environment.GetResourceString("IO.PathTooLong"));
                 
             // This will have some large effects on the rest of the runtime

--- a/src/mscorlib/src/System/IO/Path.cs
+++ b/src/mscorlib/src/System/IO/Path.cs
@@ -102,7 +102,12 @@ namespace System.IO {
         // Make this public sometime.
         // The max total path is 260, and the max individual component length is 255. 
         // For example, D:\<256 char file name> isn't legal, even though it's under 260 chars.
+#if !PLATFORM_UNIX
         internal static readonly int MaxPath = 260;
+#else
+        internal static readonly int MaxPath = 1024;
+#endif
+
         private static readonly int MaxDirectoryLength = 255;
 
         // Windows API definitions
@@ -214,7 +219,7 @@ namespace System.IO {
                     String dir = path.Substring(0, i);
 #if FEATURE_LEGACYNETCF
                     if (CompatibilitySwitches.IsAppEarlierThanWindowsPhone8) {                        
-                        if (dir.Length >= MAX_PATH - 1)
+                        if (dir.Length >= MaxPath - 1)
                             throw new PathTooLongException(Environment.GetResourceString("IO.PathTooLong"));
                     }                     
 #endif
@@ -249,7 +254,7 @@ namespace System.IO {
                 if (length >= 3 && (IsDirectorySeparator(path[2]))) i++;
             }
             return i;
-#else    
+#else
             if (length >= 1 && (IsDirectorySeparator(path[0]))) {
                 i = 1;
             }
@@ -893,8 +898,8 @@ namespace System.IO {
 #if !FEATURE_CORECLR
             new EnvironmentPermission(PermissionState.Unrestricted).Demand();
 #endif
-            StringBuilder sb = new StringBuilder(MAX_PATH);
-            uint r = Win32Native.GetTempPath(MAX_PATH, sb);
+            StringBuilder sb = new StringBuilder(MaxPath);
+            uint r = Win32Native.GetTempPath(MaxPath, sb);
             String path = sb.ToString();
             if (r==0) __Error.WinIOError();
             path = GetFullPathInternal(path);
@@ -991,7 +996,7 @@ namespace System.IO {
 #else
             new FileIOPermission(FileIOPermissionAccess.Write, path).Demand();
 #endif
-            StringBuilder sb = new StringBuilder(MAX_PATH);
+            StringBuilder sb = new StringBuilder(MaxPath);
             uint r = Win32Native.GetTempFileName(path, "tmp", 0, sb);
             if (r==0) __Error.WinIOError();
             return sb.ToString();

--- a/src/mscorlib/src/System/Reflection/Assembly.cs
+++ b/src/mscorlib/src/System/Reflection/Assembly.cs
@@ -2917,7 +2917,7 @@ namespace System.Reflection
             StringBuilder assemblyFile = new StringBuilder(useLoadFile ? location : codeBase,
                                                            0,
                                                            useLoadFile ? location.LastIndexOf('\\') + 1 : codeBase.LastIndexOf('/') + 1,
-                                                           Path.MAX_PATH);
+                                                           Path.MaxPath);
             assemblyFile.Append(an.CultureInfo.Name);
             assemblyFile.Append(useLoadFile ? '\\' : '/');
             assemblyFile.Append(name);

--- a/src/mscorlib/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/RuntimeEnvironment.cs
@@ -101,7 +101,7 @@ namespace System.Runtime.InteropServices {
         public static String SystemConfigurationFile {
             [System.Security.SecuritySafeCritical]  // auto-generated
             get {
-                StringBuilder sb = new StringBuilder(Path.MAX_PATH);
+                StringBuilder sb = new StringBuilder(Path.MaxPath);
                 sb.Append(GetRuntimeDirectory());
                 sb.Append(AppDomainSetup.RuntimeConfigurationFile);
                 String path = sb.ToString();

--- a/src/mscorlib/src/System/Runtime/InteropServices/TypeLibConverter.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/TypeLibConverter.cs
@@ -94,7 +94,7 @@ namespace System.Runtime.InteropServices {
                 throw new ArgumentNullException("notifySink");
             if (String.Empty.Equals(asmFileName))
                 throw new ArgumentException(Environment.GetResourceString("Arg_InvalidFileName"), "asmFileName");
-            if (asmFileName.Length > Path.MAX_PATH)
+            if (asmFileName.Length > Path.MaxPath)
                 throw new ArgumentException(Environment.GetResourceString("IO.PathTooLong"), asmFileName);
             if ((flags & TypeLibImporterFlags.PrimaryInteropAssembly) != 0 && publicKey == null && keyPair == null)
                 throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_PIAMustBeStrongNamed"));

--- a/src/mscorlib/src/System/Security/Util/URLString.cs
+++ b/src/mscorlib/src/System/Security/Util/URLString.cs
@@ -456,7 +456,7 @@ namespace System.Security.Util {
             }
 
             // ITEM 3 - If the path is greater than or equal (due to terminating NULL in windows) MAX_PATH, we throw.
-            if (modifiedUrl.Length >= Path.MAX_PATH)
+            if (modifiedUrl.Length >= Path.MaxPath)
             {
                 throw new PathTooLongException(Environment.GetResourceString("IO.PathTooLong"));
             }

--- a/src/mscorlib/src/System/Threading/EventWaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/EventWaitHandle.cs
@@ -48,12 +48,12 @@ namespace System.Threading
         [System.Security.SecurityCritical]  // auto-generated_required
         public EventWaitHandle(bool initialState, EventResetMode mode, string name)
         {
-            if (name != null)
+            if(name != null)
             {
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
 #else
-                if (System.IO.Path.MAX_PATH < name.Length)
+                if (System.IO.Path.MaxPath < name.Length)
                 {
                     throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
                 }
@@ -97,12 +97,12 @@ namespace System.Threading
         [System.Security.SecurityCritical]  // auto-generated_required
         public unsafe EventWaitHandle(bool initialState, EventResetMode mode, string name, out bool createdNew, EventWaitHandleSecurity eventSecurity)
         {
-            if (name != null)
+            if(name != null)
             {
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
 #else
-                if (System.IO.Path.MAX_PATH < name.Length)
+                if (System.IO.Path.MaxPath < name.Length)
                 {
                     throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
                 }
@@ -223,7 +223,7 @@ namespace System.Threading
                 throw new ArgumentException(Environment.GetResourceString("Argument_EmptyName"), "name");
             }
 
-            if(null != name && System.IO.Path.MAX_PATH < name.Length)
+            if(null != name && System.IO.Path.MaxPath < name.Length)
             {
                 throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong",name));
             }

--- a/src/mscorlib/src/System/Threading/Mutex.cs
+++ b/src/mscorlib/src/System/Threading/Mutex.cs
@@ -57,7 +57,7 @@ namespace System.Threading
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
 #else
-                if (System.IO.Path.MAX_PATH < name.Length)
+                if (System.IO.Path.MaxPath < name.Length)
                 {
                     throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
                 }
@@ -91,7 +91,7 @@ namespace System.Threading
 #if PLATFORM_UNIX
                 throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
 #else
-                if (System.IO.Path.MAX_PATH < name.Length)
+                if (System.IO.Path.MaxPath < name.Length)
                 {
                     throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
                 }
@@ -347,7 +347,7 @@ namespace System.Threading
             {
                 throw new ArgumentException(Environment.GetResourceString("Argument_EmptyName"), "name");
             }
-            if(System.IO.Path.MAX_PATH < name.Length)
+            if(System.IO.Path.MaxPath < name.Length)
             {
                 throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong",name));
             }

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -3176,9 +3176,9 @@ namespace System {
 
 
             try {
-                StringBuilder fileMuiPath = StringBuilderCache.Acquire(Win32Native.MAX_PATH);
-                fileMuiPath.Length = Win32Native.MAX_PATH;
-                int fileMuiPathLength = Win32Native.MAX_PATH;
+                StringBuilder fileMuiPath = StringBuilderCache.Acquire(Path.MaxPath);
+                fileMuiPath.Length = Path.MaxPath;
+                int fileMuiPathLength = Path.MaxPath;
                 int languageLength = 0;
                 Int64 enumerator = 0;
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -139,11 +139,16 @@ extern "C" {
 #endif
 
 #define MAX_PATH 260
-#define _MAX_PATH   260 /* max. length of full pathname */
+#define _MAX_PATH 260
 #define _MAX_DRIVE  3   /* max. length of drive component */
 #define _MAX_DIR    256 /* max. length of path component */
 #define _MAX_FNAME  256 /* max. length of file name component */
 #define _MAX_EXT    256 /* max. length of extension component */
+
+// In some Win32 APIs MAX_PATH is used for file names (even though 256 is the normal file system limit)
+// use _MAX_PATH_FNAME to indicate these cases
+#define MAX_PATH_FNAME MAX_PATH
+#define MAX_LONGPATH   1024  /* max. length of full pathname */
 
 #define MAXSHORT      0x7fff
 #define MAXLONG       0x7fffffff
@@ -1051,7 +1056,7 @@ typedef struct _WIN32_FIND_DATAA {
     DWORD nFileSizeLow;
     DWORD dwReserved0;
     DWORD dwReserved1;
-    CHAR cFileName[ MAX_PATH ];
+    CHAR cFileName[ MAX_PATH_FNAME ];
     CHAR cAlternateFileName[ 14 ];
 } WIN32_FIND_DATAA, *PWIN32_FIND_DATAA, *LPWIN32_FIND_DATAA;
 
@@ -1064,7 +1069,7 @@ typedef struct _WIN32_FIND_DATAW {
     DWORD nFileSizeLow;
     DWORD dwReserved0;
     DWORD dwReserved1;
-    WCHAR cFileName[ MAX_PATH ];
+    WCHAR cFileName[ MAX_PATH_FNAME ];
     WCHAR cAlternateFileName[ 14 ];
 } WIN32_FIND_DATAW, *PWIN32_FIND_DATAW, *LPWIN32_FIND_DATAW;
 

--- a/src/pal/src/cruntime/path.cpp
+++ b/src/pal/src/cruntime/path.cpp
@@ -105,7 +105,7 @@ _wsplitpath(
     if( lstrlenW( dospath ) >= _MAX_PATH )
     {
         ERROR("Path length is > _MAX_PATH (%d)!\n", _MAX_PATH);
-	ON_ERROR;
+        ON_ERROR;
     }
 
 

--- a/src/pal/src/file/directory.cpp
+++ b/src/pal/src/file/directory.cpp
@@ -211,6 +211,7 @@ RemoveDirectoryA(
     mb_dir[MAX_PATH - 1] = '\0';
     if (strncpy_s (mb_dir, sizeof(mb_dir), lpPathName, MAX_PATH) != SAFECRT_SUCCESS)
     {
+        WARN("mb_dir is larger than MAX_PATH (%d)!\n", MAX_PATH);
         dwLastError = ERROR_FILENAME_EXCED_RANGE;
         goto done;
     }

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -500,10 +500,10 @@ CorUnix::InternalCreateFile(
         goto done;
     }
 
-    if ( strlen(lpFileName) >= MAX_PATH )
+    if ( strlen(lpFileName) >= MAX_LONGPATH )
     {
         WARN("InternalCreateFile called with a filename whose size is "
-                "%d >= MAX_PATH (%d)\n", strlen(lpFileName), MAX_PATH);
+                "%d >= MAX_LONGPATH (%d)\n", strlen(lpFileName), MAX_LONGPATH);
         palError = ERROR_FILENAME_EXCED_RANGE;
         goto done;
     }
@@ -974,7 +974,7 @@ CreateFileW(
 {
     CPalThread *pThread;
     PAL_ERROR palError = NO_ERROR;
-    char    name[MAX_PATH];
+    char    name[MAX_LONGPATH];
     int     size;
     HANDLE  hRet = INVALID_HANDLE_VALUE;
 
@@ -988,14 +988,14 @@ CreateFileW(
 
     pThread = InternalGetCurrentThread();
 
-    size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, name, MAX_PATH,
+    size = WideCharToMultiByte( CP_ACP, 0, lpFileName, -1, name, MAX_LONGPATH,
                                 NULL, NULL );
     if( size == 0 )
     {
         DWORD dwLastError = GetLastError();
         if( dwLastError == ERROR_INSUFFICIENT_BUFFER )
         {
-            WARN("lpFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
+            WARN("lpFileName is larger than MAX_LONGPATH (%d)!\n", MAX_LONGPATH);
             palError = ERROR_FILENAME_EXCED_RANGE;
         }
         else
@@ -1130,7 +1130,7 @@ DeleteFileA(
     DWORD   dwLastError = 0;
     char    lpUnixFileName[MAX_PATH];
     LPSTR lpFullUnixFileName = NULL;
-    DWORD cchFullUnixFileName = PATH_MAX+1;// InternalCanonicalizeRealPath requires this to be atleast PATH_MAX
+    DWORD cchFullUnixFileName = MAX_LONGPATH+1;// InternalCanonicalizeRealPath requires this to be atleast PATH_MAX
 
     PERF_ENTRY(DeleteFileA);
     ENTRY("DeleteFileA(lpFileName=%p (%s))\n", lpFileName?lpFileName:"NULL", lpFileName?lpFileName:"NULL");
@@ -1138,6 +1138,7 @@ DeleteFileA(
     pThread = InternalGetCurrentThread();
     if (strlen(lpFileName) >= MAX_PATH)
     {
+        WARN("lpFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
         pThread->SetLastError(ERROR_FILENAME_EXCED_RANGE);
         goto done;
     }
@@ -1377,6 +1378,7 @@ MoveFileExA(
 
     if (strlen(lpExistingFileName) >= MAX_PATH)
     {
+        WARN("lpExistingFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
         pThread->SetLastError(ERROR_FILENAME_EXCED_RANGE);
         goto done;
     }
@@ -1387,6 +1389,7 @@ MoveFileExA(
 
     if (strlen(lpNewFileName) >= MAX_PATH)
     {
+        WARN("lpNewFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
         pThread->SetLastError(ERROR_FILENAME_EXCED_RANGE);
         goto done;
     }
@@ -1619,16 +1622,17 @@ GetFileAttributesA(
 
     PERF_ENTRY(GetFileAttributesA);
     ENTRY("GetFileAttributesA(lpFileName=%p (%s))\n", lpFileName?lpFileName:"NULL", lpFileName?lpFileName:"NULL");
-     
+
     pThread = InternalGetCurrentThread();
     if (lpFileName == NULL)
     {
         dwLastError = ERROR_PATH_NOT_FOUND;
         goto done;
     }
-    
+
     if (strlen(lpFileName) >= MAX_PATH) 
     {
+        WARN("lpFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
         dwLastError = ERROR_FILENAME_EXCED_RANGE;
         goto done;
     }

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -265,8 +265,9 @@ FindFirstFileW(
            IN LPCWSTR lpFileName,
            OUT LPWIN32_FIND_DATAW lpFindFileData)
 {
+    // MAX_PATH in this context is a file name, not a full path to a file.
     HANDLE retval = INVALID_HANDLE_VALUE;
-    CHAR FileNameA[MAX_PATH];
+    CHAR FileNameA[MAX_PATH_FNAME];
     WIN32_FIND_DATAA FindFileDataA;
         
     PERF_ENTRY(FindFirstFileW);
@@ -286,13 +287,14 @@ FindFirstFileW(
         ERROR("lpFindFileData is NULL!\n");
         SetLastError(ERROR_INVALID_PARAMETER);
         goto done;
-    }                                        
+    }
     if( 0 == WideCharToMultiByte(CP_ACP, WC_NO_BEST_FIT_CHARS, lpFileName, -1, 
-                                 FileNameA, MAX_PATH, NULL, NULL))
+                                 FileNameA, MAX_PATH_FNAME, NULL, NULL))
     {
         DWORD dwLastError = GetLastError();
         if (dwLastError == ERROR_INSUFFICIENT_BUFFER)
         {
+            WARN("lpFileName is larger than MAX_PATH_FNAME (%d)!\n", MAX_PATH_FNAME);
             SetLastError(ERROR_FILENAME_EXCED_RANGE);
         }
         else
@@ -323,11 +325,12 @@ FindFirstFileW(
     lpFindFileData->cAlternateFileName[0] = 0;
 
     if( 0 == MultiByteToWideChar(CP_ACP, 0, FindFileDataA.cFileName, -1,
-                                 lpFindFileData->cFileName, MAX_PATH))
+                                 lpFindFileData->cFileName, MAX_PATH_FNAME))
     {
         DWORD dwLastError = GetLastError();
         if (dwLastError == ERROR_INSUFFICIENT_BUFFER)
         {
+            WARN("FindFileDataA.cFileName is larger than MAX_PATH_FNAME (%d)!\n", MAX_PATH_FNAME);
             SetLastError(ERROR_FILENAME_EXCED_RANGE);
         }
         else
@@ -515,16 +518,17 @@ FindNextFileW(
     lpFindFileData->ftLastWriteTime = FindFileDataA.ftLastWriteTime;
     lpFindFileData->nFileSizeHigh = FindFileDataA.nFileSizeHigh;
     lpFindFileData->nFileSizeLow = FindFileDataA.nFileSizeLow;
-    
+
     /* no 8.3 file names */
     lpFindFileData->cAlternateFileName[0] = 0;
-    
+
     if( 0 == MultiByteToWideChar(CP_ACP, 0, FindFileDataA.cFileName, -1, 
-                                 lpFindFileData->cFileName, MAX_PATH))
+                                 lpFindFileData->cFileName, MAX_PATH_FNAME))
     {
         DWORD dwLastError = GetLastError();
         if (dwLastError == ERROR_INSUFFICIENT_BUFFER)
         {
+            WARN("FindFileDataA.cFileName is larger than MAX_PATH_FNAME (%d)!\n", MAX_PATH_FNAME);
             SetLastError(ERROR_FILENAME_EXCED_RANGE);
         }
         else
@@ -533,7 +537,7 @@ FindNextFileW(
             SetLastError(ERROR_INTERNAL_ERROR);
         }
         retval = FALSE;
-    }                            
+    }
 
 done:
     LOGEXIT("FindNextFileW returns BOOL %d\n", retval);

--- a/src/pal/src/file/path.cpp
+++ b/src/pal/src/file/path.cpp
@@ -51,10 +51,10 @@ See MSDN doc.
 DWORD
 PALAPI
 GetFullPathNameA(
-		 IN LPCSTR lpFileName,
-		 IN DWORD nBufferLength,
-		 OUT LPSTR lpBuffer,
-		 OUT LPSTR *lpFilePart)
+     IN LPCSTR lpFileName,
+     IN DWORD nBufferLength,
+     OUT LPSTR lpBuffer,
+     OUT LPSTR *lpFilePart)
 {
     DWORD  nReqPathLen, nRet = 0;
     LPSTR lpUnixPath = NULL;
@@ -96,7 +96,7 @@ GetFullPathNameA(
 
         /* allocate memory for full non-canonical path */
         max_len = strlen(lpFileName)+1; /* 1 for the slash to append */
-        max_len += MAX_PATH + 1; 
+        max_len += MAX_LONGPATH + 1; 
         lpUnixPath = (LPSTR)PAL_malloc(max_len);
         if(NULL == lpUnixPath)
         {
@@ -107,7 +107,7 @@ GetFullPathNameA(
         }
         
         /* build full path */
-        if(!GetCurrentDirectoryA(MAX_PATH + 1, lpUnixPath))
+        if(!GetCurrentDirectoryA(MAX_LONGPATH + 1, lpUnixPath))
         {
             /* no reason for this to fail now... */
             ASSERT("GetCurrentDirectoryA() failed! lasterror is %#xd\n",
@@ -186,15 +186,15 @@ See MSDN doc.
 DWORD
 PALAPI
 GetFullPathNameW(
-		 IN LPCWSTR lpFileName,
-		 IN DWORD nBufferLength,
-		 OUT LPWSTR lpBuffer,
-		 OUT LPWSTR *lpFilePart)
+     IN LPCWSTR lpFileName,
+     IN DWORD nBufferLength,
+     OUT LPWSTR lpBuffer,
+     OUT LPWSTR *lpFilePart)
 {
     LPSTR fileNameA;
     /* bufferA needs to be able to hold a path that's potentially as
        large as MAX_PATH WCHARs. */
-    CHAR  bufferA[MAX_PATH * sizeof(WCHAR)];
+    CHAR  bufferA[MAX_LONGPATH * sizeof(WCHAR)];
     LPSTR lpFilePartA;
     int   fileNameLength;
     int   srcSize;
@@ -234,7 +234,7 @@ GetFullPathNameW(
         DWORD dwLastError = GetLastError();
         if( dwLastError == ERROR_INSUFFICIENT_BUFFER )
         {
-            ERROR("lpFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
+            ERROR("lpFileName is larger than MAX_LONGPATH (%d)!\n", MAX_LONGPATH);
         }
         else
         {
@@ -269,7 +269,7 @@ GetFullPathNameW(
 
         goto done;
     }
-    
+
     /* MultiByteToWideChar counts the trailing NULL, but
        GetFullPathName does not. */
     nRet--;
@@ -1169,7 +1169,7 @@ SearchPathA(
                 pPathEnd = pPathStart + strlen(pPathStart);
                 /* we want to break out of the loop after this pass, so let
                    *pNextPath be '\0' */
-                pNextPath = pPathEnd;  
+                pNextPath = pPathEnd;
             }
             else
             {
@@ -1203,7 +1203,7 @@ SearchPathA(
                 nRet = 0;
                 goto done;
             }
-			    
+
             /* Canonicalize the path to deal with back-to-back '/', etc. */
             dw = GetFullPathNameA(FullPath, MAX_PATH,
                                   CanonicalFullPath, NULL);

--- a/src/pal/src/include/pal/file.h
+++ b/src/pal/src/include/pal/file.h
@@ -37,7 +37,7 @@ typedef struct _find_handle
     struct _find_handle *self_addr; /* for pointer verification */
 
     char   dir[_MAX_DIR];
-    char   fname[_MAX_PATH]; /* includes extension */
+    char   fname[MAX_PATH_FNAME]; /* includes extension */
     glob_t gGlob;
     char   **next;
 } find_obj;

--- a/src/pal/src/include/pal/map.hpp
+++ b/src/pal/src/include/pal/map.hpp
@@ -144,7 +144,7 @@ namespace CorUnix
     class CFileMappingImmutableData
     {
     public:
-        CHAR szFileName[MAX_PATH + 1];
+        CHAR szFileName[MAX_LONGPATH + 1];
         UINT MaxSize;               // The max size of the file mapping object
         DWORD flProtect;            // Protection desired for the file view
         BOOL bPALCreatedTempFile;   // TRUE if it's a PAL created file

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -92,7 +92,7 @@ CRITICAL_SECTION module_critsec;
 MODSTRUCT exe_module; 
 MODSTRUCT *pal_module = NULL;
 
-char g_szCoreCLRPath[MAX_PATH] = { 0 };
+char g_szCoreCLRPath[MAX_LONGPATH] = { 0 };
 
 /* static function declarations ***********************************************/
 
@@ -221,7 +221,7 @@ LoadLibraryExW(
         return NULL;
     }
     
-    CHAR lpstr[MAX_PATH];
+    CHAR lpstr[MAX_LONGPATH];
     INT name_length;
     HMODULE hModule = NULL;
 
@@ -247,13 +247,13 @@ LoadLibraryExW(
     /* do the Dos/Unix conversion on our own copy of the name */
 
     name_length = WideCharToMultiByte(CP_ACP, 0, lpLibFileName, -1, lpstr,
-                                      MAX_PATH, NULL, NULL);
+                                      MAX_LONGPATH, NULL, NULL);
     if (name_length == 0)
     {
         DWORD dwLastError = GetLastError();
         if (dwLastError == ERROR_INSUFFICIENT_BUFFER)
         {
-            ERROR("lpLibFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
+            ERROR("lpLibFileName is larger than MAX_LONGPATH (%d)!\n", MAX_LONGPATH);
         }
         else
         {
@@ -661,7 +661,7 @@ GetModuleFileNameW(
     name_length = lstrlenW(wide_name);
     if (name_length >= (INT)nSize)
     {
-        TRACE("Buffer too small to copy module's file name.\n");
+        TRACE("Buffer too small (%u) to copy module's file name (%u).\n", nSize, name_length);
         SetLastError(ERROR_INSUFFICIENT_BUFFER);
         goto done;
     }
@@ -743,7 +743,7 @@ PAL_RegisterLibraryW(
     IN LPCWSTR lpLibFileName)
 {
     HMODULE hModule = NULL;
-    CHAR    lpstr[MAX_PATH];
+    CHAR    lpstr[_MAX_FNAME];
     INT     cbMultiByteShortName = 0;
 
     static const char LIB_PREFIX[] = PAL_SHLIB_PREFIX;
@@ -767,7 +767,7 @@ PAL_RegisterLibraryW(
     // Second, copy the file name, converting to multibyte along the way
     cbMultiByteShortName = WideCharToMultiByte(CP_ACP, 0, lpLibFileName, -1, 
                                                lpstr + LIB_PREFIX_LENGTH, 
-                                               MAX_PATH - (LIB_PREFIX_LENGTH + LIB_SUFFIX_LENGTH),
+                                               _MAX_FNAME - (LIB_PREFIX_LENGTH + LIB_SUFFIX_LENGTH),
                                                NULL, NULL);
 
     if (cbMultiByteShortName == 0)
@@ -775,11 +775,11 @@ PAL_RegisterLibraryW(
         DWORD dwLastError = GetLastError();
         if (dwLastError == ERROR_INSUFFICIENT_BUFFER)
         {
-            if (lstrlenW(lpLibFileName) + LIB_PREFIX_LENGTH + LIB_SUFFIX_LENGTH < MAX_PATH)
+            if (lstrlenW(lpLibFileName) + LIB_PREFIX_LENGTH + LIB_SUFFIX_LENGTH < _MAX_FNAME)
             {
                 ASSERT("Insufficient buffer error returned incorrectly from WideCharToMultiByte!\n");
             }
-            ERROR("lpLibFileName is larger than MAX_PATH (%d)!\n", MAX_PATH);
+            ERROR("lpLibFileName is larger than _MAX_FNAME (%d)!\n", _MAX_FNAME);
         }
         else
         {
@@ -1312,7 +1312,7 @@ Return value :
 --*/
 static HMODULE LOADLoadLibrary(LPCSTR shortAsciiName, BOOL fDynamic)
 {
-    CHAR fullLibraryName[MAX_PATH];
+    CHAR fullLibraryName[MAX_LONGPATH];
     MODSTRUCT *module = NULL;
     void *dl_handle = NULL;
     DWORD dwError;
@@ -1360,7 +1360,7 @@ static HMODULE LOADLoadLibrary(LPCSTR shortAsciiName, BOOL fDynamic)
                continue;
            
             if (!dl_handle &&
-                snprintf(fullLibraryName, MAX_PATH, formatStrings[i], PAL_SHLIB_PREFIX, shortAsciiName, PAL_SHLIB_SUFFIX) < MAX_PATH &&
+                snprintf(fullLibraryName, MAX_LONGPATH, formatStrings[i], PAL_SHLIB_PREFIX, shortAsciiName, PAL_SHLIB_SUFFIX) < MAX_LONGPATH &&
                 ((dl_handle = dlopen(fullLibraryName, RTLD_LAZY | RTLD_NOLOAD)) || 
                  (dl_handle = dlopen(fullLibraryName, RTLD_LAZY))))
             {

--- a/src/pal/src/locale/unicode.cpp
+++ b/src/pal/src/locale/unicode.cpp
@@ -951,7 +951,7 @@ EXIT:
     return retval;
 }
 
-extern char g_szCoreCLRPath[MAX_PATH];
+extern char g_szCoreCLRPath[MAX_LONGPATH];
 
 /*++
 Function :
@@ -965,10 +965,10 @@ PALAPI
 PAL_BindResources(IN LPCSTR lpDomain)
 {
 #ifndef __APPLE__
-    char coreCLRDirectoryPath[MAX_PATH];
+    char coreCLRDirectoryPath[MAX_LONGPATH];
 
-    DWORD size = FILEGetDirectoryFromFullPathA(g_szCoreCLRPath, MAX_PATH, coreCLRDirectoryPath);
-    _ASSERTE(size <= MAX_PATH);
+    DWORD size = FILEGetDirectoryFromFullPathA(g_szCoreCLRPath, MAX_LONGPATH, coreCLRDirectoryPath);
+    _ASSERTE(size <= MAX_LONGPATH);
     LPCSTR boundPath = bindtextdomain(lpDomain, coreCLRDirectoryPath);
 
     return boundPath != NULL;

--- a/src/pal/src/shmemory/shmemory.cpp
+++ b/src/pal/src/shmemory/shmemory.cpp
@@ -230,7 +230,7 @@ enum SHM_POOL_SIZES
     SPS_LAST
 };
 /* Block size associated to each SPS identifier */
-static const int block_sizes[SPS_LAST] = {16,32,64,roundup((MAX_PATH+1)*2, sizeof(INT64))};
+static const int block_sizes[SPS_LAST] = {16,32,64,roundup((MAX_LONGPATH+1)*2, sizeof(INT64))};
 
 /*
 SHM_POOL_INFO
@@ -369,8 +369,8 @@ static Volatile<HANDLE> locking_thread;
 
 #ifndef CORECLR
 /* suffix template for mkstemp */
-static char segment_name_template[MAX_PATH];
-static char lockfile_name[MAX_PATH];
+static char segment_name_template[MAX_LONGPATH];
+static char lockfile_name[MAX_LONGPATH];
 #endif // !defined(CORECLR)
 
 /* Constants ******************************************************************/
@@ -445,8 +445,8 @@ BOOL SHMInitialize(void)
     int fd_map;
     int i;
     int j;
-    CHAR config_dir[MAX_PATH];
-    CHAR first_segment_name[MAX_PATH];
+    CHAR config_dir[MAX_LONGPATH];
+    CHAR first_segment_name[MAX_LONGPATH];
     ssize_t sBytes;
 #endif // !CORECLR
 
@@ -455,14 +455,14 @@ BOOL SHMInitialize(void)
     init_waste();
     
 #ifndef CORECLR
-    if ( PALGetPalConfigDir( config_dir, MAX_PATH ) )
+    if ( PALGetPalConfigDir( config_dir, MAX_LONGPATH ) )
     {
         if ( ( strlen( config_dir ) + strlen( segment_name_prefix ) + 
                                            /* + 3 for the / _ and \0 */
-               strlen( first_segment_suffix ) + 3 ) < MAX_PATH && 
+               strlen( first_segment_suffix ) + 3 ) < MAX_LONGPATH && 
              
              ( strlen( config_dir ) + strlen( segment_name_prefix ) + 
-               SEGMENT_NAME_SUFFIX_LENGTH + 3 ) < MAX_PATH ) 
+               SEGMENT_NAME_SUFFIX_LENGTH + 3 ) < MAX_LONGPATH ) 
         {
             /* build first segment's file name */
             sprintf( first_segment_name,"%s/%s_%s", config_dir,
@@ -481,7 +481,7 @@ BOOL SHMInitialize(void)
         else
         {
             ASSERT( "Configuration directory length + segment name length "
-                   "is greater then MAX_PATH.\n" );
+                   "is greater then MAX_LONGPATH.\n" );
             return FALSE;
         }
     }
@@ -973,15 +973,15 @@ void SHMCleanup(void)
     }
     else /* Clean up everything. */
     {
-        CHAR PalDir[ MAX_PATH + 1 ];
-        CHAR FileName[ MAX_PATH + 1 ];
+        CHAR PalDir[ MAX_LONGPATH + 1 ];
+        CHAR FileName[ MAX_LONGPATH + 1 ];
         UINT nEndOfPathAndPrefix = 0;
         SHM_SEGMENT_HEADER segment_header;
         LPCSTR suffix;
         int fd_segment;
 
         /* Build start of filename. */
-        if ( !PALGetPalConfigDir( PalDir, MAX_PATH ) )
+        if ( !PALGetPalConfigDir( PalDir, MAX_LONGPATH ) )
         {
             ASSERT( "Unable to determine the PAL config directory.\n" );
 #ifdef O_EXLOCK
@@ -1079,7 +1079,7 @@ Return value :
 
 Notes :
     SHMalloc will fail if the requested size is larger than a certain maximum.
-    At the moment, the maximum is 520 bytes (MAX_PATH*2).
+    At the moment, the maximum is 520 bytes (MAX_LONGPATH*2).
 --*/
 SHMPTR SHMalloc(size_t size)
 {
@@ -1839,13 +1839,13 @@ Return value :
 --*/
 static LPVOID SHMMapSegment(char *segment_name)
 {
-    char segment_path[MAX_PATH];
+    char segment_path[MAX_LONGPATH];
     int segment_fd;
     LPVOID *segment;
     struct stat sb;
 
     /* Construct the file's full path */
-    if ( !PALGetPalConfigDir( segment_path, MAX_PATH ) )
+    if ( !PALGetPalConfigDir( segment_path, MAX_LONGPATH ) )
     {
         ASSERT( "Unable to determine the PAL config directory.\n" );
         return NULL;
@@ -1965,7 +1965,7 @@ Notes :
 static BOOL SHMAddSegment(void)
 {
 #ifndef CORECLR
-    char segment_name[MAX_PATH];
+    char segment_name[MAX_LONGPATH];
     char *suffix_start;
     int fd_map;
 #endif // !CORECLR
@@ -2634,7 +2634,7 @@ static void save_waste(void)
 {
     int fd;
     FILE *log_file;
-    char file_name[MAX_PATH];
+    char file_name[MAX_LONGPATH];
     enum SHM_POOL_SIZES sps;
     int avg;
     LPSTR env_string;
@@ -2646,7 +2646,7 @@ static void save_waste(void)
         return;
     }
     
-    if ( !PALGetPalConfigDir( file_name, MAX_PATH ) )
+    if ( !PALGetPalConfigDir( file_name, MAX_LONGPATH ) )
     {
         ERROR( "Unable to determine the PAL config directory.\n" );
         return;


### PR DESCRIPTION
This change allows the happy path for a simple corerun Hello World app.
This is pretty close to the bare minimum needed to run.

Idea is that we iterate towards long path support by unblocking the Unix scenarios through
moving from MAX_PATH to MAX_LONGPATH and MAX_PATH_FNAME where we truly need
260 characters.

After culling dead code and updating all MAX_PATH references we can then work towards
allocating only the needed size to allow the outer range of path lengths (e.g. 32K on Windows).

@janvorli, @jkotas, @adityamandaleeka, @stephentoub
