### PR TITLE
Implement NativeCallableMethods for CoreCLR

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -724,6 +724,7 @@ enum CORCOMPILE_FIXUP_BLOB_KIND
     ENCODE_CHECK_FIELD_OFFSET,
 
     ENCODE_DELEGATE_CTOR,
+    ENCODE_METHOD_NATIVE_ENTRY,                     /* NativeCallable method token */
 
     ENCODE_MODULE_HANDLE      = 0x50,               /* Module token */
     ENCODE_STATIC_FIELD_ADDRESS,                    /* For accessing a static field */
@@ -1891,6 +1892,9 @@ class ICorCompileInfo
     // Takes a stub and blits it into the buffer, resetting the reference count
     // to 1 on the clone. The buffer has to be large enough to hold the stub object and the code
     virtual HRESULT GetStubClone(void *pStub, BYTE *pBuffer, DWORD dwBufferSize) = 0;
+
+    // true if the method has [NativeCallableAttribute]
+    virtual BOOL IsNativeCallableMethod(CORINFO_METHOD_HANDLE handle) = 0;
 
 #ifdef CLR_STANDALONE_BINDER
     virtual HRESULT GetMetadataRvaInfo(

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -6083,6 +6083,11 @@
       <Member MemberType="Field" Name="Sequential" />
       <Member MemberType="Field" Name="value__" />
     </Type>
+    <Type Name="System.Runtime.InteropServices.NativeCallableAttribute"> 
+      <Member Name="#ctor" />
+      <Member MemberType="Field" Name="CallingConvention" /> <!-- EE -->
+      <Member MemberType="Field" Name="EntryPoint" /> <!-- EE -->
+    </Type>
     <Type Name="System.Runtime.InteropServices.Marshal">
       <Member MemberType="Field" Name="SystemDefaultCharSize" />
       <Member Name="AddRef(System.IntPtr)" />

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -134,6 +134,7 @@
     <InteropSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\InvalidComObjectException.cs" />
     <InteropSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\SafeArrayRankMismatchException.cs" />
     <InteropSources Include="$(BclSourcesRoot)\System\Runtime\InteropServices\SafeArrayTypeMismatchException.cs" />
+    <InteropSources Condition="'$(FeatureCoreClr)'=='true'"  Include="$(BclSourcesRoot)\System\Runtime\InteropServices\NativeCallableAttribute.cs" />
     <InteropSources Condition="'$(FeatureCominterop)' != 'true'" Include="$(BclSourcesRoot)\System\Runtime\InteropServices\NonPortable.cs" />
     <InteropSources Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\System\Runtime\InteropServices\DispatchWrapper.cs" />
     <InteropSources Condition="'$(FeatureCominterop)' == 'true'" Include="$(BclSourcesRoot)\System\Runtime\InteropServices\ExtensibleClassFactory.cs" />

--- a/src/mscorlib/src/System/Runtime/InteropServices/NativeCallableAttribute.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/NativeCallableAttribute.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*=============================================================================
+** Any method marked with NativeCallableAttribute can be directly called from 
+** native code.The function token can be loaded to a local variable using LDFTN and
+** passed as a callback to native method.
+=============================================================================*/
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Runtime.InteropServices
+{
+
+    [AttributeUsage(AttributeTargets.Method)]
+    public sealed class NativeCallableAttribute : Attribute
+    {
+        public NativeCallableAttribute()
+        {
+        }
+        // Optional. If omitted , compiler will choose one for you.
+        public CallingConvention CallingConvention;
+        // Optional. If omitted, then the method is native callable, but no EAT is emitted.
+        public string EntryPoint;
+    }
+}

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -1439,6 +1439,11 @@ NotSupported_CollectibleCOM = COM Interop is not supported for collectible types
 NotSupported_CollectibleAssemblyResolve = Resolving to a collectible assembly is not supported.
 NotSupported_CollectibleBoundNonCollectible = A non-collectible assembly may not reference a collectible assembly.
 NotSupported_CollectibleDelegateMarshal = Delegate marshaling for types within collectible assemblies is not supported.
+NotSupported_NonStaticMethod = Non-static methods with NativeCallableAttribute are not supported.
+NotSupported_NativeCallableTarget = Methods with NativeCallableAttribute cannot be used as delegate target.
+NotSupported_GenericMethod = Generic methods with NativeCallableAttribute are not supported.
+NotSupported_NonBlittableTypes = Non-blittable parameter types are not supported for NativeCallable methods.
+
 #if FEATURE_WINDOWSPHONE
 NotSupported_UserDllImport = DllImport cannot be used on user-defined methods.
 NotSupported_UserCOM = COM Interop is not supported for user-defined types.

--- a/src/vm/amd64/umthunkstub.S
+++ b/src/vm/amd64/umthunkstub.S
@@ -85,6 +85,10 @@ LOCAL_LABEL(HaveThread):
 
         mov             r12, rax                // r12 <- Thread*
 
+        //FailFast if a native callable method invoked via ldftn and calli.
+        cmp             dword ptr [r12 + OFFSETOF__Thread__m_fPreemptiveGCDisabled], 1
+        jz              LOCAL_LABEL(InvalidTransition)
+
         //
         // disable preemptive GC
         //
@@ -153,6 +157,10 @@ LOCAL_LABEL(DoThreadSetup):
         call            C_FUNC(CreateThreadBlockThrow)
         jmp             LOCAL_LABEL(HaveThread)
         
+LOCAL_LABEL(InvalidTransition):
+        //No arguments to setup , ReversePInvokeBadTransition will failfast
+        call            C_FUNC(ReversePInvokeBadTransition)
+
 LOCAL_LABEL(DoTrapReturningThreadsTHROW):
         mov             rdi, r12                                                                        // Thread* pThread
         mov             rsi, [rbp - UMThunkStubAMD64_RBP_OFFSET + UMThunkStubAMD64_METHODDESC_OFFSET]   // UMEntryThunk* pUMEntry

--- a/src/vm/classnames.h
+++ b/src/vm/classnames.h
@@ -150,6 +150,7 @@
 #define g_CompilerServicesUnsafeValueTypeAttribute "System.Runtime.CompilerServices.UnsafeValueTypeAttribute"
 #define g_UnmanagedFunctionPointerAttribute "System.Runtime.InteropServices.UnmanagedFunctionPointerAttribute"
 #define g_DefaultDllImportSearchPathsAttribute "System.Runtime.InteropServices.DefaultDllImportSearchPathsAttribute"
+#define g_NativeCallableAttribute "System.Runtime.InteropServices.NativeCallableAttribute"
 
 #define g_CompilerServicesTypeDependencyAttribute "System.Runtime.CompilerServices.TypeDependencyAttribute"
 

--- a/src/vm/comdelegate.h
+++ b/src/vm/comdelegate.h
@@ -79,6 +79,10 @@ public:
 
     // Marshals a delegate to a unmanaged callback.
     static LPVOID ConvertToCallback(OBJECTREF pDelegate);
+    
+    // Marshals a managed method to an unmanaged callback , provided the method is static and uses only 
+    // blittable parameter types.
+    static PCODE ConvertToCallback(MethodDesc* pMD);
 
     // Marshals an unmanaged callback to Delegate
     static OBJECTREF ConvertToDelegate(LPVOID pCallback, MethodTable* pMT);

--- a/src/vm/compile.h
+++ b/src/vm/compile.h
@@ -330,6 +330,8 @@ class CEECompileInfo : public ICorCompileInfo
     BOOL IsEmptyString(mdString token,
                        CORINFO_MODULE_HANDLE module);
 
+    BOOL IsNativeCallableMethod(CORINFO_METHOD_HANDLE handle);
+
     BOOL IsCachingOfInliningHintsEnabled()
     {
         return m_fCachingOfInliningHintsEnabled;

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -1088,6 +1088,19 @@ UMEntryThunk *UMEntryThunkCache::GetUMEntryThunk(MethodDesc *pMD)
     RETURN pThunk;
 }
 
+// FailFast if a native callable method invoked directly from managed code.
+// UMThunkStub.asm check the mode and call this function to failfast.
+extern "C" VOID STDCALL ReversePInvokeBadTransition()
+{
+    STATIC_CONTRACT_THROWS;
+    STATIC_CONTRACT_GC_TRIGGERS;
+    // Fail 
+    EEPOLICY_HANDLE_FATAL_ERROR_WITH_MESSAGE(
+                                             COR_E_EXECUTIONENGINE,
+                                             W("Invalid Program: attempted to call a NativeCallable method from runtime-typesafe code.")
+                                            );
+}
+
 // Disable from a place that is calling into managed code via a UMEntryThunk.
 extern "C" VOID STDCALL UMThunkStubRareDisableWorker(Thread *pThread, UMEntryThunk *pUMEntryThunk)
 {

--- a/src/vm/dllimportcallback.h
+++ b/src/vm/dllimportcallback.h
@@ -162,6 +162,12 @@ public:
 
         return (CorPinvokeMap)m_callConv;
     }
+
+    VOID SetCallingConvention(const CorPinvokeMap callConv)
+    {
+        m_callConv = (UINT16)callConv;
+    }
+
 #else
     PCODE GetExecStubEntryPoint();
 #endif

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -5374,6 +5374,33 @@ void MethodDesc::ComputeSuppressUnmanagedCodeAccessAttr(IMDInternalImport *pImpo
 }
 
 //*******************************************************************************
+BOOL MethodDesc::HasNativeCallableAttribute()
+{
+
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        FORBID_FAULT;
+    }
+    CONTRACTL_END;
+
+// enable only for amd64 now, other platforms are not tested.
+#if defined(_TARGET_AMD64_) 
+
+#ifdef FEATURE_CORECLR
+    HRESULT hr = GetMDImport()->GetCustomAttributeByName(GetMemberDef(),
+        g_NativeCallableAttribute,
+        NULL,
+        NULL);
+    return (hr == S_OK);
+#endif //FEATURE_CORECLR
+
+#endif //_TARGET_AMD64_
+    return FALSE;
+}
+
+//*******************************************************************************
 BOOL MethodDesc::HasSuppressUnmanagedCodeAccessAttr()
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/vm/method.hpp
+++ b/src/vm/method.hpp
@@ -720,6 +720,7 @@ public:
 
     void ComputeSuppressUnmanagedCodeAccessAttr(IMDInternalImport *pImport);
     BOOL HasSuppressUnmanagedCodeAccessAttr();
