### PR TITLE
Add ICorDebugDataTarget4 to SOS.

### DIFF
--- a/src/ToolBox/SOS/Strike/datatarget.cpp
+++ b/src/ToolBox/SOS/Strike/datatarget.cpp
@@ -32,6 +32,12 @@ DataTarget::QueryInterface(
         AddRef();
         return S_OK;
     }
+    if (InterfaceId == IID_ICorDebugDataTarget4)
+    {
+        *Interface = (ICorDebugDataTarget4*)this;
+        AddRef();
+        return S_OK;
+    }
     else
     {
         *Interface = NULL;
@@ -187,4 +193,11 @@ DataTarget::Request(
     /* [size_is][out] */ BYTE *outBuffer)
 {
     return E_NOTIMPL;
+}
+
+HRESULT STDMETHODCALLTYPE 
+DataTarget::GetPid(
+    /* [out] */ DWORD *pdwProcessId)
+{
+    return g_ExtSystem->GetCurrentProcessId(pdwProcessId);
 }

--- a/src/ToolBox/SOS/Strike/datatarget.h
+++ b/src/ToolBox/SOS/Strike/datatarget.h
@@ -4,7 +4,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information. 
 //
 
-class DataTarget : public ICLRDataTarget
+class DataTarget : public ICLRDataTarget, ICorDebugDataTarget4
 {
 private:
     LONG m_ref;                         // Reference count.
@@ -82,4 +82,9 @@ public:
         /* [size_is][in] */ BYTE *inBuffer,
         /* [in] */ ULONG32 outBufferSize,
         /* [size_is][out] */ BYTE *outBuffer);
+
+    // ICorDebugDataTarget4
+
+    virtual HRESULT STDMETHODCALLTYPE GetPid(
+        /* [out] */ DWORD *pdwProcessId);
 };

