### PR TITLE
Allow loading assemblies on the TPA list without specifying a version

### DIFF
--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -154,8 +154,7 @@ namespace BINDER_SPACE
         static HRESULT BindByTpaList(/* in */  ApplicationContext  *pApplicationContext,
                                      /* in */  AssemblyName        *pRequestedAssemblyName,
                                      /* in */  BOOL                 fInspectionOnly,
-                                     /* out */ BindResult          *pBindResult,
-                                     /* out */ bool                *pfUnifiedAppAssemblyToPlatform);
+                                     /* out */ BindResult          *pBindResult);
         
         static HRESULT Register(/* in */  ApplicationContext *pApplicationContext,
                                 /* in */  BOOL                fInspectionOnly,


### PR DESCRIPTION
When comparing the bound assembly's version against the requested assembly name, removed the distinction between platform assemblies and app assemblies when the bound assembly is on the TPA list. A requested version of null behaves equivalently to a requested version of 0.0.0.0.

Fix #1477