### PR TITLE
Fix link to "Coding Style" page

### DIFF
--- a/Documentation/project-docs/contributing-workflow.md
+++ b/Documentation/project-docs/contributing-workflow.md
@@ -30,7 +30,7 @@ Typos are embarrassing! We will accept most PRs that fix typos. In order to make
 Coding Style Changes
 --------------------
 
-We intend to bring dotnet/corefx in to full conformance with the style guidelines described in [Coding Style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-style.md). We plan to do that with tooling, in a holistic way. In the meantime, please:
+We intend to bring dotnet/corefx in to full conformance with the style guidelines described in [Coding Style](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/coding-style.md). We plan to do that with tooling, in a holistic way. In the meantime, please:
 
 * **DO NOT** send PRs for style changes. 
 * **DO** give priority to the current style of the project or file you're changing even if it diverges from the general guidelines.


### PR DESCRIPTION
This link is currently returning a 404 error; it appears that several of these links may have been broken when a new `coding-guidelines` subdirectory was created.