### PR TITLE
Fix debugger's funceval on Linux

### DIFF
--- a/src/debug/ee/amd64/dbghelpers.S
+++ b/src/debug/ee/amd64/dbghelpers.S
@@ -12,7 +12,7 @@
 NESTED_ENTRY FuncEvalHijack, _TEXT, UnhandledExceptionHandlerUnix
         // the stack should be aligned at this point, since we do not call this
         // function explicitly
-        alloc_stack 20h
+        alloc_stack 0x20
         END_PROLOGUE
 
         mov     [rsp], rdi
@@ -46,7 +46,7 @@ NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
         // So we allocate 4 stack slots as the outgoing argument home and just copy the 
         // arguments set up by DacDbi into these stack slots.  We will take a perf hit,
         // but this is not a perf critical code path anyway.
-        alloc_stack 20h
+        alloc_stack 0x20
         END_PROLOGUE
 
         // We used to do an "alloc_stack 0h" because the stack has been allocated for us

--- a/src/debug/ee/controller.h
+++ b/src/debug/ee/controller.h
@@ -896,6 +896,7 @@ inline void VerifyExecutableAddress(const BYTE* address)
 // TODO: : when can we apply this to x86?
 #if defined(_WIN64)   
 #if defined(_DEBUG) 
+#ifndef FEATURE_PAL    
     MEMORY_BASIC_INFORMATION mbi;
     
     if (sizeof(mbi) == ClrVirtualQuery(address, &mbi, sizeof(mbi)))
@@ -913,6 +914,7 @@ inline void VerifyExecutableAddress(const BYTE* address)
                 ("VEA: address (0x%p) is not on an executable page.", address));
         }
     }
+#endif // !FEATURE_PAL    
 #endif // _DEBUG   
 #endif // _WIN64
 }

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -15406,7 +15406,11 @@ HRESULT Debugger::FuncEvalSetup(DebuggerIPCE_FuncEvalInfo *pEvalInfo,
 #if defined(_TARGET_X86_)
         filterContext->Eax = (DWORD)pDE;
 #elif defined(_TARGET_AMD64_)
+#ifdef UNIX_AMD64_ABI
+        filterContext->Rdi = (SIZE_T)pDE;
+#else // UNIX_AMD64_ABI
         filterContext->Rcx = (SIZE_T)pDE;
+#endif // !UNIX_AMD64_ABI
 #elif defined(_TARGET_ARM_)
         filterContext->R0 = (DWORD)pDE;
 #else


### PR DESCRIPTION
Address issues which prevented funceval from working on Linux:
1. Invalid stack alignment in funceval hijacks
2. Using System V calling convention for funceval hijacks
3. Disable executability check that is not implemented on Linux