### PR TITLE
Updated to new syntax of dnx run

### DIFF
--- a/Documentation/install/get-dotnetcore-dnx-windows.md
+++ b/Documentation/install/get-dotnetcore-dnx-windows.md
@@ -102,6 +102,6 @@ You need to restore packages for your app, based on your project.json, with `dnu
 
 You can run your app with the DNX command.
 
-	C:\coreclr-demo> dnx . run
+	C:\coreclr-demo> dnx run
 	Hello, Windows
 	Love from CoreCLR.


### PR DESCRIPTION
Syntax for running application changed from `dnx . run` into `dnx run` so last step in docs is always resulting in exception `System.InvalidOperationException: Unable to load application or execute command '.'.` thrown by dnx.