### PR TITLE
Use EmptyArray<T>.Value in List<T>

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -41,13 +41,11 @@ namespace System.Collections.Generic {
         [NonSerialized]
         private Object _syncRoot;
         
-        static readonly T[]  _emptyArray = new T[0];        
-            
         // Constructs a List. The list is initially empty and has a capacity
         // of zero. Upon adding the first element to the list the capacity is
         // increased to 16, and then increased in multiples of two as required.
         public List() {
-            _items = _emptyArray;
+            _items = EmptyArray<T>.Value;
         }
     
         // Constructs a List with a given initial capacity. The list is
@@ -59,7 +57,7 @@ namespace System.Collections.Generic {
             Contract.EndContractBlock();
 
             if (capacity == 0)
-                _items = _emptyArray;
+                _items = EmptyArray<T>.Value;
             else
                 _items = new T[capacity];
         }
@@ -78,7 +76,7 @@ namespace System.Collections.Generic {
                 int count = c.Count;
                 if (count == 0)
                 {
-                    _items = _emptyArray;
+                    _items = EmptyArray<T>.Value;
                 }
                 else {
                     _items = new T[count];
@@ -88,7 +86,7 @@ namespace System.Collections.Generic {
             }    
             else {                
                 _size = 0;
-                _items = _emptyArray;
+                _items = EmptyArray<T>.Value;
                 // This enumerable could be empty.  Let Add allocate a new array, if needed.
                 // Note it will also go to _defaultCapacity first, not 1, then 2, etc.
                 
@@ -124,7 +122,7 @@ namespace System.Collections.Generic {
                         _items = newItems;
                     }
                     else {
-                        _items = _emptyArray;
+                        _items = EmptyArray<T>.Value;
                     }
                 }
             }


### PR DESCRIPTION
List<T> uses a static empty array for its internal array when the capacity is
zero to reduce allocations and working set. Since there is Array.Empty<T> as
of 4.6, for much the same purpose, this can be used in that place for even
fewer allocations.