### PR TITLE
Fix some frequently failing PAL tests

### DIFF
--- a/src/pal/tests/palsuite/file_io/GetFileAttributesA/test1/GetFileAttributesA.c
+++ b/src/pal/tests/palsuite/file_io/GetFileAttributesA/test1/GetFileAttributesA.c
@@ -68,7 +68,7 @@ BOOL CleanUpFiles()
             if(!SetFileAttributesA (gfaTestsFile[i].name, FILE_ATTRIBUTE_NORMAL))
             {
                 result = FALSE;
-                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsFile[i].name, FILE_ATTRIBUTE_NORMAL); 
+                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsFile[i].name, FILE_ATTRIBUTE_NORMAL); 
             } 
 
             if(!DeleteFileA (gfaTestsFile[i].name))
@@ -104,7 +104,7 @@ BOOL SetUpFiles()
         if(!SetFileAttributesA (gfaTestsFile[i].name, gfaTestsFile[i].expectedAttribs))
         {
             result = FALSE;
-            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsFile[i].name, gfaTestsFile[i].expectedAttribs); 
+            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsFile[i].name, gfaTestsFile[i].expectedAttribs); 
         } 
     }
 
@@ -126,7 +126,7 @@ BOOL CleanUpDirs()
             if(!SetFileAttributesA (gfaTestsDir[i].name, FILE_ATTRIBUTE_DIRECTORY))
             {
                 result = FALSE;
-                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, (FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_DIRECTORY)); 
+                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsDir[i].name, (FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_DIRECTORY)); 
             } 
 
             if(!RemoveDirectoryA (gfaTestsDir[i].name))
@@ -160,14 +160,14 @@ BOOL SetUpDirs()
         if(!SetFileAttributesA (gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs))
         {
             result = FALSE;
-            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
+            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
         } 
 
         ret = GetFileAttributesA (gfaTestsDir[i].name);
         if(ret != gfaTestsDir[i].expectedAttribs)
         {
             result = FALSE;
-            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
+            Trace("ERROR: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
         } 
         //Trace("Setup Dir setting attr [%d], returned [%d]\n", gfaTestsDir[i].expectedAttribs, ret);
 

--- a/src/pal/tests/palsuite/file_io/GetFileAttributesW/test1/GetFileAttributesW.c
+++ b/src/pal/tests/palsuite/file_io/GetFileAttributesW/test1/GetFileAttributesW.c
@@ -68,7 +68,7 @@ BOOL CleanUpFiles()
             if(!SetFileAttributesA (gfaTestsFile[i].name, FILE_ATTRIBUTE_NORMAL))
             {
                 result = FALSE;
-                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsFile[i].name, FILE_ATTRIBUTE_NORMAL); 
+                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsFile[i].name, FILE_ATTRIBUTE_NORMAL); 
             } 
 
             if(!DeleteFileA (gfaTestsFile[i].name))
@@ -104,7 +104,7 @@ BOOL SetUpFiles()
         if(!SetFileAttributesA (gfaTestsFile[i].name, gfaTestsFile[i].expectedAttribs))
         {
             result = FALSE;
-            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsFile[i].name, gfaTestsFile[i].expectedAttribs); 
+            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsFile[i].name, gfaTestsFile[i].expectedAttribs); 
         } 
     }
 
@@ -126,7 +126,7 @@ BOOL CleanUpDirs()
             if(!SetFileAttributesA (gfaTestsDir[i].name, FILE_ATTRIBUTE_DIRECTORY))
             {
                 result = FALSE;
-                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, (FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_DIRECTORY)); 
+                Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsDir[i].name, (FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_DIRECTORY)); 
             } 
 
             if(!RemoveDirectoryA (gfaTestsDir[i].name))
@@ -160,14 +160,14 @@ BOOL SetUpDirs()
         if(!SetFileAttributesA (gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs))
         {
             result = FALSE;
-            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
+            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", GetLastError(), gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
         } 
 
         ret = GetFileAttributesA (gfaTestsDir[i].name);
         if(ret != gfaTestsDir[i].expectedAttribs)
         {
             result = FALSE;
-            Trace("ERROR:%d: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
+            Trace("ERROR: Error setting attributes [%s][%d]\n", gfaTestsDir[i].name, gfaTestsDir[i].expectedAttribs); 
         } 
         // Trace("Setup Dir setting attr [%d], returned [%d]\n", gfaTestsDir[i].expectedAttribs, ret);
 

--- a/src/pal/tests/palsuite/file_io/SetFileAttributesA/test1/SetFileAttributesA.c
+++ b/src/pal/tests/palsuite/file_io/SetFileAttributesA/test1/SetFileAttributesA.c
@@ -39,7 +39,22 @@ int __cdecl main(int argc, char **argv)
         return FAIL;
     }
     
