### PR TITLE
Remove GetFileInformation stat wrapper from PAL

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -50,8 +50,6 @@ GetCurrentThreadId
 GetEnvironmentStringsW
 GetEnvironmentVariableW
 GetFileAttributesExW
-GetFileInformationFromFd
-GetFileInformationFromPath
 GetFileSize
 GetFileType
 GetFullPathNameW

--- a/src/pal/inc/pal_corefx.h
+++ b/src/pal/inc/pal_corefx.h
@@ -45,35 +45,6 @@ ForkAndExecProcess(
            int* stdoutFd,
            int* stderrFd);
 
-struct fileinfo {
-    int32_t  flags;   /* flags for testing if some members are present */
-    int32_t  mode;    /* protection */
-    int32_t  uid;     /* user ID of owner */
-    int32_t  gid;     /* group ID of owner */
-    int64_t  size;    /* total size, in bytes */
-    int64_t  atime;   /* time of last access */
-    int64_t  mtime;   /* time of last modification */
-    int64_t  ctime;   /* time of last status change */
-    int64_t  btime;   /* time the file was created (birthtime) */
-};
-
-#define FILEINFO_FLAGS_NONE 0x0
-#define FILEINFO_FLAGS_HAS_BTIME 0x1
-
-PALIMPORT
-int
-PALAPI
-GetFileInformationFromPath(
-    const char* path,
-    struct fileinfo* buf);
-
-PALIMPORT
-int
-PALAPI
-GetFileInformationFromFd(
-    int fd,
-    struct fileinfo* buf);
-
 #ifdef  __cplusplus
 } // extern "C"
 #endif

--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -50,12 +50,9 @@
 #cmakedefine01 HAS_SYSV_SEMAPHORES
 #cmakedefine01 HAS_PTHREAD_MUTEXES
 #cmakedefine01 HAVE_TTRACE
-#cmakedefine01 HAVE_STAT64
-#cmakedefine01 HAVE_STAT
 
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_NSEC
-#cmakedefine01 HAVE_STAT_BIRTHTIME
 #cmakedefine01 HAVE_TM_GMTOFF
 
 #cmakedefine01 HAVE_BSD_REGS_T

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -63,12 +63,9 @@ check_function_exists(directio HAVE_DIRECTIO)
 check_function_exists(semget HAS_SYSV_SEMAPHORES)
 check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
-check_function_exists(stat64 HAVE_STAT64)
-check_function_exists(stat HAVE_STAT)
 
 check_struct_has_member ("struct stat" st_atimespec "sys/types.h;sys/stat.h" HAVE_STAT_TIMESPEC)
 check_struct_has_member ("struct stat" st_atimensec "sys/types.h;sys/stat.h" HAVE_STAT_NSEC)
-check_struct_has_member ("struct stat" st_birthtime "sys/types.h;sys/stat.h" HAVE_STAT_BIRTHTIME)
 check_struct_has_member ("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
 check_struct_has_member ("ucontext_t" uc_mcontext.gregs[0] ucontext.h HAVE_GREGSET_T)
 

--- a/src/pal/src/misc/corefx.cpp
+++ b/src/pal/src/misc/corefx.cpp
@@ -20,8 +20,6 @@ Abstract:
 #include "pal/module.h"
 #include <pal_corefx.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <errno.h>
 #include <unistd.h>
 #include <dlfcn.h>
@@ -348,96 +346,3 @@ done:
     return success ? 0 : -1;
 }
 
-#if HAVE_STAT64 && !(defined(__APPLE__) && defined(_AMD64_))
-typedef struct stat64 stat_native;
-#elif HAVE_STAT
-typedef struct stat stat_native;
-#else
-#error need an alias for stat_native to stat struct for platform
-#endif
-
-void CopyStatNativeToFileInfo(struct fileinfo* dst, const stat_native* src)
-{
-    dst->flags = FILEINFO_FLAGS_NONE;
-    dst->mode = src->st_mode;
-    dst->uid = src->st_uid;
-    dst->gid = src->st_gid;
-    dst->size = src->st_size;
-    dst->atime = src->st_atime;
-    dst->mtime = src->st_mtime;
-    dst->ctime = src->st_ctime;
-
-    #if HAVE_STAT_BIRTHTIME
-    dst->btime = src->st_birthtime;
-    dst->flags |= FILEINFO_FLAGS_HAS_BTIME;
-    #endif
-}
-
-int
-PALAPI
-GetFileInformationFromPath(
-    const char* path,
-    struct fileinfo* buf)
-{
-    PERF_ENTRY(GetFileInformationFromPath);
-    ENTRY("GetFileInformationFromPath(path=%p (%s), buf=%p\n",
-          path, path ? path : "NULL",
-          buf);
-
-    int success = FALSE;
-    stat_native result;
-    int ret;
-
-    #if HAVE_STAT64 && !(defined(__APPLE__) && defined(_AMD64_))
-    ret = stat64(path, &result);
-    #elif HAVE_STAT
-    ret = stat(path, &result);
-    #else
-    #error need implemetation of stat/stat64
-    #endif
-
-    if (ret == 0)
-    {
-        CopyStatNativeToFileInfo(buf, &result);
-        success = TRUE;
-    }
-
-    LOGEXIT("GetFileInformationFromPath returns BOOL %d with error %d\n", success, success ? 0 : errno);
-    PERF_EXIT(GetFileInformationFromPath);
-
-    return success ? 0 : -1;
-}
-
-int
-PALAPI
-GetFileInformationFromFd(
-    int fd,
-    struct fileinfo* buf)
-{
-    PERF_ENTRY(GetFileInformationFromFd);
-    ENTRY("GetFileInformationFromFd(fd=%d, buf=%p\n",
-          fd, buf);
-
-    int success = FALSE;
-    stat_native result;
-    int ret;
-
-    #if HAVE_STAT64 && !(defined(__APPLE__) && defined(_AMD64_))
-    ret = fstat64(fd, &result);
-    #elif HAVE_STAT
-    ret = fstat(fd, &result);
-    #else
-    #error need implemetation of fstat/fstat64
-    #endif
-
-    if (ret == 0)
-    {
-        CopyStatNativeToFileInfo(buf, &result);
-        success = TRUE;
-    }
-
-    LOGEXIT("GetFileInformationFromFd returns BOOL %d with error %d\n", success, success ? 0 : errno);
-    PERF_EXIT(GetFileInformationFromFd);
-
-    return success ? 0 : -1;
-}


### PR DESCRIPTION
It has been replaced by Stat shims in corefx repo

Reverts commits:
* 79ebe5605a94d559d2996997aec3cbcf8a4504c3.
* 0119283384f1bac80da8bb1736453c87d4f8e689.

NOTE: Do not merge until dotnet/corefx#2834 is merged.