### PR TITLE
Fix corner case of GC stack walking during exception handling

### DIFF
--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -552,6 +552,13 @@ public:
         return m_sfCallerOfActualHandlerFrame;
     }
 
+    StackFrame GetCallerOfCollapsedActualHandlingFrame()
+    {
+        LIMITED_METHOD_CONTRACT;
+
+        return m_EnclosingClauseInfoOfCollapsedTracker.GetEnclosingClauseCallerSP();
+    }
+
 #ifndef FEATURE_PAL          
 private:
     EHWatsonBucketTracker m_WatsonBucketTracker;


### PR DESCRIPTION
This change fixes a corner case of GC stack walking during exception handling
that I have missed in my previous fix. When GC suspends a thread while it is
performing second pass of exception handling, in some cases the previous
exception tracker is already collapsed into the current one and so the
evidence on a frame being a parent of an already executed handler funclet
cannot be extracted from previous trackers and stack walker tries to pass
an outdated reference to GC.
Fortunatelly, the information about the parent from the collapsed tracker
is stored in the tracker into which the collapsed one was merged and
so we can test it using that.