### PR TITLE
String.Join optimization for single item lists

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -159,27 +159,27 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
-            if (separator == null)
-                separator = String.Empty;
-
-
             using(IEnumerator<String> en = values.GetEnumerator()) {
                 if (!en.MoveNext())
                     return String.Empty;
 
-                StringBuilder result = StringBuilderCache.Acquire();
-                if (en.Current != null) {
-                    result.Append(en.Current);
+                String firstValue = en.Current;
+
+                if (!en.MoveNext()) {
+                    // Only one value available
+                    return firstValue ?? String.Empty;
                 }
 
-                while (en.MoveNext()) {
+                // Null separator and values are handled by the StringBuilder
+                StringBuilder result = StringBuilderCache.Acquire();
+                result.Append(firstValue);
+
+                do {
                     result.Append(separator);
-                    if (en.Current != null) {
-                        result.Append(en.Current);
-                    }
-                }            
+                    result.Append(en.Current);
+                } while (en.MoveNext());
                 return StringBuilderCache.GetStringAndRelease(result);
-            }           
+            }
         }
 
 
@@ -219,13 +219,19 @@ namespace System {
             if (count == 0) {
                 return String.Empty;
             }
-            
+
+            if (count == 1) {
+                return value[startIndex] ?? String.Empty;
+            }
+
             int jointLength = 0;
             //Figure out the total length of the strings in value
             int endIndex = startIndex + count - 1;
             for (int stringToJoinIndex = startIndex; stringToJoinIndex <= endIndex; stringToJoinIndex++) {
-                if (value[stringToJoinIndex] != null) {
-                    jointLength += value[stringToJoinIndex].Length;
+                string currentValue = value[stringToJoinIndex];
+
+                if (currentValue != null) {
+                    jointLength += currentValue.Length;
                 }
             }
             


### PR DESCRIPTION
Returns existing string instance for `String.Join` when there is only one item in the list. Optimizations for when `IEnumerable<string>` is a `IList<string>`.
I've tried to match the coding style in this file but it is a bit variable. CoreFX `System.Runtime` tests have been run on these changes.

It is common to have lists that may have multiple items but typically have only one. Running a String.Join on them will needlessly create a new string.
One example is http header parsing.

https://github.com/aspnet/HttpAbstractions/blob/dev/src/Microsoft.AspNet.Http.Extensions/ParsingHelpers.cs#L537

Some headers support multi values but will usually only have one. In the AspNet implementation all headers are in a `IEnumerable` to simplify the interfaces.

This PR is mainly about reducing allocations but there are some immediate performance benefits to go along with it. Perf tests done with 1M iterations.

### String[] Join
- Early exit when there is only one item. Avoids new string allocation. This is basically the reverse of https://github.com/dotnet/coreclr/commit/11cddd0eff920152206345acfa827df9fa855ecc#diff-d2a641ec9b77a5ea1cc985bdec3e74ef
- Store `value[stringToJoinIndex]` in a local variable to avoid double array lookup.

| Test value | Before | After | Faster |
| ---------- | -----: | ----: | -----: |
| string[1] | 46 | 13 | 254% |
| string[5] | 232 | 225 | 3% |
| string[100] | 4683 | 4564 | 3% |

### `IEnumerable<String>` Join 
- Removed null separator normalisation to `String.Empty`. `StringBuilder.Append` handles nulls and is the first check in that function. So passing null is actually more desirable.

### `IEnumerable<String>` Join when values is an `IList<String>`
- Use `IList` interface for Count and index property access. Same optimisation as many of the Linq methods. Early exit for when Count is 0 and 1, avoids new string allocation.
- Use for loop for iteration to avoid enumerator creation

| Test value | Before | After | Faster |
| ---------- | -----: | ----: | -----: |
| List<string>(1) | 89 | 14 | 538% |
| List<string>(5) | 212 | 145 | 46% |
| List<string>(100) | 3570 | 2565 | 39% |

### `IEnumerable<String>` Join when values is not an `IList<String>` (used `Queue<String>` for testing)
- Removed null checks on `en.Current`. As above, `Append` handles nulls and this removes the double property access and branch for what should be a rarer case.

| Test value | Before | After | Faster |
| ---------- | -----: | ----: | -----: |
| Queue<string>(1) | 95 | 45 | 113% |
| Queue<string>(5) | 240 | 182 | 31% |
| Queue<string>(100) | 4021 | 3236 | 24% |

Edit: `IList<string>` path is no longer included in this PR