-    
+    // Create the test file
+    FILE *testFile = fopen(FileName, "w");
+    if (testFile == NULL)
+    {
+        Fail("Unexpected error: Unable to open file %S with fopen. \n", FileName);
+    }
+    if (fputs("testing", testFile) == EOF)
+    {
+        Fail("Unexpected error: Unable to write to file %S with fputs. \n", FileName);
+    }
+    if (fclose(testFile) != 0)
+    {
+        Fail("Unexpected error: Unable to close file %S with fclose. \n", FileName);
+    }
+    testFile = NULL;
+
     /* Try to set the file to Read-only */
 
     TheResult = SetFileAttributesA(FileName, FILE_ATTRIBUTE_READONLY);

--- a/src/pal/tests/palsuite/file_io/SetFileAttributesA/test2/SetFileAttributesA.c
+++ b/src/pal/tests/palsuite/file_io/SetFileAttributesA/test2/SetFileAttributesA.c
@@ -20,14 +20,15 @@
 #include <palsuite.h>
 
 /* this cleanup method tries to revert the file back to its initial attributes */
-void do_cleanup(char* filename,DWORD attributes)
+void do_cleanup(char* filename, DWORD attributes)
 {
-	DWORD result;
-	result = SetFileAttributesA(filename, attributes);
-	if (result == 0)
-	{	Fail("ERROR:SetFileAttributesA returned 0,failure in the do_cleanup "
-		     "method when trying to revert the file back to its initial attributes");
-	}
+    DWORD result;
+    result = SetFileAttributesA(filename, attributes);
+    if (result == 0)
+    {
+        Fail("ERROR:SetFileAttributesA returned 0,failure in the do_cleanup "
+             "method when trying to revert the file back to its initial attributes (%u)", GetLastError());
+    }
 }
 
 int __cdecl main(int argc, char **argv)
@@ -42,7 +43,23 @@ int __cdecl main(int argc, char **argv)
         return FAIL;
     }
     
-	/* Get the initial attributes of the file */
+    // Create the test file
+    FILE *testFile = fopen(FileName, "w");
+    if (testFile == NULL)
+    {
+        Fail("Unexpected error: Unable to open file %S with fopen. \n", FileName);
+    }
+    if (fputs("testing", testFile) == EOF)
+    {
+        Fail("Unexpected error: Unable to write to file %S with fputs. \n", FileName);
+    }
+    if (fclose(testFile) != 0)
+    {
+        Fail("Unexpected error: Unable to close file %S with fclose. \n", FileName);
+    }
+    testFile = NULL;
+
+    /* Get the initial attributes of the file */
 
     initialAttr = GetFileAttributesA(FileName);
     

--- a/src/pal/tests/palsuite/file_io/SetFileAttributesA/test4/SetFileAttributesA.c
+++ b/src/pal/tests/palsuite/file_io/SetFileAttributesA/test4/SetFileAttributesA.c
@@ -35,7 +35,22 @@ int __cdecl main(int argc, char **argv)
         return FAIL;
     }
     
-    
+    // Create the test file
+    FILE *testFile = fopen(FileName, "w");
+    if (testFile == NULL)
+    {
+        Fail("Unexpected error: Unable to open file %S with fopen. \n", FileName);
+    }
+    if (fputs("testing", testFile) == EOF)
+    {
+        Fail("Unexpected error: Unable to write to file %S with fputs. \n", FileName);
+    }
+    if (fclose(testFile) != 0)
+    {
+        Fail("Unexpected error: Unable to close file %S with fclose. \n", FileName);
+    }
+    testFile = NULL;
+
     /* Try to set the file to Read-only|Normal ... It should
      end up as Readonly, since this overrides Normal*/
 

--- a/src/pal/tests/palsuite/file_io/SetFileAttributesW/test1/SetFileAttributesW.c
+++ b/src/pal/tests/palsuite/file_io/SetFileAttributesW/test1/SetFileAttributesW.c
@@ -33,6 +33,7 @@ int __cdecl main(int argc, char **argv)
 {
     DWORD TheResult;
     HANDLE TheFile;
+    CHAR *FileName_Multibyte = "test_file";
     WCHAR FileName[MAX_PATH];
     
     if (0 != PAL_Initialize(argc,argv))
@@ -40,11 +41,27 @@ int __cdecl main(int argc, char **argv)
         return FAIL;
     }
     
+    // Create the test file
+    FILE *testFile = fopen(FileName_Multibyte, "w");
+    if (testFile == NULL)
+    {
+        Fail("Unexpected error: Unable to open file %S with fopen. \n", FileName);
+    }
+    if (fputs("testing", testFile) == EOF)
+    {
+        Fail("Unexpected error: Unable to write to file %S with fputs. \n", FileName);
+    }
+    if (fclose(testFile) != 0)
+    {
+        Fail("Unexpected error: Unable to close file %S with fclose. \n", FileName);
+    }
+    testFile = NULL;
+
     /* Make a wide character string for the file name */
     
     MultiByteToWideChar(CP_ACP,
                         0,
-                        "test_file",
+                        FileName_Multibyte,
                         -1,
                         FileName,
                         MAX_PATH);

