### PR TITLE
Remove FuncEvalHijackPersonalityRoutine for PAL

### DIFF
--- a/src/debug/ee/amd64/dbghelpers.S
+++ b/src/debug/ee/amd64/dbghelpers.S
@@ -7,10 +7,9 @@
 #include "unixasmmacros.inc"
 
 //extern FuncEvalHijackWorker:proc
-//extern FuncEvalHijackPersonalityRoutine:proc
 
 // @dbgtodo- once we port Funceval, use the ExceptionHijack stub instead of this func-eval stub.
-NESTED_ENTRY FuncEvalHijack, _TEXT, FuncEvalHijackPersonalityRoutine
+NESTED_ENTRY FuncEvalHijack, _TEXT, UnhandledExceptionHandlerUnix
         // the stack should be aligned at this point, since we do not call this
         // function explicitly
         alloc_stack 20h
@@ -36,11 +35,10 @@ NESTED_ENTRY FuncEvalHijack, _TEXT, FuncEvalHijackPersonalityRoutine
 NESTED_END FuncEvalHijack, _TEXT
 
 //extern ExceptionHijackWorker:proc
-//extern ExceptionHijackPersonalityRoutine:proc
 
 // This is the general purpose hijacking stub. The DacDbi Hijack primitive will 
 // set up the stack and then set the IP here, and so this just makes the call.
-NESTED_ENTRY ExceptionHijack, _TEXT, NoHandler
+NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
         // the stack should be aligned at this point, since we do not call this
         // function explicitly
         // 

--- a/src/debug/ee/arm/dbghelpers.S
+++ b/src/debug/ee/arm/dbghelpers.S
@@ -15,10 +15,7 @@
 //   r0  : pointer to DebuggerEval object
 //
 
-NESTED_ENTRY FuncEvalHijack, _TEXT, FuncEvalHijackPersonalityRoutine
-
-    // NOTE: FuncEvalHijackPersonalityRoutine is dependent on the stack layout so if
-    //       you change the prolog you will also need to update the personality routine.
+NESTED_ENTRY FuncEvalHijack, _TEXT, UnhandledExceptionHandlerUnix
 
     // push arg to the stack so our personality routine can find it
     // push lr to get good stacktrace in debugger
@@ -48,7 +45,7 @@ NESTED_END FuncEvalHijack, _TEXT
 //   r3 : void* pdata
 //
 
-NESTED_ENTRY ExceptionHijack, _TEXT, ExceptionHijackPersonalityRoutine
+NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
 
     CHECK_STACK_ALIGNMENT
 

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -13482,7 +13482,7 @@ void STDCALL ExceptionHijackWorker(
     // call SetThreadContext on ourself to fix us.
 }
 
-#if defined(WIN64EXCEPTIONS)
+#if defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
 
 #if defined(_TARGET_AMD64_)
 // ----------------------------------------------------------------------------
@@ -13571,7 +13571,7 @@ ExceptionHijackPersonalityRoutine(IN     PEXCEPTION_RECORD   pExceptionRecord
     // exactly the behavior we want.
     return ExceptionCollidedUnwind;
 }
-#endif // WIN64EXCEPTIONS
+#endif // WIN64EXCEPTIONS && !FEATURE_PAL
 
 
 // UEF Prototype from excep.cpp

--- a/src/debug/ee/funceval.cpp
+++ b/src/debug/ee/funceval.cpp
@@ -3954,7 +3954,7 @@ void * STDCALL FuncEvalHijackWorker(DebuggerEval *pDE)
 }
 
 
-#if defined(WIN64EXCEPTIONS)
+#if defined(WIN64EXCEPTIONS) && !defined(FEATURE_PAL)
 
 EXTERN_C EXCEPTION_DISPOSITION
 FuncEvalHijackPersonalityRoutine(IN     PEXCEPTION_RECORD   pExceptionRecord
@@ -3985,6 +3985,6 @@ FuncEvalHijackPersonalityRoutine(IN     PEXCEPTION_RECORD   pExceptionRecord
 }
 
 
-#endif // WIN64EXCEPTIONS
+#endif // WIN64EXCEPTIONS && !FEATURE_PAL
 
 #endif // ifndef DACCESS_COMPILE


### PR DESCRIPTION
The personality routine on Windows is responsible for redirecting exception unwinding
to a different context when function evaluation is injected into a managed thread and
there is an exception that escapes the evaluation. However, the FuncEvalHijackRealWorker
catches all exceptions that happen during the function evaluation, so nothing should
escape.
Moreover, if anything escaped, it would go to the original hijacked code which is not
expected.
So I am replacing the personality routine for PAL with UnhandledExceptionHandlerUnix
to guard against unexpected exception escaping.

I am also setting the same personality routine to the ExceptionHijack function. Some
time ago, it was removed completely there as a temporary fix for a problem with limited
max number of personality routines in single executable. I have looked at it
again and I can see that no exception should escape the ExceptionHijackWorker either and
so the same thing as for FuncEvalHijack applies for ExceptionHijack too.