### PR TITLE
Fix JIT null reference checking for large field accesses on PAL

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -2027,7 +2027,12 @@ enum { LCL_FINALLY_MARK = 0xFC }; // FC = "Finally Call"
 #define CORINFO_PAGE_SIZE   0x1000                           // the page size on the machine
 
 // <TODO>@TODO: put this in the CORINFO_EE_INFO data structure</TODO>
+
+#ifndef FEATURE_PAL
 #define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((32*1024)-1)   // when generating JIT code
+#else // !FEATURE_PAL
+#define MAX_UNCHECKED_OFFSET_FOR_NULL_OBJECT ((OS_PAGE_SIZE / 2) - 1)
+#endif // !FEATURE_PAL
 
 typedef void* CORINFO_MethodPtr;            // a generic method pointer
 


### PR DESCRIPTION
The JIT needs to do explicit null checks for large field accesses if such an access might exceed the unmapped zero page in the OS. On Windows, that means fields over 32KB. On PAL platforms, we use 1/2 the OS page size. As far as I can tell, the reason we use 1/2 the known unmapped page size is for "defense in depth", in case we get it wrong somehow.
