### PR TITLE
Fix PInvokes into libraries using pthread locks

### DIFF
--- a/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
@@ -18,12 +18,11 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     )
 endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
-# FreeBSD requires pthread to be loaded by the executable process
-if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-    target_link_libraries(coreconsole
-        pthread
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+# Libc turns locks into no-ops if pthread was not loaded into process yet. Loading
+# pthread by the process executable ensures that all locks are initialized properly.
+target_link_libraries(coreconsole
+    pthread
+)
 
 add_dependencies(coreconsole
     coreclr

--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -18,12 +18,11 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
     )
 endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
-# FreeBSD requires pthread to be loaded by the executable process
-if(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-    target_link_libraries(corerun
-        pthread
-    )
-endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+# Libc turns locks into no-ops if pthread was not loaded into process yet. Loading
+# pthread by the process executable ensures that all locks are initialized properly.
+target_link_libraries(corerun
+    pthread
+)
 
 add_dependencies(corerun
     coreclr


### PR DESCRIPTION
This change fixes a problem on Linux when pinvoke loads a shared library and
that library transitively uses pthread locks. In that case, the locks may
not be initialized yet and behave as nops, causing the thread synchronization
to not to work.
Linking corerun / coreconsole with pthreads ensures that the locks are always
properly initialized.