### PR TITLE
Add skipmscorlib option to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -196,6 +196,8 @@ for i in "$@"
         __ClangMajorVersion=3
         __ClangMinorVersion=7
         ;;
+        skipmscorlib)
+        ;;
         *)
         __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
     esac


### PR DESCRIPTION
In perperation for supporting mscorlib.dll builds on *NIX, provide a
switch for the CI system to disable building mscorlib as part of the
build, since we pick up the cross compiled Linux version and our mono
seems to crash often in CI.

Once this is checked in we can start having the CI jobs pass this
switch without causing an error, then have a future commit which
enables mscorlib building key off it.