### PR TITLE
Remove thread affinity and critical region stuff for Unix

### DIFF
--- a/src/mscorlib/src/System/Threading/Thread.cs
+++ b/src/mscorlib/src/System/Threading/Thread.cs
@@ -1450,6 +1450,7 @@ namespace System.Threading {
             set { SetAbortReason(value); }
         }
 
+#if !FEATURE_CORECLR
         /*
          *  This marks the beginning of a critical code region.
          */
@@ -1483,6 +1484,7 @@ namespace System.Threading {
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         public static extern void EndThreadAffinity();
+#endif // !FEATURE_CORECLR
 
         /*=========================================================================
         ** Volatile Read & Write and MemoryBarrier methods.

--- a/src/mscorlib/src/System/Threading/WaitHandle.cs
+++ b/src/mscorlib/src/System/Threading/WaitHandle.cs
@@ -549,11 +549,13 @@ namespace System.Threading
             int ret = SignalAndWaitOne(toSignal.safeWaitHandle,toWaitOn.safeWaitHandle,millisecondsTimeout,
                                 toWaitOn.hasThreadAffinity,exitContext);
 
+#if !FEATURE_CORECLR
             if(WAIT_FAILED != ret  && toSignal.hasThreadAffinity)
             {
                 Thread.EndCriticalRegion();
                 Thread.EndThreadAffinity();
             }
+#endif
 
             if(WAIT_ABANDONED == ret)
             {

--- a/src/vm/comisolatedstorage.cpp
+++ b/src/vm/comisolatedstorage.cpp
@@ -993,7 +993,9 @@ HRESULT AccountingInfo::Lock()
     DWORD dwRet;
     {
         // m_hLock is a mutex
+#ifndef FEATURE_CORECLR        
         Thread::BeginThreadAffinityAndCriticalRegion();
+#endif
         dwRet = WaitForSingleObject(m_hLock, INFINITE);
     }
 
@@ -1064,7 +1066,9 @@ void AccountingInfo::Unlock()
     InterlockedDecrement((LPLONG)&m_dwNumLocks);
 #endif
 
+#ifndef FEATURE_CORECLR        
     Thread::EndThreadAffinityAndCriticalRegion();
+#endif
 }
 
 #endif

--- a/src/vm/common.h
+++ b/src/vm/common.h
@@ -392,9 +392,11 @@ inline VOID UnsafeEEEnterCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
     STATIC_CONTRACT_GC_NOTRIGGER;
     STATIC_CONTRACT_CAN_TAKE_LOCK;
 
+#ifndef FEATURE_CORECLR
     if (CLRTaskHosted()) {
         Thread::BeginThreadAffinity();
     }
+#endif // !FEATURE_CORECLR
     UnsafeEnterCriticalSection(lpCriticalSection);
     INCTHREADLOCKCOUNT();
 }
@@ -406,9 +408,11 @@ inline VOID UnsafeEELeaveCriticalSection(LPCRITICAL_SECTION lpCriticalSection)
 
     UnsafeLeaveCriticalSection(lpCriticalSection);
     DECTHREADLOCKCOUNT();
+#ifndef FEATURE_CORECLR
     if (CLRTaskHosted()) {
         Thread::EndThreadAffinity();
     }
+#endif // !FEATURE_CORECLR
 }
 
 inline BOOL UnsafeEETryEnterCriticalSection(LPCRITICAL_SECTION lpCriticalSection)

--- a/src/vm/comsynchronizable.cpp
+++ b/src/vm/comsynchronizable.cpp
@@ -1938,7 +1938,7 @@ UINT64 QCALLTYPE ThreadNative::GetProcessDefaultStackSize()
     return (UINT64)reserve;
 }
 
-
+#ifndef FEATURE_CORECLR
 FCIMPL0(void, ThreadNative::BeginCriticalRegion)
 {
     FCALL_CONTRACT;
@@ -1972,6 +1972,7 @@ FCIMPL0(void, ThreadNative::EndThreadAffinity)
     Thread::EndThreadAffinity();
 }
 FCIMPLEND
+#endif // !FEATURE_CORECLR
 
 
 FCIMPL1(FC_BOOL_RET, ThreadNative::IsThreadpoolThread, ThreadBaseObject* thread)

--- a/src/vm/comsynchronizable.h
+++ b/src/vm/comsynchronizable.h
@@ -110,10 +110,12 @@ public:
     UINT64 QCALLTYPE GetProcessDefaultStackSize();
 
     static FCDECL1(INT32,   GetManagedThreadId, ThreadBaseObject* th);
+#ifndef FEATURE_CORECLR
     static FCDECL0(void,    BeginCriticalRegion);
     static FCDECL0(void,    EndCriticalRegion);
     static FCDECL0(void,    BeginThreadAffinity);
     static FCDECL0(void,    EndThreadAffinity);
+#endif // !FEATURE_CORECLR
     static FCDECL1(void,    SpinWait,                       int iterations);
     static BOOL QCALLTYPE YieldThread();
     static FCDECL0(Object*, GetCurrentThread);

--- a/src/vm/comwaithandle.cpp
+++ b/src/vm/comwaithandle.cpp
@@ -275,9 +275,11 @@ FCIMPL4(INT32, WaitHandleNative::CorWaitMultipleNative, Object* waitObjectsUNSAF
     
     pWaitObjects = (PTRARRAYREF)waitObjects;  // array of objects on which to wait
     HANDLE* internalHandles = (HANDLE*) _alloca(numWaiters*sizeof(HANDLE));
+#ifndef FEATURE_CORECLR
     BOOL *hasThreadAffinity = (BOOL*) _alloca(numWaiters*sizeof(BOOL));
 
     BOOL mayRequireThreadAffinity = FALSE;
+#endif // !FEATURE_CORECLR
     for (int i=0;i<numWaiters;i++)
     {
         WAITHANDLEREF waitObject = (WAITHANDLEREF) pWaitObjects->m_Array[i];
@@ -288,15 +290,19 @@ FCIMPL4(INT32, WaitHandleNative::CorWaitMultipleNative, Object* waitObjectsUNSAF
         //   this behavior seems wrong but someone explicitly coded that condition so it must have been for a reason.        
         internalHandles[i] = waitObject->m_handle;
 
+#ifndef FEATURE_CORECLR
         // m_hasThreadAffinity is set for Mutex only 
         hasThreadAffinity[i] = waitObject->m_hasThreadAffinity;
         if (hasThreadAffinity[i]) {
             mayRequireThreadAffinity = TRUE;
         }
+#endif // !FEATURE_CORECLR
     }
 
     DWORD res = (DWORD) -1;
+#ifndef FEATURE_CORECLR
     ThreadAffinityHolder affinityHolder(mayRequireThreadAffinity);
+#endif // !FEATURE_CORECLR
     Context* targetContext;
     targetContext = pThread->GetContext();
     _ASSERTE(targetContext);
@@ -330,6 +336,7 @@ FCIMPL4(INT32, WaitHandleNative::CorWaitMultipleNative, Object* waitObjectsUNSAF
         }
     }
 
+#ifndef FEATURE_CORECLR
     if (mayRequireThreadAffinity) {
         if (waitForAll) {
             if (res >= (DWORD) WAIT_OBJECT_0 && res < (DWORD) WAIT_OBJECT_0 + numWaiters) {
@@ -367,6 +374,8 @@ FCIMPL4(INT32, WaitHandleNative::CorWaitMultipleNative, Object* waitObjectsUNSAF
             }
         }
     }
+#endif // !FEATURE_CORECLR
+
     retVal = res;
 
     HELPER_METHOD_FRAME_END();
@@ -449,5 +458,3 @@ FCIMPL5(INT32, WaitHandleNative::CorSignalAndWaitOneNative, SafeHandle* safeWait
 }
 FCIMPLEND
 #endif // !FEATURE_CORECLR
-
-

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -3165,8 +3165,9 @@ private:
     PTR_Object  m_LastThrownObjectInParentContext;                                        
     ULONG_PTR   m_LockCount;            // Number of locks the thread takes
                                         // before the transition.
+#ifndef FEATURE_CORECLR
     ULONG_PTR   m_CriticalRegionCount;
-
+#endif // !FEATURE_CORECLR
     VPTR_VTABLE_CLASS(ContextTransitionFrame, Frame)
 
 public:
@@ -3194,18 +3195,29 @@ public:
         m_LastThrownObjectInParentContext = OBJECTREFToObject(lastThrownObject);
     }
 
-    void SetLockCount(DWORD lockCount, DWORD criticalRegionCount)
+    void SetLockCount(DWORD lockCount)
     {
         LIMITED_METHOD_CONTRACT;
         m_LockCount = lockCount;
-        m_CriticalRegionCount = criticalRegionCount;
     }
-    void GetLockCount(DWORD* pLockCount, DWORD* pCriticalRegionCount)
+    DWORD GetLockCount()
     {
         LIMITED_METHOD_CONTRACT;
-        *pLockCount = (DWORD) m_LockCount;
-        *pCriticalRegionCount = (DWORD) m_CriticalRegionCount;
+        return (DWORD) m_LockCount;
     }
+
+#ifndef FEATURE_CORECLR
+    void SetCriticalRegionCount(DWORD criticalRegionCount)
+    {
+        LIMITED_METHOD_CONTRACT;
+        m_CriticalRegionCount = criticalRegionCount;
+    }
+    DWORD GetCriticalRegionCount()
+    {
+        LIMITED_METHOD_CONTRACT;
+        return (DWORD) m_CriticalRegionCount;
+    }
+#endif // !FEATURE_CORECLR
 
     // Let debugger know that we're transitioning between AppDomains.
     ETransitionType GetTransitionType()
@@ -3220,7 +3232,9 @@ public:
     , m_ReturnExecutionContext(NULL)
     , m_LastThrownObjectInParentContext(NULL)
     , m_LockCount(0)
+#ifndef FEATURE_CORECLR
     , m_CriticalRegionCount(0)
+#endif // !FEATURE_CORECLR
     {
         LIMITED_METHOD_CONTRACT;
     }


### PR DESCRIPTION
The WaitHandleNative::CorWaitMultipleNative was calling Thread::BeginThreadAffinityAndCriticalRegion
that results in incrementing the Thread::m_dwCriticalRegionCount. However, there is nothing
that would decrement it on CoreCLR, so if the WaitHandleNative::CorWaitMultipleNative was called,
in debug build we got an assert in Thread::InternalReset.

It turns out that the critical region and thread affinity stuff is not to be used in CoreCLR,
so I have disabled handling of that in CoreCLR for Unix.
The only remainder are the static methods Thread::BeginThreadAffinity and Thread::EndThreadAffinity
which are used in the ThreadAffinityHolder. Conditionally removing the holder usage would be messy,
so I have rather kept those methods and made their bodies empty.