### PR TITLE
Add mappings for ReadyToRun helpers used by llilc.

### DIFF
--- a/src/inc/readytorun.h
+++ b/src/inc/readytorun.h
@@ -195,6 +195,8 @@ enum ReadyToRunHelper
     READYTORUN_HELPER_Overflow                  = 0x22,
     READYTORUN_HELPER_RngChkFail                = 0x23,
     READYTORUN_HELPER_FailFast                  = 0x24,
+    READYTORUN_HELPER_ThrowNullRef              = 0x25,
+    READYTORUN_HELPER_ThrowDivZero              = 0x26,
 
     // Write barriers
     READYTORUN_HELPER_WriteBarrier              = 0x30,

--- a/src/inc/readytorunhelpers.h
+++ b/src/inc/readytorunhelpers.h
@@ -20,6 +20,8 @@ HELPER(READYTORUN_HELPER_Rethrow,                   CORINFO_HELP_RETHROW,       
 HELPER(READYTORUN_HELPER_Overflow,                  CORINFO_HELP_OVERFLOW,                          OPTIMIZEFORSIZE)
 HELPER(READYTORUN_HELPER_RngChkFail,                CORINFO_HELP_RNGCHKFAIL,                        OPTIMIZEFORSIZE)
 HELPER(READYTORUN_HELPER_FailFast,                  CORINFO_HELP_FAIL_FAST,                         OPTIMIZEFORSIZE)
+HELPER(READYTORUN_HELPER_ThrowNullRef,              CORINFO_HELP_THROWNULLREF,                      OPTIMIZEFORSIZE)
+HELPER(READYTORUN_HELPER_ThrowDivZero,              CORINFO_HELP_THROWDIVZERO,                      OPTIMIZEFORSIZE)
 
 HELPER(READYTORUN_HELPER_WriteBarrier,              CORINFO_HELP_ASSIGN_REF,                        )
 HELPER(READYTORUN_HELPER_CheckedWriteBarrier,       CORINFO_HELP_CHECKED_ASSIGN_REF,                )


### PR DESCRIPTION
Add READYTORUN_HELPER_ThrowNullRef and READYTORUN_HELPER_ThrowDivZero.

Allow ReadyToRun tests to be run with llilc: don't throw exceptions when llilc is enabled.