### PR TITLE
Changes to heap allocation in PAL

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3870,14 +3870,6 @@ HeapCreate(
 	       IN SIZE_T dwMaximumSize);
 
 PALIMPORT
-SIZE_T
-PALAPI
-HeapSize(
-    HANDLE hHeap,
-    DWORD dwFlags,
-    LPCVOID lpMem);
-
-PALIMPORT
 LPVOID
 PALAPI
 HeapAlloc(

--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -26,7 +26,6 @@ Revision History:
 #include "pal/handlemgr.hpp"
 #include "pal/corunix.hpp"
 #include <errno.h>
-#define HEAP_SIZEINFO_SIZE (2 * sizeof(DWORD))
 using namespace CorUnix;
 
 SET_DEFAULT_DEBUG_CHANNEL(MEM);
@@ -36,11 +35,9 @@ SET_DEFAULT_DEBUG_CHANNEL(MEM);
 // should be placed after the SET_DEFAULT_DEBUG_CHANNEL(MEM)
 #include <safemath.h>
 
-#define HEAP_MAGIC 0xEAFDC9BB
 #ifndef __APPLE__
 #define DUMMY_HEAP 0x01020304
 #endif // __APPLE__
-
 
 #ifdef __APPLE__
 #define CACHE_HEAP_ZONE
@@ -192,33 +189,6 @@ GetProcessHeap(
 
 /*++
 Function:
-HeapSize
-
-See MSDN doc.
---*/
-SIZE_T
-PALAPI
-HeapSize(
-    HANDLE hHeap,
-    DWORD dwFlags,
-    LPCVOID lpMem)
-{
-    SIZE_T ret = (SIZE_T)-1;
-    PERF_ENTRY(HeapSize);
-    ENTRY("HeapSize(hHeap=%p, dwFlags=%#x, lpMem=%p)\n",
-            hHeap, dwFlags, lpMem);
-
-    // First four bytes contain magic
-    // Second four bytes size.
-    ret = ((DWORD *)(static_cast<LPCBYTE>(lpMem) - HEAP_SIZEINFO_SIZE))[1];
-
-    LOGEXIT("HeapSize returning %d\n", ret);
-    PERF_EXIT(HeapSize);
-    return ret;
-}
-
-/*++
-Function:
   HeapAlloc
 
 Abstract
@@ -229,9 +199,9 @@ See MSDN doc.
 LPVOID
 PALAPI
 HeapAlloc(
-	  IN HANDLE hHeap,
-	  IN DWORD dwFlags,
-	  IN SIZE_T dwBytes)
+    IN HANDLE hHeap,
+    IN DWORD dwFlags,
+    IN SIZE_T dwBytes)
 {
     BYTE *pMem;
 
@@ -261,26 +231,16 @@ HeapAlloc(
         return NULL;
     }
 
-    
-    size_t fullsize;
-    if (!ClrSafeInt<size_t>::addition(dwBytes, HEAP_SIZEINFO_SIZE,fullsize))
-    {
-        ERROR("Integer Overflow\n");
-        SetLastError(ERROR_ARITHMETIC_OVERFLOW);
-        LOGEXIT("HeapAlloc returning NULL\n");
-        PERF_EXIT(HeapAlloc);
-        return NULL;
-    }
 #ifdef __APPLE__
     // This is patterned off of InternalMalloc in malloc.cpp.
     {
         CPalThread *pthrCurrent = InternalGetCurrentThread();
         pthrCurrent->suspensionInfo.EnterUnsafeRegion();
-        pMem = (BYTE *)malloc_zone_malloc((malloc_zone_t *)hHeap, fullsize);
+        pMem = (BYTE *)malloc_zone_malloc((malloc_zone_t *)hHeap, dwBytes);
         pthrCurrent->suspensionInfo.LeaveUnsafeRegion();
     }
 #else // __APPLE__
-    pMem = (BYTE *) PAL_malloc(fullsize);
+    pMem = (BYTE *) PAL_malloc(dwBytes);
 #endif // __APPLE__ else
 
     if (pMem == NULL)
@@ -292,20 +252,15 @@ HeapAlloc(
         return NULL;
     }
 
-    /* use a magic number, to know it has been allocated with HeapAlloc
-       when doing HeapFree */
-    ((DWORD *) pMem)[0] = HEAP_MAGIC;
-    /* Store the size in the second word */
-    ((DWORD *)pMem)[1] = dwBytes;
-
-    /*If the Heap Zero memory flag is set initialize to zero*/
+    /* If the HEAP_ZERO_MEMORY flag is set initialize to zero */
     if (dwFlags == HEAP_ZERO_MEMORY)
     {
-        memset(pMem+ HEAP_SIZEINFO_SIZE, 0, dwBytes);
+        memset(pMem, 0, dwBytes);
     }
-    LOGEXIT("HeapAlloc returning LPVOID %p\n", pMem + HEAP_SIZEINFO_SIZE);
+
+    LOGEXIT("HeapAlloc returning LPVOID %p\n", pMem);
     PERF_EXIT(HeapAlloc);
-    return (pMem + HEAP_SIZEINFO_SIZE);
+    return (pMem);
 }
 
 
@@ -321,9 +276,9 @@ See MSDN doc.
 BOOL
 PALAPI
 HeapFree(
-	 IN HANDLE hHeap,
-	 IN DWORD dwFlags,
-	 IN LPVOID lpMem)
+    IN HANDLE hHeap,
+    IN DWORD dwFlags,
+    IN LPVOID lpMem)
 {
     BOOL bRetVal = FALSE;
 
@@ -349,23 +304,12 @@ HeapFree(
         goto done;
     }
 
-    if ( !lpMem )
+    if (!lpMem)
     {
         bRetVal = TRUE;
         goto done;
     }
-    /*HEAP_SIZEINFO_SIZE + nMemAlloc is the size of Magic Number plus
-     *size of the int to store value of Memory allocated */
-	lpMem = static_cast<LPVOID>(static_cast<LPBYTE>(lpMem) - HEAP_SIZEINFO_SIZE);
-    
-    /* check if the memory has been allocated by HeapAlloc */
-    if (*((DWORD *) lpMem) != HEAP_MAGIC)
-    {
-        ERROR("Pointer hasn't been allocated with HeapAlloc (%p)\n",
-            static_cast<LPBYTE>(lpMem) + HEAP_SIZEINFO_SIZE);
-        SetLastError(ERROR_INVALID_PARAMETER);
-        goto done;
-    }
+
     *((DWORD *) lpMem) = 0;
 
     bRetVal = TRUE;
@@ -400,10 +344,10 @@ See MSDN doc.
 LPVOID
 PALAPI
 HeapReAlloc(
-	  IN HANDLE hHeap,
-	  IN DWORD dwFlags,
-	  IN LPVOID lpmem,
-	  IN SIZE_T dwBytes)
+    IN HANDLE hHeap,
+    IN DWORD dwFlags,
+    IN LPVOID lpmem,
+    IN SIZE_T dwBytes)
 {
     BYTE *pMem = NULL;
 
@@ -414,7 +358,7 @@ HeapReAlloc(
 #ifdef __APPLE__
     if (hHeap == NULL)
 #else // __APPLE__
-    if (hHeap != (HANDLE) DUMMY_HEAP)
+    if (hHeap != (HANDLE)DUMMY_HEAP)
 #endif // __APPLE__ else
     {
         ASSERT("Invalid heap handle\n");
@@ -438,38 +382,16 @@ HeapReAlloc(
         goto done;
     }
 
-   /*HEAP_SIZEINFO_SIZE + nMemAlloc is the size of Magic Number plus
-     *size of the int to store value of Memory allocated */
-   lpmem = static_cast<LPVOID>(static_cast<LPBYTE>(lpmem) - HEAP_SIZEINFO_SIZE);
-
-    /* check if the memory has been allocated by HeapAlloc */
-    if (*((DWORD *) lpmem) != HEAP_MAGIC)
-    {
-        ERROR("Pointer hasn't been allocated with HeapAlloc (%p)\n",
-            static_cast<LPBYTE>(lpmem) + HEAP_SIZEINFO_SIZE);
-        SetLastError(ERROR_INVALID_PARAMETER);
-        goto done;
-    }
-
-
-    size_t fullsize;
-    if (!ClrSafeInt<size_t>::addition(dwBytes, HEAP_SIZEINFO_SIZE, fullsize))
-    {
-        ERROR("Integer Overflow\n");
-        SetLastError(ERROR_ARITHMETIC_OVERFLOW);
-        goto done;
-    }
-
 #ifdef __APPLE__
     // This is patterned off of InternalRealloc in malloc.cpp.
     {
         CPalThread *pthrCurrent = InternalGetCurrentThread();
         pthrCurrent->suspensionInfo.EnterUnsafeRegion();
-        pMem = (BYTE *) malloc_zone_realloc((malloc_zone_t *)hHeap, lpmem, fullsize);
+        pMem = (BYTE *) malloc_zone_realloc((malloc_zone_t *)hHeap, lpmem, dwBytes);
         pthrCurrent->suspensionInfo.LeaveUnsafeRegion();
     }
 #else // __APPLE__
-    pMem = (BYTE *) PAL_realloc(lpmem,fullsize);
+    pMem = (BYTE *) PAL_realloc(lpmem, dwBytes);
 #endif // __APPLE__ else
 
     if (pMem == NULL)
@@ -479,14 +401,10 @@ HeapReAlloc(
         goto done;
     }
 
-    /* use a magic number, to know it has been allocated with HeapAlloc
-       when doing HeapFree */
-    *((DWORD *) pMem) = HEAP_MAGIC;
-
 done:
-    LOGEXIT("HeapReAlloc returns LPVOID %p\n", pMem ? (pMem + HEAP_SIZEINFO_SIZE) : pMem);
+    LOGEXIT("HeapReAlloc returns LPVOID %p\n", pMem);
     PERF_EXIT(HeapReAlloc);
-    return pMem ? (pMem + HEAP_SIZEINFO_SIZE) : pMem;
+    return pMem;
 }
 
 BOOL

--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -201,13 +201,13 @@ PALAPI
 HeapAlloc(
     IN HANDLE hHeap,
     IN DWORD dwFlags,
-    IN SIZE_T dwBytes)
+    IN SIZE_T numberOfBytes)
 {
     BYTE *pMem;
 
     PERF_ENTRY(HeapAlloc);
-    ENTRY("HeapAlloc (hHeap=%p, dwFlags=%#x, dwBytes=%u)\n",
-          hHeap, dwFlags, dwBytes);
+    ENTRY("HeapAlloc (hHeap=%p, dwFlags=%#x, numberOfBytes=%u)\n",
+          hHeap, dwFlags, numberOfBytes);
 
 #ifdef __APPLE__
     if (hHeap == NULL)
@@ -236,11 +236,11 @@ HeapAlloc(
     {
         CPalThread *pthrCurrent = InternalGetCurrentThread();
         pthrCurrent->suspensionInfo.EnterUnsafeRegion();
-        pMem = (BYTE *)malloc_zone_malloc((malloc_zone_t *)hHeap, dwBytes);
+        pMem = (BYTE *)malloc_zone_malloc((malloc_zone_t *)hHeap, numberOfBytes);
         pthrCurrent->suspensionInfo.LeaveUnsafeRegion();
     }
 #else // __APPLE__
-    pMem = (BYTE *) PAL_malloc(dwBytes);
+    pMem = (BYTE *) PAL_malloc(numberOfBytes);
 #endif // __APPLE__ else
 
     if (pMem == NULL)
@@ -255,7 +255,7 @@ HeapAlloc(
     /* If the HEAP_ZERO_MEMORY flag is set initialize to zero */
     if (dwFlags == HEAP_ZERO_MEMORY)
     {
-        memset(pMem, 0, dwBytes);
+        memset(pMem, 0, numberOfBytes);
     }
 
     LOGEXIT("HeapAlloc returning LPVOID %p\n", pMem);
@@ -347,13 +347,13 @@ HeapReAlloc(
     IN HANDLE hHeap,
     IN DWORD dwFlags,
     IN LPVOID lpmem,
-    IN SIZE_T dwBytes)
+    IN SIZE_T numberOfBytes)
 {
     BYTE *pMem = NULL;
 
     PERF_ENTRY(HeapReAlloc);
-    ENTRY("HeapReAlloc (hHeap=%p, dwFlags=%#x, lpmem=%p, dwBytes=%u)\n",
-          hHeap, dwFlags, lpmem, dwBytes);
+    ENTRY("HeapReAlloc (hHeap=%p, dwFlags=%#x, lpmem=%p, numberOfBytes=%u)\n",
+          hHeap, dwFlags, lpmem, numberOfBytes);
 
 #ifdef __APPLE__
     if (hHeap == NULL)
@@ -387,11 +387,11 @@ HeapReAlloc(
     {
         CPalThread *pthrCurrent = InternalGetCurrentThread();
         pthrCurrent->suspensionInfo.EnterUnsafeRegion();
-        pMem = (BYTE *) malloc_zone_realloc((malloc_zone_t *)hHeap, lpmem, dwBytes);
+        pMem = (BYTE *) malloc_zone_realloc((malloc_zone_t *)hHeap, lpmem, numberOfBytes);
         pthrCurrent->suspensionInfo.LeaveUnsafeRegion();
     }
 #else // __APPLE__
-    pMem = (BYTE *) PAL_realloc(lpmem, dwBytes);
+    pMem = (BYTE *) PAL_realloc(lpmem, numberOfBytes);
 #endif // __APPLE__ else
 
     if (pMem == NULL)


### PR DESCRIPTION
The current scheme for allocating memory in HeapAlloc involves malloc’ing more space than we really need and adding some metadata (a magic number and a size) in front of the actual data, and returning a pointer to the location in the allocated chunk that points to the beginning of the “real” data. One of the implications of this is that all users either have to have special knowledge of this allocation scheme or have to call the PAL free when they need to free this memory. This is not feasible in scenarios like reverse PInvoke where a user’s native code can get a pointer to memory allocated by a managed function and try to free it.

This change solves this problem by removing the magic number and size information from the beginning of the allocated memory range and returning a proper pointer to the beginning of the allocated memory. One implication of this was the need to remove the HeapSize API from PAL, which was relying on the size information being present.