### PR TITLE
Replace 'long' by 'int' to avoid bug on Linux

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -11076,7 +11076,7 @@ T GetSignedMagicNumberForDivide(T denom, int *shift /*out*/)
     int iters = 0;
 
     absDenom = abs(denom);
-    t = two_nminus1 + ((unsigned long)denom >> 31);
+    t = two_nminus1 + ((unsigned int)denom >> 31);
     absNc = t - 1 - (t % absDenom);     // absolute value of nc
     p = bits_minus_1;                   // initialize p
     q1 = two_nminus1 / absNc;           // initialize q1 = 2^p / abs(nc)


### PR DESCRIPTION
In GetSignedMagicNumberDivide(), a cast to (unsigned long) was doing a sign extend instead of a zero extend, leading to an apparent infinite loop with test case b147814_il.exe. This change replaces the cast with (unsigned int), which matches Windows behavior.