### PR TITLE
Fix memory leak from managed exceptions

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6364,6 +6364,25 @@ public:
         ExceptionRecord = *pExceptionRecord;
         ContextRecord = *pContextRecord;
     }
+
+    PAL_SEHException()
+    {
+    }    
+
+    PAL_SEHException(const PAL_SEHException& ex)
+    {
+        *this = ex;
+    }    
+
+    PAL_SEHException& operator=(const PAL_SEHException& ex)
+    {
+        ExceptionPointers.ExceptionRecord = &ExceptionRecord;
+        ExceptionPointers.ContextRecord = &ContextRecord;
+        ExceptionRecord = ex.ExceptionRecord;
+        ContextRecord = ex.ContextRecord;
+
+        return *this;
+    }    
 };
 
 typedef VOID (PALAPI *PHARDWARE_EXCEPTION_HANDLER)(PAL_SEHException* ex);

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -2446,6 +2446,9 @@ PAL_GetStackBase()
     status = pthread_attr_getstack(&attr, &stackAddr, &stackSize);
     _ASSERT_MSG(status == 0, "pthread_attr_getstack call failed");
 
+    status = pthread_attr_destroy(&attr);
+    _ASSERT_MSG(status == 0, "pthread_attr_destroy call failed");
+
     return (void*)((size_t)stackAddr + stackSize);
 #endif
 }
@@ -2480,6 +2483,9 @@ PAL_GetStackLimit()
 
     status = pthread_attr_getstack(&attr, &stackAddr, &stackSize);
     _ASSERT_MSG(status == 0, "pthread_attr_getstack call failed");
+
+    status = pthread_attr_destroy(&attr);
+    _ASSERT_MSG(status == 0, "pthread_attr_destroy call failed");
     
     return stackAddr;
 #endif

--- a/src/vm/amd64/unixasmhelpers.S
+++ b/src/vm/amd64/unixasmhelpers.S
@@ -291,7 +291,7 @@ LEAF_END SinglecastDelegateInvokeStub, _TEXT
 // from the passed in context and finally sets the RSP to that frame and sets the return
 // address to the target frame's RIP.
 //
-// EXTERN_C void StartUnwindingNativeFrames(CONTEXT* context);
+// EXTERN_C void StartUnwindingNativeFrames(CONTEXT* context, PAL_SEHException* ex);
 LEAF_ENTRY StartUnwindingNativeFrames, _TEXT
         // Save the RBP to the stack so that the unwind can work at the instruction after
         // loading the RBP from the context, but before loading the RSP from the context.
@@ -316,6 +316,8 @@ LEAF_ENTRY StartUnwindingNativeFrames, _TEXT
         // Store return address to the stack
         push_register rax
         push_nonvol_reg rbp
-        call    EXTERNAL_C_FUNC(__cxa_rethrow)
+        // The PAL_SEHException pointer
+        mov     rdi, rsi 
+        call    EXTERNAL_C_FUNC(ThrowExceptionHelper)
 LEAF_END StartUnwindingNativeFrames, _TEXT
 

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -323,14 +323,21 @@ VOID DECLSPEC_NORETURN UnwindAndContinueRethrowHelperAfterCatch(Frame* pEntryFra
 VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex);
 
 #define INSTALL_MANAGED_EXCEPTION_DISPATCHER        \
-        try { \
+        PAL_SEHException exCopy;                    \
+        bool hasCaughtException = false;            \
+        try {
 
 #define UNINSTALL_MANAGED_EXCEPTION_DISPATCHER      \
         }                                           \
         catch (PAL_SEHException& ex)                \
         {                                           \
-            DispatchManagedException(ex);           \
+            exCopy = ex;                            \
+            hasCaughtException = true;              \
         }                                           \
+        if (hasCaughtException)                     \
+        {                                           \
+            DispatchManagedException(exCopy);       \
+        }
 
 #else
 


### PR DESCRIPTION
Handling thrown PAL_SEHException was causing leaks for all exceptions thrown due to
two aspects:
1) PAL_GetStackBase() and PAL_GetStackLimit() were missing calls to pthread_attr_destroy()
2) We were calling the DispatchManagedException from C++ catch handlers and this function
   never returns. So the C++ exception handling never called __cxa_end_catch that is
   responsible for freeing the exception storage allocated by the C++ runtime.
The fix to the 2nd aspect was to store a copy of the exception in the catch handler, let it
complete and then call the DispatchManagedException with the copy. It was also necessary to
slightly modify the unwinding of sequences of native frames since there is now no rethrowable
exception and the StartUnwindingManagedFrames has to throw a new one.
This change has a secondary benefit - the StartUnwindingManagedFrames no longer calls
__cxa_rethrow, but rather a helper C++ function that uses regular "throw" keyword.
That makes the code more portable.