### PR TITLE
Clarify precedence

### DIFF
--- a/src/classlibnative/bcltype/decimal.cpp
+++ b/src/classlibnative/bcltype/decimal.cpp
@@ -480,8 +480,8 @@ void DecShiftLeft(DECIMAL* value)
     LIMITED_METHOD_CONTRACT
     _ASSERTE(value != NULL);
 
-    unsigned int c0 = DECIMAL_LO32(*value) & 0x80000000? 1: 0;
-    unsigned int c1 = DECIMAL_MID32(*value) & 0x80000000? 1: 0;
+    unsigned int c0 = (DECIMAL_LO32(*value) & 0x80000000) ? 1 : 0;
+    unsigned int c1 = (DECIMAL_MID32(*value) & 0x80000000) ? 1 : 0;
     DECIMAL_LO32(*value) <<= 1;
     DECIMAL_MID32(*value) = DECIMAL_MID32(*value) << 1 | c0;
     DECIMAL_HI32(*value) = DECIMAL_HI32(*value) << 1 | c1;

--- a/src/debug/di/rsthread.cpp
+++ b/src/debug/di/rsthread.cpp
@@ -8915,8 +8915,11 @@ HRESULT CordbJITILFrame::GetReturnValueForILOffsetImpl(ULONG32 ILoffset, ICorDeb
     bool found = false;
     ULONG32 currentOffset = m_nativeFrame->GetIPOffset();
     for (ULONG32 i = 0; i < count; ++i)
-        if ((found = currentOffset == offsets[i]))
+        if (currentOffset == offsets[i])
+        {
+            found = true;
             break;
+        }
 
     if (!found)
         return E_UNEXPECTED;

--- a/src/md/enc/metamodelrw.cpp
+++ b/src/md/enc/metamodelrw.cpp
@@ -8780,7 +8780,7 @@ bool FilterTable::IsTokenMarked(
         //
         return true;
     }
-    return ( (*Get(rid)) & bitMarked ? true : false);
+    return ( ((*Get(rid)) & bitMarked) ? true : false);
 } // FilterTable::IsTokenMarked
 
 

--- a/src/md/inc/metamodel.h
+++ b/src/md/inc/metamodel.h
@@ -262,7 +262,7 @@ public:
 
     unsigned __int64    m_sorted;               // Bit mask of sorted tables.
     FORCEINLINE bool IsSorted(ULONG ixTbl)
-        { return m_sorted & BIT(ixTbl) ? true : false; }
+        { return (m_sorted & BIT(ixTbl)) ? true : false; }
     void SetSorted(ULONG ixTbl, int bVal)
         { if (bVal) m_sorted |= BIT(ixTbl);
           else      m_sorted &= ~BIT(ixTbl); }

--- a/src/strongname/api/strongname.cpp
+++ b/src/strongname/api/strongname.cpp
@@ -4166,7 +4166,7 @@ HRESULT VerifySignature(__in SN_LOAD_CTX *pLoadCtx, DWORD dwInFlags, PublicKeyBl
         ((dwInFlags & SN_INFLAG_ADMIN_ACCESS) || g_fCacheVerify))
     {
         SNLOG((W("Skipping verification due to cached result\n")));
-        DbgCount(dwInFlags & SN_INFLAG_RUNTIME ? W("RuntimeSkipCache") : W("FusionSkipCache"));
+        DbgCount((dwInFlags & SN_INFLAG_RUNTIME) ? W("RuntimeSkipCache") : W("FusionSkipCache"));
         return S_OK;
     }
 
@@ -4190,7 +4190,7 @@ HRESULT VerifySignature(__in SN_LOAD_CTX *pLoadCtx, DWORD dwInFlags, PublicKeyBl
                 {
 
                     SNLOG((W("Using test public key for verification due to registry entry\n")));
-                    DbgCount(dwInFlags & SN_INFLAG_RUNTIME ? W("RuntimeSkipDelay") : W("FusionSkipDelay"));
+                    DbgCount((dwInFlags & SN_INFLAG_RUNTIME) ? W("RuntimeSkipDelay") : W("FusionSkipDelay"));
 
                     // If the assembly was not ECMA signed, then we need to update the key that it will be
                     // verified with as well.


### PR DESCRIPTION
The current code is correct but harder to read than needed - operations precedence is not immediately clear.

These suspicious pieces were found with Cppcheck.