### PR TITLE
EventSource fix to not check for duplicate task/opcode pair when no task is assigned

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -3570,12 +3570,15 @@ namespace System.Diagnostics.Tracing
                 manifest.ManifestError(Environment.GetResourceString("EventSource_EventIdReused", evtName, evtId, eventData[evtId].Name), true);
             }
 
-            for (int idx = 0; idx < eventData.Length; ++idx)
+            if (eventAttribute.Task != EventTask.None)
             {
-                if (eventData[idx].Descriptor.Task == (int)eventAttribute.Task && eventData[idx].Descriptor.Opcode == (int)eventAttribute.Opcode)
+                for (int idx = 0; idx < eventData.Length; ++idx)
                 {
-                    manifest.ManifestError(Environment.GetResourceString("EventSource_TaskOpcodePairReused",
-                                            evtName, evtId, eventData[idx].Name, idx));
+                    if (eventData[idx].Descriptor.Task == (int)eventAttribute.Task && eventData[idx].Descriptor.Opcode == (int)eventAttribute.Opcode)
+                    {
+                        manifest.ManifestError(Environment.GetResourceString("EventSource_TaskOpcodePairReused",
+                                                evtName, evtId, eventData[idx].Name, idx));
+                    }
                 }
             }
 


### PR DESCRIPTION
Fix for issue #1461 

With the [WcfEventSource](https://github.com/dotnet/wcf/blob/master/src/System.Private.ServiceModel/src/Internals/WcfEventSource.cs), this code change dramatically improves the performance of generating a manifest.
```
Before: > 2 hours
After: 3.9 secs
```