### PR TITLE
Build Code Coverage instrumented binaries for native binaries in Linux and OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,7 @@ if(CMAKE_ENABLE_CODE_COVERAGE)
     set(CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} ${CLANG_COVERAGE_LINK_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS     "${CMAKE_EXE_LINKER_FLAGS} ${CLANG_COVERAGE_LINK_FLAGS}")
   else()
-    message(WARNING "Code coverage builds not supported on current platform")
+    message(FATAL_ERROR "Code coverage builds not supported on current platform")
   endif(CLR_CMAKE_PLATFORM_UNIX)
 
 endif(CMAKE_ENABLE_CODE_COVERAGE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,26 @@ endif (WIN32)
 
 endif (OVERRIDE_CMAKE_CXX_FLAGS)
 
+OPTION(CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
+
+if(CMAKE_ENABLE_CODE_COVERAGE)
+
+  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
+  if(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+    message( WARNING "Code coverage results with an optimised (non-Debug) build may be misleading" )
+  endif(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+
+  if(CLR_CMAKE_PLATFORM_UNIX)
+    add_definitions(-fprofile-arcs -ftest-coverage -fPIC)
+    set(CLANG_COVERAGE_LINK_FLAGS  "--coverage")
+    set(CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} ${CLANG_COVERAGE_LINK_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS     "${CMAKE_EXE_LINKER_FLAGS} ${CLANG_COVERAGE_LINK_FLAGS}")
+  else()
+    message(WARNING "Code coverage builds not supported on current platform")
+  endif(CLR_CMAKE_PLATFORM_UNIX)
+
+endif(CMAKE_ENABLE_CODE_COVERAGE)
+
 if(CLR_CMAKE_PLATFORM_UNIX)
 add_definitions(-DDISABLE_CONTRACTS)
 # The -ferror-limit is helpful during the porting, it makes sure the compiler doesn't stop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,13 +341,14 @@ OPTION(CMAKE_ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 
 if(CMAKE_ENABLE_CODE_COVERAGE)
 
-  string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
-  if(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
-    message( WARNING "Code coverage results with an optimised (non-Debug) build may be misleading" )
-  endif(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
-
   if(CLR_CMAKE_PLATFORM_UNIX)
-    add_definitions(-fprofile-arcs -ftest-coverage -fPIC)
+    string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_CMAKE_BUILD_TYPE)
+    if(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+      message( WARNING "Code coverage results with an optimised (non-Debug) build may be misleading" )
+    endif(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+
+    add_compile_options(-fprofile-arcs)
+    add_compile_options(-ftest-coverage)
     set(CLANG_COVERAGE_LINK_FLAGS  "--coverage")
     set(CMAKE_SHARED_LINKER_FLAGS  "${CMAKE_SHARED_LINKER_FLAGS} ${CLANG_COVERAGE_LINK_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS     "${CMAKE_EXE_LINKER_FLAGS} ${CLANG_COVERAGE_LINK_FLAGS}")

--- a/build.sh
+++ b/build.sh
@@ -2,11 +2,12 @@
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [cross] [clangx.y] [skipmscorlib]"
+    echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [coverage] [cross] [clangx.y] [skipmscorlib]"
     echo "BuildArch can be: x64, ARM"
     echo "BuildType can be: Debug, Release"
     echo "clean - optional argument to force a clean build."
     echo "verbose - optional argument to enable verbose build output."
+    echo "coverage - optional argument to enable code coverage build (currently supported only for Linux and OSX)."
     echo "clangx.y - optional argument to build using clang version x.y."
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
@@ -61,8 +62,8 @@ build_coreclr()
     cd "$__IntermediatesDir"
 
     # Regenerate the CMake solution
-    echo "Invoking cmake with arguments: \"$__ProjectRoot\" $__CMakeArgs"
-    "$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh" "$__ProjectRoot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__CMakeArgs
+    echo "Invoking cmake with arguments: \"$__ProjectRoot\" $__BuildType $__CodeCoverage"
+    "$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh" "$__ProjectRoot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType $__CodeCoverage
 
     # Check that the makefiles were created.
 
@@ -184,7 +185,7 @@ case $OSName in
 esac
 __MSBuildBuildArch=x64
 __BuildType=Debug
-__CMakeArgs=DEBUG
+__CodeCoverage=
 
 # Set the various build properties here so that CMake and MSBuild can pick them up
 __ProjectDir="$__ProjectRoot"
@@ -230,7 +231,9 @@ for i in "$@"
         ;;
         release)
         __BuildType=Release
-        __CMakeArgs=RELEASE
+        ;;
+        coverage)
+        __CodeCoverage=Coverage
         ;;
         clean)
         __CleanBuild=1

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -61,6 +61,8 @@ foreach(IDL_SOURCE IN LISTS CORGUIDS_IDL_SOURCES)
    list(APPEND CORGUIDS_SOURCES ${C_SOURCE})
 endforeach(IDL_SOURCE)
 
+add_compile_options(-fPIC)
+
 endif(WIN32)
 
 # Compile *_i.c to lib


### PR DESCRIPTION
Add an option in build.sh called 'coverage' to produce gcov-style instrumented builds.
Example usage - ./build.sh debug coverage clean

This will generate the '.gcno' notes files for each object file in the same directory along with the instrumented native binaries. These .gcno files contain some of the coverage data like source line mappings, basic block graphs info etc.

Each time these instrumented binaries are run, a separate .gcda file is created for each object file in the same directory. These .gcda files contain arc transition counts, and some summary information.

Code Coverage reports can be generated from the .gcno and .gcda files using a tool like gcovr or lcov. *But this commit is only for generating the .gcno files while compiling with the 'coverage' option.*

The next steps
 - Add option in run-test.sh to generate code-coverage reports using the instrumented native binaries.
 - Integrate with Jenkins CI to do code-coverage runs.

Sample Report:
![image](https://cloud.githubusercontent.com/assets/9423246/9691458/706ec62e-52f7-11e5-9758-80e5de11b8fd.png)

![image](https://cloud.githubusercontent.com/assets/9423246/9691500/a300c286-52f7-11e5-8905-c72bf703c9a2.png)
