### PR TITLE
Change PAL_InjectActivation to use pthread_kill

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -5448,11 +5448,16 @@ FlushProcessWriteBuffers();
 typedef void (*PAL_ActivationFunction)(CONTEXT *context);
 
 PALIMPORT
+VOID
+PALAPI
+PAL_SetActivationFunction(
+    IN PAL_ActivationFunction pActivationFunction);
+
+PALIMPORT
 BOOL
 PALAPI
 PAL_InjectActivation(
-    IN HANDLE hThread,
-    IN PAL_ActivationFunction pActivationFunction
+    IN HANDLE hThread
 );
 
 #define VER_PLATFORM_WIN32_WINDOWS        1

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1160,7 +1160,7 @@ void EEStartupHelper(COINITIEE fFlags)
 #endif // PROFILING_SUPPORTED
 
         InitializeExceptionHandling();
-    
+
         //
         // Install our global exception filter
         //

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1691,6 +1691,8 @@ void InitThreadManager()
     // Randomize OBJREF_HASH to handle hash collision.
     Thread::OBJREF_HASH = OBJREF_TABSIZE - (DbgGetEXETimeStamp()%10);
 #endif // _DEBUG
+
+    ThreadSuspend::Initialize();
 }
 
 

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -8370,7 +8370,7 @@ bool Thread::InjectGcSuspension()
     hThread = GetThreadHandle();
     if (hThread != INVALID_HANDLE_VALUE && hThread != SWITCHOUT_HANDLE_VALUE)
     {
-        ::PAL_InjectActivation(hThread, HandleGCSuspensionForInterruptedThread);
+        ::PAL_InjectActivation(hThread);
         return true;
     }
 
@@ -8378,6 +8378,14 @@ bool Thread::InjectGcSuspension()
 }
 
 #endif // FEATURE_HIJACK && PLATFORM_UNIX
+
+// Initialize thread suspension support
+void ThreadSuspend::Initialize()
+{
+#if defined(FEATURE_HIJACK) && defined(PLATFORM_UNIX)
+    ::PAL_SetActivationFunction(HandleGCSuspensionForInterruptedThread);
+#endif
+}
 
 #ifdef _DEBUG
 BOOL Debug_IsLockedViaThreadSuspension()

--- a/src/vm/threadsuspend.h
+++ b/src/vm/threadsuspend.h
@@ -197,6 +197,9 @@ public:
     static HRESULT SuspendRuntime(ThreadSuspend::SUSPEND_REASON reason);
     static void    ResumeRuntime(BOOL bFinishedGC, BOOL SuspendSucceded);
 
+    // Initialize thread suspension support
+    static void    Initialize();
+
 private:
     static CLREvent * g_pGCSuspendEvent;
 


### PR DESCRIPTION
This change modifies the PAL_InjectActivation to use much more portable pthread_kill
instead of pthread_sigqueue. Since pthread_kill cannot pass parameter together with
the signal, the activation functions are stored in a per-thread list.