### PR TITLE
Use Array.Copy in String.Split

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -1139,11 +1139,10 @@ namespace System {
             }
 
             String[] stringArray = splitStrings;
-            if( arrIndex!= maxItems) { 
+            if( arrIndex!= maxItems)
+            {
                 stringArray = new String[arrIndex];
-                for( int j = 0; j < arrIndex; j++) {
-                    stringArray[j] = splitStrings[j];
-                }   
+                Array.Copy(splitStrings, stringArray, arrIndex);
             }
             return stringArray;
         }       


### PR DESCRIPTION
Basically what the title says.

I have quite a few of these branches coming up that say "Use `Array.Copy` in Foo," so I'll try to limit these to 2 a day.