### PR TITLE
Remove incorrect msbuild logic for creating relative paths

### DIFF
--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -148,7 +148,6 @@
   <ItemGroup>
     <!-- We want the sources to show up nicely in VS-->
     <Compile Include="@(MscorlibSources)">
-      <Link>$([MSBuild]::MakeRelative($(BclSourcesRoot), %(Identity))</Link>
     </Compile>
   </ItemGroup>
   


### PR DESCRIPTION
The logic was using Link to try and show mscorlib sources show up in VS.
Turns out the logic to add the link was both incorrect and not needed.