--- a/src/pal/tests/palsuite/file_io/SetFileAttributesW/test2/SetFileAttributesW.c
+++ b/src/pal/tests/palsuite/file_io/SetFileAttributesW/test2/SetFileAttributesW.c
@@ -20,20 +20,22 @@
 #include <palsuite.h>
 
 /* this cleanup method tries to revert the file back to its initial attributes */
-void do_cleanup(WCHAR* filename,DWORD attributes)
+void do_cleanup(WCHAR* filename, DWORD attributes)
 {
-  DWORD result;
-  result = SetFileAttributes(filename, attributes);
-  if (result == 0)
-	  {	Fail("ERROR:SetFileAttributesW returned 0,failure in the do_cleanup "
-		     "method when trying to revert the file back to its initial attributes");
-	  }
+    DWORD result;
+    result = SetFileAttributes(filename, attributes);
+    if (result == 0)
+    {
+        Fail("ERROR:SetFileAttributesW returned 0,failure in the do_cleanup "
+             "method when trying to revert the file back to its initial attributes (%u)", GetLastError());
+    }
 }
 
 int __cdecl main(int argc, char **argv)
 {
     DWORD TheResult;
 	DWORD initialAttr;
+    CHAR *FileName_Multibyte = "test_file";
     WCHAR FileName[MAX_PATH];
     
     if (0 != PAL_Initialize(argc,argv))
@@ -41,11 +43,27 @@ int __cdecl main(int argc, char **argv)
         return FAIL;
     }
     
+    // Create the test file
+    FILE *testFile = fopen(FileName_Multibyte, "w");
+    if (testFile == NULL)
+    {
+        Fail("Unexpected error: Unable to open file %S with fopen. \n", FileName);
+    }
+    if (fputs("testing", testFile) == EOF)
+    {
+        Fail("Unexpected error: Unable to write to file %S with fputs. \n", FileName);
+    }
+    if (fclose(testFile) != 0)
+    {
+        Fail("Unexpected error: Unable to close file %S with fclose. \n", FileName);
+    }
+    testFile = NULL;
+
     /* Make a wide character string for the file name */
     
     MultiByteToWideChar(CP_ACP,
                         0,
-                        "test_file",
+                        FileName_Multibyte,
                         -1,
                         FileName,
                         MAX_PATH);

--- a/src/pal/tests/palsuite/file_io/SetFileAttributesW/test4/SetFileAttributesW.c
+++ b/src/pal/tests/palsuite/file_io/SetFileAttributesW/test4/SetFileAttributesW.c
@@ -28,6 +28,7 @@ int __cdecl main(int argc, char **argv)
 {
     DWORD TheResult;
     HANDLE TheFile;
+    CHAR *FileName_Multibyte = "test_file";
     WCHAR FileName[MAX_PATH];
     
     if (0 != PAL_Initialize(argc,argv))
@@ -35,11 +36,27 @@ int __cdecl main(int argc, char **argv)
         return FAIL;
     }
     
+    // Create the test file
+    FILE *testFile = fopen(FileName_Multibyte, "w");
+    if (testFile == NULL)
+    {
+        Fail("Unexpected error: Unable to open file %S with fopen. \n", FileName);
+    }
+    if (fputs("testing", testFile) == EOF)
+    {
+        Fail("Unexpected error: Unable to write to file %S with fputs. \n", FileName);
+    }
+    if (fclose(testFile) != 0)
+    {
+        Fail("Unexpected error: Unable to close file %S with fclose. \n", FileName);
+    }
+    testFile = NULL;
+
     /* Make a wide character string for the file name */
     
     MultiByteToWideChar(CP_ACP,
                         0,
-                        "test_file",
+                        FileName_Multibyte,
                         -1,
                         FileName,
                         MAX_PATH);


### PR DESCRIPTION
Fix some frequently failing PAL tests

Some PAL tests are frequently failing in the CI. The specified output folder is currently used as the working folder for all PAL tests. The CI machine happened to have the output folder on a mount mounted as fuseblk instead of ext4. We don't know why this is happening. For the moment, I'm fixing the test runner to work around this issue.

Changes:
- Use /tmp/PalTestOutput/default as the output folder by default
- If a specific folder is specified for the output, use a unique folder inside /tmp/PalTestOutput for output files, and copy them to the specified folder at the end. A unique folder is used to support parallel runs on the same machine in this mode.
- Run each test in its own folder. Many PAL tests don't clean up after themselves, and create/use the same file/folder names in the current folder.
- Add a few more checks to some tests to hopefully provide more information upon the next failure
- Fix GetFileAttributes tests, which were crashing upon some failures due to mismatched number of placeholders and arguments to vprintf

Fixes #1561