### PR TITLE
Fix for Issue #3164.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1971,7 +1971,17 @@ public:
     //-------------------------------------------------------------------------
 
     GenTreePtr              gtFoldExpr       (GenTreePtr    tree);
-    GenTreePtr              gtFoldExprConst  (GenTreePtr    tree);
+    GenTreePtr              
+#ifdef __clang__
+        // TODO-Amd64-Unix: Remove this when the clang optimizer is fixed and/or the method implementation is refactored in a simpler code.
+        // This is a workaround for a bug in the clang-3.5 optimizer. The issue is that in release build the optimizer is mistyping 
+        // (or just wrongly decides to use 32 bit operation for a corner case of MIN_LONG) the args of the (ltemp / lval2)
+        // to int (it does a 32 bit div operation instead of 64 bit) - see the implementation of the method in gentree.cpp. 
+        // For the case of lval1 and lval2 equal to MIN_LONG (0x8000000000000000) this results in raising a SIGFPE. 
+        // The method implementation is rather complex. Disable optimizations for now.
+    __attribute__((optnone))
+#endif // __clang__
+                            gtFoldExprConst(GenTreePtr      tree);
     GenTreePtr              gtFoldExprSpecial(GenTreePtr    tree);
     GenTreePtr              gtFoldExprCompare(GenTreePtr    tree);
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -10166,6 +10166,18 @@ LNG_ADD_CHKOVF:
                             goto LNG_OVF;
                         }
                         if ((ltemp/lval2) != lval1) goto LNG_OVF;
+#ifdef UNIX_AMD64_ABI
+                        // There is a clang 3.5 optimizer bug that in case of lval1 and lval2 equal
+                        // of 0x80000000 (MIN_LONG) the above expression (ltemp / lval2) results
+                        // in 0x80000000 (MIN_LONG. This causes an overflowing mul expression 
+                        // to be repalced with a 0, instead of throwing an overflow exception.
+                        // The following extra check fixes the issue. If the bug is fixed in later releases 
+                        // of clang this fix becomes dead code since the goto above will trigger.
+                        // In debug builds the expression result is correct - 0.
+                        // The lval1 and lval2 are checked to be non-zeroes above.
+                        // If multiplication of 2 non-zeroes results in a zero results, it must be an overflow.
+                        if (ltemp == 0) goto LNG_OVF;
+#endif // UNIX_AMD64_ABI
                     }
                 }
             }


### PR DESCRIPTION
Added extra code to work around an optimizer bug in clang 3.5. In a
particular case 0/MIN_LONG results into MIN_LONG that causes a const
folding to produce a result of 0 instead of overflow exception for
MIN_LONG * MIN_LONG.