+    BOOL HasNativeCallableAttribute();
 
 #ifdef FEATURE_COMINTEROP 
     inline DWORD IsComPlusCall()

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -1287,10 +1287,18 @@ public:
         if (token != mdTokenNil)
         {
             _ASSERTE(TypeFromToken(token) == mdtMethodDef || TypeFromToken(token) == mdtMemberRef);
-
-            pTable->EncodeModule(
-                (TypeFromToken(token) == mdtMethodDef) ? ENCODE_METHOD_ENTRY_DEF_TOKEN : ENCODE_METHOD_ENTRY_REF_TOKEN,
-                referencingModule, pSigBuilder);
+            
+            // It's a NativeCallable method , then encode it as ENCODE_METHOD_NATIVE_ENTRY
+            if (pTable->GetCompileInfo()->IsNativeCallableMethod(handle))
+            {
+                pTable->EncodeModule(ENCODE_METHOD_NATIVE_ENTRY, referencingModule, pSigBuilder);
+            }
+            else
+            {
+                pTable->EncodeModule(
+                    (TypeFromToken(token) == mdtMethodDef) ? ENCODE_METHOD_ENTRY_DEF_TOKEN : ENCODE_METHOD_ENTRY_REF_TOKEN,
+                    referencingModule, pSigBuilder);
+            }
 
             pSigBuilder->AppendData(RidFromToken(token));
         }

