### PR TITLE
Fix build regression for ARM.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -134,7 +134,7 @@ build_mscorlib()
     fi
 
     # Invoke MSBuild
-    mono "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:OSGroup=$__BuildOS /p:BuildOS=$__BuildOS /p:UseRoslynCompiler=true /p:BuildNugetPackage=false
+    mono "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:OSGroup=$__BuildOS /p:BuildOS=$__BuildOS /p:BuildArch=$__MSBuildBuildArch /p:UseRoslynCompiler=true /p:BuildNugetPackage=false
 }
 
 echo "Commencing CoreCLR Repo build"

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -72,10 +72,11 @@ extern "C" {
 #define _cdecl
 #define CDECL
 
-#ifndef PAL_STDCPP_COMPAT
+// On ARM __fastcall is ignored and causes a compile error
+#if !defined(PAL_STDCPP_COMPAT) || defined(__arm__)
 #define __fastcall
 #define _fastcall
-#endif // PAL_STDCPP_COMPAT
+#endif // !defined(PAL_STDCPP_COMPAT) || defined(__arm__)
 
 #endif  // !defined(__i386__)
 
@@ -594,7 +595,12 @@ typedef LONG_PTR LPARAM;
 
 #ifdef PAL_STDCPP_COMPAT
 
+#ifdef BIT64
 typedef unsigned long int uintptr_t;
+#else // !BIT64
+typedef unsigned int uintptr_t;
+#endif // !BIT64
+
 typedef char16_t WCHAR;
 
 #else // PAL_STDCPP_COMPAT


### PR DESCRIPTION
This fixes a build regression on ARM, and allows mscorlib.dll to be built for ARM64 and ARM on Linux. @mikem8361 's commit 2f44626 appeared to cause the regression.

@mmitche this should fix the error you were seeing.