### PR TITLE
Enable gcroot and other gc related sos commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,7 +383,6 @@ include_directories("src/pal/prebuilt/inc")
 if (CLR_CMAKE_PLATFORM_UNIX)
   include_directories("src/pal/inc")
   include_directories("src/pal/inc/rt")
-  include_directories("src/pal/inc/rt/cpp")
   include_directories("src/pal/src/safecrt")
 endif (CLR_CMAKE_PLATFORM_UNIX)
 

--- a/build.out
+++ b/build.out
@@ -1,0 +1,1646 @@
+Commencing CoreCLR Repo build
+
+Checking pre-requisites...
+
+Commencing build of native components for Windows_NT.x64.Debug
+
+-- Configuring done
+-- Generating done
+-- Build files have been written to: C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug
+Build started 8/17/2015 12:08:11 PM.
+     1>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\install.vcxproj" on node 1 (default targets).
+     1>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\install.vcxproj" (1) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) on node 1 (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ZERO_CHECK.vcxproj" (6) on node 19 (default targets).
+     6>InitializeBuildStatus:
+         Creating "x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+       CustomBuild:
+         All outputs are up-to-date.
+       FinalizeBuildStatus:
+         Deleting file "x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\unsuccessfulbuild".
+         Touching "x64\Debug\ZERO_CHECK\ZERO_CHECK.tlog\ZERO_CHECK.lastbuildstate".
+     6>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ZERO_CHECK.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\crossgen\cee_crossgen.vcxproj" (25) on node 17 (default targets).
+    25>InitializeBuildStatus:
+         Creating "cee_crossgen.dir\Debug\cee_crossgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) on node 3 (default targets).
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\crossgen\mdwinmd_crossgen.vcxproj" (53) on node 13 (default targets).
+    53>InitializeBuildStatus:
+         Creating "mdwinmd_crossgen.dir\Debug\mdwinmd_crossgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\cryptography\comcrypt_wks.vcxproj" (63) on node 24 (default targets).
+    63>InitializeBuildStatus:
+         Creating "comcrypt_wks.dir\Debug\comcrypt_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) on node 6 (default targets).
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\wks\mdruntimerw_wks.vcxproj" (56) on node 22 (default targets).
+    56>InitializeBuildStatus:
+         Creating "mdruntimerw_wks.dir\Debug\mdruntimerw_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\crossgen\mdcompiler_crossgen.vcxproj" (40) on node 2 (default targets).
+    40>InitializeBuildStatus:
+         Creating "mdcompiler_crossgen.dir\Debug\mdcompil.3A393107.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscorrc\full\mscorrc.debug.vcxproj" (67) on node 11 (default targets).
+    67>InitializeBuildStatus:
+         Creating "mscorrc.debug.dir\Debug\mscorrc.debug.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\crossgen\utilcode_crossgen.vcxproj" (72) on node 23 (default targets).
+    72>InitializeBuildStatus:
+         Creating "utilcode_crossgen.dir\Debug\utilcode.B9718DD5.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    25>CustomBuild:
+         All outputs are up-to-date.
+    53>CustomBuild:
+         All outputs are up-to-date.
+    72>CustomBuild:
+         All outputs are up-to-date.
+    40>CustomBuild:
+         All outputs are up-to-date.
+    63>CustomBuild:
+         All outputs are up-to-date.
+    67>CustomBuild:
+         All outputs are up-to-date.
+    56>CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\unwinder\dac\unwinder_dac.vcxproj" (73) on node 16 (default targets).
+    73>InitializeBuildStatus:
+         Creating "unwinder_dac.dir\Debug\unwinder_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\dac\mdruntime_dac.vcxproj" (55) on node 12 (default targets).
+    55>InitializeBuildStatus:
+         Creating "mdruntime_dac.dir\Debug\mdruntime_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\wks\mdcompiler_wks.vcxproj" (41) on node 14 (default targets).
+    41>InitializeBuildStatus:
+         Creating "mdcompiler_wks.dir\Debug\mdcompiler_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\crossgen\mdruntime_crossgen.vcxproj" (50) on node 3 (default targets).
+    50>InitializeBuildStatus:
+         Creating "mdruntime_crossgen.dir\Debug\mdruntim.CE340F8D.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    53>ClCompile:
+         All outputs are up-to-date.
+    67>ResourceCompile:
+         All outputs are up-to-date.
+    50>CustomBuild:
+         All outputs are up-to-date.
+    55>CustomBuild:
+         All outputs are up-to-date.
+    73>CustomBuild:
+         All outputs are up-to-date.
+    41>CustomBuild:
+         All outputs are up-to-date.
+    53>ClCompile:
+         All outputs are up-to-date.
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr_exports.vcxproj" (46) on node 6 (default targets).
+    46>InitializeBuildStatus:
+         Creating "x64\Debug\coreclr_exports\coreclr_exports.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    56>ClCompile:
+         All outputs are up-to-date.
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\dyncrt\utilcode.vcxproj" (68) on node 4 (default targets).
+    68>InitializeBuildStatus:
+         Creating "utilcode.dir\Debug\utilcode.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\crossgen\mdhotdata_crossgen.vcxproj" (44) on node 5 (default targets).
+    44>InitializeBuildStatus:
+         Creating "mdhotdata_crossgen.dir\Debug\mdhotdat.AE9DD455.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\binder\v3binder_crossgen\v3binder_crossgen.vcxproj" (60) on node 21 (default targets).
+    60>InitializeBuildStatus:
+         Creating "v3binder_crossgen.dir\Debug\v3binder.5915B88A.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    46>CustomBuild:
+         All outputs are up-to-date.
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\crossgen\strongname_crossgen.vcxproj" (58) on node 10 (default targets).
+    58>InitializeBuildStatus:
+         Creating "strongname_crossgen.dir\Debug\strongna.53BAF8C9.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscorrc\small\mscorrc.vcxproj" (65) on node 18 (default targets).
+    65>InitializeBuildStatus:
+         Creating "mscorrc.dir\Debug\mscorrc.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    72>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\dbi\mdcompiler-dbi.vcxproj" (39) on node 8 (default targets).
+    39>InitializeBuildStatus:
+         Creating "mdcompiler-dbi.dir\Debug\mdcompiler-dbi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    68>CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\dbi\mdwinmd_dbi.vcxproj" (66) on node 7 (default targets).
+    66>InitializeBuildStatus:
+         Creating "mdwinmd_dbi.dir\Debug\mdwinmd_dbi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\full-staticcrt\mdhotdata-staticcrt.vcxproj" (36) on node 20 (default targets).
+    36>InitializeBuildStatus:
+         Creating "mdhotdata-staticcrt.dir\Debug\mdhotdat.5F707255.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    56>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\wks\cee_wks.vcxproj" (34) on node 15 (default targets).
+    34>InitializeBuildStatus:
+         Creating "cee_wks.dir\Debug\cee_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\dbgshim.vcxproj" (4) on node 1 (default targets).
+     4>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\dbgshim.vcxproj" (4) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\shim\debugshim.vcxproj" (26) on node 1 (default targets).
+    26>InitializeBuildStatus:
+         Creating "debugshim.dir\Debug\debugshim.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\dac\strongname_dac.vcxproj" (70) on node 9 (default targets).
+    70>InitializeBuildStatus:
+         Creating "strongname_dac.dir\Debug\strongname_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    46>FinalizeBuildStatus:
+         Deleting file "x64\Debug\coreclr_exports\coreclr_exports.tlog\unsuccessfulbuild".
+         Touching "x64\Debug\coreclr_exports\coreclr_exports.tlog\coreclr_exports.lastbuildstate".
+    44>CustomBuild:
+         All outputs are up-to-date.
+    46>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr_exports.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\gcinfo\lib\gcinfo.vcxproj" (28) on node 13 (default targets).
+    28>InitializeBuildStatus:
+         Creating "gcinfo.dir\Debug\gcinfo.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\wks\strongname_wks.vcxproj" (49) on node 11 (default targets).
+    49>InitializeBuildStatus:
+         Creating "strongname_wks.dir\Debug\strongname_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    34>PreBuildEvent:
+         setlocal
+         C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Bypass "& ""C:/ssd/coreclr/src/vm/h2inc.ps1""" """C:/ssd/coreclr/src/vm/amd64/asmconstants.h""" >"C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/vm/wks/AsmConstants.tmp"
+         if %errorlevel% neq 0 goto :cmEnd
+         "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\cl.exe" -DDEBUG -D_DEBUG -D_DBG -DURTBLDENV_FRIENDLY=Checked -DBUILDENV_CHECKED=1 -DWRITE_BARRIER_CHECK=1     -DFEATURE_EVENT_TRACE=1 -D_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS -DDEV10 -DWIN32 -DDEVL=1 -D_WIN32_WINNT=0x0602 -D_WIN32_IE=0x0900 -DWINNT=1 -DNT_INST=0 -DCONDITION_HANDLING=1 -DNTDDI_VERSION=NTDDI_WIN8 -DDBG_TARGET_AMD64 -D_TARGET_AMD64_=1 -D_CRT_SECURE_NO_WARNINGS -DNTMAKEENV -D_BLD_CLR -DWINVER=0x0602 -DWIN32_LEAN_AND_MEAN=1 -DDEBUGGING_SUPPORTED -DEnC_SUPPORTED -DFEATURE_APPDOMAIN_RESOURCE_MONITORING -DFEATURE_ARRAYSTUB_AS_IL -DFEATURE_ASYNC_IO -DFEATURE_BCL_FORMATTING -DFEATURE_COLLECTIBLE_TYPES -DFEATURE_CLASSIC_COMINTEROP -DFEATURE_APPX -DFEATURE_COMINTEROP -DFEATURE_COMINTEROP_APARTMENT_SUPPORT -DFEATURE_COMINTEROP_UNMANAGED_ACTIVATION -DFEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION -DFEATURE_ICASTABLE -DFEATURE_CORECLR -DFEATURE_CORESYSTEM -DFEATURE_CORRUPTING_EXCEPTIONS -DFEATURE_CRYPTO -DFEATURE_EXCEPTIONDISPATCHINFO -DFEATURE_FRAMEWORK_INTERNAL -DFEATURE_HIJACK -DFEATURE_HOST_ASSEMBLY_RESOLVER -DFEATURE_HOSTED_BINDER -DFEATURE_ISOSTORE -DFEATURE_ISOSTORE_LIGHT -DFEATURE_ISYM_READER -DFEATURE_LEGACYNETCF -DFEATURE_LEGACYNETCFCRYPTO -DFEATURE_LEGACYNETCF_DBG_HOST_CONTROL -DFEATURE_LEGACYNETCFFAS -DFEATURE_LEGACYSURFACE -DFEATURE_LOADER_OPTIMIZATION -DFEATURE_MANAGED_ETW -DFEATURE_MANAGED_ETW_CHANNELS -DFEATURE_MAIN_CLR_MODULE_USES_CORE_NAME -DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE -DFEATURE_MERGE_JIT_AND_ENGINE -DFEATURE_NORM_IDNA_ONLY -DFEATURE_PREJIT -DFEATURE_RANDOMIZED_STRING_HASHING -DFEATURE_READYTORUN -DFEATURE_STANDALONE_SN -DFEATURE_STRONGNAME_DELAY_SIGNING_ALLOWED -DFEATURE_STRONGNAME_MIGRATION -DFEATURE_STRONGNAME_TESTKEY_ALLOWED -DFEATURE_SVR_GC -DFEATURE_SYNTHETIC_CULTURES -DFEATURE_VERSIONING -DFEATURE_VERSIONING_LOG -DFEATURE_WIN32_REGISTRY -DFEATURE_WINDOWSPHONE -DFEATURE_WINMD_RESILIENT -DFEATURE_X509 -DFEATURE_X509_SECURESTRINGS -DPROFILING_SUPPORTED -DFEATURE_MULTICOREJIT -DFEATURE_USE_ASM_GC_WRITE_BARRIERS -DFEATURE_SYMDIFF -D_AMD64_ -D_AMD64_SIMULATOR_ -D_AMD64_SIMULATOR_PERF_ -D_AMD64_WORKAROUND_ -D_WIN64 -DAMD64 -D_SKIP_IF_SIMULATOR_ -D_SECURE_SCL=0 -D_NEW_SDK=1 -DOFFICIAL_BUILD=0 -DBETA=0 -DFX_BRANCH_SYNC_COUNTER_VALUE=0 -DUNICODE -D_UNICODE -D_TARGET_AMD64_=1 -DDBG_TARGET_64BIT=1 -DDBG_TARGET_AMD64=1 -DDBG_TARGET_WIN64=1 -DFEATURE_LEAVE_RUNTIME_HOLDER=1 -DUNICODE -D_UNICODE -DFEATURE_MERGE_JIT_AND_ENGINE /EP C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/vm/wks/AsmConstants.tmp >"C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/vm/wks/AsmConstants.inc"
+         if %errorlevel% neq 0 goto :cmEnd
+         :cmEnd
+         endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
+         :cmErrorLevel
+         exit /b %1
+         :cmDone
+         if %errorlevel% neq 0 goto :VCEnd
+         :VCEnd
+    58>CustomBuild:
+         All outputs are up-to-date.
+    60>CustomBuild:
+         All outputs are up-to-date.
+    39>CustomBuild:
+         All outputs are up-to-date.
+    65>CustomBuild:
+         All outputs are up-to-date.
+    40>ClCompile:
+         All outputs are up-to-date.
+    28>CustomBuild:
+         All outputs are up-to-date.
+    49>CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\dac\mdwinmd_dac.vcxproj" (62) on node 6 (default targets).
+    62>InitializeBuildStatus:
+         Creating "mdwinmd_dac.dir\Debug\mdwinmd_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    66>CustomBuild:
+         All outputs are up-to-date.
+    36>CustomBuild:
+         All outputs are up-to-date.
+    26>CustomBuild:
+         All outputs are up-to-date.
+    70>CustomBuild:
+         All outputs are up-to-date.
+    65>ResourceCompile:
+         All outputs are up-to-date.
+    56>Lib:
+         All outputs are up-to-date.
+    55>ClCompile:
+         All outputs are up-to-date.
+    56>Lib:
+         mdruntimerw_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\wks\Debug\mdruntimerw_wks.lib
+    50>ClCompile:
+         All outputs are up-to-date.
+    62>CustomBuild:
+         All outputs are up-to-date.
+    41>ClCompile:
+         All outputs are up-to-date.
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordac\mscordaccore.vcxproj" (47) on node 8 (default targets).
+    47>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordac\mscordaccore.vcxproj" (47) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordac\mscordaccore_def.vcxproj" (74) on node 22 (default targets).
+    74>InitializeBuildStatus:
+         Creating "x64\Debug\mscordaccore_def\mscordaccore_def.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    26>ClCompile:
+         All outputs are up-to-date.
+    28>ClCompile:
+         All outputs are up-to-date.
+    55>ClCompile:
+         All outputs are up-to-date.
+    44>ClCompile:
+         All outputs are up-to-date.
+    65>Link:
+         All outputs are up-to-date.
+    26>Lib:
+         All outputs are up-to-date.
+    50>ClCompile:
+         All outputs are up-to-date.
+    26>Lib:
+         debugshim.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\shim\Debug\debugshim.lib
+    68>ClCompile:
+         All outputs are up-to-date.
+    65>Link:
+         mscorrc.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscorrc\small\Debug\mscorrc.dll
+    40>ClCompile:
+         All outputs are up-to-date.
+    36>ClCompile:
+         All outputs are up-to-date.
+    26>FinalizeBuildStatus:
+         Deleting file "debugshim.dir\Debug\debugshim.tlog\unsuccessfulbuild".
+    28>Lib:
+         All outputs are up-to-date.
+    26>FinalizeBuildStatus:
+         Touching "debugshim.dir\Debug\debugshim.tlog\debugshim.lastbuildstate".
+    65>FinalizeBuildStatus:
+         Deleting file "mscorrc.dir\Debug\mscorrc.tlog\unsuccessfulbuild".
+    26>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\shim\debugshim.vcxproj" (default targets).
+    65>FinalizeBuildStatus:
+         Touching "mscorrc.dir\Debug\mscorrc.tlog\mscorrc.lastbuildstate".
+    28>Lib:
+         gcinfo.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\gcinfo\lib\Debug\gcinfo.lib
+    65>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscorrc\small\mscorrc.vcxproj" (default targets).
+    28>FinalizeBuildStatus:
+         Deleting file "gcinfo.dir\Debug\gcinfo.tlog\unsuccessfulbuild".
+    55>Lib:
+         All outputs are up-to-date.
+    50>Lib:
+         All outputs are up-to-date.
+    55>Lib:
+         mdruntime_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\dac\Debug\mdruntime_dac.lib
+    28>FinalizeBuildStatus:
+         Touching "gcinfo.dir\Debug\gcinfo.tlog\gcinfo.lastbuildstate".
+    50>Lib:
+         mdruntime_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\crossgen\Debug\mdruntime_crossgen.lib
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\crossgen\mdruntimerw_crossgen.vcxproj" (42) on node 1 (default targets).
+    42>InitializeBuildStatus:
+         Creating "mdruntimerw_crossgen.dir\Debug\mdruntim.AFC3F5D9.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    28>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\gcinfo\lib\gcinfo.vcxproj" (default targets).
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\wks\mdruntime_wks.vcxproj" (48) on node 18 (default targets).
+    48>InitializeBuildStatus:
+         Creating "mdruntime_wks.dir\Debug\mdruntime_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    55>FinalizeBuildStatus:
+         Deleting file "mdruntime_dac.dir\Debug\mdruntime_dac.tlog\unsuccessfulbuild".
+    50>FinalizeBuildStatus:
+         Deleting file "mdruntime_crossgen.dir\Debug\mdruntim.CE340F8D.tlog\unsuccessfulbuild".
+    55>FinalizeBuildStatus:
+         Touching "mdruntime_dac.dir\Debug\mdruntime_dac.tlog\mdruntime_dac.lastbuildstate".
+    50>FinalizeBuildStatus:
+         Touching "mdruntime_crossgen.dir\Debug\mdruntim.CE340F8D.tlog\mdruntime_crossgen.lastbuildstate".
+    40>Lib:
+         All outputs are up-to-date.
+    55>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\dac\mdruntime_dac.vcxproj" (default targets).
+    42>CustomBuild:
+         All outputs are up-to-date.
+    41>ClCompile:
+         All outputs are up-to-date.
+    50>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\crossgen\mdruntime_crossgen.vcxproj" (default targets).
+    40>Lib:
+         mdcompiler_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\crossgen\Debug\mdcompiler_crossgen.lib
+    53>Lib:
+         All outputs are up-to-date.
+    36>ClCompile:
+         All outputs are up-to-date.
+    48>CustomBuild:
+         All outputs are up-to-date.
+    53>Lib:
+         mdwinmd_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\crossgen\Debug\mdwinmd_crossgen.lib
+    66>ClCompile:
+         All outputs are up-to-date.
+    39>ClCompile:
+         All outputs are up-to-date.
+    40>FinalizeBuildStatus:
+         Deleting file "mdcompiler_crossgen.dir\Debug\mdcompil.3A393107.tlog\unsuccessfulbuild".
+     4>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\dbgshim.vcxproj" (4) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\staticnohost\utilcodestaticnohost.vcxproj" (43) on node 12 (default targets).
+    43>InitializeBuildStatus:
+         Creating "utilcodestaticnohost.dir\Debug\utilcode.F8854E0D.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    53>FinalizeBuildStatus:
+         Deleting file "mdwinmd_crossgen.dir\Debug\mdwinmd_crossgen.tlog\unsuccessfulbuild".
+    40>FinalizeBuildStatus:
+         Touching "mdcompiler_crossgen.dir\Debug\mdcompil.3A393107.tlog\mdcompiler_crossgen.lastbuildstate".
+    53>FinalizeBuildStatus:
+         Touching "mdwinmd_crossgen.dir\Debug\mdwinmd_crossgen.tlog\mdwinmd_crossgen.lastbuildstate".
+    40>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\crossgen\mdcompiler_crossgen.vcxproj" (default targets).
+    53>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\crossgen\mdwinmd_crossgen.vcxproj" (default targets).
+    44>ClCompile:
+         All outputs are up-to-date.
+    62>ClCompile:
+         All outputs are up-to-date.
+    43>CustomBuild:
+         All outputs are up-to-date.
+    66>ClCompile:
+         All outputs are up-to-date.
+    36>Lib:
+         All outputs are up-to-date.
+    41>Lib:
+         All outputs are up-to-date.
+    74>FinalizeBuildStatus:
+         Deleting file "x64\Debug\mscordaccore_def\mscordaccore_def.tlog\unsuccessfulbuild".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\daccess\daccess.vcxproj" (21) on node 2 (default targets).
+    21>InitializeBuildStatus:
+         Creating "daccess.dir\Debug\daccess.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    74>FinalizeBuildStatus:
+         Touching "x64\Debug\mscordaccore_def\mscordaccore_def.tlog\mscordaccore_def.lastbuildstate".
+    36>Lib:
+         mdhotdata-staticcrt.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\full-staticcrt\Debug\mdhotdata-staticcrt.lib
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\clretwrc\clretwrc.vcxproj" (19) on node 13 (default targets).
+    19>InitializeBuildStatus:
+         Creating "clretwrc.dir\Debug\clretwrc.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    41>Lib:
+         mdcompiler_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\wks\Debug\mdcompiler_wks.lib
+    74>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordac\mscordaccore_def.vcxproj" (default targets).
+    44>Lib:
+         All outputs are up-to-date.
+    19>PreBuildEvent:
+         Description: MessageCompile C:/ssd/coreclr/src/vm/ClrEtwAll.man
+    56>FinalizeBuildStatus:
+         Deleting file "mdruntimerw_wks.dir\Debug\mdruntimerw_wks.tlog\unsuccessfulbuild".
+    19>PreBuildEvent:
+         setlocal
+         mc -h C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/clretwrc -r C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/clretwrc -b -co -um -p FireEtw C:/ssd/coreclr/src/vm/ClrEtwAll.man
+         if %errorlevel% neq 0 goto :cmEnd
+         :cmEnd
+         endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
+         :cmErrorLevel
+         exit /b %1
+         :cmDone
+         if %errorlevel% neq 0 goto :VCEnd
+         :VCEnd
+    44>Lib:
+         mdhotdata_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\crossgen\Debug\mdhotdata_crossgen.lib
+    56>FinalizeBuildStatus:
+         Touching "mdruntimerw_wks.dir\Debug\mdruntimerw_wks.tlog\mdruntimerw_wks.lastbuildstate".
+    36>FinalizeBuildStatus:
+         Deleting file "mdhotdata-staticcrt.dir\Debug\mdhotdat.5F707255.tlog\unsuccessfulbuild".
+    41>FinalizeBuildStatus:
+         Deleting file "mdcompiler_wks.dir\Debug\mdcompiler_wks.tlog\unsuccessfulbuild".
+    36>FinalizeBuildStatus:
+         Touching "mdhotdata-staticcrt.dir\Debug\mdhotdat.5F707255.tlog\mdhotdata-staticcrt.lastbuildstate".
+    56>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\wks\mdruntimerw_wks.vcxproj" (default targets).
+    62>ClCompile:
+         All outputs are up-to-date.
+    66>Lib:
+         All outputs are up-to-date.
+    21>CustomBuild:
+         All outputs are up-to-date.
+    41>FinalizeBuildStatus:
+         Touching "mdcompiler_wks.dir\Debug\mdcompiler_wks.tlog\mdcompiler_wks.lastbuildstate".
+    36>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\full-staticcrt\mdhotdata-staticcrt.vcxproj" (default targets).
+    41>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\wks\mdcompiler_wks.vcxproj" (default targets).
+    44>FinalizeBuildStatus:
+         Deleting file "mdhotdata_crossgen.dir\Debug\mdhotdat.AE9DD455.tlog\unsuccessfulbuild".
+         Touching "mdhotdata_crossgen.dir\Debug\mdhotdat.AE9DD455.tlog\mdhotdata_crossgen.lastbuildstate".
+    63>ClCompile:
+         All outputs are up-to-date.
+    44>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\crossgen\mdhotdata_crossgen.vcxproj" (default targets).
+    66>Lib:
+         mdwinmd_dbi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\dbi\Debug\mdwinmd_dbi.lib
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\dac\mdruntimerw_dac.vcxproj" (69) on node 20 (default targets).
+    69>InitializeBuildStatus:
+         Creating "mdruntimerw_dac.dir\Debug\mdruntimerw_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\coreclr\hosts\corerun\CoreRun.vcxproj" (31) on node 22 (default targets).
+    31>InitializeBuildStatus:
+         Creating "CoreRun.dir\Debug\CoreRun.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\dac\utilcode_dac.vcxproj" (75) on node 14 (default targets).
+    75>InitializeBuildStatus:
+         Creating "utilcode_dac.dir\Debug\utilcode_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    66>FinalizeBuildStatus:
+         Deleting file "mdwinmd_dbi.dir\Debug\mdwinmd_dbi.tlog\unsuccessfulbuild".
+    62>Lib:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\dbi\mdruntimerw-dbi.vcxproj" (57) on node 5 (default targets).
+    57>InitializeBuildStatus:
+         Creating "mdruntimerw-dbi.dir\Debug\mdruntimerw-dbi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    73>ClCompile:
+         All outputs are up-to-date.
+    62>Lib:
+         mdwinmd_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\dac\Debug\mdwinmd_dac.lib
+    66>FinalizeBuildStatus:
+         Touching "mdwinmd_dbi.dir\Debug\mdwinmd_dbi.tlog\mdwinmd_dbi.lastbuildstate".
+    66>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\dbi\mdwinmd_dbi.vcxproj" (default targets).
+    63>Lib:
+         All outputs are up-to-date.
+    39>ClCompile:
+         All outputs are up-to-date.
+    63>Lib:
+         comcrypt_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\cryptography\Debug\comcrypt_wks.lib
+    43>ClCompile:
+         All outputs are up-to-date.
+    62>FinalizeBuildStatus:
+         Deleting file "mdwinmd_dac.dir\Debug\mdwinmd_dac.tlog\unsuccessfulbuild".
+    31>CustomBuild:
+         All outputs are up-to-date.
+    69>CustomBuild:
+         All outputs are up-to-date.
+    75>CustomBuild:
+         All outputs are up-to-date.
+    62>FinalizeBuildStatus:
+         Touching "mdwinmd_dac.dir\Debug\mdwinmd_dac.tlog\mdwinmd_dac.lastbuildstate".
+    62>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\dac\mdwinmd_dac.vcxproj" (default targets).
+    57>CustomBuild:
+         All outputs are up-to-date.
+    63>FinalizeBuildStatus:
+         Deleting file "comcrypt_wks.dir\Debug\comcrypt_wks.tlog\unsuccessfulbuild".
+    73>Lib:
+         All outputs are up-to-date.
+    63>FinalizeBuildStatus:
+         Touching "comcrypt_wks.dir\Debug\comcrypt_wks.tlog\comcrypt_wks.lastbuildstate".
+    73>Lib:
+         unwinder_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\unwinder\dac\Debug\unwinder_dac.lib
+    42>ClCompile:
+         All outputs are up-to-date.
+    63>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\cryptography\comcrypt_wks.vcxproj" (default targets).
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\full\mdhotdata_full.vcxproj" (45) on node 7 (default targets).
+    45>InitializeBuildStatus:
+         Creating "mdhotdata_full.dir\Debug\mdhotdata_full.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    48>ClCompile:
+         All outputs are up-to-date.
+    73>FinalizeBuildStatus:
+         Deleting file "unwinder_dac.dir\Debug\unwinder_dac.tlog\unsuccessfulbuild".
+         Touching "unwinder_dac.dir\Debug\unwinder_dac.tlog\unwinder_dac.lastbuildstate".
+    72>ClCompile:
+         All outputs are up-to-date.
+    45>CustomBuild:
+         All outputs are up-to-date.
+    73>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\unwinder\dac\unwinder_dac.vcxproj" (default targets).
+    39>Lib:
+         All outputs are up-to-date.
+    31>ClCompile:
+         All outputs are up-to-date.
+    39>Lib:
+         mdcompiler-dbi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\dbi\Debug\mdcompiler-dbi.lib
+       FinalizeBuildStatus:
+         Deleting file "mdcompiler-dbi.dir\Debug\mdcompiler-dbi.tlog\unsuccessfulbuild".
+         Touching "mdcompiler-dbi.dir\Debug\mdcompiler-dbi.tlog\mdcompiler-dbi.lastbuildstate".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\dac\mdhotdata_dac.vcxproj" (54) on node 16 (default targets).
+    54>InitializeBuildStatus:
+         Creating "mdhotdata_dac.dir\Debug\mdhotdata_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    25>ClCompile:
+         All outputs are up-to-date.
+    31>ResourceCompile:
+         All outputs are up-to-date.
+    39>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\dbi\mdcompiler-dbi.vcxproj" (default targets).
+    48>ClCompile:
+         All outputs are up-to-date.
+    42>ClCompile:
+         All outputs are up-to-date.
+    58>ClCompile:
+         All outputs are up-to-date.
+    75>ClCompile:
+         All outputs are up-to-date.
+    54>CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\dac\cordbee_dac.vcxproj" (7) on node 8 (default targets).
+     7>InitializeBuildStatus:
+         Creating "cordbee_dac.dir\Debug\cordbee_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    48>Lib:
+         All outputs are up-to-date.
+    42>Lib:
+         All outputs are up-to-date.
+     7>CustomBuild:
+         All outputs are up-to-date.
+    49>ClCompile:
+         All outputs are up-to-date.
+    48>Lib:
+         mdruntime_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\wks\Debug\mdruntime_wks.lib
+    42>Lib:
+         mdruntimerw_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\crossgen\Debug\mdruntimerw_crossgen.lib
+    31>Link:
+         All outputs are up-to-date.
+    58>Lib:
+         All outputs are up-to-date.
+    45>ClCompile:
+         All outputs are up-to-date.
+    58>Lib:
+         strongname_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\crossgen\Debug\strongname_crossgen.lib
+    42>FinalizeBuildStatus:
+         Deleting file "mdruntimerw_crossgen.dir\Debug\mdruntim.AFC3F5D9.tlog\unsuccessfulbuild".
+    31>Link:
+         CoreRun.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\coreclr\hosts\corerun\Debug\CoreRun.exe
+    69>ClCompile:
+         All outputs are up-to-date.
+    42>FinalizeBuildStatus:
+         Touching "mdruntimerw_crossgen.dir\Debug\mdruntim.AFC3F5D9.tlog\mdruntimerw_crossgen.lastbuildstate".
+    70>ClCompile:
+         All outputs are up-to-date.
+    42>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\crossgen\mdruntimerw_crossgen.vcxproj" (default targets).
+    57>ClCompile:
+         All outputs are up-to-date.
+    60>ClCompile:
+         All outputs are up-to-date.
+    58>FinalizeBuildStatus:
+         Deleting file "strongname_crossgen.dir\Debug\strongna.53BAF8C9.tlog\unsuccessfulbuild".
+    48>FinalizeBuildStatus:
+         Deleting file "mdruntime_wks.dir\Debug\mdruntime_wks.tlog\unsuccessfulbuild".
+    58>FinalizeBuildStatus:
+         Touching "strongname_crossgen.dir\Debug\strongna.53BAF8C9.tlog\strongname_crossgen.lastbuildstate".
+    48>FinalizeBuildStatus:
+         Touching "mdruntime_wks.dir\Debug\mdruntime_wks.tlog\mdruntime_wks.lastbuildstate".
+    31>FinalizeBuildStatus:
+         Deleting file "CoreRun.dir\Debug\CoreRun.tlog\unsuccessfulbuild".
+    72>Lib:
+         All outputs are up-to-date.
+    49>Lib:
+         All outputs are up-to-date.
+    68>ClCompile:
+         All outputs are up-to-date.
+    49>Lib:
+         strongname_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\wks\Debug\strongname_wks.lib
+    31>FinalizeBuildStatus:
+         Touching "CoreRun.dir\Debug\CoreRun.tlog\CoreRun.lastbuildstate".
+    58>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\crossgen\strongname_crossgen.vcxproj" (default targets).
+    48>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\wks\mdruntime_wks.vcxproj" (default targets).
+    31>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\coreclr\hosts\corerun\CoreRun.vcxproj" (default targets).
+    54>ClCompile:
+         All outputs are up-to-date.
+    70>Lib:
+         All outputs are up-to-date.
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\binder\v3binder\v3binder.vcxproj" (61) on node 1 (default targets).
+    61>InitializeBuildStatus:
+         Creating "v3binder.dir\Debug\v3binder.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    70>Lib:
+         strongname_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\dac\Debug\strongname_dac.lib
+    45>ClCompile:
+         All outputs are up-to-date.
+    49>FinalizeBuildStatus:
+         Deleting file "strongname_wks.dir\Debug\strongname_wks.tlog\unsuccessfulbuild".
+         Touching "strongname_wks.dir\Debug\strongname_wks.tlog\strongname_wks.lastbuildstate".
+    72>Lib:
+         utilcode_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\crossgen\Debug\utilcode_crossgen.lib
+    49>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\wks\strongname_wks.vcxproj" (default targets).
+    69>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\crossgen\jit_crossgen.vcxproj" (32) on node 10 (default targets).
+    32>InitializeBuildStatus:
+         Creating "jit_crossgen.dir\Debug\jit_crossgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ildbsymlib\ildbsymlib.vcxproj" (29) on node 18 (default targets).
+    29>InitializeBuildStatus:
+         Creating "ildbsymlib.dir\Debug\ildbsymlib.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    57>ClCompile:
+         All outputs are up-to-date.
+    70>FinalizeBuildStatus:
+         Deleting file "strongname_dac.dir\Debug\strongname_dac.tlog\unsuccessfulbuild".
+         Touching "strongname_dac.dir\Debug\strongname_dac.tlog\strongname_dac.lastbuildstate".
+    61>CustomBuild:
+         All outputs are up-to-date.
+    70>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\strongname\api\dac\strongname_dac.vcxproj" (default targets).
+    60>Lib:
+         All outputs are up-to-date.
+         v3binder_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\binder\v3binder_crossgen\Debug\v3binder_crossgen.lib
+    45>Lib:
+         All outputs are up-to-date.
+    72>FinalizeBuildStatus:
+         Deleting file "utilcode_crossgen.dir\Debug\utilcode.B9718DD5.tlog\unsuccessfulbuild".
+    32>CustomBuild:
+         All outputs are up-to-date.
+    29>CustomBuild:
+         All outputs are up-to-date.
+    72>FinalizeBuildStatus:
+         Touching "utilcode_crossgen.dir\Debug\utilcode.B9718DD5.tlog\utilcode_crossgen.lastbuildstate".
+    45>Lib:
+         mdhotdata_full.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\full\Debug\mdhotdata_full.lib
+    54>ClCompile:
+         All outputs are up-to-date.
+    72>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\crossgen\utilcode_crossgen.vcxproj" (default targets).
+    69>Lib:
+         All outputs are up-to-date.
+    60>FinalizeBuildStatus:
+         Deleting file "v3binder_crossgen.dir\Debug\v3binder.5915B88A.tlog\unsuccessfulbuild".
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\wks\mdwinmd_wks.vcxproj" (52) on node 9 (default targets).
+    52>InitializeBuildStatus:
+         Creating "mdwinmd_wks.dir\Debug\mdwinmd_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    69>Lib:
+         mdruntimerw_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\dac\Debug\mdruntimerw_dac.lib
+    60>FinalizeBuildStatus:
+         Touching "v3binder_crossgen.dir\Debug\v3binder.5915B88A.tlog\v3binder_crossgen.lastbuildstate".
+    60>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\binder\v3binder_crossgen\v3binder_crossgen.vcxproj" (default targets).
+    45>FinalizeBuildStatus:
+         Deleting file "mdhotdata_full.dir\Debug\mdhotdata_full.tlog\unsuccessfulbuild".
+    67>Link:
+         All outputs are up-to-date.
+    45>FinalizeBuildStatus:
+         Touching "mdhotdata_full.dir\Debug\mdhotdata_full.tlog\mdhotdata_full.lastbuildstate".
+    67>Link:
+         mscorrc.debug.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscorrc\full\Debug\mscorrc.debug.dll
+    45>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\full\mdhotdata_full.vcxproj" (default targets).
+    57>Lib:
+         All outputs are up-to-date.
+    69>FinalizeBuildStatus:
+         Deleting file "mdruntimerw_dac.dir\Debug\mdruntimerw_dac.tlog\unsuccessfulbuild".
+    52>CustomBuild:
+         All outputs are up-to-date.
+    67>FinalizeBuildStatus:
+         Deleting file "mscorrc.debug.dir\Debug\mscorrc.debug.tlog\unsuccessfulbuild".
+    69>FinalizeBuildStatus:
+         Touching "mdruntimerw_dac.dir\Debug\mdruntimerw_dac.tlog\mdruntimerw_dac.lastbuildstate".
+    57>Lib:
+         mdruntimerw-dbi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\dbi\Debug\mdruntimerw-dbi.lib
+    54>Lib:
+         All outputs are up-to-date.
+    69>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\dac\mdruntimerw_dac.vcxproj" (default targets).
+    67>FinalizeBuildStatus:
+         Touching "mscorrc.debug.dir\Debug\mscorrc.debug.tlog\mscorrc.debug.lastbuildstate".
+    67>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscorrc\full\mscorrc.debug.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ipcman\ipcman-staticcrt\ipcmanager-staticcrt.vcxproj" (33) on node 21 (default targets).
+    33>InitializeBuildStatus:
+         Creating "ipcmanager-staticcrt.dir\Debug\ipcmanag.6BB38EC3.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    54>Lib:
+         mdhotdata_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\dac\Debug\mdhotdata_dac.lib
+    57>FinalizeBuildStatus:
+         Deleting file "mdruntimerw-dbi.dir\Debug\mdruntimerw-dbi.tlog\unsuccessfulbuild".
+         Touching "mdruntimerw-dbi.dir\Debug\mdruntimerw-dbi.tlog\mdruntimerw-dbi.lastbuildstate".
+    43>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\diasdk\dialib.vcxproj" (27) on node 7 (default targets).
+    27>InitializeBuildStatus:
+         Creating "x64\Debug\dialib\dialib.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    57>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\enc\dbi\mdruntimerw-dbi.vcxproj" (default targets).
+    68>Lib:
+         All outputs are up-to-date.
+    54>FinalizeBuildStatus:
+         Deleting file "mdhotdata_dac.dir\Debug\mdhotdata_dac.tlog\unsuccessfulbuild".
+         Touching "mdhotdata_dac.dir\Debug\mdhotdata_dac.tlog\mdhotdata_dac.lastbuildstate".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\InjectResource\InjectResource.vcxproj" (8) on node 20 (default targets).
+     8>InitializeBuildStatus:
+         Creating "InjectResource.dir\Debug\InjectResource.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    33>CustomBuild:
+         All outputs are up-to-date.
+    54>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\hotdata\dac\mdhotdata_dac.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\gcinfo\crossgen\gcinfo_crossgen.vcxproj" (30) on node 11 (default targets).
+    30>InitializeBuildStatus:
+         Creating "gcinfo_crossgen.dir\Debug\gcinfo_crossgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    68>Lib:
+         utilcode.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\dyncrt\Debug\utilcode.lib
+    29>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\inc\corguids.vcxproj" (18) on node 5 (default targets).
+    18>InitializeBuildStatus:
+         Creating "corguids.dir\Debug\corguids.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    68>FinalizeBuildStatus:
+         Deleting file "utilcode.dir\Debug\utilcode.tlog\unsuccessfulbuild".
+     8>CustomBuild:
+         All outputs are up-to-date.
+    30>CustomBuild:
+         All outputs are up-to-date.
+    68>FinalizeBuildStatus:
+         Touching "utilcode.dir\Debug\utilcode.tlog\utilcode.lastbuildstate".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\dac\cee_dac.vcxproj" (24) on node 16 (default targets).
+    24>InitializeBuildStatus:
+         Creating "cee_dac.dir\Debug\cee_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    68>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\dyncrt\utilcode.vcxproj" (default targets).
+    21>ClCompile:
+         All outputs are up-to-date.
+    29>Lib:
+         All outputs are up-to-date.
+         ildbsymlib.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ildbsymlib\Debug\ildbsymlib.lib
+    24>CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\dac\mdcompiler_dac.vcxproj" (37) on node 4 (default targets).
+    37>InitializeBuildStatus:
+         Creating "mdcompiler_dac.dir\Debug\mdcompiler_dac.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    27>CustomBuild:
+         dia2.idl
+     8>ClCompile:
+         All outputs are up-to-date.
+    29>FinalizeBuildStatus:
+         Deleting file "ildbsymlib.dir\Debug\ildbsymlib.tlog\unsuccessfulbuild".
+    18>CustomBuild:
+         All outputs are up-to-date.
+    29>FinalizeBuildStatus:
+         Touching "ildbsymlib.dir\Debug\ildbsymlib.tlog\ildbsymlib.lastbuildstate".
+    27>CustomBuild:
+         Microsoft (R) 32b/64b MIDL Compiler Version 8.00.0603 
+         Copyright (c) Microsoft Corporation. All rights reserved.
+    29>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ildbsymlib\ildbsymlib.vcxproj" (default targets).
+    75>ClCompile:
+         All outputs are up-to-date.
+    37>CustomBuild:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Microsoft Visual Studio 12.0\DIA SDK\idl\dia2.idl
+    52>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\bcltype\bcltype.vcxproj" (12) on node 18 (default targets).
+    12>InitializeBuildStatus:
+         Creating "bcltype.dir\Debug\bcltype.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    43>Lib:
+         All outputs are up-to-date.
+     8>Link:
+         All outputs are up-to-date.
+    30>ClCompile:
+         All outputs are up-to-date.
+     8>Link:
+         InjectResource.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\InjectResource\Debug\InjectResource.exe
+    43>Lib:
+         utilcodestaticnohost.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\staticnohost\Debug\utilcodestaticnohost.lib
+    12>CustomBuild:
+         All outputs are up-to-date.
+    21>ClCompile:
+         All outputs are up-to-date.
+    52>ClCompile:
+         All outputs are up-to-date.
+     8>FinalizeBuildStatus:
+         Deleting file "InjectResource.dir\Debug\InjectResource.tlog\unsuccessfulbuild".
+    43>FinalizeBuildStatus:
+         Deleting file "utilcodestaticnohost.dir\Debug\utilcode.F8854E0D.tlog\unsuccessfulbuild".
+     8>FinalizeBuildStatus:
+         Touching "InjectResource.dir\Debug\InjectResource.tlog\InjectResource.lastbuildstate".
+    43>FinalizeBuildStatus:
+         Touching "utilcodestaticnohost.dir\Debug\utilcode.F8854E0D.tlog\utilcodestaticnohost.lastbuildstate".
+    33>ClCompile:
+         All outputs are up-to-date.
+     8>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\InjectResource\InjectResource.vcxproj" (default targets).
+    43>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\staticnohost\utilcodestaticnohost.vcxproj" (default targets).
+     7>ClCompile:
+         All outputs are up-to-date.
+    30>Lib:
+         All outputs are up-to-date.
+         gcinfo_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\gcinfo\crossgen\Debug\gcinfo_crossgen.lib
+    25>ClCompile:
+         All outputs are up-to-date.
+    52>Lib:
+         All outputs are up-to-date.
+         mdwinmd_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\wks\Debug\mdwinmd_wks.lib
+    18>ClCompile:
+         All outputs are up-to-date.
+    21>Lib:
+         All outputs are up-to-date.
+    30>FinalizeBuildStatus:
+         Deleting file "gcinfo_crossgen.dir\Debug\gcinfo_crossgen.tlog\unsuccessfulbuild".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\coreclr\hosts\coreconsole\CoreConsole.vcxproj" (9) on node 12 (default targets).
+     9>InitializeBuildStatus:
+         Creating "CoreConsole.dir\Debug\CoreConsole.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    30>FinalizeBuildStatus:
+         Touching "gcinfo_crossgen.dir\Debug\gcinfo_crossgen.tlog\gcinfo_crossgen.lastbuildstate".
+    21>Lib:
+         daccess.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\daccess\Debug\daccess.lib
+    30>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\gcinfo\crossgen\gcinfo_crossgen.vcxproj" (default targets).
+    33>ClCompile:
+         All outputs are up-to-date.
+    75>Lib:
+         All outputs are up-to-date.
+    52>FinalizeBuildStatus:
+         Deleting file "mdwinmd_wks.dir\Debug\mdwinmd_wks.tlog\unsuccessfulbuild".
+         Touching "mdwinmd_wks.dir\Debug\mdwinmd_wks.tlog\mdwinmd_wks.lastbuildstate".
+    75>Lib:
+         utilcode_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\dac\Debug\utilcode_dac.lib
+    21>FinalizeBuildStatus:
+         Deleting file "daccess.dir\Debug\daccess.tlog\unsuccessfulbuild".
+     7>ClCompile:
+         All outputs are up-to-date.
+    52>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\winmd\wks\mdwinmd_wks.vcxproj" (default targets).
+     9>CustomBuild:
+         All outputs are up-to-date.
+    21>FinalizeBuildStatus:
+         Touching "daccess.dir\Debug\daccess.tlog\daccess.lastbuildstate".
+    19>CustomBuild:
+         All outputs are up-to-date.
+    21>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\daccess\daccess.vcxproj" (default targets).
+    75>FinalizeBuildStatus:
+         Deleting file "utilcode_dac.dir\Debug\utilcode_dac.tlog\unsuccessfulbuild".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\float\comfloat_wks.vcxproj" (11) on node 11 (default targets).
+    11>InitializeBuildStatus:
+         Creating "comfloat_wks.dir\Debug\comfloat_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    75>FinalizeBuildStatus:
+         Touching "utilcode_dac.dir\Debug\utilcode_dac.tlog\utilcode_dac.lastbuildstate".
+    75>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\utilcode\dac\utilcode_dac.vcxproj" (default targets).
+    33>Lib:
+         All outputs are up-to-date.
+         ipcmanager-staticcrt.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ipcman\ipcman-staticcrt\Debug\ipcmanager-staticcrt.lib
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\datasource\dbi\mddatasource_dbi.vcxproj" (38) on node 9 (default targets).
+    38>InitializeBuildStatus:
+         Creating "mddatasource_dbi.dir\Debug\mddatasource_dbi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    18>Lib:
+         All outputs are up-to-date.
+    37>ClCompile:
+         All outputs are up-to-date.
+     7>Lib:
+         All outputs are up-to-date.
+    18>Lib:
+         corguids.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\inc\Debug\corguids.lib
+    11>CustomBuild:
+         All outputs are up-to-date.
+    33>FinalizeBuildStatus:
+         Deleting file "ipcmanager-staticcrt.dir\Debug\ipcmanag.6BB38EC3.tlog\unsuccessfulbuild".
+     7>Lib:
+         cordbee_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\dac\Debug\cordbee_dac.lib
+     9>ClCompile:
+         All outputs are up-to-date.
+    33>FinalizeBuildStatus:
+         Touching "ipcmanager-staticcrt.dir\Debug\ipcmanag.6BB38EC3.tlog\ipcmanager-staticcrt.lastbuildstate".
+    33>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ipcman\ipcman-staticcrt\ipcmanager-staticcrt.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\ceefilegen\ceefgen.vcxproj" (15) on node 14 (default targets).
+    15>InitializeBuildStatus:
+         Creating "ceefgen.dir\Debug\ceefgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    19>ResourceCompile:
+         C:\Program Files (x86)\Windows Kits\8.1\bin\x86\rc.exe /D DEBUG /D _DEBUG /D _DBG /D URTBLDENV_FRIENDLY=Checked /D BUILDENV_CHECKED=1 /D WRITE_BARRIER_CHECK=1 /D FEATURE_EVENT_TRACE=1 /D _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS /D DEV10 /D WIN32 /D DEVL=1 /D _WIN32_WINNT=0x0602 /D _WIN32_IE=0x0900 /D WINNT=1 /D NT_INST=0 /D CONDITION_HANDLING=1 /D NTDDI_VERSION=NTDDI_WIN8 /D DBG_TARGET_AMD64 /D _TARGET_AMD64_=1 /D _CRT_SECURE_NO_WARNINGS /D NTMAKEENV /D _BLD_CLR /D WINVER=0x0602 /D WIN32_LEAN_AND_MEAN=1 /D DEBUGGING_SUPPORTED /D EnC_SUPPORTED /D FEATURE_APPDOMAIN_RESOURCE_MONITORING /D FEATURE_ARRAYSTUB_AS_IL /D FEATURE_ASYNC_IO /D FEATURE_BCL_FORMATTING /D FEATURE_COLLECTIBLE_TYPES /D FEATURE_CLASSIC_COMINTEROP /D FEATURE_APPX /D FEATURE_COMINTEROP /D FEATURE_COMINTEROP_APARTMENT_SUPPORT /D FEATURE_COMINTEROP_UNMANAGED_ACTIVATION /D FEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION /D FEATURE_ICASTABLE /D FEATURE_CORECLR /D FEATURE_CORESYSTEM /D FEATURE_CORRUPTING_EXCEPTIONS /D FEATURE_CRYPTO /D FEATURE_EXCEPTIONDISPATCHINFO /D FEATURE_FRAMEWORK_INTERNAL /D FEATURE_HIJACK /D FEATURE_HOST_ASSEMBLY_RESOLVER /D FEATURE_HOSTED_BINDER /D FEATURE_ISOSTORE /D FEATURE_ISOSTORE_LIGHT /D FEATURE_ISYM_READER /D FEATURE_LEGACYNETCF /D FEATURE_LEGACYNETCFCRYPTO /D FEATURE_LEGACYNETCF_DBG_HOST_CONTROL /D FEATURE_LEGACYNETCFFAS /D FEATURE_LEGACYSURFACE /D FEATURE_LOADER_OPTIMIZATION /D FEATURE_MANAGED_ETW /D FEATURE_MANAGED_ETW_CHANNELS /D FEATURE_MAIN_CLR_MODULE_USES_CORE_NAME /D FEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE /D FEATURE_MERGE_JIT_AND_ENGINE /D FEATURE_NORM_IDNA_ONLY /D FEATURE_PREJIT /D FEATURE_RANDOMIZED_STRING_HASHING /D FEATURE_READYTORUN /D FEATURE_STANDALONE_SN /D FEATURE_STRONGNAME_DELAY_SIGNING_ALLOWED /D FEATURE_STRONGNAME_MIGRATION /D FEATURE_STRONGNAME_TESTKEY_ALLOWED /D FEATURE_SVR_GC /D FEATURE_SYNTHETIC_CULTURES /D FEATURE_VERSIONING /D FEATURE_VERSIONING_LOG /D FEATURE_WIN32_REGISTRY /D FEATURE_WINDOWSPHONE /D FEATURE_WINMD_RESILIENT /D FEATURE_X509 /D FEATURE_X509_SECURESTRINGS /D PROFILING_SUPPORTED /D FEATURE_MULTICOREJIT /D FEATURE_USE_ASM_GC_WRITE_BARRIERS /D FEATURE_SYMDIFF /D _AMD64_ /D _AMD64_SIMULATOR_ /D _AMD64_SIMULATOR_PERF_ /D _AMD64_WORKAROUND_ /D _WIN64 /D AMD64 /D _SKIP_IF_SIMULATOR_ /D _SECURE_SCL=0 /D _NEW_SDK=1 /D OFFICIAL_BUILD=0 /D BETA=0 /D FX_BRANCH_SYNC_COUNTER_VALUE=0 /D UNICODE /D _UNICODE /D FX_VER_INTERNALNAME_STR=clretwrc.dll /D "CMAKE_INTDIR=\\\"Debug\\\"" /D clretwrc_EXPORTS /D _UNICODE /D UNICODE /l"0x0409" /IC:\ssd\coreclr\src\pal\prebuilt\inc /IC:\ssd\coreclr\src\inc /IC:\ssd\coreclr\src\strongname\inc /IC:\ssd\coreclr\src\inc\winrt /IC:\ssd\coreclr\src\debug\inc /IC:\ssd\coreclr\src\debug\inc\amd64 /IC:\ssd\coreclr\src\debug\inc\dump /IC:\ssd\coreclr\src\md\inc /IC:\ssd\coreclr\src\classlibnative\bcltype /IC:\ssd\coreclr\src\classlibnative\cryptography /IC:\ssd\coreclr\src\classlibnative\inc /IC:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\clretwrc /nologo /fo"clretwrc.dir\Debug\clretwrc.res" C:\ssd\coreclr\src\dlls\clretwrc\clretwrc.rc 
+    18>FinalizeBuildStatus:
+         Deleting file "corguids.dir\Debug\corguids.tlog\unsuccessfulbuild".
+    38>CustomBuild:
+         All outputs are up-to-date.
+     7>FinalizeBuildStatus:
+         Deleting file "cordbee_dac.dir\Debug\cordbee_dac.tlog\unsuccessfulbuild".
+    18>FinalizeBuildStatus:
+         Touching "corguids.dir\Debug\corguids.tlog\corguids.lastbuildstate".
+     7>FinalizeBuildStatus:
+         Touching "cordbee_dac.dir\Debug\cordbee_dac.tlog\cordbee_dac.lastbuildstate".
+    18>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\inc\corguids.vcxproj" (default targets).
+     7>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\dac\cordbee_dac.vcxproj" (default targets).
+     9>ResourceCompile:
+         All outputs are up-to-date.
+    15>CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\GenClrDebugResource\GenClrDebugResource.vcxproj" (22) on node 21 (default targets).
+    22>InitializeBuildStatus:
+         Creating "GenClrDebugResource.dir\Debug\GenClrDe.9F55F0BD.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+       CustomBuild:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         dia2.idl
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\um\objidl.idl
+     9>Link:
+         All outputs are up-to-date.
+         CoreConsole.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\coreclr\hosts\coreconsole\Debug\CoreConsole.exe
+    22>ClCompile:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         objidl.idl
+     9>FinalizeBuildStatus:
+         Deleting file "CoreConsole.dir\Debug\CoreConsole.tlog\unsuccessfulbuild".
+         Touching "CoreConsole.dir\Debug\CoreConsole.tlog\CoreConsole.lastbuildstate".
+     9>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\coreclr\hosts\coreconsole\CoreConsole.vcxproj" (default targets).
+    37>ClCompile:
+         All outputs are up-to-date.
+    61>ClCompile:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\um\unknwn.idl
+    32>ClCompile:
+         All outputs are up-to-date.
+    22>Link:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         unknwn.idl
+    22>Link:
+         GenClrDebugResource.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe
+    38>ClCompile:
+         All outputs are up-to-date.
+    22>FinalizeBuildStatus:
+         Deleting file "GenClrDebugResource.dir\Debug\GenClrDe.9F55F0BD.tlog\unsuccessfulbuild".
+         Touching "GenClrDebugResource.dir\Debug\GenClrDe.9F55F0BD.tlog\GenClrDebugResource.lastbuildstate".
+    22>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\GenClrDebugResource\GenClrDebugResource.vcxproj" (default targets).
+    61>Lib:
+         All outputs are up-to-date.
+    37>Lib:
+         All outputs are up-to-date.
+    61>Lib:
+         v3binder.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\binder\v3binder\Debug\v3binder.lib
+    15>ClCompile:
+         All outputs are up-to-date.
+    37>Lib:
+         mdcompiler_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\dac\Debug\mdcompiler_dac.lib
+    61>FinalizeBuildStatus:
+         Deleting file "v3binder.dir\Debug\v3binder.tlog\unsuccessfulbuild".
+         Touching "v3binder.dir\Debug\v3binder.tlog\v3binder.lastbuildstate".
+    38>ClCompile:
+         All outputs are up-to-date.
+    61>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\binder\v3binder\v3binder.vcxproj" (default targets).
+    37>FinalizeBuildStatus:
+         Deleting file "mdcompiler_dac.dir\Debug\mdcompiler_dac.tlog\unsuccessfulbuild".
+         Touching "mdcompiler_dac.dir\Debug\mdcompiler_dac.tlog\mdcompiler_dac.lastbuildstate".
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\shared\wtypes.idl
+    37>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\compiler\dac\mdcompiler_dac.vcxproj" (default targets).
+    15>ClCompile:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         wtypes.idl
+     4>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\dbgshim.vcxproj" (4) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\debug-pal\debug-pal.vcxproj" (10) on node 1 (default targets).
+    10>InitializeBuildStatus:
+         Creating "debug-pal.dir\Debug\debug-pal.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    38>Lib:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\zap\crossgen\corzap_crossgen.vcxproj" (23) on node 4 (default targets).
+    23>InitializeBuildStatus:
+         Creating "corzap_crossgen.dir\Debug\corzap_crossgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    38>Lib:
+         mddatasource_dbi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\datasource\dbi\Debug\mddatasource_dbi.lib
+    32>Lib:
+         All outputs are up-to-date.
+         jit_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\crossgen\Debug\jit_crossgen.lib
+    19>Link:
+         C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\link.exe /ERRORREPORT:QUEUE /OUT:"C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\clretwrc\Debug\clretwrc.dll" /INCREMENTAL:NO /NOLOGO /MANIFEST:NO /DEBUG /PDB:"C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/clretwrc/Debug/clretwrc.pdb" /SUBSYSTEM:CONSOLE /LARGEADDRESSAWARE /OPT:REF /OPT:ICF /TLBID:1 /NOENTRY /RELEASE /DYNAMICBASE /NXCOMPAT /IMPLIB:"C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/clretwrc/Debug/clretwrc.lib" /MACHINE:X64  /machine:x64 /SUBSYSTEM:WINDOWS,6.00 /DEBUGTYPE:cv,fixup /PDBCOMPRESS /IGNORE:4197,4013,4254,4070,4221 /NOVCFEATURE /DLL clretwrc.dir\Debug\clretwrc.res
+    10>CustomBuild:
+         All outputs are up-to-date.
+    15>Lib:
+         All outputs are up-to-date.
+    38>FinalizeBuildStatus:
+         Deleting file "mddatasource_dbi.dir\Debug\mddatasource_dbi.tlog\unsuccessfulbuild".
+         Touching "mddatasource_dbi.dir\Debug\mddatasource_dbi.tlog\mddatasource_dbi.lastbuildstate".
+    23>CustomBuild:
+         All outputs are up-to-date.
+    32>FinalizeBuildStatus:
+         Deleting file "jit_crossgen.dir\Debug\jit_crossgen.tlog\unsuccessfulbuild".
+    38>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\datasource\dbi\mddatasource_dbi.vcxproj" (default targets).
+    32>FinalizeBuildStatus:
+         Touching "jit_crossgen.dir\Debug\jit_crossgen.tlog\jit_crossgen.lastbuildstate".
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\shared\wtypesbase.idl
+    32>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\crossgen\jit_crossgen.vcxproj" (default targets).
+    15>Lib:
+         ceefgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\ceefilegen\Debug\ceefgen.lib
+    10>ClCompile:
+         All outputs are up-to-date.
+    24>ClCompile:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         wtypesbase.idl
+    15>FinalizeBuildStatus:
+         Deleting file "ceefgen.dir\Debug\ceefgen.tlog\unsuccessfulbuild".
+         Touching "ceefgen.dir\Debug\ceefgen.tlog\ceefgen.lastbuildstate".
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\di\cordbdi.vcxproj" (14) on node 9 (default targets).
+    14>InitializeBuildStatus:
+         Creating "cordbdi.dir\Debug\cordbdi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    15>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\ceefilegen\ceefgen.vcxproj" (default targets).
+    34>PreBuildEvent:
+         Microsoft (R) C/C++ Optimizing Compiler Version 18.00.40629 for x64
+         Copyright (C) Microsoft Corporation.  All rights reserved.
+         
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\nls\comnls_wks.vcxproj" (17) on node 10 (default targets).
+    17>InitializeBuildStatus:
+         Creating "comnls_wks.dir\Debug\comnls_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    34>PreBuildEvent:
+         AsmConstants.tmp
+    10>Lib:
+         All outputs are up-to-date.
+         debug-pal.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\debug-pal\Debug\debug-pal.lib
+       FinalizeBuildStatus:
+         Deleting file "debug-pal.dir\Debug\debug-pal.tlog\unsuccessfulbuild".
+    25>ClCompile:
+         All outputs are up-to-date.
+    10>FinalizeBuildStatus:
+         Touching "debug-pal.dir\Debug\debug-pal.tlog\debug-pal.lastbuildstate".
+    10>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\debug-pal\debug-pal.vcxproj" (default targets).
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\shared\basetsd.h
+    12>ClCompile:
+         All outputs are up-to-date.
+    11>ClCompile:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         basetsd.h
+     4>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\dbgshim.vcxproj" (4) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\dbgutil\dbgutil.vcxproj" (5) on node 1 (default targets).
+     5>InitializeBuildStatus:
+         Creating "dbgutil.dir\Debug\dbgutil.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    23>ClCompile:
+         All outputs are up-to-date.
+    34>CustomBuild:
+         All outputs are up-to-date.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+     5>CustomBuild:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\shared\guiddef.h
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    25>Lib:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    12>Lib:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    25>Lib:
+         cee_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\crossgen\Debug\cee_crossgen.lib
+    11>Lib:
+         All outputs are up-to-date.
+    12>Lib:
+         bcltype.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\bcltype\Debug\bcltype.lib
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    17>CustomBuild:
+         All outputs are up-to-date.
+    11>Lib:
+         comfloat_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\float\Debug\comfloat_wks.lib
+    23>ClCompile:
+         All outputs are up-to-date.
+     5>ClCompile:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         guiddef.h
+    25>FinalizeBuildStatus:
+         Deleting file "cee_crossgen.dir\Debug\cee_crossgen.tlog\unsuccessfulbuild".
+    12>FinalizeBuildStatus:
+         Deleting file "bcltype.dir\Debug\bcltype.tlog\unsuccessfulbuild".
+    11>FinalizeBuildStatus:
+         Deleting file "comfloat_wks.dir\Debug\comfloat_wks.tlog\unsuccessfulbuild".
+    12>FinalizeBuildStatus:
+         Touching "bcltype.dir\Debug\bcltype.tlog\bcltype.lastbuildstate".
+    25>FinalizeBuildStatus:
+         Touching "cee_crossgen.dir\Debug\cee_crossgen.tlog\cee_crossgen.lastbuildstate".
+    14>CustomBuild:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    11>FinalizeBuildStatus:
+         Touching "comfloat_wks.dir\Debug\comfloat_wks.tlog\comfloat_wks.lastbuildstate".
+    12>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\bcltype\bcltype.vcxproj" (default targets).
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    25>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\crossgen\cee_crossgen.vcxproj" (default targets).
+    11>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\float\comfloat_wks.vcxproj" (default targets).
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    14>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+       _MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+     5>Lib:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    24>ClCompile:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+    23>Lib:
+         All outputs are up-to-date.
+    34>_MASM:
+       Skipping target "_MASM" because all output files are up-to-date with respect to the input files.
+     5>Lib:
+         dbgutil.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\dbgutil\Debug\dbgutil.lib
+    16>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (16) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\crossgen_mscorlib\mscorlib_crossgen.vcxproj" (59) on node 17 (default targets).
+    59>InitializeBuildStatus:
+         Creating "mscorlib_crossgen.dir\Debug\mscorlib.2ECF530A.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    23>Lib:
+         corzap_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\zap\crossgen\Debug\corzap_crossgen.lib
+     5>FinalizeBuildStatus:
+         Deleting file "dbgutil.dir\Debug\dbgutil.tlog\unsuccessfulbuild".
+         Touching "dbgutil.dir\Debug\dbgutil.tlog\dbgutil.lastbuildstate".
+     5>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\dbgutil\dbgutil.vcxproj" (default targets).
+    59>CustomBuild:
+         All outputs are up-to-date.
+    23>FinalizeBuildStatus:
+         Deleting file "corzap_crossgen.dir\Debug\corzap_crossgen.tlog\unsuccessfulbuild".
+         Touching "corzap_crossgen.dir\Debug\corzap_crossgen.tlog\corzap_crossgen.lastbuildstate".
+    23>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\zap\crossgen\corzap_crossgen.vcxproj" (default targets).
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\um\oaidl.idl
+    59>ClCompile:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\dll\ClrJit.vcxproj" (3) on node 1 (default targets).
+     3>InitializeBuildStatus:
+         Creating "ClrJit.dir\Debug\ClrJit.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    27>CustomBuild:
+         oaidl.idl
+    14>ClCompile:
+         All outputs are up-to-date.
+     3>CustomBuild:
+         All outputs are up-to-date.
+    59>Lib:
+         All outputs are up-to-date.
+         mscorlib_crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\crossgen_mscorlib\Debug\mscorlib_crossgen.lib
+       FinalizeBuildStatus:
+         Deleting file "mscorlib_crossgen.dir\Debug\mscorlib.2ECF530A.tlog\unsuccessfulbuild".
+         Touching "mscorlib_crossgen.dir\Debug\mscorlib.2ECF530A.tlog\mscorlib_crossgen.lastbuildstate".
+    59>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\crossgen_mscorlib\mscorlib_crossgen.vcxproj" (default targets).
+    17>ClCompile:
+         All outputs are up-to-date.
+    14>ClCompile:
+         All outputs are up-to-date.
+    24>Lib:
+         All outputs are up-to-date.
+         cee_dac.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\dac\Debug\cee_dac.lib
+    17>Lib:
+         All outputs are up-to-date.
+         comnls_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\nls\Debug\comnls_wks.lib
+    27>CustomBuild:
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\um\propidl.idl
+    24>FinalizeBuildStatus:
+         Deleting file "cee_dac.dir\Debug\cee_dac.tlog\unsuccessfulbuild".
+         Touching "cee_dac.dir\Debug\cee_dac.tlog\cee_dac.lastbuildstate".
+    24>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\dac\cee_dac.vcxproj" (default targets).
+    17>FinalizeBuildStatus:
+         Deleting file "comnls_wks.dir\Debug\comnls_wks.tlog\unsuccessfulbuild".
+         Touching "comnls_wks.dir\Debug\comnls_wks.tlog\comnls_wks.lastbuildstate".
+    17>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\classlibnative\nls\comnls_wks.vcxproj" (default targets).
+    14>Lib:
+         All outputs are up-to-date.
+    27>CustomBuild:
+         propidl.idl
+    14>Lib:
+         cordbdi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\di\Debug\cordbdi.lib
+       FinalizeBuildStatus:
+         Deleting file "cordbdi.dir\Debug\cordbdi.tlog\unsuccessfulbuild".
+         Touching "cordbdi.dir\Debug\cordbdi.tlog\cordbdi.lastbuildstate".
+    14>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\di\cordbdi.vcxproj" (default targets).
+    27>CustomBuild:
+         Processing C:/Program Files (x86)/Microsoft Visual Studio 12.0/DIA SDK/include\cvconst.h
+         cvconst.h
+         Processing C:\Program Files (x86)\Windows Kits\8.1\Include\um\oaidl.acf
+         oaidl.acf
+     3>ClCompile:
+         All outputs are up-to-date.
+    34>ClCompile:
+         All outputs are up-to-date.
+    19>Link:
+         clretwrc.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\clretwrc\Debug\clretwrc.dll
+     3>Lib:
+         All outputs are up-to-date.
+         ClrJit.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\dll\Debug\ClrJit.lib
+    19>FinalizeBuildStatus:
+         Deleting file "clretwrc.dir\Debug\clretwrc.tlog\unsuccessfulbuild".
+         Touching "clretwrc.dir\Debug\clretwrc.tlog\clretwrc.lastbuildstate".
+    19>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\clretwrc\clretwrc.vcxproj" (default targets).
+     3>FinalizeBuildStatus:
+         Deleting file "ClrJit.dir\Debug\ClrJit.tlog\unsuccessfulbuild".
+         Touching "ClrJit.dir\Debug\ClrJit.tlog\ClrJit.lastbuildstate".
+     3>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\jit\dll\ClrJit.vcxproj" (default targets).
+    47>InitializeBuildStatus:
+         Creating "mscordaccore.dir\Debug\mscordaccore.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    16>InitializeBuildStatus:
+         Creating "crossgen.dir\Debug\crossgen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    47>CustomBuild:
+         All outputs are up-to-date.
+     4>InitializeBuildStatus:
+         Creating "dbgshim.dir\Debug\dbgshim.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    16>CustomBuild:
+         All outputs are up-to-date.
+    47>ClCompile:
+         All outputs are up-to-date.
+     4>CustomBuild:
+         All outputs are up-to-date.
+    47>ResourceCompile:
+         All outputs are up-to-date.
+    16>ClCompile:
+         All outputs are up-to-date.
+       ResourceCompile:
+         All outputs are up-to-date.
+     4>ClCompile:
+         All outputs are up-to-date.
+       ResourceCompile:
+         All outputs are up-to-date.
+    47>PreLinkEvent:
+         Description: Generating mscordaccore.exp export file
+         setlocal
+         lib.exe /OUT:"C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/Debug/mscordaccore.lib" /DEF:"C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/mscordac.def" C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/debug/daccess/Debug/daccess.lib  C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/mscordaccore.dir/Debug/mscordac.obj
+         if %errorlevel% neq 0 goto :cmEnd
+         :cmEnd
+         endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
+         :cmErrorLevel
+         exit /b %1
+         :cmDone
+         if %errorlevel% neq 0 goto :VCEnd
+         :VCEnd
+     4>Link:
+         All outputs are up-to-date.
+         dbgshim.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\Debug\dbgshim.dll
+    34>ClCompile:
+         All outputs are up-to-date.
+    16>Link:
+         All outputs are up-to-date.
+         crossgen.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\Debug\crossgen.exe
+     4>FinalizeBuildStatus:
+         Deleting file "dbgshim.dir\Debug\dbgshim.tlog\unsuccessfulbuild".
+         Touching "dbgshim.dir\Debug\dbgshim.tlog\dbgshim.lastbuildstate".
+     4>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\dbgshim\dbgshim.vcxproj" (default targets).
+    47>PreLinkEvent:
+         Microsoft (R) Library Manager Version 12.00.40629.0
+         Copyright (C) Microsoft Corporation.  All rights reserved.
+         
+    16>FinalizeBuildStatus:
+         Deleting file "crossgen.dir\Debug\crossgen.tlog\unsuccessfulbuild".
+         Touching "crossgen.dir\Debug\crossgen.tlog\crossgen.lastbuildstate".
+    16>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\tools\crossgen\crossgen.vcxproj" (default targets).
+    47>PreLinkEvent:
+            Creating library C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/Debug/mscordaccore.lib and object C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/Debug/mscordaccore.exp
+       Link:
+         All outputs are up-to-date.
+         mscordaccore.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordac\Debug\mscordaccore.dll
+       FinalizeBuildStatus:
+         Deleting file "mscordaccore.dir\Debug\mscordaccore.tlog\unsuccessfulbuild".
+         Touching "mscordaccore.dir\Debug\mscordaccore.tlog\mscordaccore.lastbuildstate".
+    47>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordac\mscordaccore.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj" (71) on node 3 (default targets).
+    71>InitializeBuildStatus:
+         Touching "sos.dir\Debug\sos.tlog\unsuccessfulbuild".
+       CustomBuild:
+         All outputs are up-to-date.
+    34>ClCompile:
+         All outputs are up-to-date.
+         All outputs are up-to-date.
+    71>ClCompile:
+         C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\CL.exe /c /IC:\ssd\coreclr\src\vm /IC:\ssd\coreclr\src\pal\prebuilt\inc /IC:\ssd\coreclr\src\inc /IC:\ssd\coreclr\src\strongname\inc /IC:\ssd\coreclr\src\inc\winrt /IC:\ssd\coreclr\src\debug\inc /IC:\ssd\coreclr\src\debug\inc\amd64 /IC:\ssd\coreclr\src\debug\inc\dump /IC:\ssd\coreclr\src\md\inc /IC:\ssd\coreclr\src\classlibnative\bcltype /IC:\ssd\coreclr\src\classlibnative\cryptography /IC:\ssd\coreclr\src\classlibnative\inc /IC:\ssd\coreclr\src\ToolBox\SOS\Strike\inc /IC:\ssd\coreclr\src\gcdump /IC:\ssd\coreclr\src\debug\shim /I"C:\Program Files (x86)\Microsoft Visual Studio 12.0\DIA SDK\include" /Zi /nologo /W3 /WX /MP /O1 /Oi /Oy- /D DEBUG /D _DEBUG /D _DBG /D URTBLDENV_FRIENDLY=Checked /D BUILDENV_CHECKED=1 /D WRITE_BARRIER_CHECK=1 /D FEATURE_EVENT_TRACE=1 /D _CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS /D DEV10 /D WIN32 /D DEVL=1 /D _WIN32_WINNT=0x0602 /D _WIN32_IE=0x0900 /D WINNT=1 /D NT_INST=0 /D CONDITION_HANDLING=1 /D NTDDI_VERSION=NTDDI_WIN8 /D DBG_TARGET_AMD64 /D _TARGET_AMD64_=1 /D _CRT_SECURE_NO_WARNINGS /D NTMAKEENV /D _BLD_CLR /D WINVER=0x0602 /D WIN32_LEAN_AND_MEAN=1 /D DEBUGGING_SUPPORTED /D EnC_SUPPORTED /D FEATURE_APPDOMAIN_RESOURCE_MONITORING /D FEATURE_ARRAYSTUB_AS_IL /D FEATURE_ASYNC_IO /D FEATURE_BCL_FORMATTING /D FEATURE_COLLECTIBLE_TYPES /D FEATURE_CLASSIC_COMINTEROP /D FEATURE_APPX /D FEATURE_COMINTEROP /D FEATURE_COMINTEROP_APARTMENT_SUPPORT /D FEATURE_COMINTEROP_UNMANAGED_ACTIVATION /D FEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION /D FEATURE_ICASTABLE /D FEATURE_CORECLR /D FEATURE_CORESYSTEM /D FEATURE_CORRUPTING_EXCEPTIONS /D FEATURE_CRYPTO /D FEATURE_EXCEPTIONDISPATCHINFO /D FEATURE_FRAMEWORK_INTERNAL /D FEATURE_HIJACK /D FEATURE_HOST_ASSEMBLY_RESOLVER /D FEATURE_HOSTED_BINDER /D FEATURE_ISOSTORE /D FEATURE_ISOSTORE_LIGHT /D FEATURE_ISYM_READER /D FEATURE_LEGACYNETCF /D FEATURE_LEGACYNETCFCRYPTO /D FEATURE_LEGACYNETCF_DBG_HOST_CONTROL /D FEATURE_LEGACYNETCFFAS /D FEATURE_LEGACYSURFACE /D FEATURE_LOADER_OPTIMIZATION /D FEATURE_MANAGED_ETW /D FEATURE_MANAGED_ETW_CHANNELS /D FEATURE_MAIN_CLR_MODULE_USES_CORE_NAME /D FEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE /D FEATURE_MERGE_JIT_AND_ENGINE /D FEATURE_NORM_IDNA_ONLY /D FEATURE_PREJIT /D FEATURE_RANDOMIZED_STRING_HASHING /D FEATURE_READYTORUN /D FEATURE_STANDALONE_SN /D FEATURE_STRONGNAME_DELAY_SIGNING_ALLOWED /D FEATURE_STRONGNAME_MIGRATION /D FEATURE_STRONGNAME_TESTKEY_ALLOWED /D FEATURE_SVR_GC /D FEATURE_SYNTHETIC_CULTURES /D FEATURE_VERSIONING /D FEATURE_VERSIONING_LOG /D FEATURE_WIN32_REGISTRY /D FEATURE_WINDOWSPHONE /D FEATURE_WINMD_RESILIENT /D FEATURE_X509 /D FEATURE_X509_SECURESTRINGS /D PROFILING_SUPPORTED /D FEATURE_MULTICOREJIT /D FEATURE_USE_ASM_GC_WRITE_BARRIERS /D FEATURE_SYMDIFF /D _AMD64_ /D _AMD64_SIMULATOR_ /D _AMD64_SIMULATOR_PERF_ /D _AMD64_WORKAROUND_ /D _WIN64 /D AMD64 /D _SKIP_IF_SIMULATOR_ /D _SECURE_SCL=0 /D _NEW_SDK=1 /D OFFICIAL_BUILD=0 /D BETA=0 /D FX_BRANCH_SYNC_COUNTER_VALUE=0 /D SOS_TARGET_AMD64=1 /D _TARGET_WIN64_=1 /D DBG_TARGET_64BIT /D DBG_TARGET_WIN64=1 /D STRIKE /D USE_STL /D FX_VER_INTERNALNAME_STR=SOS.dll /D "CMAKE_INTDIR=\"Debug\"" /D sos_EXPORTS /D _WINDLL /D _MBCS /U_MT /GF /Gm- /EHa /MT /Zp8 /GS /Gy /fp:precise /Zc:wchar_t- /Zc:forScope /GR- /Fo"sos.dir\Debug\\" /Fd"sos.dir\Debug\vc120.pdb" /Gd /TP /wd4960 /wd4961 /wd4603 /wd4627 /wd4838 /wd4456 /wd4457 /wd4458 /wd4459 /wd4091 /FIWarningControl.h /FC /Zl /errorReport:queue /we4640  /d2Zi+ /Zm200 /homeparams C:\ssd\coreclr\src\ToolBox\SOS\Strike\disasm.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\dllsext.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\eeheap.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\EventCallbacks.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\ExpressionNode.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\exts.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\gchist.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\gcroot.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\metadata.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\sildasm.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\sos.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\stressLogDump.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\strike.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\util.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\vm.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\WatchCmd.cpp C:\ssd\coreclr\src\ToolBox\SOS\Strike\disasmX86.cpp
+    34>Lib:
+         All outputs are up-to-date.
+         cee_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\wks\Debug\cee_wks.lib
+    27>FinalizeBuildStatus:
+         Deleting file "x64\Debug\dialib\dialib.tlog\unsuccessfulbuild".
+         Touching "x64\Debug\dialib\dialib.tlog\dialib.lastbuildstate".
+    27>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\diasdk\dialib.vcxproj" (default targets).
+    34>FinalizeBuildStatus:
+         Deleting file "cee_wks.dir\Debug\cee_wks.tlog\unsuccessfulbuild".
+         Touching "cee_wks.dir\Debug\cee_wks.tlog\cee_wks.lastbuildstate".
+    34>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\vm\wks\cee_wks.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\wks\cordbee_wks.vcxproj" (13) on node 7 (default targets).
+    13>InitializeBuildStatus:
+         Creating "cordbee_wks.dir\Debug\cordbee_wks.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+       CustomBuild:
+         All outputs are up-to-date.
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\dbi\mdruntime-dbi.vcxproj" (64) on node 15 (default targets).
+    64>InitializeBuildStatus:
+         Creating "mdruntime-dbi.dir\Debug\mdruntime-dbi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    71>ClCompile:
+         disasm.cpp
+         dllsext.cpp
+    64>CustomBuild:
+         All outputs are up-to-date.
+    71>ClCompile:
+         eeheap.cpp
+         EventCallbacks.cpp
+         ExpressionNode.cpp
+    64>ClCompile:
+         All outputs are up-to-date.
+    13>ClCompile:
+         All outputs are up-to-date.
+    71>ClCompile:
+         exts.cpp
+         gchist.cpp
+         gcroot.cpp
+         metadata.cpp
+         sildasm.cpp
+         sos.cpp
+         stressLogDump.cpp
+         strike.cpp
+         util.cpp
+         vm.cpp
+         WatchCmd.cpp
+         disasmX86.cpp
+    64>ClCompile:
+         All outputs are up-to-date.
+    13>ClCompile:
+         All outputs are up-to-date.
+    64>Lib:
+         All outputs are up-to-date.
+         mdruntime-dbi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\dbi\Debug\mdruntime-dbi.lib
+    13>Lib:
+         All outputs are up-to-date.
+         cordbee_wks.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\wks\Debug\cordbee_wks.lib
+    64>FinalizeBuildStatus:
+         Deleting file "mdruntime-dbi.dir\Debug\mdruntime-dbi.tlog\unsuccessfulbuild".
+         Touching "mdruntime-dbi.dir\Debug\mdruntime-dbi.tlog\mdruntime-dbi.lastbuildstate".
+    64>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\md\runtime\dbi\mdruntime-dbi.vcxproj" (default targets).
+    13>FinalizeBuildStatus:
+         Deleting file "cordbee_wks.dir\Debug\cordbee_wks.tlog\unsuccessfulbuild".
+         Touching "cordbee_wks.dir\Debug\cordbee_wks.tlog\cordbee_wks.lastbuildstate".
+    13>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\debug\ee\wks\cordbee_wks.vcxproj" (default targets).
+     2>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (2) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\DacTableGen\dactablegen.vcxproj" (35) on node 23 (default targets).
+    35>InitializeBuildStatus:
+         Creating "x64\Debug\dactablegen\dactablegen.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+    20>Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (20) is building "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordbi\mscordbi.vcxproj" (51) on node 2 (default targets).
+    51>InitializeBuildStatus:
+         Creating "mscordbi.dir\Debug\mscordbi.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+       CustomBuild:
+         All outputs are up-to-date.
+       ClCompile:
+         All outputs are up-to-date.
+         All outputs are up-to-date.
+       ResourceCompile:
+         All outputs are up-to-date.
+       Link:
+         All outputs are up-to-date.
+         mscordbi.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordbi\Debug\mscordbi.dll
+       FinalizeBuildStatus:
+         Deleting file "mscordbi.dir\Debug\mscordbi.tlog\unsuccessfulbuild".
+         Touching "mscordbi.dir\Debug\mscordbi.tlog\mscordbi.lastbuildstate".
+    51>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscordbi\mscordbi.vcxproj" (default targets).
+    35>CustomBuild:
+         Microsoft (R) Visual C# Compiler version 12.0.40629.0
+         
+         for C# 5
+         Copyright (C) Microsoft Corporation. All rights reserved.
+         
+       FinalizeBuildStatus:
+         Deleting file "x64\Debug\dactablegen\dactablegen.tlog\unsuccessfulbuild".
+         Touching "x64\Debug\dactablegen\dactablegen.tlog\dactablegen.lastbuildstate".
+    35>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\DacTableGen\dactablegen.vcxproj" (default targets).
+    20>InitializeBuildStatus:
+         Creating "coreclr.dir\Debug\coreclr.tlog\unsuccessfulbuild" because "AlwaysCreate" was specified.
+       CustomBuild:
+         All outputs are up-to-date.
+       ClCompile:
+         All outputs are up-to-date.
+       ResourceCompile:
+         All outputs are up-to-date.
+       Link:
+         All outputs are up-to-date.
+         coreclr.vcxproj -> C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\Debug\coreclr.dll
+       PostBuildEvent:
+         Description: coreclr
+         setlocal
+         "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\bin\x86_amd64\cl.exe" /P /EP /TP -DDEBUG -D_DEBUG -D_DBG -DURTBLDENV_FRIENDLY=Checked -DBUILDENV_CHECKED=1 -DWRITE_BARRIER_CHECK=1     -DFEATURE_EVENT_TRACE=1 -D_CRT_STDIO_ARBITRARY_WIDE_SPECIFIERS -DDEV10 -DWIN32 -DDEVL=1 -D_WIN32_WINNT=0x0602 -D_WIN32_IE=0x0900 -DWINNT=1 -DNT_INST=0 -DCONDITION_HANDLING=1 -DNTDDI_VERSION=NTDDI_WIN8 -DDBG_TARGET_AMD64 -D_TARGET_AMD64_=1 -D_CRT_SECURE_NO_WARNINGS -DNTMAKEENV -D_BLD_CLR -DWINVER=0x0602 -DWIN32_LEAN_AND_MEAN=1 -DDEBUGGING_SUPPORTED -DEnC_SUPPORTED -DFEATURE_APPDOMAIN_RESOURCE_MONITORING -DFEATURE_ARRAYSTUB_AS_IL -DFEATURE_ASYNC_IO -DFEATURE_BCL_FORMATTING -DFEATURE_COLLECTIBLE_TYPES -DFEATURE_CLASSIC_COMINTEROP -DFEATURE_APPX -DFEATURE_COMINTEROP -DFEATURE_COMINTEROP_APARTMENT_SUPPORT -DFEATURE_COMINTEROP_UNMANAGED_ACTIVATION -DFEATURE_COMINTEROP_WINRT_MANAGED_ACTIVATION -DFEATURE_ICASTABLE -DFEATURE_CORECLR -DFEATURE_CORESYSTEM -DFEATURE_CORRUPTING_EXCEPTIONS -DFEATURE_CRYPTO -DFEATURE_EXCEPTIONDISPATCHINFO -DFEATURE_FRAMEWORK_INTERNAL -DFEATURE_HIJACK -DFEATURE_HOST_ASSEMBLY_RESOLVER -DFEATURE_HOSTED_BINDER -DFEATURE_ISOSTORE -DFEATURE_ISOSTORE_LIGHT -DFEATURE_ISYM_READER -DFEATURE_LEGACYNETCF -DFEATURE_LEGACYNETCFCRYPTO -DFEATURE_LEGACYNETCF_DBG_HOST_CONTROL -DFEATURE_LEGACYNETCFFAS -DFEATURE_LEGACYSURFACE -DFEATURE_LOADER_OPTIMIZATION -DFEATURE_MANAGED_ETW -DFEATURE_MANAGED_ETW_CHANNELS -DFEATURE_MAIN_CLR_MODULE_USES_CORE_NAME -DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE -DFEATURE_MERGE_JIT_AND_ENGINE -DFEATURE_NORM_IDNA_ONLY -DFEATURE_PREJIT -DFEATURE_RANDOMIZED_STRING_HASHING -DFEATURE_READYTORUN -DFEATURE_STANDALONE_SN -DFEATURE_STRONGNAME_DELAY_SIGNING_ALLOWED -DFEATURE_STRONGNAME_MIGRATION -DFEATURE_STRONGNAME_TESTKEY_ALLOWED -DFEATURE_SVR_GC -DFEATURE_SYNTHETIC_CULTURES -DFEATURE_VERSIONING -DFEATURE_VERSIONING_LOG -DFEATURE_WIN32_REGISTRY -DFEATURE_WINDOWSPHONE -DFEATURE_WINMD_RESILIENT -DFEATURE_X509 -DFEATURE_X509_SECURESTRINGS -DPROFILING_SUPPORTED -DFEATURE_MULTICOREJIT -DFEATURE_USE_ASM_GC_WRITE_BARRIERS -DFEATURE_SYMDIFF -D_AMD64_ -D_AMD64_SIMULATOR_ -D_AMD64_SIMULATOR_PERF_ -D_AMD64_WORKAROUND_ -D_WIN64 -DAMD64 -D_SKIP_IF_SIMULATOR_ -D_SECURE_SCL=0 -D_NEW_SDK=1 -DOFFICIAL_BUILD=0 -DBETA=0 -DFX_BRANCH_SYNC_COUNTER_VALUE=0 -DUNICODE -D_UNICODE -DFX_VER_INTERNALNAME_STR=CoreCLR.dll -DDACCESS_COMPILE -DDBG_TARGET_64BIT=1 -DDBG_TARGET_WIN64=1 -DDBG_TARGET_AMD64=1 -IC:/ssd/coreclr/src/pal/prebuilt/inc -IC:/ssd/coreclr/src/inc -IC:/ssd/coreclr/src/strongname/inc -IC:/ssd/coreclr/src/inc/winrt -IC:/ssd/coreclr/src/debug/inc -IC:/ssd/coreclr/src/debug/inc/amd64 -IC:/ssd/coreclr/src/debug/inc/dump -IC:/ssd/coreclr/src/md/inc -IC:/ssd/coreclr/src/classlibnative/bcltype -IC:/ssd/coreclr/src/classlibnative/cryptography -IC:/ssd/coreclr/src/classlibnative/inc -IC:/ssd/coreclr/src/dlls/mscoree/../../inc -IC:/ssd/coreclr/src/vm -IC:/ssd/coreclr/src/vm/amd64 -IC:/ssd/coreclr/src/debug/ee -IC:/ssd/coreclr/src/gc /FiC:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/daccess.i C:/ssd/coreclr/src/debug/daccess/daccess.cpp
+         if %errorlevel% neq 0 goto :cmEnd
+         ..\..\..\ToolBox\SOS\DacTableGen\dactablegen.exe /dac:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/daccess.i /pdb:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/Debug/coreclr.pdb /dll:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/Debug/coreclr.dll /bin:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/wks.bin
+         if %errorlevel% neq 0 goto :cmEnd
+         ..\..\..\tools\InjectResource\Debug\InjectResource.exe /bin:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/wks.bin /dll:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/Debug/coreclr.dll
+         if %errorlevel% neq 0 goto :cmEnd
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe /dac:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/Debug/mscordaccore.dll /dbi:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordbi/Debug/mscordbi.dll /sku:onecoreclr /out:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/clrDebugResource.bin
+         if %errorlevel% neq 0 goto :cmEnd
+         ..\..\..\tools\InjectResource\Debug\InjectResource.exe /bin:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/clrDebugResource.bin /dll:C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/Debug/coreclr.dll /name:CLRDEBUGINFO
+         if %errorlevel% neq 0 goto :cmEnd
+         :cmEnd
+         endlocal & call :cmErrorLevel %errorlevel% & goto :cmDone
+         :cmErrorLevel
+         exit /b %1
+         :cmDone
+         if %errorlevel% neq 0 goto :VCEnd
+         :VCEnd
+         Microsoft (R) C/C++ Optimizing Compiler Version 18.00.40629 for x64
+         Copyright (C) Microsoft Corporation.  All rights reserved.
+         
+         daccess.cpp
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(487): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(561): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(563): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(645): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(715): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\util.cpp(4380): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(9934): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(10033): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(10525): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(10544): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(11295): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(11297): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(13096): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+    71>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj" (default targets) -- FAILED.
+    20>PostBuildEvent:
+         Microsoft (R) CLR External Data Access Data Table Generator Version 0.3
+         Copyright (C) Microsoft Corp.  All rights reserved.
+         
+         Processing DLL with PDB timestamp: Monday, August 17, 2015 11:33:31 AM
+         Loaded PDB file: C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\Debug\coreclr.pdb
+         
+             0xfef8f8, // ExecutionManager::m_CodeRangeList
+             0xfef8d0, // ExecutionManager::m_pDefaultCodeMan
+             0xfef900, // ExecutionManager::m_dwReaderCount
+             0xfef904, // ExecutionManager::m_dwWriterLock
+             0xfef8d8, // ExecutionManager::m_pEEJitManager
+             0xfef8e0, // ExecutionManager::m_pNativeImageJitManager
+             0xfef8e8, // ExecutionManager::m_pReadyToRunJitManager
+             0xceb720, // hlpFuncTable
+             0xfd2710, // hlpDynamicFuncTable
+             0xfeef08, // StubManager::g_pFirstManager
+             0xfeeed0, // PrecodeStubManager::g_pManager
+             0xfeeed8, // StubLinkStubManager::g_pManager
+             0xfeeee0, // ThunkHeapStubManager::g_pManager
+             0xfeeee8, // JumpStubStubManager::g_pManager
+             0xfeeef0, // RangeSectionStubManager::g_pManager
+             0xfeeef8, // DelegateInvokeStubManager::g_pManager
+             0xff1dc0, // VirtualCallStubManagerManager::g_pManager
+             0xfeed58, // ThreadStore::s_pThreadStore
+             0xff9184, // ThreadpoolMgr::cpuUtilization
+             0xff90f8, // ThreadpoolMgr::WorkerCounter
+             0xff90c8, // ThreadpoolMgr::MinLimitTotalWorkerThreads
+             0xff90cc, // ThreadpoolMgr::MaxLimitTotalWorkerThreads
+             0xff90e0, // ThreadpoolMgr::WorkRequestHead
+             0xff90e8, // ThreadpoolMgr::WorkRequestTail
+             0xff9170, // ThreadpoolMgr::CPThreadCounter
+             0xff917c, // ThreadpoolMgr::MaxFreeCPThreads
+             0xfd3894, // ThreadpoolMgr::MaxLimitTotalCPThreads
+             0xff9178, // ThreadpoolMgr::MinLimitTotalCPThreads
+             0xff9138, // ThreadpoolMgr::TimerQueue
+             0xffc6f0, // HillClimbingLog
+             0xffd690, // HillClimbingLogFirstIndex
+             0xffd694, // HillClimbingLogSize
+             0xfda108, // g_pFinalizerThread
+             0xfda110, // g_pSuspensionThread
+             0xff2358, // GCHeap::gcHeapType
+             0xff73b0, // WKS::gc_heap::alloc_allocated
+             0xff4c10, // WKS::gc_heap::ephemeral_heap_segment
+             0xff4248, // WKS::gc_heap::finalize_queue
+             0xff7a34, // SVR::gc_heap::n_heaps
+             0xff7a38, // SVR::gc_heap::g_heaps
+             0xff4250, // WKS::gc_heap::oom_info
+             0xfefa68, // SystemDomain::m_pSystemDomain
+             0xfefa80, // SystemDomain::m_appDomainIndexList
+             0xfefb24, // SystemDomain::s_fForceDebug
+             0xfefb28, // SystemDomain::s_fForceProfiling
+             0xfefb2c, // SystemDomain::s_fForceInstrument
+             0xfefb48, // SharedDomain::m_pSharedDomain
+             0xfd04f4, // CExecutionEngine::TlsIndex
+             0xfd3358, // CNameSpace::m_GcStructuresInvalidCnt
+             0xfd9c8c, // CCLRErrorReportingManager::g_ECustomDumpFlavor
+             0xfd9260, // SString::s_Empty
+             0xfd9ac8, // g_fAppX
+             0xfd01e8, // SString::s_IsANSIMultibyte
+             0xfda258, // ArrayBase::s_arrayBoundsZero
+             0xfea5b8, // StackwalkCache::s_Enabled
+             0xfd9b48, // g_pNotificationTable
+             0xfd9b50, // g_dacNotificationFlags
+             0xfd9b58, // g_pGcNotificationTable
+             0xfd1518, // gThreadTLSIndex
+             0xfd151c, // gAppDomainTLSIndex
+             0xfd9fa0, // g_pConfig
+             0xfef020, // g_Mscorlib
+             0xfda1a8, // g_profControlBlock
+             0xff73c0, // generation_table
+             0xff2338, // g_card_table
+             0xff2328, // g_lowest_address
+             0xff2330, // g_highest_address
+             0xff2320, // g_pGCHeap
+             0xfd9e68, // g_pThinLockThreadIdDispenser
+             0xfd9e70, // g_pModuleIndexDispenser
+             0xfd9fa8, // g_pObjectClass
+             0xfd9fb0, // g_pRuntimeTypeClass
+             0xfd9fb8, // g_pCanonMethodTableClass
+             0xfd9fc0, // g_pStringClass
+             0xfd9fc8, // g_pArrayClass
+             0xfd9fd0, // g_pSZArrayHelperClass
+             0xfd9fd8, // g_pNullableClass
+             0xfd9fe0, // g_pExceptionClass
+             0xfd9fe8, // g_pThreadAbortExceptionClass
+             0xfd9ff0, // g_pOutOfMemoryExceptionClass
+             0xfd9ff8, // g_pStackOverflowExceptionClass
+             0xfda000, // g_pExecutionEngineExceptionClass
+             0xfda008, // g_pDelegateClass
+             0xfda010, // g_pMulticastDelegateClass
+             0xfda018, // g_pFreeObjectMethodTable
+             0xfda048, // g_pOverlappedDataClass
+             0xfda020, // g_pValueTypeClass
+             0xfda028, // g_pEnumClass
+             0xfda030, // g_pThreadClass
+             0xfda038, // g_pCriticalFinalizerObjectClass
+             0xfda040, // g_pAsyncFileStream_AsyncResultClass
+             0xfd9e80, // g_pPredefinedArrayTypes
+             0xfda050, // g_ArgumentHandleMT
+             0xfda058, // g_ArgIteratorMT
+             0xfda060, // g_TypedReferenceMT
+             0xfda068, // g_pBaseCOMObject
+             0xfda070, // g_pBaseRuntimeClass
+             0xfda078, // g_pICastableInterface
+             0xfda080, // g_pPrepareConstrainedRegionsMethod
+             0xfda088, // g_pExecuteBackoutCodeHelperMethod
+             0xfda090, // g_pObjectCtorMD
+             0xfda098, // g_pObjectFinalizerMD
+             0xfd9e07, // g_fProcessDetach
+             0xfd9e60, // g_fEEShutDown
+             0xfd9c70, // g_fHostConfig
+             0xfda130, // g_CORDebuggerControlFlags
+             0x1001778, // g_pDebugger
+             0xfda128, // g_pDebugInterface
+             0xfda138, // g_pEEDbgInterfaceImpl
+             0x1001c50, // g_pEEInterface
+             0xfd5aa8, // Debugger::s_fCanChangeNgenFlags
+             0x10021b0, // DebuggerController::g_patches
+             0x10021b8, // DebuggerController::g_patchTableValid
+             0xfd2b90, // gLowestFCall
+             0xff16e8, // gHighestFCall
+             0xff16f0, // gFCallMethods
+             0xfda118, // g_pSyncTable
+             0xfda120, // g_pRCWCleanupList
+             0xfd2bd0, // RCWWalker::s_bIsGlobalPeggingOn
+             0xfd9e40, // g_runtimeLoadedBaseAddress
+             0xfd9e48, // g_runtimeVirtualSize
+             0xfea2d0, // SyncBlockCache::s_pSyncBlockCache
+             0xfea238, // g_HandleTableMap
+             0xfd0578, // g_pStressLog
+             0xc95908, // s_gsCookie
+             0xfd2b98, // g_FCDynamicallyAssignedImplementations
+             0xff4610, // WKS::gc_heap::internal_root_array
+             0xff4618, // WKS::gc_heap::internal_root_array_index
+             0xfd33d8, // WKS::gc_heap::heap_analyze_success
+             0xff4a90, // WKS::gc_heap::mark_array
+             0xfd33f0, // WKS::gc_heap::current_c_gc_state
+             0xff4238, // WKS::gc_heap::next_sweep_obj
+             0xff72c0, // WKS::gc_heap::saved_sweep_ephemeral_seg
+             0xff72c8, // WKS::gc_heap::saved_sweep_ephemeral_start
+             0xff72d0, // WKS::gc_heap::background_saved_lowest_address
+             0xff72d8, // WKS::gc_heap::background_saved_highest_address
+             0x1001c58, // g_hContinueStartupEvent
+             0xfd04f0, // CorHost2::m_dwStartupFlags
+             0xfd91e8, // g_hrFatalError
+             0xfee638, // PEFile::s_NGENDebugFlags
+             0xff3640, // g_MiniMetaDataBuffMaxSize
+             0xff3648, // g_MiniMetaDataBuffAddress
+             0x6ee05c, // ThreadpoolMgr::AsyncTimerCallbackCompletion
+             0x2d1740, // DACNotifyCompilationFinished
+             0x56a600, // ThePreStub
+             0x56a6a5, // ThePreStubPatchLabel
+             0x3e3540, // PrecodeFixupThunk
+             0x74da80, // StubDispatchFixupStub
+             0x74db2b, // StubDispatchFixupPatchLabel
+             0x469248, // Unknown_AddRef
+             0x454c7c, // Unknown_AddRefSpecial
+             0x45498c, // Unknown_AddRefInner
+             0xcd4e10, // vtable Thread
+             0xd06090, // vtable EEJitManager
+             0xd061f8, // vtable NativeImageJitManager
+             0xd062a0, // vtable ReadyToRunJitManager
+             0xd05f20, // vtable EECodeManager
+             0xe6ce38, // vtable RangeList
+             0xcddb08, // vtable LockedRangeList
+             0xd73f90, // vtable EditAndContinueModule
+             0xcfdb30, // vtable Module
+             0xcfdcf8, // vtable ReflectionModule
+             0xd0ef28, // vtable AppDomain
+             0xd0f378, // vtable SharedDomain
+             0xd0f1c8, // vtable SystemDomain
+             0xd679a8, // vtable DomainAssembly
+             0xcddb20, // vtable PrecodeStubManager
+             0xcddb60, // vtable StubLinkStubManager
+             0xd039e8, // vtable ThePreStubManager
+             0xcddba0, // vtable ThunkHeapStubManager
+             0xd22a40, // vtable VirtualCallStubManager
+             0xd22b48, // vtable VirtualCallStubManagerManager
+             0xcddbe0, // vtable JumpStubStubManager
+             0xcddc20, // vtable RangeSectionStubManager
+             0xcddc60, // vtable ILStubManager
+             0xcddcb8, // vtable InteropDispatchStubManager
+             0xcddd00, // vtable DelegateInvokeStubManager
+             0xcddd48, // vtable TailCallStubManager
+             0xcb7580, // vtable PEFile
+             0xcb75b8, // vtable PEAssembly
+             0xd757c8, // vtable PEImageLayout
+             0xd757d0, // vtable RawImageLayout
+             0xd757d8, // vtable ConvertedImageLayout
+             0xd757e0, // vtable MappedImageLayout
+             0xd757f0, // vtable LoadedImageLayout
+             0xd75848, // vtable FlatImageLayout
+             0xcc9488, // vtable ComMethodFrame
+             0xd15bd0, // vtable ComPlusMethodFrame
+             0xd160a8, // vtable ComPrestubMethodFrame
+             0xc94460, // vtable ContextTransitionFrame
+             0xd0f4d0, // vtable DebuggerClassInitMarkFrame
+             0xcefaf0, // vtable DebuggerSecurityCodeMarkFrame
+             0xcefb98, // vtable DebuggerExitFrame
+             0xcd50c8, // vtable DebuggerU2MCatchHandlerFrame
+             0xca8d48, // vtable FaultingExceptionFrame
+             0xd15a78, // vtable FuncEvalFrame
+             0xd16158, // vtable GCFrame
+             0xcb1a78, // vtable HelperMethodFrame
+             0xcb1bb8, // vtable HelperMethodFrame_1OBJ
+             0xcb1c60, // vtable HelperMethodFrame_2OBJ
+             0xd15b28, // vtable HelperMethodFrame_PROTECTOBJ
+             0xcda170, // vtable HijackFrame
+             0xcb43f0, // vtable InlinedCallFrame
+             0xcab760, // vtable SecureDelegateFrame
+             0xd16400, // vtable SecurityContextFrame
+             0xcab810, // vtable MulticastFrame
+             0xd15c80, // vtable PInvokeCalliFrame
+             0xd15d30, // vtable PrestubMethodFrame
+             0xd16208, // vtable ProtectByRefsFrame
+             0xd162b0, // vtable ProtectValueClassFrame
+             0xcb4298, // vtable ResumableFrame
+             0xcb4340, // vtable RedirectedThreadFrame
+             0xd15de0, // vtable StubDispatchFrame
+             0xd15e90, // vtable ExternalMethodFrame
+             0xd15f40, // vtable DynamicHelperFrame
+             0xd15ff0, // vtable StubHelperFrame
+             0xcefc40, // vtable TailCallFrame
+             0xd16358, // vtable ExceptionFilterFrame
+             0xcefce8, // vtable AssumeByrefFromJITStack
+             0xe73178, // vtable Debugger
+             0xc91478, // vtable EEDbgInterfaceImpl
+             0xe82510, // vtable DebuggerController
+             0xe7fd88, // vtable DebuggerMethodInfoTable
+             0xe823a8, // vtable DebuggerPatchTable
+             0xd05fd8, // vtable LoaderCodeHeap
+             0xd9d1f8, // vtable HostCodeHeap
+             0xd0ecc8, // vtable GlobalLoaderAllocator
+             0xd0ecf8, // vtable AppDomainLoaderAllocator
+             0xd2e278, // vtable AssemblyLoaderAllocator
+             0xdbbf38, // vtable AssemblySecurityDescriptor
+             0xdadfc0, // vtable ApplicationSecurityDescriptor
+         Updated C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/Debug/coreclr.dll
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe: Reading data from DAC: C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordac/Debug/mscordaccore.dll
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe: DAC timeStamp = 0x55d228cf sizeOfImage = 0x257000
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe: Reading data from DBI: C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscordbi/Debug/mscordbi.dll
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe: DBI timeStamp = 0x55d2287c sizeOfImage = 0x351000
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe: Writing binary resource file: C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/clrDebugResource.bin
+         ..\..\..\tools\GenClrDebugResource\Debug\GenClrDebugResource.exe: Success. Returning 0
+         Updated C:/ssd/coreclr/bin/obj/Windows_NT.x64.Debug/src/dlls/mscoree/coreclr/Debug/coreclr.dll
+       FinalizeBuildStatus:
+         Deleting file "coreclr.dir\Debug\coreclr.tlog\unsuccessfulbuild".
+         Touching "coreclr.dir\Debug\coreclr.tlog\coreclr.lastbuildstate".
+    20>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\dlls\mscoree\coreclr\coreclr.vcxproj" (default targets).
+     2>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (default targets) -- FAILED.
+     1>Done Building Project "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\install.vcxproj" (default targets) -- FAILED.
+
+Build FAILED.
+
+       "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\install.vcxproj" (default target) (1) ->
+       "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\ALL_BUILD.vcxproj" (default target) (2) ->
+       "C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj" (default target) (71) ->
+       (ClCompile target) -> 
+         c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(487): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(561): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(563): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(645): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\expressionnode.cpp(715): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\util.cpp(4380): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(9934): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(10033): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(10525): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(10544): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(11295): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(11297): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+         c:\ssd\coreclr\src\toolbox\sos\strike\strike.cpp(13096): error C3861: 'wscncmp': identifier not found [C:\ssd\coreclr\bin\obj\Windows_NT.x64.Debug\src\ToolBox\SOS\Strike\sos.vcxproj]
+
+    0 Warning(s)
+    13 Error(s)
+
+Time Elapsed 00:00:12.65
+Native component build failed. Refer C:\ssd\coreclr\bin\Logs\CoreCLR_Windows_NT__x64__Debug.log for details.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,11 @@ include_directories("classlibnative/cryptography")
 include_directories("classlibnative/inc")
 
 if(CLR_CMAKE_PLATFORM_UNIX)
