### PR TITLE
Fix erroneous check

### DIFF
--- a/src/pal/src/cruntime/wchar.cpp
+++ b/src/pal/src/cruntime/wchar.cpp
@@ -1450,7 +1450,7 @@ PAL_wcsncat( wchar_16 * strDest, const wchar_16 *strSource, size_t count )
 static BOOL MISC_CRT_WCSTOD_IsValidCharacter( WCHAR c )
 {
     if ( c == '+' || c == '-' || c == '.' || ( c >= '0' && c <= '9' ) || 
-         c == 'e' || c == 'E' || c == 'd' || c == 'd' )
+         c == 'e' || c == 'E' || c == 'd' || c == 'D' )
     {
         return TRUE;
     }


### PR DESCRIPTION
The check used to contain a typo which causes the same condition being checked twice for no reason. The spec says both `d` and `D` are permitted so the real intent was to check for either of them.

This defect was found with Cppcheck.