### PR TITLE
Use Array.Copy in RegistryKey

### DIFF
--- a/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/mscorlib/src/Microsoft/Win32/RegistryKey.cs
@@ -1275,22 +1275,13 @@ namespace Microsoft.Win32 {
 
                                  // make sure the string is null terminated before processing the data
                                  if (blob.Length > 0 && blob[blob.Length - 1] != (char)0) {
-                                     try {
-                                         char[] newBlob = new char[checked(blob.Length + 1)];
-                                         for (int i = 0; i < blob.Length; i++) {
-                                             newBlob[i] = blob[i];
-                                         }
-                                         newBlob[newBlob.Length - 1] = (char)0;
-                                         blob = newBlob;
-                                     }
-                                     catch (OverflowException e) {
-                                         throw new IOException(Environment.GetResourceString("Arg_RegGetOverflowBug"), e);
-                                     }
-                                     blob[blob.Length - 1] = (char)0;
+                                     char[] newBlob = new char[blob.Length + 1];
+                                     Array.Copy(blob, newBlob, blob.Length);
+                                     blob = newBlob;
                                  }
                
 
-                                 IList<String> strings = new List<String>();
+                                 List<String> strings = new List<String>();
                                  int cur = 0;
                                  int len = blob.Length;
 


### PR DESCRIPTION
I found `RegistryKey` in both here and [CoreFX](https://github.com/dotnet/corefx/pull/3115) for some reason, so I'm just submitting PRs to both places.

Regarding the PR: also made a few readability improvements by removing a few redundant checks, e.g. checked addition when we'll run into an OOME long before that.