--- a/tests/src/Interop/NativeCallable/NativeCallableTest.cs
+++ b/tests/src/Interop/NativeCallable/NativeCallableTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+public class Program
+{
+    public static class NativeMethods
+    {
+        [DllImport("user32.dll")]
+        public static extern int EnumWindows(IntPtr enumProc, IntPtr lParam);
+    }
+
+    private delegate void NativeMethodInvoker();
+    static EventWaitHandle waitHandle = new AutoResetEvent(false);
+
+    public static int Main()
+    {
+        //NegativeTest_NonBlittable();
+        TestNativeCallableValid();
+        //NegativeTest_ViaDelegate();
+        //NegativeTest_ViaLdftn();
+        return 100;
+    }
+
+    public static void TestNativeCallableValid()
+    {
+        /*
+           void TestNativeCallable()
+           {
+                   .locals init ([0] native int ptr)
+                   IL_0000:  nop  
+                   IL_0002:  ldftn      int32 CallbackMethod(native int,native int)
+
+                   IL_0012:  stloc.0
+                   IL_0013:  ldloc.0
+                   IL_0014:  ldsfld     native int [mscorlib]System.IntPtr::Zero
+                   IL_0019:  call       bool NativeMethods::EnumWindows(native int,
+                                                                                      native int)
+                   IL_001e:  pop
+                   IL_001f:  ret
+             }
+           */
+        DynamicMethod testNativeCallable = new DynamicMethod("TestNativeCallable", null, null, typeof(Program).Module);
+        ILGenerator il = testNativeCallable.GetILGenerator();
+        il.DeclareLocal(typeof(IntPtr));
+        il.Emit(OpCodes.Nop);
+        il.Emit(OpCodes.Ldftn, typeof(Program).GetMethod("CallbackMethod"));
+        il.Emit(OpCodes.Stloc_0);
+        il.Emit(OpCodes.Ldloc_0);
+        il.Emit(OpCodes.Ldsfld, typeof(IntPtr).GetField("Zero"));
+        il.Emit(OpCodes.Call, typeof(NativeMethods).GetMethod("EnumWindows"));
+        il.Emit(OpCodes.Pop);
+        il.Emit(OpCodes.Ret);
+        NativeMethodInvoker testNativeMethod = (NativeMethodInvoker)testNativeCallable.CreateDelegate(typeof(NativeMethodInvoker));
+        testNativeMethod();
+    }
+
+    public static void NegativeTest_ViaDelegate()
+    {
+        // Try invoking method directly 
+        try
+        {
+            Func<IntPtr, IntPtr, int> invoker = CallbackMethod;
+            invoker(IntPtr.Zero, IntPtr.Zero);
+        }
+        catch (Exception)
+        {
+
+        }
+    }
+
+    public static void NegativeTest_NonBlittable()
+    {
+        // Try invoking method directly 
+        try
+        {
+            Func<bool, int> invoker = CallbackMethodNonBlitabble;
+            invoker(true);
+        }
+        catch (Exception)
+        {
+            Console.WriteLine(":bla");
+        }
+    }
+
+
+    public static void NegativeTest_ViaLdftn()
+    {
+        /*
+           .locals init (native int V_0)
+           IL_0000:  nop
+           IL_0001:  ldftn      void ConsoleApplication1.Program::callback(int32)
+           IL_0007:  stloc.0
+           IL_0008:  ldc.i4.s   12
+           IL_000a:  ldloc.0
+           IL_000b:  calli      void(int32)
+           IL_0010:  nop
+           IL_0011:  ret
+       */
+        DynamicMethod testNativeCallable = new DynamicMethod("TestNativeCallableLdftn", null, null, typeof(Program).Module);
+        ILGenerator il = testNativeCallable.GetILGenerator();
+        il.DeclareLocal(typeof(IntPtr));
+        il.Emit(OpCodes.Nop);
+        il.Emit(OpCodes.Ldftn, typeof(Program).GetMethod("LdftnCallback"));
+        il.Emit(OpCodes.Stloc_0);
+        il.Emit(OpCodes.Ldc_I4,12);
+        il.Emit(OpCodes.Ldloc_0);
+
+        SignatureHelper sig =  SignatureHelper.GetMethodSigHelper(typeof(Program).Module, null, new Type[] { typeof(int) });
+        sig.AddArgument(typeof(int));
+
+        // il.EmitCalli is not available  and the below is not correct
+        il.Emit(OpCodes.Calli,sig);
+        il.Emit(OpCodes.Nop);
+        il.Emit(OpCodes.Ret);
+
+        NativeMethodInvoker testNativeMethod = (NativeMethodInvoker)testNativeCallable.CreateDelegate(typeof(NativeMethodInvoker));
+        testNativeMethod();
+
+    }
+
+    #region callbacks
+    [NativeCallable]
+    public static void LdftnCallback(int val)
+    {
+    }
+
+    [NativeCallable]
+    public static int CallbackMethod(IntPtr hWnd, IntPtr lParam)
+    {
+        waitHandle.Set();
+        return 1;
+    }
+
+    [NativeCallable]
+    public static int CallbackMethodGeneric<T>(IntPtr hWnd, IntPtr lParam)
+    {
+        return 1;
+    }
+
+    [NativeCallable]
+    public static int CallbackMethodNonBlitabble(bool x1)
+    {
+        return 1;
+    }
+    #endregion //callbacks
+
+}

