### PR TITLE
Make DBI/SOS stackwalk work when thread is running native code or throws managed exception

### DIFF
--- a/src/debug/di/shimremotedatatarget.cpp
+++ b/src/debug/di/shimremotedatatarget.cpp
@@ -286,7 +286,6 @@ ShimRemoteDataTarget::GetThreadContext(
 {
     ReturnFailureIfStateNotOk();
         
-#ifdef FEATURE_DBGIPC_TRANSPORT_DI
     // GetThreadContext() is currently not implemented in ShimRemoteDataTarget, which is used with our pipe transport 
     // (FEATURE_DBGIPC_TRANSPORT_DI). Pipe transport is used on POSIX system, but occasionally we can turn it on for Windows for testing,
     // and then we'd like to have same behavior as on POSIX system (zero context).
@@ -297,15 +296,8 @@ ShimRemoteDataTarget::GetThreadContext(
     // Instead, we just zero out the seed CONTEXT for the stackwalk.  This tells the stackwalker to
     // start the stackwalk with the first explicit frame.  This won't work when we do native debugging, 
     // but that won't happen on the POSIX systems since they don't support native debugging.
-    ZeroMemory(pContext, contextSize);        
-    return S_OK;
-#else
-    // ICorDebugDataTarget::GetThreadContext() and ICorDebugDataTarget::SetThreadContext() are currently only 
-    // required for interop-debugging and inspection of floating point registers, both of which are not 
-    // implemented on Mac.
-    _ASSERTE(!"The remote data target doesn't know how to get a thread's CONTEXT.");
+    ZeroMemory(pContext, contextSize);
     return E_NOTIMPL;
-#endif  // DFEATURE_DBGIPC_TRANSPORT_DI
 }
 
 // impl of interface method ICorDebugMutableDataTarget::SetThreadContext

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -531,6 +531,12 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
   #define FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END    DEBUG_OK_TO_RETURN_END(LAZYMACHSTATE)
 #endif
 
+#ifdef FEATURE_PAL
+#define PAL_ONLY(x) x
+#else
+#define PAL_ONLY(x)
+#endif
+
 // BEGIN: before gcpoll
 //FCallGCCanTriggerNoDtor __fcallGcCanTrigger;        
 //__fcallGcCanTrigger.Enter();                        
@@ -551,6 +557,10 @@ LPVOID __FCThrowArgument(LPVOID me, enum RuntimeExceptionKind reKind, LPCWSTR ar
             helperFrame;                                        \
             FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_BEGIN;          \
             FORLAZYMACHSTATE(CAPTURE_STATE(__helperframe.MachineState(), ret);) \
+            /* On Unix DAC can't unwind native stack out-of-proc yet */ \
+            /* that's why we have to pre-unwind it in-proc when helper frams is created */ \
+            /* UNIXTODO: Get rid of the next line when DAC native unwind is implemented */ \
+            PAL_ONLY(FORLAZYMACHSTATE(__helperframe.InsureInit(false, NULL);))  \
             FORLAZYMACHSTATE_DEBUG_OK_TO_RETURN_END;            \
             INDEBUG(__helperframe.SetAddrOfHaveCheckedRestoreState(&__haveCheckedRestoreState)); \
             DEBUG_ASSURE_NO_RETURN_BEGIN(HELPER_METHOD_FRAME);  \

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1657,8 +1657,6 @@ void HelperMethodFrame::Push()
     _ASSERTE(GetGSCookiePtr() == (((GSCookie *)(this)) - 1));
     *(((GSCookie *)(this)) - 1) = GetProcessGSCookie();
 
-    _ASSERTE(!m_MachState.isValid());
-
     Thread * pThread = ::GetThread();
     m_pThread = pThread;
 


### PR DESCRIPTION
This change makes it possible for managed debuggers and SOS to obtain a managed stack for threads currently running native code or threads throwing managed exceptions.

Since we don't have a way to do out-of-proc native stackwalk on Linux or Mac, I had to do in-proc one step stackwalk every time HelperMethodFrame is created. Since it introduces a potential performance hit, we'll have to implement native stackwalk for Linux and Mac and remove this eager stackwalk  in the future. 