### PR TITLE
Rebuild the resource file when the input file changes

### DIFF
--- a/src/mscorlib/GenerateSplitStringResources.targets
+++ b/src/mscorlib/GenerateSplitStringResources.targets
@@ -5,7 +5,7 @@
   </PropertyGroup>
     
   <Target Name="GenerateSplitStringResources"
-          Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFile)"
+          Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFile);$(BclSourcesRoot)\mscorlib.txt"
           Outputs="@(SplitTextStringResource->'$(IntermediateOutputPath)%(Filename).resources')">
          
     <ItemGroup>


### PR DESCRIPTION
When building mscorlib resources we are not taking into account the file
that contains the resource strings when deciding if we need to rebuild the
resources file.

Becasue of this, adding/modifying a resource string will not show up in the
build resource file until you delete the intermediate folder.

Fixes #1386 