### PR TITLE
Remove Binder assertion for BindByWhereRef

### DIFF
--- a/src/vm/coreassemblyspec.cpp
+++ b/src/vm/coreassemblyspec.cpp
@@ -176,14 +176,6 @@ VOID  AssemblySpec::Bind(AppDomain      *pAppDomain,
     }
     else
     {
-        // BindByWhereRef is supported only for the default (TPA) Binder in CoreCLR.
-        _ASSERTE(pBinder == pTPABinder);
-        if (pBinder != pTPABinder)
-        {
-            // Fail with an exception for better diagnosis.
-            COMPlusThrowHR(COR_E_INVALIDOPERATION);
-        }
-        
         hr = pTPABinder->Bind(assemblyDisplayName,
                            m_wszCodeBase,
                            GetParentAssembly()? GetParentAssembly()->GetFile():NULL,


### PR DESCRIPTION
Some use cases of CoreCLR require overriding the assembly load context, triggering this assertion. However, this override does not necessarily break support of BindByWhereRef, and so it should be attempted on a best-effort basis, instead of bailing out prematurely.