### PR TITLE
Fix release build of mscorlib from build.sh

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -195,7 +195,7 @@ call "!VS%__VSProductVersion%COMNTOOLS!\VsDevCmd.bat"
 echo Commencing build of mscorlib for %__BuildOS%.%__BuildArch%.%__BuildType%
 echo.
 set "__MScorlibBuildLog=%__LogsDir%\MScorlib_%__BuildOS%__%__BuildArch%__%__BuildType%.log"
-%_msbuildexe% "%__ProjectFilesDir%\build.proj" %__MSBCleanBuildArgs% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__MScorlibBuildLog%" /p:OSGroup=%__BuildOS% %__AdditionalMSBuildArgs%
+%_msbuildexe% "%__ProjectFilesDir%\build.proj" %__MSBCleanBuildArgs% /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%__MScorlibBuildLog%" %__AdditionalMSBuildArgs%
 IF NOT ERRORLEVEL 1 (
   if defined __MscorlibOnly exit /b 0
   goto CrossGenMscorlib

--- a/build.sh
+++ b/build.sh
@@ -134,7 +134,12 @@ build_mscorlib()
     fi
 
     # Invoke MSBuild
-    mono "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:OSGroup=$__BuildOS /p:BuildOS=$__BuildOS /p:BuildArch=$__MSBuildBuildArch /p:UseRoslynCompiler=true /p:BuildNugetPackage=false
+    mono "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__MSBuildBuildArch /p:__BuildType=$__BuildType /p:UseRoslynCompiler=true /p:BuildNugetPackage=false
+
+    if [ $? -ne 0 ]; then
+        echo "Failed to build mscorlib."
+        exit 1
+    fi
 }
 
 echo "Commencing CoreCLR Repo build"


### PR DESCRIPTION
The mscorlib build in build.sh was not correctly flowing __BuildType
into MSBuild, which caused us to always build a Debug mscorlib.

While I was in the area, I removed the defines for OSGroup (which are
unused, as we use __BuildOS instead) and cleaned up some of the property
switches so we always pass prefixed properties (the bare names are the
computed ones from our targets in msbuild).