### PR TITLE
Fix ARM unwind regression

### DIFF
--- a/src/debug/inc/dbgipcevents.h
+++ b/src/debug/inc/dbgipcevents.h
@@ -181,7 +181,7 @@ struct MSLAYOUT DebuggerIPCRuntimeOffsets
 // aren't any embedded buffers in the DebuggerIPCControlBlock).
 
 #if defined(DBG_TARGET_X86) || defined(DBG_TARGET_ARM)
-#define CorDBIPC_BUFFER_SIZE (1500) // hand tuned to ensure that ipc block in IPCHeader.h fits in 1 page.
+#define CorDBIPC_BUFFER_SIZE (2088) // hand tuned to ensure that ipc block in IPCHeader.h fits in 1 page.
 #else  // !_TARGET_X86_ && !_TARGET_ARM_
 // This is the size of a DebuggerIPCEvent.  You will hit an assert in Cordb::Initialize() (DI\process.cpp)
 // if this is not defined correctly.  AMD64 actually has a page size of 0x1000, not 0x2000.

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -323,7 +323,8 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
 #error don't know how to unwind on this platform
 #endif
 
-
+// These methods are only used on the AMD64 build
+#ifdef _AMD64_
 #ifdef __LINUX__
 
 
@@ -539,6 +540,7 @@ BOOL PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 }
 
 #endif // !__LINUX__
+#endif // _AMD64_
 
 /*++
 Function:


### PR DESCRIPTION
Fixes #1570 . Could someone check my change of `CorDBIPC_BUFFER_SIZE`, this fixes the build but I'm not entirely sure it's correct.

cc:\ @Djuffin @mmitche 