+  add_subdirectory(ToolBox/SOS/Strike)
+
+  # Include the dummy c++ include files
+  include_directories("pal/inc/rt/cpp")
+
   # This prevents inclusion of standard C compiler headers
   add_compile_options(-nostdinc)
 
@@ -29,7 +34,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     # This prevents inclusion of standard C++ compiler headers
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdinc++")
   endif(NOT CLR_CMAKE_PLATFORM_DARWIN)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(utilcode)

--- a/src/ToolBox/SOS/CMakeLists.txt
+++ b/src/ToolBox/SOS/CMakeLists.txt
@@ -1,5 +1,5 @@
-add_subdirectory(Strike)
 if(WIN32)
+    add_subdirectory(Strike)
     add_subdirectory(DacTableGen)
     add_subdirectory(diasdk)
 endif(WIN32)

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -91,6 +91,10 @@ if(WIN32)
     ntdll.lib
   )
 else(WIN32)
+  add_definitions(-DPAL_STDCPP_COMPAT=1)
+  add_compile_options(-Wno-null-arithmetic)
+  add_compile_options(-Wno-format)
+
   include_directories(../lldbplugin/inc)
   include_directories(BEFORE ${VM_DIR})
   include_directories(${CLR_DIR}/src/debug/shim)

--- a/src/ToolBox/SOS/Strike/ExpressionNode.cpp
+++ b/src/ToolBox/SOS/Strike/ExpressionNode.cpp
@@ -474,17 +474,17 @@ BOOL ExpressionNode::ShouldExpandVariable(__in_z WCHAR* varToExpand)
     if(pAbsoluteExpression == NULL || varToExpand == NULL) return FALSE;
 
     // if there is a cast operation, move past it
