### PR TITLE
Dictionary: include the key in the "duplicate key" exception message

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -330,7 +330,11 @@ namespace System.Collections.Generic {
             for (int i = buckets[targetBucket]; i >= 0; i = entries[i].next) {
                 if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key)) {
                     if (add) { 
+#if FEATURE_CORECLR
+                        ThrowHelper.ThrowAddingDuplicateWithKeyArgumentException(key);
+#else
                         ThrowHelper.ThrowArgumentException(ExceptionResource.Argument_AddingDuplicate);
+#endif
                     }
                     entries[i].value = value;
                     version++;

--- a/src/mscorlib/src/System/ThrowHelper.cs
+++ b/src/mscorlib/src/System/ThrowHelper.cs
@@ -53,6 +53,12 @@ namespace System {
             throw new ArgumentException(Environment.GetResourceString("Arg_WrongType", value, targetType), "value");
         }
 
+#if FEATURE_CORECLR
+        internal static void ThrowAddingDuplicateWithKeyArgumentException(object key) {
+            throw new ArgumentException(Environment.GetResourceString("Argument_AddingDuplicateWithKey", key));
+        }
+#endif
+
         internal static void ThrowKeyNotFoundException() {
             throw new System.Collections.Generic.KeyNotFoundException();
         }

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -121,6 +121,9 @@ Access_Void = Cannot create an instance of void.
 Arg_TypedReference_Null = The TypedReference must be initialized.
 Argument_AddingDuplicate__ = Item has already been added. Key in dictionary: '{0}'  Key being added: '{1}'
 Argument_AddingDuplicate = An item with the same key has already been added.
+#if FEATURE_CORECLR
+Argument_AddingDuplicateWithKey = An item with the same key has already been added. Key: {0}
+#endif // FEATURE_CORECLR
 Argument_MethodDeclaringTypeGenericLcg = Method '{0}' has a generic declaring type '{1}'. Explicitly provide the declaring type to GetTokenFor. 
 Argument_MethodDeclaringTypeGeneric = Cannot resolve method {0} because the declaring type of the method handle {1} is generic. Explicitly provide the declaring type to GetMethodFromHandle. 
 Argument_FieldDeclaringTypeGeneric = Cannot resolve field {0} because the declaring type of the field handle {1} is generic. Explicitly provide the declaring type to GetFieldFromHandle.


### PR DESCRIPTION
Fixes https://github.com/dotnet/corefx/issues/1187
Related fix for ImmutableCollections: https://github.com/dotnet/corefx/pull/185

/cc @ellismg 