### PR TITLE
Fix pow1 test to run on Linux

### DIFF
--- a/tests/src/JIT/Directed/intrinsic/pow/pow1.cs
+++ b/tests/src/JIT/Directed/intrinsic/pow/pow1.cs
@@ -16,19 +16,18 @@ internal class pow1
         //Check if the test is being executed on ARM
         bool isProcessorArm = false;
 
+        string processorArchEnvVar = null;
+
 #if CORECLR 
-        if (TestLibrary.Env.GetEnvVariable("PROCESSOR_ARCHITECTURE").Equals(
-                   "ARM", StringComparison.CurrentCultureIgnoreCase))
-        {
-            isProcessorArm = true;
-        }
+        processorArchEnvVar = TestLibrary.Env.GetEnvVariable("PROCESSOR_ARCHITECTURE");
 #else
-        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE").Equals(
-            "ARM", StringComparison.CurrentCultureIgnoreCase))
+        processorArchEnvVar = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+#endif
+
+        if ((processorArchEnvVar != null) && processorArchEnvVar.Equals("ARM", StringComparison.CurrentCultureIgnoreCase))
         {
             isProcessorArm = true;
         }
-#endif
 
         x = 0;
         y = 0;


### PR DESCRIPTION
This test queries PROCESSOR_ARCHITECTURE to see if it is running on ARM. This returns a null string on Linux. So, check for null on continue. If necessary, this could be adjusted later if we need to do something special for non-Windows .NET Core on ARM.