-    WCHAR* pEndCast = wcschr(varToExpand, L')');
+    WCHAR* pEndCast = _wcschr(varToExpand, L')');
     varToExpand = (pEndCast == NULL) ? varToExpand : pEndCast+1; 
 
-    size_t varToExpandLen = wcslen(varToExpand);
-    size_t currentExpansionLen = wcslen(pAbsoluteExpression);
+    size_t varToExpandLen = _wcslen(varToExpand);
+    size_t currentExpansionLen = _wcslen(pAbsoluteExpression);
     if(currentExpansionLen > varToExpandLen) return FALSE;
     if(currentExpansionLen < varToExpandLen && 
         varToExpand[currentExpansionLen] != L'.' &&
         varToExpand[currentExpansionLen] != L'[')
         return FALSE;
-    if(wcsncmp(pAbsoluteExpression, varToExpand, currentExpansionLen) != 0) return FALSE;
+    if(_wcsncmp(pAbsoluteExpression, varToExpand, currentExpansionLen) != 0) return FALSE;
 
     return TRUE;
 }
@@ -558,9 +558,9 @@ HRESULT ExpressionNode::ExpandFields(ICorDebugValue* pInnerValue, __in_z WCHAR* 
     ExpressionNode* pBaseTypeNode = NULL;
     if(SUCCEEDED(pType->GetBase(&pBaseType)) && pBaseType != NULL && SUCCEEDED(CalculateTypeName(pBaseType, baseTypeName, mdNameLen)))
     {
-        if(wcsncmp(baseTypeName, L"System.Enum", 11) == 0)
+        if(_wcsncmp(baseTypeName, L"System.Enum", 11) == 0)
             return S_OK;
-        else if(wcsncmp(baseTypeName, L"System.Object", 13) != 0 && wcsncmp(baseTypeName, L"System.ValueType", 16) != 0)
+        else if(_wcsncmp(baseTypeName, L"System.Object", 13) != 0 && _wcsncmp(baseTypeName, L"System.ValueType", 16) != 0)
         {
             pBaseTypeNode = new ExpressionNode(pAbsoluteExpression, ChildKind_BaseClass, L"<baseclass>", pInnerValue, pBaseType, pILFrame);
             AddChild(pBaseTypeNode);
@@ -629,9 +629,9 @@ HRESULT ExpressionNode::ExpandFields(ICorDebugValue* pInnerValue, __in_z WCHAR* 
     if(pBaseTypeNode == NULL) return Status;
     if(fieldExpanded) return Status;
 
-    WCHAR* pEndCast = wcschr(varToExpand, L')');
+    WCHAR* pEndCast = _wcschr(varToExpand, L')');
     WCHAR* pNonCast = (pEndCast == NULL) ? varToExpand : pEndCast+1;
-    if(wcscmp(pNonCast, pAbsoluteExpression) != 0)
+    if(_wcscmp(pNonCast, pAbsoluteExpression) != 0)
     {
         pBaseTypeNode->Expand(varToExpand);
         return Status;
@@ -641,8 +641,8 @@ HRESULT ExpressionNode::ExpandFields(ICorDebugValue* pInnerValue, __in_z WCHAR* 
     {
         int cchCastTypeName = ((int)(pEndCast-1)-(int)varToExpand)/2;
         PopulateType();
-        if(wcslen(pTypeName) != (cchCastTypeName) ||
-            wcsncmp(varToExpand+1, pTypeName, cchCastTypeName) != 0)
+        if(_wcslen(pTypeName) != (cchCastTypeName) ||
+            _wcsncmp(varToExpand+1, pTypeName, cchCastTypeName) != 0)
         {
             pBaseTypeNode->Expand(varToExpand);
             return Status;
@@ -712,7 +712,7 @@ BOOL ExpressionNode::IsEnum(ICorDebugValue * pInputValue)
     if(FAILED(pType->GetBase(&pBaseType)) || pBaseType == NULL) return FALSE;
     if(FAILED(CalculateTypeName(pBaseType, baseTypeName, mdNameLen))) return  FALSE;
 
-    return (wcsncmp(baseTypeName, L"System.Enum", 11) == 0);
+    return (_wcsncmp(baseTypeName, L"System.Enum", 11) == 0);
 }
 
 // Calculates the value text for nodes that have enum values
@@ -1208,7 +1208,7 @@ VOID ExpressionNode::EvaluateExpressionFrameScanCallback(ICorDebugFrame* pFrame,
 VOID ExpressionNode::EvaluateExpressionVariableScanCallback(ICorDebugValue* pValue, __in_z WCHAR* pName, __out_z WCHAR* pErrorMessage, VOID* pUserData)
 {
     EvaluateExpressionFrameScanData* pData = (EvaluateExpressionFrameScanData*)pUserData;
-    if(wcscmp(pName, pData->pIdentifier) == 0)
+    if(_wcscmp(pName, pData->pIdentifier) == 0)
     {
         // found it
         pData->pFoundValue = pValue;
@@ -1484,7 +1484,7 @@ HRESULT ExpressionNode::CreateExpressionNodeHelper(__in_z WCHAR* pExpression,
                 UVCP_CONSTANT     pDefaultValue;
                 ULONG             cchDefaultValue;
                 if(SUCCEEDED(pBaseTypeMD->GetFieldProps(fieldDef, NULL, mdName, mdNameLen, &nameLen, &fieldAttr, NULL, NULL, (DWORD*)&fieldDefaultValueEt, &pDefaultValue, &cchDefaultValue)) &&
-                    wcscmp(mdName, pIdentifier) == 0)
+                    _wcscmp(mdName, pIdentifier) == 0)
                 {
                     ToRelease<ICorDebugType> pFieldValType = NULL;
                     ToRelease<ICorDebugValue> pFieldVal;
@@ -1576,12 +1576,12 @@ HRESULT ExpressionNode::ParseNextIdentifier(__in_z WCHAR** expression, __inout_e
 
     WCHAR* expressionStart = *expression;
     DWORD currentCharsParsed = *charactersParsed;
-    DWORD identifierLen = (DWORD) wcscspn(expressionStart, L".[");
+    DWORD identifierLen = (DWORD) _wcscspn(expressionStart, L".[");
     // if the first character was a . or [ skip over it. Note that we don't
     // do this always in case the first WCHAR was part of a surrogate pair
     if(identifierLen == 0)
     {
-        identifierLen = (DWORD) wcscspn(expressionStart+1, L".[") + 1;
+        identifierLen = (DWORD) _wcscspn(expressionStart+1, L".[") + 1;
     }
 
     *expression += identifierLen;
@@ -1676,7 +1676,7 @@ HRESULT ExpressionNode::EnumerateParameters(IMetaDataImport * pMD,
             if(SUCCEEDED(pMD->GetParamForMethodIndex(methodDef, idx, &paramDef)))
                 pMD->GetParamProps(paramDef, NULL, NULL, paramName, mdNameLen, &paramNameLen, NULL, NULL, NULL, NULL);
         }
-        if(wcslen(paramName) == 0)
+        if(_wcslen(paramName) == 0)
             swprintf_s(paramName, mdNameLen, L"param_%d\0", i);
 
         ToRelease<ICorDebugValue> pValue;
@@ -1736,7 +1736,7 @@ HRESULT ExpressionNode::EnumerateLocals(IMetaDataImport * pMD,
                 ULONG cArgsFetched;
                 hr = pLocalsEnum->Next(1, &pValue, &cArgsFetched);
             }
-            if(wcslen(paramName) == 0)
+            if(_wcslen(paramName) == 0)
                 swprintf_s(paramName, mdNameLen, L"local_%d\0", i);
 
             if (FAILED(hr))
@@ -1899,75 +1899,75 @@ HRESULT ExpressionNode::GetCanonicalElementTypeForTypeName(__in_z WCHAR* pTypeNa
     //Sadly ICorDebug deliberately prevents creating ICorDebugType instances
     //that use canonical short form element types... seems like an issue to me.
 
-    if(wcscmp(pTypeName, L"System.String")==0)
+    if(_wcscmp(pTypeName, L"System.String")==0)
     {
         *et = ELEMENT_TYPE_STRING;
     }
-    else if(wcscmp(pTypeName, L"System.Object")==0)
+    else if(_wcscmp(pTypeName, L"System.Object")==0)
     {
         *et = ELEMENT_TYPE_OBJECT;
     }
-    else if(wcscmp(pTypeName, L"System.Void")==0)
+    else if(_wcscmp(pTypeName, L"System.Void")==0)
     {
         *et = ELEMENT_TYPE_VOID;
     }
-    else if(wcscmp(pTypeName, L"System.Boolean")==0)
+    else if(_wcscmp(pTypeName, L"System.Boolean")==0)
     {
         *et = ELEMENT_TYPE_BOOLEAN;
     }
-    else if(wcscmp(pTypeName, L"System.Char")==0)
+    else if(_wcscmp(pTypeName, L"System.Char")==0)
     {
         *et = ELEMENT_TYPE_CHAR;
     }
-    else if(wcscmp(pTypeName, L"System.Byte")==0)
+    else if(_wcscmp(pTypeName, L"System.Byte")==0)
     {
         *et = ELEMENT_TYPE_U1;
     }
-    else if(wcscmp(pTypeName, L"System.Sbyte")==0)
+    else if(_wcscmp(pTypeName, L"System.Sbyte")==0)
     {
         *et = ELEMENT_TYPE_I1;
     }
-    else if(wcscmp(pTypeName, L"System.Int16")==0)
+    else if(_wcscmp(pTypeName, L"System.Int16")==0)
     {
         *et = ELEMENT_TYPE_I2;
     }
-    else if(wcscmp(pTypeName, L"System.UInt16")==0)
+    else if(_wcscmp(pTypeName, L"System.UInt16")==0)
     {
         *et = ELEMENT_TYPE_U2;
     }
-    else if(wcscmp(pTypeName, L"System.UInt32")==0)
+    else if(_wcscmp(pTypeName, L"System.UInt32")==0)
     {
         *et = ELEMENT_TYPE_U4;
     }
-    else if(wcscmp(pTypeName, L"System.Int32")==0)
+    else if(_wcscmp(pTypeName, L"System.Int32")==0)
     {
         *et = ELEMENT_TYPE_I4;
     }
-    else if(wcscmp(pTypeName, L"System.UInt64")==0)
+    else if(_wcscmp(pTypeName, L"System.UInt64")==0)
     {
         *et = ELEMENT_TYPE_U8;
     }
-    else if(wcscmp(pTypeName, L"System.Int64")==0)
+    else if(_wcscmp(pTypeName, L"System.Int64")==0)
     {
         *et = ELEMENT_TYPE_I8;
     }
-    else if(wcscmp(pTypeName, L"System.Single")==0)
+    else if(_wcscmp(pTypeName, L"System.Single")==0)
     {
         *et = ELEMENT_TYPE_R4;
     }
-    else if(wcscmp(pTypeName, L"System.Double")==0)
+    else if(_wcscmp(pTypeName, L"System.Double")==0)
     {
         *et = ELEMENT_TYPE_R8;
     }
-    else if(wcscmp(pTypeName, L"System.IntPtr")==0)
+    else if(_wcscmp(pTypeName, L"System.IntPtr")==0)
     {
         *et = ELEMENT_TYPE_U;
     }
-    else if(wcscmp(pTypeName, L"System.UIntPtr")==0)
+    else if(_wcscmp(pTypeName, L"System.UIntPtr")==0)
     {
         *et = ELEMENT_TYPE_I;
     }
-    else if(wcscmp(pTypeName, L"System.TypedReference")==0)
+    else if(_wcscmp(pTypeName, L"System.TypedReference")==0)
     {
         *et = ELEMENT_TYPE_TYPEDBYREF;
     }
@@ -2056,8 +2056,8 @@ HRESULT ExpressionNode::FindTypeByName(ICorDebugModule* pModule, __in_z WCHAR* p
     // before the list
     WCHAR rootName[mdNameLen];
     WCHAR* pRootName = NULL;
-    int typeNameLen = (int) wcslen(pTypeName);
-    int genericParamListStart = (int) wcscspn(pTypeName, L"<");
+    int typeNameLen = (int) _wcslen(pTypeName);
+    int genericParamListStart = (int) _wcscspn(pTypeName, L"<");
     if(genericParamListStart != typeNameLen)
     {
         if(pTypeName[typeNameLen-1] != L'>' || genericParamListStart > mdNameLen)
@@ -2112,8 +2112,8 @@ HRESULT ExpressionNode::FindTypeByName(ICorDebugModule* pModule, __in_z WCHAR* p
         for(int i = 0; i < countTypeParams; i++)
         {
             WCHAR typeParamName[mdNameLen];
-            WCHAR* pNextComma = wcschr(pCurName, L',');
-            int len = (pNextComma != NULL) ? (int)(pNextComma - pCurName) : (int)wcslen(pCurName)-1;
+            WCHAR* pNextComma = _wcschr(pCurName, L',');
+            int len = (pNextComma != NULL) ? (int)(pNextComma - pCurName) : (int)_wcslen(pCurName)-1;
             if(len > mdNameLen)
                 return E_FAIL;
             wcsncpy_s(typeParamName, mdNameLen, pCurName, len);
@@ -2166,8 +2166,8 @@ HRESULT ExpressionNode::IsTokenValueTypeOrEnum(mdToken token, IMetaDataImport* p
         IfFailRet(pMetadata->GetTypeDefProps(token, nameBuffer, _countof(nameBuffer), &chTypeDef, NULL, NULL));
     }
 
-    if(wcscmp(nameBuffer, L"System.ValueType") == 0 ||
-        wcscmp(nameBuffer, L"System.Enum") == 0)
+    if(_wcscmp(nameBuffer, L"System.ValueType") == 0 ||
+        _wcscmp(nameBuffer, L"System.Enum") == 0)
     {
         *pResult = TRUE;
     }

--- a/src/ToolBox/SOS/Strike/WatchCmd.cpp
+++ b/src/ToolBox/SOS/Strike/WatchCmd.cpp
@@ -112,7 +112,7 @@ HRESULT WatchCmd::Print(int expansionIndex, __in_z WCHAR* expansionPath, __in_z 
         pFilterList = pPersistListHead;
         while(pFilterList != NULL)
         {
-            if(wcscmp(pFilterList->pName, pFilterName)==0)
+            if(_wcscmp(pFilterList->pName, pFilterName)==0)
                 break;
             pFilterList = pFilterList->pNext;
         }
@@ -135,7 +135,7 @@ HRESULT WatchCmd::Print(int expansionIndex, __in_z WCHAR* expansionPath, __in_z 
             PersistWatchExpression* pCurFilterExpr = pHeadFilterExpr;
             while(pCurFilterExpr != NULL)
             {
-                if(wcscmp(pCurFilterExpr->pExpression, pResult->GetAbsoluteExpression())==0)
+                if(_wcscmp(pCurFilterExpr->pExpression, pResult->GetAbsoluteExpression())==0)
                     break;
                 pCurFilterExpr = pCurFilterExpr->pNext;
             }
@@ -146,7 +146,7 @@ HRESULT WatchCmd::Print(int expansionIndex, __in_z WCHAR* expansionPath, __in_z 
             {
                 WCHAR pCurPersistResult[MAX_EXPRESSION];
                 FormatPersistResult(pCurPersistResult, MAX_EXPRESSION, pResult);
-                if(wcscmp(pCurPersistResult, pCurFilterExpr->pPersistResult)==0)
+                if(_wcscmp(pCurPersistResult, pCurFilterExpr->pPersistResult)==0)
                 {
                     print = FALSE;
                 }
@@ -178,7 +178,7 @@ HRESULT WatchCmd::RemoveList(__in_z WCHAR* pListName)
     PersistList** ppList = &pPersistListHead;
     while(*ppList != NULL)
     {
-        if(wcscmp((*ppList)->pName, pListName) == 0)
+        if(_wcscmp((*ppList)->pName, pListName) == 0)
         {
             PersistList* toDelete = *ppList;
             *ppList = (*ppList)->pNext;
@@ -193,12 +193,12 @@ HRESULT WatchCmd::RemoveList(__in_z WCHAR* pListName)
 // Renames a previously saved persisted watch list
 HRESULT WatchCmd::RenameList(__in_z WCHAR* pOldName, __in_z WCHAR* pNewName)
 {
-    if(wcscmp(pOldName, pNewName)==0)
+    if(_wcscmp(pOldName, pNewName)==0)
         return S_OK;
     PersistList** ppList = &pPersistListHead;
     while(*ppList != NULL)
     {
-        if(wcscmp((*ppList)->pName, pOldName) == 0)
+        if(_wcscmp((*ppList)->pName, pOldName) == 0)
         {
             PersistList* pListToChangeName = *ppList;
             RemoveList(pNewName);
@@ -300,9 +300,9 @@ VOID WatchCmd::EvalPrintCallback(ExpressionNode* pExpressionNode, int depth, VOI
     {
         // names can have '<' and '>' in them, need to escape
         WCHAR pEscapedTypeName[MAX_EXPRESSION];
-        DmlEscape(pExpressionNode->GetTypeName(), (int)wcslen(pExpressionNode->GetTypeName()), pEscapedTypeName, MAX_EXPRESSION);
+        DmlEscape(pExpressionNode->GetTypeName(), (int)_wcslen(pExpressionNode->GetTypeName()), pEscapedTypeName, MAX_EXPRESSION);
         WCHAR pRelativeExpression[MAX_EXPRESSION];
-        DmlEscape(pExpressionNode->GetRelativeExpression(), (int)wcslen(pExpressionNode->GetRelativeExpression()), pRelativeExpression, MAX_EXPRESSION);
+        DmlEscape(pExpressionNode->GetRelativeExpression(), (int)_wcslen(pExpressionNode->GetRelativeExpression()), pRelativeExpression, MAX_EXPRESSION);
         DMLOut("%S <exec cmd=\"%S (%S)%S\">%S</exec> %S\n", pEscapedTypeName, pData->pCommand, pEscapedTypeName, pExpressionNode->GetAbsoluteExpression(), pRelativeExpression, pExpressionNode->GetTextValue());
     }
 }

--- a/src/ToolBox/SOS/Strike/datatarget.cpp
+++ b/src/ToolBox/SOS/Strike/datatarget.cpp
@@ -21,8 +21,8 @@ DataTarget::DataTarget(void) :
 STDMETHODIMP
 DataTarget::QueryInterface(
     THIS_
-    __in REFIID InterfaceId,
-    __out PVOID* Interface
+    ___in REFIID InterfaceId,
+    ___out PVOID* Interface
     )
 {
     if (InterfaceId == IID_IUnknown ||

--- a/src/ToolBox/SOS/Strike/datatarget.h
+++ b/src/ToolBox/SOS/Strike/datatarget.h
@@ -16,8 +16,8 @@ public:
     // IUnknown.
     STDMETHOD(QueryInterface)(
         THIS_
-        __in REFIID InterfaceId,
-        __out PVOID* Interface
+        ___in REFIID InterfaceId,
+        ___out PVOID* Interface
         );
     STDMETHOD_(ULONG, AddRef)(
         THIS

--- a/src/ToolBox/SOS/Strike/disasm.cpp
+++ b/src/ToolBox/SOS/Strike/disasm.cpp
@@ -515,7 +515,7 @@ void NextTerm (__deref_inout_z char *& ptr)
 // Parses something like 6e24d310, 0x6e24d310, or 6e24d310h.  
 // On 64-bit, also parses things like 000006fb`f9b70f50 and 
 // 000006fbf9b70f50 (as well as their 0x-prefix, -h suffix variations).
-INT_PTR ParseHexNumber (__in_z char *ptr, __out char **endptr)
+INT_PTR ParseHexNumber (__in_z char *ptr, ___out char **endptr)
 {
     char *endptr1;
     INT_PTR value1 = strtoul(ptr, &endptr1, 16);
@@ -705,7 +705,7 @@ const char * HelperFuncName (size_t IP)
 // Note:
 //   The return is a pointer to a global buffer, therefore this value must
 //   be consumed as soon as possible after a call to this function.
-LPCWSTR EHTypedClauseTypeName(__in const DACEHInfo* pEHInfo)
+LPCWSTR EHTypedClauseTypeName(___in const DACEHInfo* pEHInfo)
 {
     _ASSERTE(pEHInfo != NULL);
     if ((pEHInfo->clauseType == EHTyped) && pEHInfo->isCatchAllHandler)

--- a/src/ToolBox/SOS/Strike/disasm.h
+++ b/src/ToolBox/SOS/Strike/disasm.h
@@ -80,7 +80,7 @@ HRESULT CheckEEDll ();
 
 void DisasmAndClean (DWORD_PTR &IP, __out_ecount_opt(length) char *line, ULONG length);
 
-INT_PTR GetValueFromExpr(__in __in_z char *ptr, INT_PTR &value);
+INT_PTR GetValueFromExpr(___in __in_z char *ptr, INT_PTR &value);
 
 void NextTerm (__deref_inout_z char *& ptr);
 

--- a/src/ToolBox/SOS/Strike/disasmX86.cpp
+++ b/src/ToolBox/SOS/Strike/disasmX86.cpp
@@ -50,7 +50,7 @@ struct Register
 };
 
 // Find the index for a register name
-inline RegIndex FindReg (__in __in_z char *ptr, __out_opt int *plen = NULL, __out_opt int *psize = NULL)
+inline RegIndex FindReg (___in __in_z char *ptr, __out_opt int *plen = NULL, __out_opt int *psize = NULL)
 {
     struct RegName
     {
@@ -169,7 +169,7 @@ inline RegIndex FindReg (__in __in_z char *ptr, __out_opt int *plen = NULL, __ou
 }
 
 // Find the value of an expression.
-inline BOOL FindSrc (__in_z char *ptr, __in Register *reg, INT_PTR &value, BOOL &bDigit)
+inline BOOL FindSrc (__in_z char *ptr, ___in Register *reg, INT_PTR &value, BOOL &bDigit)
 {
     if (GetValueFromExpr (ptr, value))
     {
@@ -220,7 +220,7 @@ struct InstData
     INT_PTR value;
 };
 
-void FindMainReg (__in __in_z char *ptr, RegState &reg)
+void FindMainReg (___in __in_z char *ptr, RegState &reg)
 {
     int size = 0;
 
@@ -229,7 +229,7 @@ void FindMainReg (__in __in_z char *ptr, RegState &reg)
     reg.bFullReg = (reg.reg!=NONE && sizeof(void*)==size) ? TRUE : FALSE;
 }
 
-static void DecodeAddressIndirect (__in __in_z char *term, InstData& arg)
+static void DecodeAddressIndirect (___in __in_z char *term, InstData& arg)
 {
     arg.mode = BAD;
     arg.value = 0;
@@ -308,7 +308,7 @@ static void DecodeAddressIndirect (__in __in_z char *term, InstData& arg)
     }
 }
 
-void DecodeAddressTerm (__in __in_z char *term, InstData& arg)
+void DecodeAddressTerm (___in __in_z char *term, InstData& arg)
 {
     arg.mode = BAD;
     arg.reg[0].scale = 0;
@@ -1133,7 +1133,7 @@ void
 ///
 /// This is dead code, not called from anywhere, not linked in the final product.
 ///
-static BOOL DecodeLine (__in __in_z char *line, __in __in_z const char *const inst, InstData& arg1, InstData& arg2)
+static BOOL DecodeLine (___in __in_z char *line, ___in __in_z const char *const inst, InstData& arg1, InstData& arg2)
 {
     char *ptr = line;
     if (inst[0] == '*' || !strncmp (ptr, inst, strlen (inst)))

--- a/src/ToolBox/SOS/Strike/dllsext.cpp
+++ b/src/ToolBox/SOS/Strike/dllsext.cpp
@@ -270,7 +270,7 @@ DllsName(
     }
     
 #ifndef FEATURE_PAL
-    if (wcsrchr (dllName, '\\') == NULL) {
+    if (_wcsrchr (dllName, '\\') == NULL) {
         DllsNameFromPeb (addrContaining,dllName);
     }
 #endif

--- a/src/ToolBox/SOS/Strike/eeheap.cpp
+++ b/src/ToolBox/SOS/Strike/eeheap.cpp
@@ -38,15 +38,15 @@ void HeapStat::Add(DWORD_PTR aData, DWORD aSize)
         
         if (bHasStrings)
         {
-            size_t capacity_pNew = wcslen((wchar_t*)aData) + 1;
-            wchar_t *pNew = new wchar_t[capacity_pNew];
+            size_t capacity_pNew = _wcslen((WCHAR*)aData) + 1;
+            WCHAR *pNew = new WCHAR[capacity_pNew];
             if (pNew == NULL)
             {
                ReportOOM();               
                ControlC = TRUE;
                return;
             }
-            wcscpy_s(pNew, capacity_pNew, (wchar_t*)aData);
+            wcscpy_s(pNew, capacity_pNew, (WCHAR*)aData);
             aData = (DWORD_PTR)pNew;            
         }
 
@@ -96,15 +96,15 @@ void HeapStat::Add(DWORD_PTR aData, DWORD aSize)
 
         if (bHasStrings)
         {
-            size_t capacity_pNew = wcslen((wchar_t*)aData) + 1;
-            wchar_t *pNew = new wchar_t[capacity_pNew];
+            size_t capacity_pNew = _wcslen((WCHAR*)aData) + 1;
+            WCHAR *pNew = new WCHAR[capacity_pNew];
             if (pNew == NULL)
             {
                ReportOOM();
                ControlC = TRUE;
                return;
             }
-            wcscpy_s(pNew, capacity_pNew, (wchar_t*)aData);
+            wcscpy_s(pNew, capacity_pNew, (WCHAR*)aData);
             aData = (DWORD_PTR)pNew;            
         }
         
@@ -131,7 +131,7 @@ void HeapStat::Add(DWORD_PTR aData, DWORD aSize)
 int HeapStat::CompareData(DWORD_PTR d1, DWORD_PTR d2)
 {
     if (bHasStrings)
-        return wcscmp((wchar_t*)d1, (wchar_t*)d2);
+        return _wcscmp((WCHAR*)d1, (WCHAR*)d2);
 
     if (d1 > d2)
         return 1;
@@ -329,7 +329,7 @@ void HeapStat::Delete()
         head = head->right;
 
         if (bHasStrings)
-            delete[] ((wchar_t*)tmp->data);
+            delete[] ((WCHAR*)tmp->data);
         delete tmp;
     }
 

--- a/src/ToolBox/SOS/Strike/exts.cpp
+++ b/src/ToolBox/SOS/Strike/exts.cpp
@@ -153,9 +153,9 @@ extern HMODULE g_hInstance;
 // This function throws an exception that can be caught by the debugger,
 // instead of allowing the default CRT behavior of invoking Watson to failfast.
 void __cdecl _SOS_invalid_parameter(
-   const wchar_t * expression,
-   const wchar_t * function, 
-   const wchar_t * file, 
+   const WCHAR * expression,
+   const WCHAR * function, 
+   const WCHAR * file, 
    unsigned int line,
    uintptr_t pReserved
 )

--- a/src/ToolBox/SOS/Strike/gchist.cpp
+++ b/src/ToolBox/SOS/Strike/gchist.cpp
@@ -31,8 +31,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <malloc.h>
 #include <stddef.h>
 
 // We need to define the target address type.  This will be used in the 

--- a/src/ToolBox/SOS/Strike/metadata.cpp
+++ b/src/ToolBox/SOS/Strike/metadata.cpp
@@ -48,7 +48,7 @@ static HRESULT NameForTypeDef_s(mdTypeDef tkTypeDef, IMetaDataImport *pImport,
     if (hr != S_OK) {
         return hr;
     }
-    size_t Len = wcslen (mdName);
+    size_t Len = _wcslen (mdName);
     if (Len < mdNameLen-2) {
         mdName[Len++] = L'+';
         mdName[Len] = L'\0';
@@ -245,10 +245,10 @@ HRESULT NameForTokenNew(mdTypeDef mb, IMDInternalImport *pImport, WCHAR *mdName,
                     if (mdClass != mdTypeDefNil && bClassName)
                     {
                         hr = NameForTypeDefNew (mdClass, pImport, mdName);
-                        wcscat (mdName, W("."));
+                        _wcscat (mdName, W("."));
                     }
                     name[size] = L'\0';
-                    wcscat (mdName, name);
+                    _wcscat (mdName, name);
                 }
             }
             else if (TypeFromToken(mb) ==  mdtMethodDef)
@@ -263,10 +263,10 @@ HRESULT NameForTokenNew(mdTypeDef mb, IMDInternalImport *pImport, WCHAR *mdName,
                     if (mdClass != mdTypeDefNil && bClassName)
                     {
                         hr = NameForTypeDefNew (mdClass, pImport, mdName);
-                        wcscat (mdName, W("."));
+                        _wcscat (mdName, W("."));
                     }
                     name[size] = L'\0';
-                    wcscat (mdName, name);
+                    _wcscat (mdName, name);
                 }
             }
             else
@@ -427,7 +427,7 @@ void GetMethodName(mdMethodDef methodDef, IMetaDataImport * pImport, CQuickBytes
 
 
 // Tables for mapping element type to text
-const wchar_t *g_wszMapElementType[] = 
+const WCHAR *g_wszMapElementType[] = 
 {
     W("End"),          // 0x0
     W("Void"),         // 0x1
@@ -465,7 +465,7 @@ const wchar_t *g_wszMapElementType[] =
     W("INTERNAL"),
 };
  
-const wchar_t *g_wszCalling[] = 
+const WCHAR *g_wszCalling[] = 
 {   
     W("[DEFAULT]"),
     W("[C]"),
@@ -755,7 +755,7 @@ LPCWSTR MDInfo::TypeDeforRefName(mdToken inToken)
 HRESULT MDInfo::AddToSigBuffer(LPCWSTR string)
 {
     HRESULT     hr;
-    IfFailRet(m_pSigBuf->ReSize((wcslen((LPWSTR)m_pSigBuf->Ptr()) + wcslen(string) + 1) * sizeof(WCHAR)));
+    IfFailRet(m_pSigBuf->ReSize((_wcslen((LPWSTR)m_pSigBuf->Ptr()) + _wcslen(string) + 1) * sizeof(WCHAR)));
     wcscat_s((LPWSTR)m_pSigBuf->Ptr(), m_pSigBuf->Size()/sizeof(WCHAR),string);
     return NOERROR;
 }

--- a/src/ToolBox/SOS/Strike/sildasm.cpp
+++ b/src/ToolBox/SOS/Strike/sildasm.cpp
@@ -389,14 +389,14 @@ void DecodeIL(IMetaDataImport *pImport, BYTE *buffer, ULONG bufSize)
             long l = readData<long>();
 
             ULONG numChars;
-            wchar_t str[84];
+            WCHAR str[84];
 
             if ((pImport != NULL) && (pImport->GetUserString((mdString) l, str, 80, &numChars) == S_OK))
             {
                 if (numChars < 80)
                     str[numChars] = 0;
                 wcscpy_s(&str[79], 4, L"...");
-                wchar_t* ptr = str;
+                WCHAR* ptr = str;
                 while(*ptr != 0) {
                     if (*ptr < 0x20 || * ptr >= 0x80) {
                         *ptr = '.';

--- a/src/ToolBox/SOS/Strike/sos.cpp
+++ b/src/ToolBox/SOS/Strike/sos.cpp
@@ -143,7 +143,7 @@ namespace sos
         return TO_TADDR(objData.ElementTypeHandle);
     }
 
-    const wchar_t *Object::GetTypeName() const
+    const WCHAR *Object::GetTypeName() const
     {
         if (mTypeName == NULL)
             mTypeName = CreateMethodTableName(GetMT(), GetComponentMT());
@@ -293,7 +293,7 @@ namespace sos
     {
         // Zombie objects are objects that reside in an unloaded AppDomain.
         MethodTable mt = addr;
-        return wcscmp(mt.GetName(), W("<Unloaded Type>")) == 0;
+        return _wcscmp(mt.GetName(), W("<Unloaded Type>")) == 0;
     }
     
     void MethodTable::Clear()
@@ -305,7 +305,7 @@ namespace sos
         }
     }
     
-    const wchar_t *MethodTable::GetName() const
+    const WCHAR *MethodTable::GetName() const
     {
         if (mName == NULL)
             mName = CreateMethodTableName(mMT);
@@ -356,7 +356,7 @@ namespace sos
         return out.ThreadId != 0 && out.ThreadPtr != NULL;
     }
     
-    bool Object::GetStringData(__out_ecount(size) wchar_t *buffer, size_t size) const
+    bool Object::GetStringData(__out_ecount(size) WCHAR *buffer, size_t size) const
     {
         SOS_Assert(IsString());
         SOS_Assert(buffer);
@@ -849,7 +849,7 @@ namespace sos
         return TO_TADDR(mData.appDomainPtr);
     }
     
-    void BuildTypeWithExtraInfo(TADDR addr, unsigned int size, __inout_ecount(size) wchar_t *buffer)
+    void BuildTypeWithExtraInfo(TADDR addr, unsigned int size, __inout_ecount(size) WCHAR *buffer)
     {
         try
         {
@@ -866,7 +866,7 @@ namespace sos
             }
             else if (isString)
             {
-                wchar_t str[32];
+                WCHAR str[32];
                 obj.GetStringData(str, _countof(str));
                 
                 _snwprintf_s(buffer, size, _TRUNCATE, W("%s: \"%s\""), mt.GetName(), str);
@@ -880,10 +880,10 @@ namespace sos
         {
             int len = MultiByteToWideChar(CP_ACP, 0, e.what(), -1, NULL, 0);
             
-            ArrayHolder<wchar_t> tmp = new wchar_t[len];
-            MultiByteToWideChar(CP_ACP, 0, e.what(), -1, (wchar_t*)tmp, len);
+            ArrayHolder<WCHAR> tmp = new WCHAR[len];
+            MultiByteToWideChar(CP_ACP, 0, e.what(), -1, (WCHAR*)tmp, len);
             
-            swprintf_s(buffer, size, W("<invalid object: '%s'>"), (wchar_t*)tmp);
+            swprintf_s(buffer, size, W("<invalid object: '%s'>"), (WCHAR*)tmp);
         }
     }
 }

--- a/src/ToolBox/SOS/Strike/sos.h
+++ b/src/ToolBox/SOS/Strike/sos.h
@@ -222,14 +222,14 @@ namespace sos
          * valid through the lifetime of the MethodTable object and should not be
          * freed.
          */
-        const wchar_t *GetName() const;
+        const WCHAR *GetName() const;
 
     private:
         void Clear();
 
     private:
         TADDR mMT;
-        mutable wchar_t *mName;
+        mutable WCHAR *mName;
     };
 
     /* This represents an object on the GC heap in the target process.  This class
@@ -416,7 +416,7 @@ namespace sos
          *   True if the string data was successfully requested and placed in
          *   buffer, false otherwise.
          */
-        bool GetStringData(__out_ecount(size) wchar_t *buffer, size_t size) const;
+        bool GetStringData(__out_ecount(size) WCHAR *buffer, size_t size) const;
 
         /* Returns the name of the type of this object.  E.g. System.String.
          * Throws:
@@ -424,7 +424,7 @@ namespace sos
          * Returns:
          *    A string containing the type of the object.
          */
-        const wchar_t *GetTypeName() const;
+        const WCHAR *GetTypeName() const;
 
     private:
         void FillMTData() const;
@@ -442,7 +442,7 @@ namespace sos
         mutable size_t mSize;
         mutable bool mPointers;
         mutable DacpMethodTableData *mMTData;
-        mutable wchar_t *mTypeName;
+        mutable WCHAR *mTypeName;
     };
 
     /* Enumerates all the GC references (objects) contained in an object.  This uses the GCDesc
@@ -789,5 +789,5 @@ namespace sos
     }
     
     
-    void BuildTypeWithExtraInfo(TADDR addr, unsigned int size, __inout_ecount(size) wchar_t *buffer);
+    void BuildTypeWithExtraInfo(TADDR addr, unsigned int size, __inout_ecount(size) WCHAR *buffer);
 }

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -85,8 +85,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include <malloc.h>
 #include <stddef.h>
 
 #include "strike.h"
@@ -1499,12 +1497,12 @@ HRESULT PrintObj(TADDR taObj, BOOL bPrintFields = TRUE)
     DWORD_PTR size = (DWORD_PTR)objData.Size;
     ExtOut("Size:        %" POINTERSIZE_TYPE "d(0x%" POINTERSIZE_TYPE "x) bytes\n", size, size);
 
-    if (wcscmp(obj.GetTypeName(), W("System.RuntimeType")) == 0)
+    if (_wcscmp(obj.GetTypeName(), W("System.RuntimeType")) == 0)
     {
         PrintRuntimeTypeInfo(taObj, objData);
     }
 
-    if (wcscmp(obj.GetTypeName(), W("System.RuntimeType+RuntimeTypeCache")) == 0)
+    if (_wcscmp(obj.GetTypeName(), W("System.RuntimeType+RuntimeTypeCache")) == 0)
     {
         // Get the method table
         int iOffset = GetObjFieldOffset (taObj, objData.MethodTable, W("m_runtimeType"));
@@ -1666,7 +1664,7 @@ HRESULT PrintPermissionSet (TADDR p_PermSet)
 
     
     sos::MethodTable mt = TO_TADDR(PermSetData.MethodTable);
-    if (wcscmp (W("System.Security.PermissionSet"), mt.GetName()) != 0 && wcscmp(W("System.Security.NamedPermissionSet"), mt.GetName()) != 0)
+    if (_wcscmp (W("System.Security.PermissionSet"), mt.GetName()) != 0 && _wcscmp(W("System.Security.NamedPermissionSet"), mt.GetName()) != 0)
     {
         ExtOut("Invalid PermissionSet object\n");
         return S_FALSE;
@@ -1886,7 +1884,7 @@ HRESULT PrintArray(DacpObjectData& objData, DumpArrayFlags& flags, BOOL isPermSe
     //length is only supported for single-dimension array
     if (objData.dwRank == 1 && flags.Length != (DWORD_PTR)-1)
     {
-        bounds[0] = min(bounds[0], (DWORD)(flags.Length + flags.startIndex) - lowerBounds[0]);
+        bounds[0] = _min(bounds[0], (DWORD)(flags.Length + flags.startIndex) - lowerBounds[0]);
     }
     
     DWORD *indices = (DWORD *)alloca(dwRankAllocSize);
@@ -2053,7 +2051,7 @@ CLRDATA_ADDRESS isSecurityExceptionObj(CLRDATA_ADDRESS mtObj)
             break;            
         }
         NameForMT_s(TO_TADDR(walkMT), g_mdName, mdNameLen);                
-        if (wcscmp(W("System.Security.SecurityException"), g_mdName) == 0)
+        if (_wcscmp(W("System.Security.SecurityException"), g_mdName) == 0)
         {
             return walkMT;
         }
@@ -2076,7 +2074,7 @@ size_t AddExceptionHeader (__out_ecount_opt(bufferLength) WCHAR *wszBuffer, size
     {
         swprintf_s(wszBuffer, bufferLength, wszHeader);
     }
-    return wcslen(wszHeader);
+    return _wcslen(wszHeader);
 }
 
 struct StackTraceElement 
@@ -2106,8 +2104,8 @@ public:
 
     BOOL Append(__in_z LPCWSTR pszStr)
     {
-        size_t iInputLen = wcslen (pszStr);        
-        size_t iCurLen = wcslen (cs.String());
+        size_t iInputLen = _wcslen (pszStr);        
+        size_t iCurLen = _wcslen (cs.String());
         if ((iCurLen + iInputLen + 1) > cs.Size())
         {
             if (cs.ReSize(iCurLen + iInputLen + 1) != S_OK)
@@ -2122,7 +2120,7 @@ public:
     
     size_t Length()
     {
-        return wcslen(cs.String());
+        return _wcslen(cs.String());
     }
 
     WCHAR *String()
@@ -2318,7 +2316,7 @@ size_t FormatGeneratedException (DWORD_PTR dataPtr,
                 swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %s [%S @ %d]\n"), so.String(), filename, linenum);
             }
 
-            Length += wcslen(wszLineBuffer);
+            Length += _wcslen(wszLineBuffer);
 
             if (wszBuffer)
             {
@@ -3493,7 +3491,7 @@ void PrintRuntimeTypes(DWORD_PTR objAddr,size_t Size,DWORD_PTR methodTable,LPVOI
     {
         NameForMT_s(methodTable, g_mdName, mdNameLen);
 
-        if (wcscmp(g_mdName, W("System.RuntimeType")) == 0)
+        if (_wcscmp(g_mdName, W("System.RuntimeType")) == 0)
         {
             pArgs->mtOfRuntimeType = methodTable;
             pArgs->handleFieldOffset = GetObjFieldOffset(objAddr, methodTable, W("m_handle"));
@@ -3793,7 +3791,7 @@ private:
         if (mType != NULL)
         {
             WString name = obj.GetTypeName();
-            return wcsstr(name.c_str(), mType) != NULL;
+            return _wcsstr(name.c_str(), mType) != NULL;
         }
 
         return true;
@@ -3881,7 +3879,7 @@ private:
             str[0] = 0;
         }
         
-        StringSetEntry(__in_ecount(64) wchar_t tmp[64], size_t _size)
+        StringSetEntry(__in_ecount(64) WCHAR tmp[64], size_t _size)
             : count(1), size(_size)
         {
             memcpy(str, tmp, sizeof(str));
@@ -3895,11 +3893,11 @@ private:
         
         mutable size_t count;
         mutable size_t size;
-        wchar_t str[64];
+        WCHAR str[64];
         
         bool operator<(const StringSetEntry &rhs) const
         {
-            return wcscmp(str, rhs.str) == -1;
+            return _wcscmp(str, rhs.str) == -1;
         }
     };
 
@@ -3937,12 +3935,12 @@ private:
 
                 // Don't bother calculating the size of the string, just read the full 64 characters of the buffer.  The null
                 // terminator we read will terminate the string.
-                HRESULT hr = g_ExtData->ReadVirtual(TO_CDADDR(addr+offset), tmp.str, sizeof(wchar_t)*(_countof(tmp.str)-1), &fetched);
+                HRESULT hr = g_ExtData->ReadVirtual(TO_CDADDR(addr+offset), tmp.str, sizeof(WCHAR)*(_countof(tmp.str)-1), &fetched);
                 if (SUCCEEDED(hr))
                 {
                     // Ensure we null terminate the string.  Note that this will not overrun the buffer as we only
                     // wrote a max of 63 characters into the 64 character buffer.
-                    tmp.str[fetched/sizeof(wchar_t)] = 0;
+                    tmp.str[fetched/sizeof(WCHAR)] = 0;
                     Set::iterator sitr = set.find(tmp);
                     if (sitr == set.end())
                     {
@@ -3972,7 +3970,7 @@ private:
             if (IsInterrupt())
                 break;
                 
-            Flatten(vitr->str, (unsigned int)wcslen(vitr->str));
+            Flatten(vitr->str, (unsigned int)_wcslen(vitr->str));
             out.WriteRow(Decimal(vitr->size), Decimal(vitr->count), vitr->str);
         }
 #endif // FEATURE_PAL
@@ -4031,7 +4029,7 @@ private:
          mDead;
 
 
-    wchar_t *mType;
+    WCHAR *mType;
 
 private:
 #if !defined(FEATURE_PAL)
@@ -4471,7 +4469,7 @@ DECLARE_API(ListNearObj)
     candidate.reserve(10);
 
     // since we'll be reading back I'll prime the read cache to a buffer before the current address
-    MOVE(taddrCur, max(trngSeg.start, taddrObj-DT_OS_PAGE_SIZE));
+    MOVE(taddrCur, _max(trngSeg.start, taddrObj-DT_OS_PAGE_SIZE));
 
     // ===== Look for a good candidate preceeding taddrObj
 
@@ -5547,7 +5545,7 @@ HRESULT PrintThreadsFromThreadStore(BOOL bMiniDump, BOOL bPrintLiveThreadsOnly)
 
     const bool hosted = (ThreadStore.fHostConfig & CLRTASKHOSTED) != 0;
     table.ReInit(hosted ? 12 : 11, POINTERSIZE_HEX);
-    table.SetWidths(10, 4, 4, 4, max(9, POINTERSIZE_HEX), 
+    table.SetWidths(10, 4, 4, 4, _max(9, POINTERSIZE_HEX), 
                       8, 11, 1+POINTERSIZE_HEX*2, POINTERSIZE_HEX,
                       5, 3, POINTERSIZE_HEX);
 
@@ -6367,11 +6365,11 @@ public:
 
         //get a pointer to just the filename (the portion after the last backslash)
         WCHAR* pModuleFilename = wszNameBuffer;
-        WCHAR* pSlash = wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
+        WCHAR* pSlash = _wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
         while(pSlash != NULL)
         {
             pModuleFilename = pSlash+1;
-            pSlash = wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
+            pSlash = _wcschr(pModuleFilename, DIRECTORY_SEPARATOR_CHAR_W);
         }
 
         ImageInfo ii;
@@ -6417,7 +6415,7 @@ public:
         HRESULT Status = S_OK;
         IfFailRet(g_sos->GetModule(mod, &module));
 
-        WideCharToMultiByte(CP_ACP, 0, pModuleName, (int) (wcslen(pModuleName) + 1),
+        WideCharToMultiByte(CP_ACP, 0, pModuleName, (int) (_wcslen(pModuleName) + 1),
             szName, mdNameLen, NULL, NULL);            
 
         ArrayHolder<DWORD_PTR> moduleList = ModuleFromName(szName, &numModule);
@@ -6522,7 +6520,7 @@ private:
         {
             if (pCur->ModuleMatches(mod) && 
                 _wcsicmp(pCur->szModuleName, szModule) == 0 &&
-                wcscmp(pCur->szFunctionName, szName) == 0)
+                _wcscmp(pCur->szFunctionName, szName) == 0)
             {
                 return TRUE;
             }
@@ -8736,7 +8734,7 @@ DECLARE_API (ProcInfo)
             WCHAR *pt = buffer;
             WCHAR *end = pt;
             while (pt < &buffer[DT_OS_PAGE_SIZE/2]) {
-                end = wcschr (pt, L'\0');
+                end = _wcschr (pt, L'\0');
                 if (end == NULL) {
                     char format[20];
                     sprintf_s (format,_countof (format), "%dS", &buffer[DT_OS_PAGE_SIZE/2] - pt);
@@ -8983,7 +8981,7 @@ DECLARE_API(Token2EE)
             FileNameForModule(dwAddr, FileName);
 
             // We'd like a short form for this output
-            LPWSTR pszFilename = wcsrchr (FileName, DIRECTORY_SEPARATOR_CHAR_W);
+            LPWSTR pszFilename = _wcsrchr (FileName, DIRECTORY_SEPARATOR_CHAR_W);
             if (pszFilename == NULL)
             {
                 pszFilename = FileName;
@@ -9113,7 +9111,7 @@ DECLARE_API(Name2EE)
             FileNameForModule (dwAddr, FileName);
 
             // We'd like a short form for this output
-            LPWSTR pszFilename = wcsrchr (FileName, DIRECTORY_SEPARATOR_CHAR_W);
+            LPWSTR pszFilename = _wcsrchr (FileName, DIRECTORY_SEPARATOR_CHAR_W);
             if (pszFilename == NULL)
             {
                 pszFilename = FileName;
@@ -9132,7 +9130,6 @@ DECLARE_API(Name2EE)
     return Status;
 }
 
-#ifndef FEATURE_PAL
 
 #ifndef FEATURE_PAL
 DECLARE_API(PathTo)
@@ -9186,7 +9183,6 @@ DECLARE_API(PathTo)
 \**********************************************************************/
 DECLARE_API(GCRoot)
 {
-#ifndef FEATURE_PAL
     INIT_API();
     MINIDUMP_NOT_SUPPORTED();    
 
@@ -9200,7 +9196,9 @@ DECLARE_API(GCRoot)
     {   // name, vptr, type, hasValue
         {"-nostacks", &bNoStacks, COBOOL, FALSE},
         {"-all", &all, COBOOL, FALSE},
+#ifndef FEATURE_PAL
         {"/d", &dml, COBOOL, FALSE},
+#endif
     };
     CMDValue arg[] = 
 
@@ -9230,10 +9228,9 @@ DECLARE_API(GCRoot)
         ExtOut("Found %d unique roots (run '!GCRoot -all' to see all roots).\n", i);
 
     return Status;
-#else
-    return E_NOTIMPL;
-#endif
 }
+
+#ifndef FEATURE_PAL
 
 DECLARE_API(GCWhere)
 {
@@ -9707,7 +9704,7 @@ private:
             TADDR objAddr = 0;
             TADDR mtAddr = 0;
             size_t size = 0;
-            const wchar_t *mtName = 0;
+            const WCHAR *mtName = 0;
             const char *type = 0;
             
             if (FAILED(MOVE(objAddr, data[i].Handle)))
@@ -9869,7 +9866,7 @@ BOOL derivedFrom(CLRDATA_ADDRESS mtObj, __in_z LPWSTR baseString)
             break;            
         }
         NameForMT_s (TO_TADDR(walkMT), g_mdName, mdNameLen);                
-        if (wcscmp (baseString, g_mdName) == 0)
+        if (_wcscmp (baseString, g_mdName) == 0)
         {
             return TRUE;
         }
@@ -9932,7 +9929,7 @@ DECLARE_API(TraceToCode)
 
                 // get the MethodDesc name
                 if ((g_sos->GetMethodDescName(addr, 1024, wszNameBuffer, NULL) == S_OK) &&
-                    wcsncmp(W("DomainBoundILStubClass"), wszNameBuffer, 22)==0)
+                    _wcsncmp(W("DomainBoundILStubClass"), wszNameBuffer, 22)==0)
                 {
                     ExtOut("ILStub\n");
                     codeType = 2;
@@ -10031,7 +10028,7 @@ DECLARE_API(GetCodeTypeFlags)
 
         // get the MethodDesc name
         if (g_sos->GetMethodDescName(addr, 1024, wszNameBuffer, NULL) == S_OK &&
-            wcsncmp(W("DomainBoundILStubClass"), wszNameBuffer, 22)==0)
+            _wcsncmp(W("DomainBoundILStubClass"), wszNameBuffer, 22)==0)
         {
             ExtOut("ILStub\n");
             codeType = 2;
@@ -10194,7 +10191,7 @@ DECLARE_API(StopOnException)
         if (SafeReadMemory(taLTOH, &taMT, sizeof(taMT), NULL))
         {            
             NameForMT_s (taMT, g_mdName, mdNameLen);
-            if ((wcscmp(g_mdName,typeNameWide) == 0) ||
+            if ((_wcscmp(g_mdName,typeNameWide) == 0) ||
                 (fDerived && derivedFrom(taMT, typeNameWide)))
             {
                 sprintf_s(buffer,_countof (buffer),
@@ -10519,11 +10516,11 @@ private:
     {
         if(currentExpansion == NULL || varToExpand == NULL) return FALSE;
 
-        size_t varToExpandLen = wcslen(varToExpand);
-        size_t currentExpansionLen = wcslen(currentExpansion);
+        size_t varToExpandLen = _wcslen(varToExpand);
+        size_t currentExpansionLen = _wcslen(currentExpansion);
         if(currentExpansionLen > varToExpandLen) return FALSE;
         if(currentExpansionLen < varToExpandLen && varToExpand[currentExpansionLen] != L'.') return FALSE;
-        if(wcsncmp(currentExpansion, varToExpand, currentExpansionLen) != 0) return FALSE;
+        if(_wcsncmp(currentExpansion, varToExpand, currentExpansionLen) != 0) return FALSE;
 
         return TRUE;
     }
@@ -10542,7 +10539,7 @@ private:
         if(FAILED(pType->GetBase(&pBaseType)) || pBaseType == NULL) return FALSE;
         if(FAILED(GetTypeOfValue(pBaseType, baseTypeName, mdNameLen))) return  FALSE;
 
-        return (wcsncmp(baseTypeName, W("System.Enum"), 11) == 0);
+        return (_wcsncmp(baseTypeName, W("System.Enum"), 11) == 0);
     }
     static HRESULT AddGenericArgs(ICorDebugType * pType, __inout_ecount(typeNameLen) WCHAR* typeName, ULONG typeNameLen)
     {
@@ -10913,7 +10910,7 @@ private:
         else ExtOut("   (%d elements)\n", cElements);
 
         if(!ShouldExpandVariable(varToExpand, currentExpansion)) return S_OK;
-        size_t currentExpansionLen = wcslen(currentExpansion);
+        size_t currentExpansionLen = _wcslen(currentExpansion);
 
         for (ULONG32 i=0; i < cElements; i++)
         {
@@ -11136,7 +11133,7 @@ private:
                     if(SUCCEEDED(pMD->GetParamForMethodIndex(methodDef, idx, &paramDef)))
                         pMD->GetParamProps(paramDef, NULL, NULL, paramName, mdNameLen, &paramNameLen, NULL, NULL, NULL, NULL);
                 }
-                if(wcslen(paramName) == 0)
+                if(_wcslen(paramName) == 0)
                     swprintf_s(paramName, mdNameLen, W("param_%d\0"), i);
 
                 ToRelease<ICorDebugValue> pValue;
@@ -11209,7 +11206,7 @@ private:
                     ULONG cArgsFetched;
                     Status = pLocalsEnum->Next(1, &pValue, &cArgsFetched);
                 }
-                if(wcslen(paramName) == 0)
+                if(_wcslen(paramName) == 0)
                     swprintf_s(paramName, mdNameLen, W("local_%d\0"), i);
 
                 if (FAILED(Status))
@@ -11257,7 +11254,7 @@ private:
     static HRESULT ProcessFields(ICorDebugValue* pInputValue, ICorDebugType* pTypeCast, ICorDebugILFrame * pILFrame, int indent, __in_z WCHAR* varToExpand, __inout_ecount(currentExpansionSize) WCHAR* currentExpansion, DWORD currentExpansionSize, int currentFrame)
     {
         if(!ShouldExpandVariable(varToExpand, currentExpansion)) return S_OK;
-        size_t currentExpansionLen = wcslen(currentExpansion);
+        size_t currentExpansionLen = _wcslen(currentExpansion);
 
         HRESULT Status = S_OK;
 
@@ -11293,9 +11290,9 @@ private:
         ToRelease<ICorDebugType> pBaseType;
         if(SUCCEEDED(pType->GetBase(&pBaseType)) && pBaseType != NULL && SUCCEEDED(GetTypeOfValue(pBaseType, baseTypeName, mdNameLen)))
         {
-            if(wcsncmp(baseTypeName, W("System.Enum"), 11) == 0)
+            if(_wcsncmp(baseTypeName, W("System.Enum"), 11) == 0)
                 return S_OK;
-            else if(wcsncmp(baseTypeName, W("System.Object"), 13) != 0 && wcsncmp(baseTypeName, W("System.ValueType"), 16) != 0)
+            else if(_wcsncmp(baseTypeName, W("System.Object"), 13) != 0 && _wcsncmp(baseTypeName, W("System.ValueType"), 16) != 0)
             {
                 currentExpansion[currentExpansionLen] = W('\0');
                 wcscat_s(currentExpansion, currentExpansionSize, W(".\0"));
@@ -11559,7 +11556,7 @@ WString BuildRegisterOutput(const SOSStackRefData &ref, bool printObj)
     
     if (ref.HasRegisterInformation)
     {
-        wchar_t reg[32];
+        WCHAR reg[32];
         HRESULT hr = g_sos->GetRegisterName(ref.Register, _countof(reg), reg, NULL);
         if (SUCCEEDED(hr))
             res = reg;
@@ -11615,7 +11612,7 @@ void PrintRef(const SOSStackRefData &ref, TableOutput &out)
     
     if (ref.Object && (ref.Flags & SOSRefInterior) == 0)
     {
-        wchar_t type[128];
+        WCHAR type[128];
         sos::BuildTypeWithExtraInfo(TO_TADDR(ref.Object), _countof(type), type);
         
         res += WString(W(" - ")) + type;
@@ -12220,7 +12217,7 @@ DECLARE_API(ClrStack)
         if(cvariableName.data != NULL && strlen(cvariableName.data) > 0)
             swprintf_s(wvariableName, mdNameLen, W("%S\0"), cvariableName.data);
         
-        if(wcslen(wvariableName) > 0)
+        if(_wcslen(wvariableName) > 0)
             bParams = bLocals = TRUE;
 
         EnableDMLHolder dmlHolder(TRUE);
@@ -12620,7 +12617,7 @@ static HRESULT DumpMDInfoBuffer(DWORD_PTR dwStartAddr, DWORD Flags, ULONG64 Esp,
     //   returns a module qualified method name
     HRESULT hr = g_sos->GetMethodDescName(dwStartAddr, 1024, wszNameBuffer, NULL);
 
-    WCHAR* pwszMethNameBegin = (hr != S_OK ? NULL : wcschr(wszNameBuffer, L'!'));
+    WCHAR* pwszMethNameBegin = (hr != S_OK ? NULL : _wcschr(wszNameBuffer, L'!'));
     if (!bModuleNameWorked && hr == S_OK && pwszMethNameBegin != NULL)
     {
         // if we weren't able to get the module name, but GetMethodName returned
@@ -12986,7 +12983,7 @@ Exit:
         }
         else
         {
-            *puiTextLength = wcslen (so.String()) + 1;
+            *puiTextLength = _wcslen (so.String()) + 1;
         }
 
         if (puiTransitionContextCount)
@@ -13094,14 +13091,14 @@ BOOL FormatFromRemoteString(DWORD_PTR strObjPointer, __out_ecount(cchString) PWS
     UINT Length = 0;
     while(1)
     {
-        if (wcsncmp(pwszPointer, PSZSEP, _countof(PSZSEP)-1) != 0)
+        if (_wcsncmp(pwszPointer, PSZSEP, _countof(PSZSEP)-1) != 0)
         {
             delete [] pwszBuf;
             return bRet;
         }
 
-        pwszPointer += wcslen(PSZSEP);
-        LPWSTR nextPos = wcsstr(pwszPointer, PSZSEP);
+        pwszPointer += _wcslen(PSZSEP);
+        LPWSTR nextPos = _wcsstr(pwszPointer, PSZSEP);
         if (nextPos == NULL)
         {
             // Done! Note that we are leaving the function before we add the last
@@ -13118,7 +13115,7 @@ BOOL FormatFromRemoteString(DWORD_PTR strObjPointer, __out_ecount(cchString) PWS
 
         // Note that we don't add a newline because we have this embedded in wszLineBuffer
         swprintf_s(wszLineBuffer, _countof(wszLineBuffer), W("    %p %p %s"), (void*)(size_t)-1, (void*)(size_t)-1, pwszPointer);
-        Length += (UINT)wcslen(wszLineBuffer);
+        Length += (UINT)_wcslen(wszLineBuffer);
         
         if (wszBuffer)
         {            
@@ -13794,7 +13791,7 @@ _EFN_GetManagedObjectName(
 
     sos::Object obj = TO_TADDR(objAddr);
 
-    if (WideCharToMultiByte(CP_ACP, 0, obj.GetTypeName(), (int) (wcslen(obj.GetTypeName()) + 1),
+    if (WideCharToMultiByte(CP_ACP, 0, obj.GetTypeName(), (int) (_wcslen(obj.GetTypeName()) + 1),
                             szName, cbName, NULL, NULL) == 0)
     {
         return E_FAIL;

--- a/src/ToolBox/SOS/Strike/strike.h
+++ b/src/ToolBox/SOS/Strike/strike.h
@@ -15,7 +15,6 @@
 #define _countof(x) (sizeof(x)/sizeof(x[0]))
 #endif
 
-
 #if defined(_MSC_VER)
 #pragma warning(disable:4245)   // signed/unsigned mismatch
 #pragma warning(disable:4100)   // unreferenced formal parameter
@@ -23,6 +22,34 @@
 #pragma warning(disable:4127)   // conditional expression is constant
 #pragma warning(disable:6255)   // Prefast: alloca indicates failure by raising a stack overflow exception
 #endif
+
+#ifdef PAL_STDCPP_COMPAT
+#define _iswprint   PAL_iswprint
+#define _wcslen     PAL_wcslen
+#define _wcsncmp    PAL_wcsncmp
+#define _wcsrchr    PAL_wcsrchr
+#define _wcscmp     PAL_wcscmp
+#define _wcschr     PAL_wcschr
+#define _wcscspn    PAL_wcscspn
+#define _wcscat     PAL_wcscat
+#define _wcsstr     PAL_wcsstr
+#else // PAL_STDCPP_COMPAT
+#define _iswprint   iswprint
+#define _wcslen     wcslen
+#define _wcsncmp    wcsncmp
+#define _wcsrchr    wcsrchr
+#define _wcscmp     wcscmp
+#define _wcschr     wcschr
+#define _wcscspn    wcscspn
+#define _wcscat     wcscat
+#define _wcsstr     wcsstr
+#endif // !PAL_STDCPP_COMPAT
+
+#define ___in       _SAL1_Source_(__in, (), _In_)
+#define ___out      _SAL1_Source_(__out, (), _Out_)
+
+#define _max(a, b) (((a) > (b)) ? (a) : (b))
+#define _min(a, b) (((a) < (b)) ? (a) : (b))
 
 #include <winternl.h>
 #include <winver.h>
@@ -46,7 +73,9 @@
 #include <string.h>
 
 
+#ifndef PAL_STDCPP_COMPAT
 #include <malloc.h>
+#endif
 #include <stddef.h>
 
 #ifndef FEATURE_PAL

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -181,7 +181,7 @@ HRESULT CreateInstanceCustomImpl(
     if (ppItf == NULL)
         return E_POINTER;
 
-    WCHAR wszClsid[64] = L"<CLSID>";
+    WCHAR wszClsid[64] = W("<CLSID>");
 
     // Step 1: Attempt activation using an installed runtime
     if ((cciOptions & cciFxMask) != 0)
@@ -249,7 +249,7 @@ HRESULT CreateInstanceCustomImpl(
                 continue;
             }
 
-            ArrayHolder<wchar_t> imgPath = new wchar_t[pathSize+MAX_PATH+1];
+            ArrayHolder<WCHAR> imgPath = new WCHAR[pathSize+MAX_PATH+1];
             if (imgPath == NULL)
             {
                 continue;
@@ -262,12 +262,12 @@ HRESULT CreateInstanceCustomImpl(
             }
 
             LPWSTR ctx;
-            LPCWSTR pathElem = wcstok_s(imgPath, L";", &ctx);
+            LPCWSTR pathElem = wcstok_s(imgPath, W(";"), &ctx);
             while (pathElem != NULL)
             {
                 WCHAR fullName[MAX_PATH];
                 wcscpy_s(fullName, _countof(fullName), pathElem);
-                if (wcscat_s(fullName, L"\\") == 0 && wcscat_s(fullName, dllName) == 0)
+                if (wcscat_s(fullName, W("\\")) == 0 && wcscat_s(fullName, dllName) == 0)
                 {
                     if (SUCCEEDED(CreateInstanceFromPath(clsid, iid, fullName, ppItf)))
                     {
@@ -275,7 +275,7 @@ HRESULT CreateInstanceCustomImpl(
                     }
                 }
 
-                pathElem = wcstok_s(NULL, L";", &ctx);
+                pathElem = wcstok_s(NULL, W(";"), &ctx);
             }
         }
 
@@ -329,7 +329,7 @@ HRESULT ClrCreateInstance(
     HMODULE hMscoree = NULL;
 
     // if there's a v4+ shim on the debugger machine
-    if (GetProcAddressT("CLRCreateInstance", L"mscoree.dll", &pfnCLRCreateInstance, &hMscoree))
+    if (GetProcAddressT("CLRCreateInstance", W("mscoree.dll"), &pfnCLRCreateInstance, &hMscoree))
     {
         // attempt to create an ICLRMetaHost instance
         ToRelease<ICLRMetaHost> spMH;
@@ -564,15 +564,15 @@ QWORD VerString2Qword(LPCWSTR vStr)
     QWORD result = 0;
 
     DWORD v1, v2, v3;
-    if (swscanf_s(vStr+1, L"%d.%d.%d", &v1, &v2, &v3) == 3)
+    if (swscanf_s(vStr+1, W("%d.%d.%d"), &v1, &v2, &v3) == 3)
     {
         result = ((QWORD)v1 << 48) | ((QWORD)v2 << 32) | ((QWORD)v3 << 16);
     }
-    else if (swscanf_s(vStr+1, L"%d.%d", &v1, &v2) == 2)
+    else if (swscanf_s(vStr+1, W("%d.%d"), &v1, &v2) == 2)
     {
         result = ((QWORD)v1 << 48) | ((QWORD)v2 << 32);
     }
-    else if (swscanf_s(vStr+1, L"%d", &v1) == 1)
+    else if (swscanf_s(vStr+1, W("%d"), &v1) == 1)
     {
         result = ((QWORD)v1 << 48);
     }
@@ -596,7 +596,7 @@ BOOL GetPathFromModule(
     if (len == 0 || len == cFqPath)
         return FALSE;
 
-    WCHAR *pLastSep = wcsrchr(fqPath, DIRECTORY_SEPARATOR_CHAR_W);
+    WCHAR *pLastSep = _wcsrchr(fqPath, DIRECTORY_SEPARATOR_CHAR_W);
     if (pLastSep == NULL || pLastSep+1 >= fqPath+cFqPath)
         return FALSE;
 
@@ -647,7 +647,7 @@ HRESULT CreateInstanceCustom(
 *    windbg.                                                           *
 *                                                                      *
 \**********************************************************************/
-DWORD_PTR GetValueFromExpression (__in __in_z const char *const instr)
+DWORD_PTR GetValueFromExpression (___in __in_z const char *const instr)
 {
     ULONG64 dwAddr;
     const char *str = instr;
@@ -1515,7 +1515,7 @@ void ComposeName_s(CorElementType Type, __out_ecount(capacity_buffer) LPSTR buff
 LPWSTR FormatTypeName (__out_ecount (maxChars) LPWSTR pszName, UINT maxChars)
 {
     UINT iStart = 0;
-    UINT iLen = (int) wcslen(pszName);
+    UINT iLen = (int) _wcslen(pszName);
     if (iLen > maxChars)
     {
         iStart = iLen - maxChars;
@@ -1802,7 +1802,7 @@ int GetObjFieldOffset(CLRDATA_ADDRESS cdaObj, CLRDATA_ADDRESS cdaMT, __in_z LPCW
         {
             DWORD offset = vFieldDesc.dwOffset + sizeof(BaseObject);          
             NameForToken_s (TokenFromRid(vFieldDesc.mb, mdtFieldDef), pImport, g_mdName, mdNameLen, false);
-            if (wcscmp (wszFieldName, g_mdName) == 0)
+            if (_wcscmp (wszFieldName, g_mdName) == 0)
             {
                 return offset;
             }
@@ -2141,7 +2141,7 @@ void AssemblyInfo(DacpAssemblyData *pAssembly)
             }
             else
             {
-                ExtOut("%S\n", (moduleData.bIsReflection) ? L"Dynamic Module" : L"Unknown Module");
+                ExtOut("%S\n", (moduleData.bIsReflection) ? W("Dynamic Module") : W("Unknown Module"));
             }
         }        
     }
@@ -2294,14 +2294,14 @@ BOOL NameForMT_s(DWORD_PTR MTAddr, __out_ecount (capacity_mdName) WCHAR *mdName,
     return SUCCEEDED(hr);
 }
 
-wchar_t *CreateMethodTableName(TADDR mt, TADDR cmt)
+WCHAR *CreateMethodTableName(TADDR mt, TADDR cmt)
 {
     bool array = false;
-    wchar_t *res = NULL;
+    WCHAR *res = NULL;
     
     if (mt == sos::MethodTable::GetFreeMT())
     {
-        res = new wchar_t[5];
+        res = new WCHAR[5];
         wcscpy_s(res, 5, W("Free"));
         return res;
     }
@@ -2319,7 +2319,7 @@ wchar_t *CreateMethodTableName(TADDR mt, TADDR cmt)
     if (SUCCEEDED(hr))
     {
         // +2 for [], if we need it.
-        res = new wchar_t[needed+2];
+        res = new WCHAR[needed+2];
         hr = g_sos->GetMethodTableName(mt, needed, res, NULL);
         
         if (FAILED(hr))
@@ -2626,7 +2626,7 @@ BOOL IsFusionLoadedModule (LPCSTR fusionName, LPCSTR mName)
     return FALSE;
 }
     
-BOOL DebuggerModuleNamesMatch (CLRDATA_ADDRESS PEFileAddr, __in __in_z LPSTR mName)
+BOOL DebuggerModuleNamesMatch (CLRDATA_ADDRESS PEFileAddr, ___in __in_z LPSTR mName)
 {
     // Another way to see if a module is the same is
     // to accept that mName may be the debugger's name for
@@ -2650,11 +2650,7 @@ BOOL DebuggerModuleNamesMatch (CLRDATA_ADDRESS PEFileAddr, __in __in_z LPSTR mNa
                     if (g_ExtSymbols->GetModuleNames(Index, base, NULL, 0, NULL, ModuleName, 
                         MAX_PATH, NULL, NULL, 0, NULL) == S_OK)
                     {
-#ifndef FEATURE_PAL
                         if (_stricmp (ModuleName, mName) == 0)
-#else
-                        if (strcmp (ModuleName, mName) == 0)
-#endif
                         {
                             return TRUE;
                         }
@@ -2883,8 +2879,8 @@ void GetInfoFromName(DWORD_PTR ModulePtr, const char* name)
     mdToken tkEnclose = mdTokenNil;
     WCHAR *pName;
     WCHAR *pHead = wszName;
-    while ( ((pName = wcschr (pHead,L'+')) != NULL) ||
-             ((pName = wcschr (pHead,L'/')) != NULL)) {
+    while ( ((pName = _wcschr (pHead,L'+')) != NULL) ||
+             ((pName = _wcschr (pHead,L'/')) != NULL)) {
         pName[0] = L'\0';
         if (FAILED(pImport->FindTypeDefByName(pHead,tkEnclose,&tkEnclose)))
             return;
@@ -2902,7 +2898,7 @@ void GetInfoFromName(DWORD_PTR ModulePtr, const char* name)
     
     // See if it is a method
     WCHAR *pwzMethod;
-    if ((pwzMethod = wcsrchr(pName, L'.')) == NULL)
+    if ((pwzMethod = _wcsrchr(pName, L'.')) == NULL)
         return;
 
     if (pwzMethod[-1] == L'.')
@@ -3673,7 +3669,7 @@ void CharArrayContent(TADDR pos, ULONG num, bool widechar)
 
     if (widechar)
     {
-        ArrayHolder<wchar_t> data = new wchar_t[num+1];
+        ArrayHolder<WCHAR> data = new WCHAR[num+1];
         if (!data)
         {
             ReportOOM();
@@ -3769,7 +3765,7 @@ void StringObjectContent(size_t obj, BOOL fLiteral, const int length)
             ULONG j,k=0;
             for (j = 0; j < wcharsRead; j ++) 
             {
-                if (iswprint (buffer[j])) {
+                if (_iswprint (buffer[j])) {
                     out[k] = buffer[j];
                     k ++;
                 }
@@ -4230,8 +4226,8 @@ typedef struct _FindFileCallbackData
 //           FALSE if the search should stop (the file is good)
 BOOL
 FindFileInPathCallback(
-    __in PCWSTR filename,
-    __in PVOID context
+    ___in PCWSTR filename,
+    ___in PVOID context
     )
 {
     HRESULT hr;
@@ -4381,7 +4377,7 @@ public:
         }
 
         // if we are looking for the DAC, just load the one windbg already found
-        if(wcsncmp(pwszFileName, W("mscordac"), wcslen(W("mscordac")))==0)
+        if(_wcsncmp(pwszFileName, W("mscordac"), _wcslen(W("mscordac")))==0)
         {
             FindFileInPathCallback(dacPath, &callbackData);
             *phModule = callbackData.hModule;
@@ -4412,7 +4408,7 @@ public:
             return hr;
         }
 
-        ArrayHolder<wchar_t> symbolPath = new wchar_t[pathSize+MAX_PATH+1];
+        ArrayHolder<WCHAR> symbolPath = new WCHAR[pathSize+MAX_PATH+1];
 
 
 
@@ -5259,7 +5255,7 @@ OutputVaList(
     char str[1024];
 
     // Try and format our string into a fixed buffer first and see if it fits
-    int length = PAL__vsnprintf(str, sizeof(str), format, args);
+    int length = _vsnprintf(str, sizeof(str), format, args);
     if (length > 0)
     {
         return g_ExtControl->Output(mask, "%s", str);
@@ -5474,7 +5470,7 @@ CachedString Output::BuildManagedVarValue(__in_z LPCWSTR expansionName, ULONG fr
         numFrameDigits = 1;
     }
     
-    size_t totalStringLength = strlen(DMLFormats[type]) + wcslen(expansionName) + numFrameDigits + wcslen(simpleName) + 1;
+    size_t totalStringLength = strlen(DMLFormats[type]) + _wcslen(expansionName) + numFrameDigits + _wcslen(simpleName) + 1;
     if (totalStringLength > ret.GetStrLen())
     {
         ret.Allocate(static_cast<int>(totalStringLength));
@@ -5562,8 +5558,8 @@ NoOutputHolder::~NoOutputHolder()
 // containing the addressed passed in "Base".
 HRESULT
 GetImageFromBase(
-    __in ULONG64 Base,
-    __out ImageInfo* Image)
+    ___in ULONG64 Base,
+    ___out ImageInfo* Image)
 {
     ULONG modIdx = 0;
     ULONG64 modBase = 0;
@@ -5581,9 +5577,9 @@ GetImageFromBase(
 // passed in, and the extent type requested.
 HRESULT
 GetClrModuleImages(
-    __in IXCLRDataModule* Module,
-    __in CLRDataModuleExtentType DesiredType,
-    __out ImageInfo* FirstAdd)
+    ___in IXCLRDataModule* Module,
+    ___in CLRDataModuleExtentType DesiredType,
+    ___out ImageInfo* FirstAdd)
 {
     HRESULT Status;
     CLRDATA_ENUM EnumExtents;
@@ -5629,8 +5625,8 @@ GetClrModuleImages(
 // passed in. First look for NGENed module, second for IL modules.
 HRESULT
 FindClrModuleImage(
-    __in IXCLRDataModule* Module,
-    __out ImageInfo* Image)
+    ___in IXCLRDataModule* Module,
+    ___out ImageInfo* Image)
 {
     HRESULT Status;
     
@@ -5653,8 +5649,8 @@ FindClrModuleImage(
 // passed in native offset.
 HRESULT
 GetClrMethodInstance(
-    __in ULONG64 NativeOffset,
-    __out IXCLRDataMethodInstance** Method)
+    ___in ULONG64 NativeOffset,
+    ___out IXCLRDataMethodInstance** Method)
 {
     HRESULT Status;
     CLRDATA_ENUM MethEnum;
@@ -5676,9 +5672,9 @@ GetClrMethodInstance(
 // identified by the passed in IXCLRDataMethodInstance* instance.
 HRESULT
 GetMethodInstanceTokenAndScope(
-    __in IXCLRDataMethodInstance* Method,
-    __out mdMethodDef* MethodToken,
-    __out ImageInfo* Image)
+    ___in IXCLRDataMethodInstance* Method,
+    ___out mdMethodDef* MethodToken,
+    ___out ImageInfo* Image)
 {
     HRESULT Status;
     IXCLRDataModule* Module;
@@ -5699,8 +5695,8 @@ GetMethodInstanceTokenAndScope(
 // managed method, and returns the highest non-epilog offset.
 HRESULT
 GetLastMethodIlOffset(
-    __in IXCLRDataMethodInstance* Method, 
-    __out PULONG32 MethodOffs)
+    ___in IXCLRDataMethodInstance* Method, 
+    ___out PULONG32 MethodOffs)
 {
     HRESULT Status;
     CLRDATA_IL_ADDRESS_MAP MapLocal[16];
@@ -5767,11 +5763,11 @@ GetLastMethodIlOffset(
 // represent an "IL offset".
 HRESULT
 ConvertNativeToIlOffset(
-    __in ULONG64 Native,
+    ___in ULONG64 Native,
     __in_opt IXCLRDataMethodInstance* MethodInst,
-    __out ImageInfo* Image,
-    __out mdMethodDef* MethodToken,
-    __out PULONG32 MethodOffs)
+    ___out ImageInfo* Image,
+    ___out mdMethodDef* MethodToken,
+    ___out PULONG32 MethodOffs)
 {
     HRESULT Status;
 
@@ -5829,10 +5825,10 @@ ConvertNativeToIlOffset(
 // identifies the corresponding source file name and line number.
 HRESULT
 GetLineByOffset(
-    __in  ULONG64 Offset,
-    __out ULONG *pLinenum,
+    ___in ULONG64 Offset,
+    ___out ULONG *pLinenum,
     __out_ecount(cbFileName) LPSTR lpszFileName,
-    __in ULONG cbFileName)
+    ___in ULONG cbFileName)
 {
 
 #ifdef FEATURE_PAL
@@ -6229,7 +6225,7 @@ HRESULT SymbolReader::LoadSymbols(IMetaDataImport * pMD, ULONG64 baseAddress, __
         return Status;
     }
 
-    ArrayHolder<wchar_t> symbolPath = new wchar_t[pathSize];
+    ArrayHolder<WCHAR> symbolPath = new WCHAR[pathSize];
     Status = spSym3->GetSymbolPathWide(symbolPath, pathSize, NULL);
     if(S_OK != Status)
     {
@@ -6371,7 +6367,7 @@ HRESULT SymbolReader::ResolveSequencePoint(__in_z WCHAR* pFilename, ULONG32 line
     cDocs = cDocsNeeded;
     IfFailRet(m_pSymReader->GetDocuments(cDocs, &cDocsNeeded, &(pDocs[0])));
 
-    ULONG32 filenameLen = (ULONG32) wcslen(pFilename);
+    ULONG32 filenameLen = (ULONG32) _wcslen(pFilename);
 
     for(ULONG32 i = 0; i < cDocs; i++)
     {
@@ -6535,7 +6531,7 @@ WString MethodNameFromIP(CLRDATA_ADDRESS ip, BOOL bSuppressLines)
             SUCCEEDED(GetLineByOffset(TO_CDADDR(ip), &linenum, filename, MAX_PATH+1)))
         {
             int len = MultiByteToWideChar(CP_ACP, 0, filename, -1, NULL, 0);
-            ArrayHolder<wchar_t> wfilename = new wchar_t[len];
+            ArrayHolder<WCHAR> wfilename = new WCHAR[len];
             MultiByteToWideChar(CP_ACP, 0, filename, -1, wfilename, len);
             
             methodOutput += WString(W(" [")) + wfilename + W(" @ ") + Decimal(linenum) + W("]");

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -21,9 +21,9 @@ inline void RestoreSOToleranceState() {}
 #include <clrdata.h>
 #include <palclr.h>
 #include <metahost.h>
+#include <new>
 
 #if !defined(FEATURE_PAL)
-#include <new>
 #include <dia2.h>
 #endif
 
@@ -33,12 +33,10 @@ inline void RestoreSOToleranceState() {}
 #pragma warning(default:4200)
 #endif
 #include "data.h"
-
 #endif //STRIKE
 
 #include "cordebug.h"
 #include "static_assert.h"
-
 
 typedef LPCSTR  LPCUTF8;
 typedef LPSTR   LPUTF8;
@@ -185,7 +183,7 @@ interface ICorDebugProcess;
 extern ICorDebugProcess * g_pCorDebugProcess;
 
 // This class is templated for easy modification.  We may need to update the CachedString
-// or related classes to use wchar_t instead of char in the future.
+// or related classes to use WCHAR instead of char in the future.
 template <class T, int count, int size>
 class StaticData
 {
@@ -608,7 +606,7 @@ private:
 };
 
 typedef BaseString<char, strlen, strcpy_s> String;
-typedef BaseString<wchar_t, wcslen, wcscpy_s> WString;
+typedef BaseString<WCHAR, _wcslen, wcscpy_s> WString;
 
 
 template<class T>
@@ -785,7 +783,7 @@ namespace Output
             const char *cstr = (const char *)str;
         
             int len = MultiByteToWideChar(CP_ACP, 0, cstr, -1, NULL, 0);
-            wchar_t *buffer = (wchar_t *)alloca(len*sizeof(wchar_t));
+            WCHAR *buffer = (WCHAR *)alloca(len*sizeof(WCHAR));
         
             MultiByteToWideChar(CP_ACP, 0, cstr, -1, buffer, len);
         
@@ -961,15 +959,15 @@ namespace Output
     /* Format class for wide char strings.
      */
     template <>
-    class Format<const wchar_t *>
+    class Format<const WCHAR *>
     {
     public:
-        Format(const wchar_t *value)
+        Format(const WCHAR *value)
             : mValue(value)
         {
         }
 
-        Format(const Format<const wchar_t *> &rhs)
+        Format(const Format<const WCHAR *> &rhs)
             : mValue(rhs.mValue)
         {
         }
@@ -984,7 +982,7 @@ namespace Output
 
         void OutputColumn(Alignment align, int width) const
         {
-            int precision = (int)wcslen(mValue);
+            int precision = (int)_wcslen(mValue);
             if (precision > width)
                 precision = width;
 
@@ -997,7 +995,7 @@ namespace Output
         }
 
     private:
-        const wchar_t *mValue;
+        const WCHAR *mValue;
     };
 
 
@@ -1288,17 +1286,17 @@ public:
 
     void WriteColumn(int col, const WString &str)
     {
-        WriteColumn(col, Output::Format<const wchar_t *>(str));
+        WriteColumn(col, Output::Format<const WCHAR *>(str));
     }
 
     void WriteColumn(int col, __in_z WCHAR *str)
     {
-        WriteColumn(col, Output::Format<const wchar_t *>(str));
+        WriteColumn(col, Output::Format<const WCHAR *>(str));
     }
 
     void WriteColumn(int col, const WCHAR *str)
     {
-        WriteColumn(col, Output::Format<const wchar_t *>(str));
+        WriteColumn(col, Output::Format<const WCHAR *>(str));
     }
     
     inline void WriteColumn(int col, __in_z char *str)
@@ -1324,9 +1322,9 @@ public:
         WriteColumn(col, result);
     }
     
-    void WriteColumnFormat(int col, const wchar_t *fmt, ...)
+    void WriteColumnFormat(int col, const WCHAR *fmt, ...)
     {
-        wchar_t result[128];
+        WCHAR result[128];
         
         va_list list;
         va_start(list, fmt);
@@ -1630,10 +1628,10 @@ inline BOOL SafeReadMemory (CLRDATA_ADDRESS offset, PVOID lpBuffer, ULONG cb, PU
 BOOL NameForMD_s (DWORD_PTR pMD, __out_ecount (capacity_mdName) WCHAR *mdName, size_t capacity_mdName);
 BOOL NameForMT_s (DWORD_PTR MTAddr, __out_ecount (capacity_mdName) WCHAR *mdName, size_t capacity_mdName);
 
-wchar_t *CreateMethodTableName(TADDR mt, TADDR cmt = NULL);
+WCHAR *CreateMethodTableName(TADDR mt, TADDR cmt = NULL);
 
 void isRetAddr(DWORD_PTR retAddr, DWORD_PTR* whereCalled);
-DWORD_PTR GetValueFromExpression (__in __in_z const char *const str);
+DWORD_PTR GetValueFromExpression (___in __in_z const char *const str);
 
 #ifndef FEATURE_PAL
 // ensure we always allocate on the process heap
@@ -2404,10 +2402,10 @@ public:
 
 HRESULT
 GetLineByOffset(
-        __in  ULONG64 IP,
-        __out ULONG *pLinenum,
+        ___in ULONG64 IP,
+        ___out ULONG *pLinenum,
         __out_ecount(cbFileName) LPSTR lpszFileName,
-        __in ULONG cbFileName);
+        ___in ULONG cbFileName);
 
 /// X86 Context
 #define X86_SIZE_OF_80387_REGISTERS      80
@@ -2795,7 +2793,6 @@ public:
             MoveToPage(start, size);
         }
     }
-
     
     void ClearStats()
     {
@@ -2806,8 +2803,6 @@ public:
 #endif
     }
     
-#ifndef FEATURE_PAL
-
     void PrintStats(const char *func)
     {
 #ifdef _DEBUG
@@ -2819,8 +2814,6 @@ public:
 #endif
     }
 
-#endif // !FEATURE_PAL
-    
 private:
     /* Sets the cache to the page specified by addr, or false if we could not move to
      * that page.
@@ -2857,11 +2850,9 @@ private:
 // Methods for creating a database out of the gc heap and it's roots in xml format or CLRProfiler format
 //
 
-#ifndef FEATURE_PAL
 #include <unordered_map>
 #include <unordered_set>
 #include <list>
-#endif
 
 class TypeTree;
 enum { FORMAT_XML=0, FORMAT_CLRPROFILER=1 };
@@ -2877,9 +2868,7 @@ private:
     bool m_verify;
     LinearReadCache mCache;
     
-#ifndef FEATURE_PAL
     std::unordered_map<TADDR, std::list<TADDR>> mDependentHandleMap;
-#endif
     
 public:           
     HeapTraverser(bool verify);
@@ -2919,7 +2908,6 @@ private:
     void TraceHandles();
 };
 
-#ifndef FEATURE_PAL
 
 class GCRootImpl
 {
@@ -2927,7 +2915,7 @@ private:
     struct MTInfo
     {
         TADDR MethodTable;
-        wchar_t  *TypeName;
+        WCHAR  *TypeName;
 
         TADDR *Buffer;
         CGCDesc *GCDesc;
@@ -2937,13 +2925,13 @@ private:
         size_t BaseSize;
         size_t ComponentSize;
         
-        const wchar_t *GetTypeName()
+        const WCHAR *GetTypeName()
         {
             if (!TypeName)
                 TypeName = CreateMethodTableName(MethodTable);
             
             if (!TypeName)
-                return L"<error>";
+                return W("<error>");
             
             return TypeName;
         }
@@ -2976,10 +2964,10 @@ private:
         RootNode *GCRefs;
         
         
-        const wchar_t *GetTypeName()
+        const WCHAR *GetTypeName()
         {
             if (!MTInfo)
-                return L"<unknown>";
+                return W("<unknown>");
                 
             return MTInfo->GetTypeName();
         }
@@ -3119,8 +3107,6 @@ private:
     LinearReadCache mCache;     // A linear cache which stops us from having to read from the target process more than 1-2 times per object.
 };
 
-#endif // !FEATURE_PAL
-
 //
 // Helper class used for type-safe bitflags
 //   T - the enum type specifying the individual bit flags
@@ -3229,7 +3215,7 @@ HRESULT CreateInstanceCustom(
 template <typename T>
 BOOL
 GetProcAddressT(
-    __in PCSTR FunctionName,
+    ___in PCSTR FunctionName,
     __in_opt PCWSTR DllName,
     __inout T* OutFunctionPointer,
     __inout HMODULE* InOutDllHandle
@@ -3264,9 +3250,9 @@ struct ImageInfo
 
 HRESULT
 GetClrModuleImages(
-    __in IXCLRDataModule* Module,
-    __in CLRDataModuleExtentType DesiredType,
-    __out ImageInfo* FirstAdd);
+    ___in IXCLRDataModule* Module,
+    ___in CLRDataModuleExtentType DesiredType,
+    ___out ImageInfo* FirstAdd);
 
 // Helper class used in ClrStackFromPublicInterface() to keep track of explicit EE Frames
 // (i.e., "internal frames") on the stack.  Call Init() with the appropriate

--- a/src/ToolBox/SOS/Strike/vm.cpp
+++ b/src/ToolBox/SOS/Strike/vm.cpp
@@ -325,7 +325,7 @@ PrintVmStatsHeader(
 
 VOID
 PrintIndividualStat(
-    __in __in_z IN PSTR Name,
+    ___in __in_z IN PSTR Name,
     IN PINDIVIDUAL_STAT Stat
     )
 {
@@ -380,7 +380,7 @@ PrintIndividualStat(
 
 VOID
 PrintVmStats(
-    __in __in_z IN PSTR Name,
+    ___in __in_z IN PSTR Name,
     IN PVM_STATS Stats
     )
 {

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -537,8 +537,12 @@
 
 #define DACCESS_TABLE_RESOURCE "COREXTERNALDATAACCESSRESOURCE"
 
+#ifdef PAL_STDCPP_COMPAT
+#include <type_traits>
+#else
 #include "clr_std/type_traits"
 #include "crosscomp.h"
+#endif
 
 // Information stored in the DAC table of interest to the DAC implementation
 // Note that this information is shared between all instantiations of ClrDataAccess, so initialize
@@ -1413,14 +1417,14 @@ public:
 
 // Pointer wrapper for 16-bit strings.
 template<typename type, ULONG32 maxChars = 32760>
-class __Str16Ptr : public __DPtr<wchar_t>
+class __Str16Ptr : public __DPtr<WCHAR>
 {
 public:
     typedef type _Type;
     typedef type* _Ptr;
     
-    __Str16Ptr< type, maxChars >(void) : __DPtr<wchar_t>() {}
-    __Str16Ptr< type, maxChars >(TADDR addr) : __DPtr<wchar_t>(addr) {}
+    __Str16Ptr< type, maxChars >(void) : __DPtr<WCHAR>() {}
+    __Str16Ptr< type, maxChars >(TADDR addr) : __DPtr<WCHAR>(addr) {}
     explicit __Str16Ptr< type, maxChars >(__TPtrBase addr)
     {
         m_addr = addr.GetAddr();
@@ -2354,8 +2358,8 @@ typedef S8PTR(char)           PTR_STR;
 typedef S8PTR(const char)     PTR_CSTR;
 typedef S8PTR(char)           PTR_UTF8;
 typedef S8PTR(const char)     PTR_CUTF8;
-typedef S16PTR(wchar_t)       PTR_WSTR;
-typedef S16PTR(const wchar_t) PTR_CWSTR;
+typedef S16PTR(WCHAR)         PTR_WSTR;
+typedef S16PTR(const WCHAR)   PTR_CWSTR;
 
 typedef DPTR(T_CONTEXT)                  PTR_CONTEXT;
 typedef DPTR(PTR_CONTEXT)                PTR_PTR_CONTEXT;

--- a/src/inc/fusionbind.h
+++ b/src/inc/fusionbind.h
@@ -29,7 +29,11 @@
 #include "fusionsetup.h"
 #include "sstring.h"
 #include "ex.h"
+#ifdef PAL_STDCPP_COMPAT
+#include <type_traits>
+#else
 #include "clr_std/type_traits"
+#endif
 
 #include "binderngen.h"
 #include "clrprivbinding.h"

--- a/src/inc/holder.h
+++ b/src/inc/holder.h
@@ -13,8 +13,14 @@
 #include "staticcontract.h"
 #include "volatile.h"
 #include "palclr.h"
+
+#ifdef PAL_STDCPP_COMPAT
+#include <utility>
+#include <type_traits>
+#else
 #include "clr_std/utility"
 #include "clr_std/type_traits"
+#endif
 
 #if defined(FEATURE_COMINTEROP) && !defined(STRIKE)
 #include <Activation.h>

--- a/src/inc/safemath.h
+++ b/src/inc/safemath.h
@@ -35,9 +35,9 @@
 
 #ifdef PAL_STDCPP_COMPAT
 #include <type_traits>
-#else  // PAL_STDCPP_COMPAT
+#else
 #include "clr_std/type_traits"
-#endif // PAL_STDCPP_COMPAT
+#endif
 
 //==================================================================
 // Semantics: if val can be represented as the exact same value

--- a/src/inc/sospriv.idl
+++ b/src/inc/sospriv.idl
@@ -186,13 +186,13 @@ interface ISOSDacInterface : IUnknown
     HRESULT GetAppDomainStoreData(struct DacpAppDomainStoreData *data);
     HRESULT GetAppDomainList(unsigned int count, CLRDATA_ADDRESS values[], unsigned int *pNeeded);
     HRESULT GetAppDomainData(CLRDATA_ADDRESS addr, struct DacpAppDomainData *data);
-    HRESULT GetAppDomainName(CLRDATA_ADDRESS addr, unsigned int count, wchar_t *name, unsigned int *pNeeded);
+    HRESULT GetAppDomainName(CLRDATA_ADDRESS addr, unsigned int count, WCHAR *name, unsigned int *pNeeded);
     HRESULT GetDomainFromContext(CLRDATA_ADDRESS context, CLRDATA_ADDRESS *domain);
     
     // Assemblies
     HRESULT GetAssemblyList(CLRDATA_ADDRESS appDomain, int count, CLRDATA_ADDRESS values[], int *pNeeded);
     HRESULT GetAssemblyData(CLRDATA_ADDRESS baseDomainPtr, CLRDATA_ADDRESS assembly, struct DacpAssemblyData *data);
-    HRESULT GetAssemblyName(CLRDATA_ADDRESS assembly, unsigned int count, wchar_t *name, unsigned int *pNeeded);
+    HRESULT GetAssemblyName(CLRDATA_ADDRESS assembly, unsigned int count, WCHAR *name, unsigned int *pNeeded);
     
     // Modules
     HRESULT GetModule(CLRDATA_ADDRESS addr, IXCLRDataModule **mod);
@@ -209,7 +209,7 @@ interface ISOSDacInterface : IUnknown
     // MethodDescs
     HRESULT GetMethodDescData(CLRDATA_ADDRESS methodDesc, CLRDATA_ADDRESS ip, struct DacpMethodDescData *data, ULONG cRevertedRejitVersions, struct DacpReJitData * rgRevertedRejitData, ULONG * pcNeededRevertedRejitData);
     HRESULT GetMethodDescPtrFromIP(CLRDATA_ADDRESS ip, CLRDATA_ADDRESS * ppMD);
-    HRESULT GetMethodDescName(CLRDATA_ADDRESS methodDesc, unsigned int count, wchar_t *name, unsigned int *pNeeded);
+    HRESULT GetMethodDescName(CLRDATA_ADDRESS methodDesc, unsigned int count, WCHAR *name, unsigned int *pNeeded);
     HRESULT GetMethodDescPtrFromFrame(CLRDATA_ADDRESS frameAddr, CLRDATA_ADDRESS * ppMD);
     HRESULT GetMethodDescFromToken(CLRDATA_ADDRESS moduleAddr, mdToken token, CLRDATA_ADDRESS *methodDesc);
     HRESULT GetMethodDescTransparencyData(CLRDATA_ADDRESS methodDesc, struct DacpMethodDescTransparencyData *data);
@@ -227,11 +227,11 @@ interface ISOSDacInterface : IUnknown
 
     // Objects
     HRESULT GetObjectData(CLRDATA_ADDRESS objAddr, struct DacpObjectData *data);
-    HRESULT GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, wchar_t *stringData, unsigned int *pNeeded);
-    HRESULT GetObjectClassName(CLRDATA_ADDRESS obj, unsigned int count, wchar_t *className, unsigned int *pNeeded);
+    HRESULT GetObjectStringData(CLRDATA_ADDRESS obj, unsigned int count, WCHAR *stringData, unsigned int *pNeeded);
+    HRESULT GetObjectClassName(CLRDATA_ADDRESS obj, unsigned int count, WCHAR *className, unsigned int *pNeeded);
     
     // MethodTable
-    HRESULT GetMethodTableName(CLRDATA_ADDRESS mt, unsigned int count, wchar_t *mtName, unsigned int *pNeeded);
+    HRESULT GetMethodTableName(CLRDATA_ADDRESS mt, unsigned int count, WCHAR *mtName, unsigned int *pNeeded);
     HRESULT GetMethodTableData(CLRDATA_ADDRESS mt, struct DacpMethodTableData *data);
     HRESULT GetMethodTableSlot(CLRDATA_ADDRESS mt, unsigned int slot, CLRDATA_ADDRESS *value);
     HRESULT GetMethodTableFieldData(CLRDATA_ADDRESS mt, struct DacpMethodTableFieldData *data);
@@ -244,12 +244,12 @@ interface ISOSDacInterface : IUnknown
     HRESULT GetFieldDescData(CLRDATA_ADDRESS fieldDesc, struct DacpFieldDescData *data);
 
     // Frames
-    HRESULT GetFrameName(CLRDATA_ADDRESS vtable, unsigned int count, wchar_t *frameName, unsigned int *pNeeded);
+    HRESULT GetFrameName(CLRDATA_ADDRESS vtable, unsigned int count, WCHAR *frameName, unsigned int *pNeeded);
 
 
     // PEFiles
     HRESULT GetPEFileBase(CLRDATA_ADDRESS addr, CLRDATA_ADDRESS *base);
-    HRESULT GetPEFileName(CLRDATA_ADDRESS addr, unsigned int count, wchar_t *fileName, unsigned int *pNeeded);
+    HRESULT GetPEFileName(CLRDATA_ADDRESS addr, unsigned int count, WCHAR *fileName, unsigned int *pNeeded);
 
     // GC
     HRESULT GetGCHeapData(struct DacpGcHeapData *data);
@@ -310,20 +310,20 @@ interface ISOSDacInterface : IUnknown
      * Enumerates all references on a given callstack.
      */
     HRESULT GetStackReferences([in] DWORD osThreadID, [out] ISOSStackRefEnum **ppEnum);
-    HRESULT GetRegisterName([in] int regName, [in] unsigned int count, [out] wchar_t *buffer, [out] unsigned int *pNeeded);
+    HRESULT GetRegisterName([in] int regName, [in] unsigned int count, [out] WCHAR *buffer, [out] unsigned int *pNeeded);
 
     HRESULT GetThreadAllocData(CLRDATA_ADDRESS thread, struct DacpAllocData *data);
     HRESULT GetHeapAllocData(unsigned int count, struct DacpGenerationAllocData *data, unsigned int *pNeeded);
     
     // For BindingDisplay plugin
     HRESULT GetFailedAssemblyList(CLRDATA_ADDRESS appDomain, int count, CLRDATA_ADDRESS values[], unsigned int *pNeeded);
-    HRESULT GetPrivateBinPaths(CLRDATA_ADDRESS appDomain, int count, wchar_t *paths, unsigned int *pNeeded);
-    HRESULT GetAssemblyLocation(CLRDATA_ADDRESS assembly, int count, wchar_t *location, unsigned int *pNeeded);
-    HRESULT GetAppDomainConfigFile(CLRDATA_ADDRESS appDomain, int count, wchar_t *configFile, unsigned int *pNeeded);
-    HRESULT GetApplicationBase(CLRDATA_ADDRESS appDomain, int count, wchar_t *base, unsigned int *pNeeded);
+    HRESULT GetPrivateBinPaths(CLRDATA_ADDRESS appDomain, int count, WCHAR *paths, unsigned int *pNeeded);
+    HRESULT GetAssemblyLocation(CLRDATA_ADDRESS assembly, int count, WCHAR *location, unsigned int *pNeeded);
+    HRESULT GetAppDomainConfigFile(CLRDATA_ADDRESS appDomain, int count, WCHAR *configFile, unsigned int *pNeeded);
+    HRESULT GetApplicationBase(CLRDATA_ADDRESS appDomain, int count, WCHAR *base, unsigned int *pNeeded);
     HRESULT GetFailedAssemblyData(CLRDATA_ADDRESS assembly, unsigned int *pContext, HRESULT *pResult);
-    HRESULT GetFailedAssemblyLocation(CLRDATA_ADDRESS assesmbly, unsigned int count, wchar_t *location, unsigned int *pNeeded);
-    HRESULT GetFailedAssemblyDisplayName(CLRDATA_ADDRESS assembly, unsigned int count, wchar_t *name, unsigned int *pNeeded);
+    HRESULT GetFailedAssemblyLocation(CLRDATA_ADDRESS assesmbly, unsigned int count, WCHAR *location, unsigned int *pNeeded);
+    HRESULT GetFailedAssemblyDisplayName(CLRDATA_ADDRESS assembly, unsigned int count, WCHAR *name, unsigned int *pNeeded);
 };
 
 [

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -30,7 +30,12 @@
 #include "winnls.h"
 #include "check.h"
 #include "safemath.h"
+
+#ifdef PAL_STDCPP_COMPAT
+#include <type_traits>
+#else
 #include "clr_std/type_traits"
+#endif
 
 #include "contract.h"
 #include "entrypoints.h"

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -57,10 +57,12 @@ extern "C" {
 #define CDECL          __cdecl
 #endif
 
+#ifndef PAL_STDCPP_COMPAT
 #undef __fastcall
 #define __fastcall      __stdcall
 #undef _fastcall
 #define _fastcall       __fastcall
+#endif // PAL_STDCPP_COMPAT
 
 #else   // !defined(__i386__)
 
@@ -69,8 +71,11 @@ extern "C" {
 #define __cdecl
 #define _cdecl
 #define CDECL
+
+#ifndef PAL_STDCPP_COMPAT
 #define __fastcall
 #define _fastcall
+#endif // PAL_STDCPP_COMPAT
 
 #endif  // !defined(__i386__)
 

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -139,6 +139,7 @@ typedef enum tagEFaultRepRetVal
 
 #include "pal.h"
 
+#ifndef PAL_STDCPP_COMPAT
 #ifdef __cplusplus
 #ifndef __PLACEMENT_NEW_INLINE
 #define __PLACEMENT_NEW_INLINE
@@ -147,7 +148,8 @@ inline void *__cdecl operator new(size_t, void *_P)
     return (_P);
 }
 #endif // __PLACEMENT_NEW_INLINE
-#endif
+#endif // __cplusplus
+#endif // !PAL_STDCPP_COMPAT
 
 #include <pal_assert.h>
 
@@ -225,11 +227,15 @@ inline void *__cdecl operator new(size_t, void *_P)
 
 #if defined(__GNUC__) && (__GNUC__ == 3 && __GNUC_MINOR__ >= 5 || __GNUC__ > 3)
 #define FIELD_OFFSET(type, field) __builtin_offsetof(type, field)
+#ifndef offsetof
 #define offsetof(type, field) __builtin_offsetof(type, field)
+#endif
 #define PAL_safe_offsetof(type, field) __builtin_offsetof(type, field)
 #else
 #define FIELD_OFFSET(type, field) (((LONG)(LONG_PTR)&(((type *)64)->field)) - 64)
+#ifndef offsetof
 #define offsetof(s,m)          ((size_t)((ptrdiff_t)&(((s *)64)->m)) - 64)
+#endif
 #define PAL_safe_offsetof(s,m) ((size_t)((ptrdiff_t)&(char&)(((s *)64)->m))-64)
 #endif
 

--- a/src/pal/inc/rt/sal.h
+++ b/src/pal/inc/rt/sal.h
@@ -2654,8 +2654,8 @@ buffer, use the table in the buffer annotations section.
 -------------------------------------------------------------------------------
 */
 
-#ifndef PAL_STDCPP_COMPAT
 // These macros conflict with c++ headers.
+#ifndef PAL_STDCPP_COMPAT
 #define __in                                                     _SAL1_Source_(__in, (), _In_)
 #define __out                                                    _SAL1_Source_(__out, (), _Out_)
 #endif // !PAL_STDCPP_COMPAT

--- a/src/pal/inc/rt/specstrings.h
+++ b/src/pal/inc/rt/specstrings.h
@@ -312,8 +312,10 @@ __ANNOTATION(SAL_failureDefault(enum __SAL_failureKind));
 #define __post_invalid                      _Post_ __notvalid
 /* integer related macros */
 #define __allocator                         __inner_allocator
+#ifndef PAL_STDCPP_COMPAT
 #define __deallocate(kind)                  _Pre_ __notnull __post_invalid
 #define __deallocate_opt(kind)              _Pre_ __maybenull __post_invalid
+#endif
 #define __bound                             __inner_bound
 #define __range(lb,ub)                      __inner_range(lb,ub)
 #define __in_bound                          _Pre_ __inner_bound

--- a/src/pal/inc/strsafe.h
+++ b/src/pal/inc/strsafe.h
@@ -5561,7 +5561,7 @@ STRSAFEAPI StringVPrintfWorkerA(char* pszDest, size_t cchDest, const char* pszFo
         // leave the last space for the null terminator
         cchMax = cchDest - 1;
 
-        iRet = PAL__vsnprintf(pszDest, cchMax, pszFormat, argList);
+        iRet = _vsnprintf(pszDest, cchMax, pszFormat, argList);
         // ASSERT((iRet < 0) || (((size_t)iRet) <= cchMax));
 
         if ((iRet < 0) || (((size_t)iRet) > cchMax))
@@ -5687,7 +5687,7 @@ STRSAFEAPI StringVPrintfExWorkerA(char* pszDest, size_t cchDest, size_t cbDest, 
                 // leave the last space for the null terminator
                 cchMax = cchDest - 1;
 
-                iRet = PAL__vsnprintf(pszDest, cchMax, pszFormat, argList);
+                iRet = _vsnprintf(pszDest, cchMax, pszFormat, argList);
                 // ASSERT((iRet < 0) || (((size_t)iRet) <= cchMax));
 
                 if ((iRet < 0) || (((size_t)iRet) > cchMax))

--- a/src/pal/prebuilt/inc/sospriv.h
+++ b/src/pal/prebuilt/inc/sospriv.h
@@ -680,7 +680,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetAppDomainName( 
             CLRDATA_ADDRESS addr,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetDomainFromContext( 
@@ -701,7 +701,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetAssemblyName( 
             CLRDATA_ADDRESS assembly,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetModule( 
@@ -758,7 +758,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetMethodDescName( 
             CLRDATA_ADDRESS methodDesc,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetMethodDescPtrFromFrame( 
@@ -812,19 +812,19 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetObjectStringData( 
             CLRDATA_ADDRESS obj,
             unsigned int count,
-            wchar_t *stringData,
+            WCHAR *stringData,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetObjectClassName( 
             CLRDATA_ADDRESS obj,
             unsigned int count,
-            wchar_t *className,
+            WCHAR *className,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetMethodTableName( 
             CLRDATA_ADDRESS mt,
             unsigned int count,
-            wchar_t *mtName,
+            WCHAR *mtName,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetMethodTableData( 
@@ -855,7 +855,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetFrameName( 
             CLRDATA_ADDRESS vtable,
             unsigned int count,
-            wchar_t *frameName,
+            WCHAR *frameName,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetPEFileBase( 
@@ -865,7 +865,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetPEFileName( 
             CLRDATA_ADDRESS addr,
             unsigned int count,
-            wchar_t *fileName,
+            WCHAR *fileName,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetGCHeapData( 
@@ -1012,7 +1012,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetRegisterName( 
             /* [in] */ int regName,
             /* [in] */ unsigned int count,
-            /* [out] */ wchar_t *buffer,
+            /* [out] */ WCHAR *buffer,
             /* [out] */ unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetThreadAllocData( 
@@ -1033,25 +1033,25 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetPrivateBinPaths( 
             CLRDATA_ADDRESS appDomain,
             int count,
-            wchar_t *paths,
+            WCHAR *paths,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetAssemblyLocation( 
             CLRDATA_ADDRESS assembly,
             int count,
-            wchar_t *location,
+            WCHAR *location,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetAppDomainConfigFile( 
             CLRDATA_ADDRESS appDomain,
             int count,
-            wchar_t *configFile,
+            WCHAR *configFile,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetApplicationBase( 
             CLRDATA_ADDRESS appDomain,
             int count,
-            wchar_t *base,
+            WCHAR *base,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyData( 
@@ -1062,13 +1062,13 @@ EXTERN_C const IID IID_ISOSDacInterface;
         virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyLocation( 
             CLRDATA_ADDRESS assesmbly,
             unsigned int count,
-            wchar_t *location,
+            WCHAR *location,
             unsigned int *pNeeded) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE GetFailedAssemblyDisplayName( 
             CLRDATA_ADDRESS assembly,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded) = 0;
         
     };
@@ -1115,7 +1115,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetDomainFromContext )( 
@@ -1140,7 +1140,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetModule )( 
@@ -1208,7 +1208,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS methodDesc,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetMethodDescPtrFromFrame )( 
@@ -1274,21 +1274,21 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS obj,
             unsigned int count,
-            wchar_t *stringData,
+            WCHAR *stringData,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetObjectClassName )( 
             ISOSDacInterface * This,
             CLRDATA_ADDRESS obj,
             unsigned int count,
-            wchar_t *className,
+            WCHAR *className,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetMethodTableName )( 
             ISOSDacInterface * This,
             CLRDATA_ADDRESS mt,
             unsigned int count,
-            wchar_t *mtName,
+            WCHAR *mtName,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetMethodTableData )( 
@@ -1326,7 +1326,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS vtable,
             unsigned int count,
-            wchar_t *frameName,
+            WCHAR *frameName,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetPEFileBase )( 
@@ -1338,7 +1338,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS addr,
             unsigned int count,
-            wchar_t *fileName,
+            WCHAR *fileName,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetGCHeapData )( 
@@ -1520,7 +1520,7 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             /* [in] */ int regName,
             /* [in] */ unsigned int count,
-            /* [out] */ wchar_t *buffer,
+            /* [out] */ WCHAR *buffer,
             /* [out] */ unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetThreadAllocData )( 
@@ -1545,28 +1545,28 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
-            wchar_t *paths,
+            WCHAR *paths,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetAssemblyLocation )( 
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             int count,
-            wchar_t *location,
+            WCHAR *location,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetAppDomainConfigFile )( 
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
-            wchar_t *configFile,
+            WCHAR *configFile,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetApplicationBase )( 
             ISOSDacInterface * This,
             CLRDATA_ADDRESS appDomain,
             int count,
-            wchar_t *base,
+            WCHAR *base,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyData )( 
@@ -1579,14 +1579,14 @@ EXTERN_C const IID IID_ISOSDacInterface;
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assesmbly,
             unsigned int count,
-            wchar_t *location,
+            WCHAR *location,
             unsigned int *pNeeded);
         
         HRESULT ( STDMETHODCALLTYPE *GetFailedAssemblyDisplayName )( 
             ISOSDacInterface * This,
             CLRDATA_ADDRESS assembly,
             unsigned int count,
-            wchar_t *name,
+            WCHAR *name,
             unsigned int *pNeeded);
         
         END_INTERFACE

--- a/src/pal/src/cruntime/silent_printf.cpp
+++ b/src/pal/src/cruntime/silent_printf.cpp
@@ -26,6 +26,7 @@ Revision History:
 #include "pal/palinternal.h"
 #include "pal/cruntime.h"
 #include "pal/locale.h"
+#include "pal/printfcpp.hpp"
 
 /* clip strings (%s, %S) at this number of characters */
 #define MAX_STR_LEN 300


### PR DESCRIPTION
PAL_STDCPP_COMPAT is the define that the VS team added to allow the xplat
headers to be used. This is neccessary for the whole SOS directory now
because gcroot and other gc commands need unorderd_map, unorderd_set, etc.
from the stdlib.

Had to change all wchar_t to WCHAR because the xplat stdlib default is UTF32.

Had to rename and provide macros that conflict with the stdlib:

wcslen -> _wcslen
wcsncmp -> _wcsncmp
wcsrchr -> _wcsrchr
wcscmp -> _wcscmp
wcschr -> _wcschr
wcscspn -> _wcscspn
wcscat -> _wcscat

__in -> ___in
__out -> ___out

max(a, b) -> _max(a, b)
min(a, b) -> _min(a, b)

Had to ifdef PAL_STDCPP_COMPAT a lot more of pal.h, palrt.h and some other header files.

Changed

Changed a bunch of  L"" to W("").