### PR TITLE
Use Ordinal when searching for collation keyword

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
@@ -69,7 +70,7 @@ namespace System.Globalization
             this.sWindowsName = StringBuilderCache.GetStringAndRelease(sb); // the name passed to subsequent ICU calls
 
             // Replace the ICU collation keyword with an _
-            index = realNameBuffer.IndexOf(ICU_COLLATION_KEYWORD);
+            index = realNameBuffer.IndexOf(ICU_COLLATION_KEYWORD, StringComparison.Ordinal);
             if (index >= 0)
             {
                 this.sName = this.sWindowsName.Substring(0, index) + "_" + alternateSortName;


### PR DESCRIPTION
IndexOf by default is culture specific, which could lead to us doing
the wrong thing depending on the current culture and also can cause
problems where we need to access CultureData while we are still building
up culture information, causing infinite recursion.

Some collection tests were triggering the latter case and failing after
we merged in the ICU changes.