### PR TITLE
Fix timing in more PAL tests for FreeBSD on hypervisors

### DIFF
--- a/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.c
+++ b/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.c
@@ -26,13 +26,11 @@ DWORD SleepTimes[] =
     50,
     100,
     500,
-    1000
+    2000
 };
 
-/* Milliseconds of error which are acceptable Function execution time, etc.
-   FreeBSD has a "standard" resolution of 10ms for waiting operations, so we 
-   must take that into account as well */
-DWORD AcceptableTimeError = 15; 
+/* Milliseconds of error which are acceptable Function execution time, etc. */
+DWORD AcceptableTimeError = 150;
 
 int __cdecl main( int argc, char **argv ) 
 {

--- a/src/pal/tests/palsuite/threading/Sleep/test2/sleep.c
+++ b/src/pal/tests/palsuite/threading/Sleep/test2/sleep.c
@@ -30,10 +30,8 @@ DWORD SleepTimes[] =
     3200000
 };
 
-/* Milliseconds of error which are acceptable Function execution time, etc.
-   FreeBSD has a "standard" resolution of 10ms for waiting operations, so we 
-   must take that into account as well */
-DWORD AcceptableTimeError = 150; 
+/* Milliseconds of error which are acceptable Function execution time, etc. */
+DWORD AcceptableTimeError = 150;
 
 int __cdecl main( int argc, char **argv ) 
 {

--- a/src/pal/tests/palsuite/threading/SleepEx/test1/test1.c
+++ b/src/pal/tests/palsuite/threading/SleepEx/test1/test1.c
@@ -27,19 +27,17 @@ testCase testCases[] =
     {50, FALSE},
     {100, FALSE},
     {500, FALSE},
-    {1000, FALSE},
+    {2000, FALSE},
 
     {0, TRUE},
     {50, TRUE},
     {100, TRUE},
     {500, TRUE},
-    {1000, TRUE},
+    {2000, TRUE},
 };
 
-/* Milliseconds of error which are acceptable Function execution time, etc.
-   FreeBSD has a "standard" resolution of 10ms for waiting operations, so we 
-   must take that into account as well */
-DWORD AcceptableTimeError = 15; 
+/* Milliseconds of error which are acceptable Function execution time, etc. */
+DWORD AcceptableTimeError = 150;
 
 int __cdecl main( int argc, char **argv ) 
 {


### PR DESCRIPTION
Replicate #1112 in all PAL tests. This stop intermittent FreeBSD test failures in CI.