### PR TITLE
Fix link to CoreFX Performance Guidelines

### DIFF
--- a/Documentation/project-docs/performance-guidelines.md
+++ b/Documentation/project-docs/performance-guidelines.md
@@ -3,7 +3,7 @@ Performance Requirements
 
 The .NET runtime supports a wide variety of high performance applications.  As such, performance is a key design element for every change.  This guidance is designed to share how we collect data and analyze the performance of the runtime.
 
-You may also want to read about [CoreFX performance guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/performance-guidelines.md).
+You may also want to read about [CoreFX performance guidelines](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/performance-guidelines.md).
 
 # Design Phase #
 Make sure to address performance during the design phase of any change.  It is much easier to tweak a design to fit performance goals and requirements before implementation has started.


### PR DESCRIPTION
This link currently returns a 404 error.

It appears to be one of several links broken by some of the CoreFX
documentation having been moved into the new `coding-guidelines`
subdirectory.