--- a/src/ToolBox/SOS/lldbplugin/debugclient.cpp
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.cpp
@@ -734,9 +734,34 @@ DebugClient::GetModuleBase(
 //----------------------------------------------------------------------------
 
 HRESULT 
+DebugClient::GetCurrentProcessId(
+    PULONG id)
+{
+    if (id == NULL)  
+    {
+        return E_INVALIDARG;
+    }
+
+    lldb::SBProcess process = GetCurrentProcess();
+    if (!process.IsValid())
+    {
+        *id = 0;
+        return E_FAIL;
+    }
+
+    *id = process.GetProcessID();
+    return S_OK;
+}
+
+HRESULT 
 DebugClient::GetCurrentThreadId(
     PULONG id)
 {
+    if (id == NULL)  
+    {
+        return E_INVALIDARG;
+    }
+
     lldb::SBThread thread = GetCurrentThread();
     if (!thread.IsValid())
     {
@@ -778,6 +803,11 @@ HRESULT
 DebugClient::GetCurrentThreadSystemId(
     PULONG sysId)
 {
+    if (sysId == NULL)  
+    {
+        return E_INVALIDARG;
+    }
+
     lldb::SBThread thread = GetCurrentThread();
     if (!thread.IsValid())
     {
@@ -807,6 +837,11 @@ DebugClient::GetThreadIdBySystemId(
 
     lldb::SBProcess process;
     lldb::SBThread thread;
+
+    if (threadId == NULL)  
+    {
+        return E_INVALIDARG;
+    }
 
     process = GetCurrentProcess();
     if (!process.IsValid())
@@ -850,7 +885,7 @@ DebugClient::GetThreadContextById(
     DT_CONTEXT *dtcontext;
     HRESULT hr = E_FAIL;
 
-    if (contextSize < sizeof(DT_CONTEXT))
+    if (context == NULL || contextSize < sizeof(DT_CONTEXT))
     {
         goto exit;
     }

--- a/src/ToolBox/SOS/lldbplugin/debugclient.h
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.h
@@ -145,6 +145,9 @@ public:
     // IDebugSystemObjects
     //----------------------------------------------------------------------------
 
+    HRESULT GetCurrentProcessId(
+        PULONG id);
+
     HRESULT GetCurrentThreadId(
         PULONG id);
 

--- a/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
@@ -367,6 +367,9 @@ typedef class IDebugSymbols* PDEBUG_SYMBOLS;
 class IDebugSystemObjects 
 {
 public:
+    virtual HRESULT GetCurrentProcessId(
+        PULONG id) = 0;
+
     // Controls implicit thread used by the
     // debug engine.  The debuggers current
     // thread is just a piece of data held

--- a/src/ToolBox/SOS/lldbplugin/mstypes.h
+++ b/src/ToolBox/SOS/lldbplugin/mstypes.h
@@ -50,6 +50,7 @@ typedef int HRESULT;
 #define S_FALSE                          (HRESULT)0x00000001
 #define E_NOTIMPL                        (HRESULT)0x80004001
 #define E_FAIL                           (HRESULT)0x80004005
+#define E_INVALIDARG                     (HRESULT)0x80070057
 
 #define MAX_PATH                         260 
 

--- a/src/debug/daccess/datatargetadapter.cpp
+++ b/src/debug/daccess/datatargetadapter.cpp
@@ -45,18 +45,18 @@ DataTargetAdapter::~DataTargetAdapter()
 // Standard impl of IUnknown::QueryInterface
 HRESULT STDMETHODCALLTYPE
 DataTargetAdapter::QueryInterface(
-    REFIID InterfaceId,
+    REFIID interfaceId,
     PVOID* pInterface)
 {
-    if (InterfaceId == IID_IUnknown)
+    if (interfaceId == IID_IUnknown)
     {
         *pInterface = static_cast<IUnknown *>(static_cast<ICorDebugDataTarget *>(this));
     }
-    else if (InterfaceId == IID_ICorDebugDataTarget)
+    else if (interfaceId == IID_ICorDebugDataTarget)
     {
         *pInterface = static_cast<ICorDebugDataTarget *>(this);
     }
-    else if (InterfaceId == IID_ICorDebugMutableDataTarget)
+    else if (interfaceId == IID_ICorDebugMutableDataTarget)
     {
         // Note that we always implement the mutable interface, even though our underlying target
         // may return E_NOTIMPL for all the functions on this interface.  There is no reliable way
@@ -65,8 +65,8 @@ DataTargetAdapter::QueryInterface(
     }
     else
     {
-        *pInterface = NULL;
-        return E_NOINTERFACE;
+        // For ICorDebugDataTarget4 and other interfaces directly implemented by the legacy data target.
+        return m_pLegacyTarget->QueryInterface(interfaceId, pInterface);
     }
 
     AddRef();

--- a/src/debug/daccess/datatargetadapter.h
+++ b/src/debug/daccess/datatargetadapter.h
@@ -25,7 +25,7 @@ interface ICLRDataTarget;
  * for dbgeng (watson, windbg, etc.) and for any other 3rd parties since 
  * it is a documented API for dump generation.
  */
-class DataTargetAdapter : public ICorDebugMutableDataTarget 
+class DataTargetAdapter : public ICorDebugMutableDataTarget
 {
 public:
     // Create an adapter over the supplied legacy data target interface

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -46,7 +46,6 @@ Revision History:
 #define E_UNEXPECTED                     _HRESULT_TYPEDEF_(0x8000FFFFL)
 #define E_OUTOFMEMORY                    _HRESULT_TYPEDEF_(0x8007000EL)
 #define E_INVALIDARG                     _HRESULT_TYPEDEF_(0x80070057L)
-#define E_INVALIDARG                     _HRESULT_TYPEDEF_(0x80070057L)
 #define E_POINTER                        _HRESULT_TYPEDEF_(0x80004003L)
 #define E_HANDLE                         _HRESULT_TYPEDEF_(0x80070006L)
 #define E_ABORT                          _HRESULT_TYPEDEF_(0x80004004L)


### PR DESCRIPTION
Now that Eugene fixed out of context unwinding in the DAC for Linux after
this change, the SOS "clrstack" command should always work and not hang anymore.