### PR TITLE
Handle newer tzfiles by allowing for the "big bang" transition.

### DIFF
--- a/src/mscorlib/src/System/DateTimeOffset.cs
+++ b/src/mscorlib/src/System/DateTimeOffset.cs
@@ -43,7 +43,10 @@ namespace System {
         private const long UnixEpochTicks = TimeSpan.TicksPerDay * DateTime.DaysTo1970; // 621,355,968,000,000,000
         private const long UnixEpochSeconds = UnixEpochTicks / TimeSpan.TicksPerSecond; // 62,135,596,800
         private const long UnixEpochMilliseconds = UnixEpochTicks / TimeSpan.TicksPerMillisecond; // 62,135,596,800,000
-    
+
+        internal const long UnixMinSeconds = DateTime.MinTicks / TimeSpan.TicksPerSecond - UnixEpochSeconds;
+        internal const long UnixMaxSeconds = DateTime.MaxTicks / TimeSpan.TicksPerSecond - UnixEpochSeconds;
+
         // Static Fields
         public static readonly DateTimeOffset MinValue = new DateTimeOffset(DateTime.MinTicks, TimeSpan.Zero);
         public static readonly DateTimeOffset MaxValue = new DateTimeOffset(DateTime.MaxTicks, TimeSpan.Zero);        
@@ -474,12 +477,9 @@ namespace System {
         }
 
         public static DateTimeOffset FromUnixTimeSeconds(long seconds) {
-            const long MinSeconds = DateTime.MinTicks / TimeSpan.TicksPerSecond - UnixEpochSeconds;
-            const long MaxSeconds = DateTime.MaxTicks / TimeSpan.TicksPerSecond - UnixEpochSeconds;
-
-            if (seconds < MinSeconds || seconds > MaxSeconds) {
+            if (seconds < UnixMinSeconds || seconds > UnixMaxSeconds) {
                 throw new ArgumentOutOfRangeException("seconds",
-                    string.Format(Environment.GetResourceString("ArgumentOutOfRange_Range"), MinSeconds, MaxSeconds));
+                    string.Format(Environment.GetResourceString("ArgumentOutOfRange_Range"), UnixMinSeconds, UnixMaxSeconds));
             }
 
             long ticks = seconds * TimeSpan.TicksPerSecond + UnixEpochTicks;


### PR DESCRIPTION
In the TZ release 2014c, a new "big bang" transition time was added
to the beginning of the tzfiles. This broke the TimeZoneInfo parsing
logic because the transition time was for 13 billion years ago, which
is unrepresentable by DateTime.

To handle these new transitions, check for times really far in the past and future, and use DateTime.Min/Max to represent them.  Then skip over any DateTime.MinValue times when generating the AdjustmentRules.

Fix https://github.com/dotnet/corefx/issues/2816.

@tarekgh