### PR TITLE
Throw PlatformNotSupported for named sync primitives on Unix

### DIFF
--- a/src/mscorlib/src/System/Threading/EventWaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/EventWaitHandle.cs
@@ -48,9 +48,16 @@ namespace System.Threading
         [System.Security.SecurityCritical]  // auto-generated_required
         public EventWaitHandle(bool initialState, EventResetMode mode, string name)
         {
-            if(null != name && System.IO.Path.MAX_PATH < name.Length)
+            if (name != null)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong",name));
+#if PLATFORM_UNIX
+                throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
+                if (System.IO.Path.MAX_PATH < name.Length)
+                {
+                    throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+                }
+#endif
             }
             Contract.EndContractBlock();
             
@@ -90,9 +97,16 @@ namespace System.Threading
         [System.Security.SecurityCritical]  // auto-generated_required
         public unsafe EventWaitHandle(bool initialState, EventResetMode mode, string name, out bool createdNew, EventWaitHandleSecurity eventSecurity)
         {
-            if(null != name && System.IO.Path.MAX_PATH < name.Length)
+            if (name != null)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong",name));
+#if PLATFORM_UNIX
+                throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
+                if (System.IO.Path.MAX_PATH < name.Length)
+                {
+                    throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+                }
+#endif
             }
             Contract.EndContractBlock();
             Win32Native.SECURITY_ATTRIBUTES secAttrs = null;
@@ -196,6 +210,9 @@ namespace System.Threading
         [System.Security.SecurityCritical]  // auto-generated_required
         private static OpenExistingResult OpenExistingWorker(string name, EventWaitHandleRights rights, out EventWaitHandle result)
         {
+#if PLATFORM_UNIX
+            throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
             if (name == null)
             {
                 throw new ArgumentNullException("name", Environment.GetResourceString("ArgumentNull_WithParamName"));
@@ -236,6 +253,7 @@ namespace System.Threading
             }
             result = new EventWaitHandle(myHandle);
             return OpenExistingResult.Success;
+#endif
         }
         [System.Security.SecuritySafeCritical]  // auto-generated
         public bool Reset()

--- a/src/mscorlib/src/System/Threading/Mutex.cs
+++ b/src/mscorlib/src/System/Threading/Mutex.cs
@@ -52,10 +52,17 @@ namespace System.Threading
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         public unsafe Mutex(bool initiallyOwned, String name, out bool createdNew, MutexSecurity mutexSecurity)
         {
-            if(null != name && System.IO.Path.MAX_PATH < name.Length)
+            if (name != null)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong",name));
-            }            
+#if PLATFORM_UNIX
+                throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
+                if (System.IO.Path.MAX_PATH < name.Length)
+                {
+                    throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+                }
+#endif
+            }
             Contract.EndContractBlock();
             Win32Native.SECURITY_ATTRIBUTES secAttrs = null;
 #if FEATURE_MACL
@@ -79,9 +86,16 @@ namespace System.Threading
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         internal Mutex(bool initiallyOwned, String name, out bool createdNew, Win32Native.SECURITY_ATTRIBUTES secAttrs) 
         {
-            if (null != name && Path.MAX_PATH < name.Length) 
+            if (name != null)
             {
-                throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+#if PLATFORM_UNIX
+                throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
+                if (System.IO.Path.MAX_PATH < name.Length)
+                {
+                    throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+                }
+#endif
             }
             Contract.EndContractBlock();
 
@@ -321,6 +335,9 @@ namespace System.Threading
         [System.Security.SecurityCritical]
         private static OpenExistingResult OpenExistingWorker(string name, MutexRights rights, out Mutex result)
         {
+#if PLATFORM_UNIX
+            throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
             if (name == null)
             {
                 throw new ArgumentNullException("name", Environment.GetResourceString("ArgumentNull_WithParamName"));
@@ -371,6 +388,7 @@ namespace System.Threading
 
             result = new Mutex(myHandle);
             return OpenExistingResult.Success;
+#endif
         }
 
         // Note: To call ReleaseMutex, you must have an ACL granting you

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -2130,6 +2130,11 @@ event_SpinLock_FastPathFailed=SpinLock beginning to spin.
 event_SpinWait_NextSpinWillYield=Next spin will yield.
 event_Barrier_PhaseFinished=Barrier finishing phase {1}.
 
+#if PLATFORM_UNIX
+; Unix threading
+PlatformNotSupported_NamedSynchronizationPrimitives=Named synchronization primitives are not supported on this platform.
+#endif
+
 ;
 ; System.Threading.Tasks
 ;


### PR DESCRIPTION
libcoreclr's synchronization primitives implementation currently supports names, but those names have process-wide rather than system-wide scope.  This is very dangerous for most code that would want names, as they're typically used for cross-process synchronization, and as such the current behavior could lead to bad race conditions difficult to diagnose.  Until a better solution is available, we will throw PlatformNotSupportedException when trying to create such named primitives.