### PR TITLE
Fix for ref counting issue introduced in a recent optimization.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4108,6 +4108,13 @@ GenTreePtr          Compiler::fgMorphArrayIndex(GenTreePtr tree)
 
         bndsChk = arrBndsChk;
 
+        // Make sure to increment ref-counts if already ref-counted.
+        if (lvaLocalVarRefCounted)
+        {
+            lvaRecursiveIncRefCounts(index);
+            lvaRecursiveIncRefCounts(arrRef);
+        }
+
         // Now we'll switch to using the second copies for arrRef and index
         // to compute the address expression
 


### PR DESCRIPTION
A recent optimization failed to update references to a LclVar when a
bounds check node and index were intruduced. This change is making sure
the ref count is maintained properly. (Ported a fix from schellap.)