### PR TITLE
Handle direct call ReadyToRun helpers

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5097,7 +5097,7 @@ void CodeGen::genCallInstruction(GenTreePtr node)
 #if defined(_TARGET_AMD64_) && defined(FEATURE_READYTORUN_COMPILER)
     else if (call->gtEntryPoint.addr != nullptr)
     {
-        genEmitCall(emitter::EC_FUNC_TOKEN_INDIR,
+        genEmitCall((call->gtEntryPoint.accessType == IAT_VALUE) ? emitter::EC_FUNC_TOKEN : emitter::EC_FUNC_TOKEN_INDIR,
                     methHnd,
                     INDEBUG_LDISASM_COMMA(sigInfo)
                     (void*) call->gtEntryPoint.addr,

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5094,13 +5094,16 @@ void CodeGen::genCallInstruction(GenTreePtr node)
                         genConsumeReg(target));
         }
     }
-#if defined(_TARGET_AMD64_) && defined(FEATURE_READYTORUN_COMPILER)
+#ifdef FEATURE_READYTORUN_COMPILER
     else if (call->gtEntryPoint.addr != nullptr)
     {
         genEmitCall((call->gtEntryPoint.accessType == IAT_VALUE) ? emitter::EC_FUNC_TOKEN : emitter::EC_FUNC_TOKEN_INDIR,
                     methHnd,
                     INDEBUG_LDISASM_COMMA(sigInfo)
                     (void*) call->gtEntryPoint.addr,
+#ifdef _TARGET_X86_
+                    stackArgBytes,
+#endif // _TARGET_X86_
                     retSize,
                     ilOffset);
     }


### PR DESCRIPTION
Add missing check in the JIT to generate correct code for direct call ReadyToRun helpers. I have run into this bug while experimenting with ReadyToRun optimizations. It is not observable bug today because of crossgen happens to always emit ReadyToRun helpers as indirect calls.