### PR TITLE
Allow to supply an external buffer to FileStream

### DIFF
--- a/src/mscorlib/src/System/IO/FileStream.cs
+++ b/src/mscorlib/src/System/IO/FileStream.cs
@@ -1358,6 +1358,24 @@ namespace System.IO {
             }
         }
 
+
+        // This method allows the user to specify an external buffer, which can then be pooled or shared
+        // among mulitple instances of FileStream. Note that this buffer can _only_ be used by a single
+        // instance of FileStream at a time. 
+        // This should be called before any action is done on the FileStream, otherwise a buffer will 
+        // be allocation, and we'll miss this optimization
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public override void SetBuffer(byte[] externalBuffer)
+        {
+            if (externalBuffer==null)
+                throw new ArgumentNullException("externalBuffer", Environment.GetResourceString("ArgumentNull_Buffer"));
+            if (externalBuffer.Length < _bufferSize)
+                throw new ArgumentOutOfRangeException("externalBuffer", Environment.GetResourceString("Arg_BufferTooSmall"));
+            // it is okay to use a buffer that is too big, only _bufferSize is ever used for checking
+            // and this allows to use a larger buffer in a stream that have a smaller buffer size.
+            _buffer = externalBuffer;
+        }
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override void SetLength(long value)
         {


### PR DESCRIPTION
The idea is to avoid 4KB allocation for buffer whenever we need to work with large number of files.
Consider the following code:

	foreach (var file in System.IO.Directory.GetFiles(dirToCheck, "*.dat"))
	{
	    using (var fs = new FileStream(file, FileMode.Open))
	    {
                 // do something to read from the stream
	    }
	}

The problem is that each instance of FileStream will allocate an independent buffer. If we are reading 10,000 files, that will result in 40MB(!) being allocated, even if we are very careful about allocations in general.

This PR adds a method, SetExternalBuffer(byte[]) which allows the caller to send an external buffer, which they can manage on their own, to the FileStream.

This gives callers the chance to pool the buffer or share it between multiple FileStream instances (obviously with only one stream using the buffer at at time.

Sample usage:

	byte[] buffer = new byte[4096];
	foreach (var file in System.IO.Directory.GetFiles(dirToCheck, "*.dat"))
	{
	    using (var fs = new FileStream(file, FileMode.Open))
	    {
                 fs.SetExternalBuffer(buffer);
                 // do something to read from the stream
	    }
	}

And now we have no more allocations. The cost of calling this code went from 40MB to 4KB.