### PR TITLE
Remove Clean Target in Test Build Proj.

### DIFF
--- a/tests/build.proj
+++ b/tests/build.proj
@@ -25,9 +25,4 @@
 
   <!-- Override RestorePackages from dir.traversal.targets and do a batch restore -->
   <Target Name="RestorePackages" DependsOnTargets="BatchRestorePackages" />
-
-  <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
-  <Target Name="Clean">
-    <RemoveDir Directories="$(PackagesDir)" />
-  </Target>
 </Project>


### PR DESCRIPTION
Removing the packages directory is not necessary in test project build. 

Clean build of CoreCLR fails saying packages folder is not required.
There are multiple reports of users running into this issue.  See
https://github.com/dotnet/coreclr/issues/1457 and https://github.com/dotnet/coreclr/issues/1351

The comment for Clean target does not indicate that removing the
packages directory was the intention.  The comment says BinDir should be
removed, and this only applies for Sources and not test project.

Tested the current change and noticed that the packages subfolder under
tests gets created correctly and the build clean command succeeds
without any errors.  Pasted below is the summary text from build clean
command.

---

Repo successfully built.

Product binaries are available at 
c:\git\coreclr\bin\Product\Windows_NT.x64.Debug
Test binaries are available at 
c:\git\coreclr\bin\tests\Windows_NT.x64.Debug

---


