### PR TITLE
LTTng supports hardware context

### DIFF
--- a/Documentation/coding-guidelines/cross-platform-performance-and-eventing.md
+++ b/Documentation/coding-guidelines/cross-platform-performance-and-eventing.md
@@ -68,7 +68,6 @@ Given that the performance and tracing tool space on Linux is quite fragmented, 
 
 #### Cons
 
-- No hardware counter support (CPU samples, context switches, etc.)
 - No built-in callstack collection.
 
 ### SystemTap


### PR DESCRIPTION
LTTng supports the annotation of events (both kernel and userspace) with perf hardware counters via the use of the "add-context" command.

For instance, userspace events can be annotated with the Instruction Cache Prefetch Misses counter using
```
$ lttng add-context --userspace --type perf:thread:L1-icache-prefetch-misses
```

The complete list of available contexts is given by
```
$ lttng add-context --help
usage: lttng add-context -t TYPE [-k|-u] [OPTIONS]

If no channel is given (-c), the context is added to
all channels.

Otherwise the context is added only to the channel (-c).

Exactly one domain (-k or -u) must be specified.

Options:
  -h, --help               Show this help
      --list-options       Simple listing of options
  -s, --session NAME       Apply to session name
  -c, --channel NAME       Apply to channel
  -k, --kernel             Apply to the kernel tracer
  -u, --userspace          Apply to the user-space tracer

Context:
  -t, --type TYPE          Context type. You can repeat that option on
                           the command line to specify multiple contexts at once.
                           (--kernel preempts --userspace)
                           TYPE can be one of the strings below:
                               pid, procname, prio, nice, vpid, tid, pthread_id,
                               vtid, ppid, vppid, hostname, ip,
                               perf:cpu:cpu-cycles, perf:cpu:cycles,
                               perf:cpu:stalled-cycles-frontend,
                               perf:cpu:idle-cycles-frontend,
                               perf:cpu:stalled-cycles-backend,
                               perf:cpu:idle-cycles-backend,
                               perf:cpu:instructions, perf:cpu:cache-references,
                               perf:cpu:cache-misses,
                               perf:cpu:branch-instructions, perf:cpu:branches,
                               perf:cpu:branch-misses, perf:cpu:bus-cycles,
                               perf:cpu:L1-dcache-loads,
                               perf:cpu:L1-dcache-load-misses,
                               perf:cpu:L1-dcache-stores,
                               perf:cpu:L1-dcache-store-misses,
                               perf:cpu:L1-dcache-prefetches,
                               perf:cpu:L1-dcache-prefetch-misses,
                               perf:cpu:L1-icache-loads,
                               perf:cpu:L1-icache-load-misses,
                               perf:cpu:L1-icache-stores,
                               perf:cpu:L1-icache-store-misses,
                               perf:cpu:L1-icache-prefetches,
                               perf:cpu:L1-icache-prefetch-misses,
                               perf:cpu:LLC-loads, perf:cpu:LLC-load-misses,
                               perf:cpu:LLC-stores, perf:cpu:LLC-store-misses,
                               perf:cpu:LLC-prefetches,
                               perf:cpu:LLC-prefetch-misses,
                               perf:cpu:dTLB-loads, perf:cpu:dTLB-load-misses,
                               perf:cpu:dTLB-stores, perf:cpu:dTLB-store-misses,
                               perf:cpu:dTLB-prefetches,
                               perf:cpu:dTLB-prefetch-misses,
                               perf:cpu:iTLB-loads, perf:cpu:iTLB-load-misses,
                               perf:cpu:branch-loads,
                               perf:cpu:branch-load-misses, perf:cpu:cpu-clock,
                               perf:cpu:task-clock, perf:cpu:page-fault,
                               perf:cpu:faults, perf:cpu:major-faults,
                               perf:cpu:minor-faults, perf:cpu:context-switches,
                               perf:cpu:cs, perf:cpu:cpu-migrations,
                               perf:cpu:migrations, perf:cpu:alignment-faults,
                               perf:cpu:emulation-faults,
                               perf:thread:cpu-cycles, perf:thread:cycles,
                               perf:thread:stalled-cycles-frontend,
                               perf:thread:idle-cycles-frontend,
                               perf:thread:stalled-cycles-backend,
                               perf:thread:idle-cycles-backend,
                               perf:thread:instructions,
                               perf:thread:cache-references,
                               perf:thread:cache-misses,
                               perf:thread:branch-instructions,
                               perf:thread:branches, perf:thread:branch-misses,
                               perf:thread:bus-cycles,
                               perf:thread:L1-dcache-loads,
                               perf:thread:L1-dcache-load-misses,
                               perf:thread:L1-dcache-stores,
                               perf:thread:L1-dcache-store-misses,
                               perf:thread:L1-dcache-prefetches,
                               perf:thread:L1-dcache-prefetch-misses,
                               perf:thread:L1-icache-loads,
                               perf:thread:L1-icache-load-misses,
                               perf:thread:L1-icache-stores,
                               perf:thread:L1-icache-store-misses,
                               perf:thread:L1-icache-prefetches,
                               perf:thread:L1-icache-prefetch-misses,
                               perf:thread:LLC-loads,
                               perf:thread:LLC-load-misses,
                               perf:thread:LLC-stores,
                               perf:thread:LLC-store-misses,
                               perf:thread:LLC-prefetches,
                               perf:thread:LLC-prefetch-misses,
                               perf:thread:dTLB-loads,
                               perf:thread:dTLB-load-misses,
                               perf:thread:dTLB-stores,
                               perf:thread:dTLB-store-misses,
                               perf:thread:dTLB-prefetches,
                               perf:thread:dTLB-prefetch-misses,
                               perf:thread:iTLB-loads,
                               perf:thread:iTLB-load-misses,
                               perf:thread:branch-loads,
                               perf:thread:branch-load-misses,
                               perf:thread:cpu-clock, perf:thread:task-clock,
                               perf:thread:page-fault, perf:thread:faults,
                               perf:thread:major-faults,
                               perf:thread:minor-faults,
                               perf:thread:context-switches, perf:thread:cs,
                               perf:thread:cpu-migrations,
                               perf:thread:migrations,
                               perf:thread:alignment-faults,
                               perf:thread:emulation-faults
Note that the vpid, vppid and vtid context types represent the virtual process id,
virtual parent process id and virtual thread id as seen from the current execution context
as opposed to the pid, ppid and tid which are kernel internal data structures.

Example:
This command will add the context information 'prio' and two per-cpu
perf counters (hardware branch misses and cache misses), to all channels
in the trace data output:
# lttng add-context -k -t prio -t perf:cpu:branch-misses -t perf:cpu:cache-misses
```

However, the counters cannot be "sampled"; they are only recorded along with events to which the context has been associated.

https://lttng.org/docs/#doc-adding-context