### PR TITLE
Fix TryGetRawMetadata to return false when the assembly is not a Runt…

### DIFF
--- a/src/mscorlib/src/System/Reflection/Metadata/AssemblyExtensions.cs
+++ b/src/mscorlib/src/System/Reflection/Metadata/AssemblyExtensions.cs
@@ -33,7 +33,14 @@ namespace System.Reflection.Metadata
 
             blob = null;
             length = 0;
-            return InternalTryGetRawMetadata((RuntimeAssembly)assembly, ref blob, ref length);
+
+            var runtimeAssembly = assembly as RuntimeAssembly;
+            if (runtimeAssembly == null)
+            {
+                return false;
+            }
+
+            return InternalTryGetRawMetadata(runtimeAssembly, ref blob, ref length);
         }
     }
 }


### PR DESCRIPTION
…imeAssembly

As mentioned in the issue, it should return false for AssemblyBuilder.

Related to dotnet/corefx#2768