--- a/tests/src/Interop/NativeCallable/NativeCallableTest.csproj
+++ b/tests/src/Interop/NativeCallable/NativeCallableTest.csproj
@@ -1,0 +1,41 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>NativeCallableTest</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
+    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="NativeCallableTest.cs" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/Interop/NativeCallable/app.config
+++ b/tests/src/Interop/NativeCallable/app.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/Interop/NativeCallable/project.json
+++ b/tests/src/Interop/NativeCallable/project.json
@@ -1,0 +1,7 @@
+﻿{
+  "dependencies": {
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/tests/src/Interop/NativeCallable/project.lock.json
+++ b/tests/src/Interop/NativeCallable/project.lock.json
@@ -1,0 +1,12 @@
+{
+  "locked": true,
+  "version": -9996,
+  "targets": {
+    "DNXCore,Version=v5.0": {}
+  },
+  "libraries": {},
+  "projectFileDependencyGroups": {
+    "": [],
+    "DNXCore,Version=v5.0": []
+  }
+}


### PR DESCRIPTION
Feature Description
--------------------------
 
Apply [NativeCallable] attribute to a managed method and then it can be called from native code.Typical use would be passing a managed method as callback to native , now it can be done by wrapping the method in a delegate or directly using Marshal.GetFunctionPointerForDelegate.This's fine as long as we  make sure that  delegate is not garbage  collected. 

[NativeCallable] introduce another way , where you can directly load the function pointer of a native callable method  and use it as  callback.This feature cannot be directly used from C# , but can be very useful in dynamic code generation scenarios where you want a callback to be passed to native.

Usage
---------

Here's an example of how it can be used.
  public static class NativeMethods
    {
        [DllImport("user32.dll")]
        public static extern int EnumWindows(IntPtr enumProc, IntPtr lParam);
    }

// Native callable callback method
 [NativeCallable]
 public static int CallbackMethod(IntPtr hWnd, IntPtr lParam)
  {
     return 1;
  }
Now you can generate the below IL to load native callable function pointer ( LDFTN) and then pass it a native method.  

                   .locals init ([0] native int ptr)
                   IL_0000:  nop  
                   IL_0001:  ldftn      int32 CallbackMethod(native int,native int)
                   IL_0002:  stloc.0
                   IL_0003:  ldloc.0
                   IL_0004:  ldsfld     native int [mscorlib]System.IntPtr::Zero
                   IL_0005:  call       bool NativeMethods::EnumWindows(native int,native int)                                                                                  
                   IL_0006:  pop
                   IL_0007:  ret

Implementation
---------------------
During JIT we treat method with [NativeCallable] attribute as special and create a reverse  PInvoke thunk for it. Essentially it takes the same code path as reverse pinvoke.  
 
Advantages and Limitations
------------------------------------

Advantages of this method are , you don't have to create delegate matching the callback , and also you don't have to keep track of the delegates to  make sure they are not collected.

Currently we require the native callable method to be 
1.Static , Non Generic and no variable number of arguments.
2.Uses only blittable parameter types.
