### PR TITLE
Fix compilation warnings in gcinfoencoder.

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -1526,6 +1526,7 @@ void GcInfoEncoder::Build()
                     UINT32 liveStateOffset;
                     bool found = hashMap.Lookup(&liveState, &liveStateOffset);
                     _ASSERTE(found);
+                    (void)found;
                     GCINFO_WRITE(m_Info1, liveStateOffset, numBitsPerPointer, CallSiteStateSize);
 
 
@@ -1550,6 +1551,7 @@ void GcInfoEncoder::Build()
                 UINT32 liveStateOffset;
                 bool found = hashMap.Lookup(&liveState, &liveStateOffset);
                 _ASSERTE(found);
+                (void)found;
                 for( ; callSiteIndex < m_NumCallSites; callSiteIndex++)
                 {
                     GCINFO_WRITE(m_Info1, liveStateOffset, numBitsPerPointer, CallSiteStateSize);


### PR DESCRIPTION
Add fake uses for two variables referenced only in asserts.