### PR TITLE
Avoid the enumerator allocation in Dictionary's constructor

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -107,6 +107,22 @@ namespace System.Collections.Generic {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.dictionary);
             }
 
+            // It is likely that the passed-in dictionary is Dictionary<TKey,TValue>. When this is the case,
+            // avoid the enumerator allocation and overhead by looping through the entries array directly.
+            // We only do this when dictionary is Dictionary<TKey,TValue> and not a subclass, to maintain
+            // back-compat with subclasses that may have overridden the enumerator behavior.
+            if (dictionary.GetType() == typeof(Dictionary<TKey,TValue>)) {
+                Dictionary<TKey,TValue> d = (Dictionary<TKey,TValue>)dictionary;
+                int count = d.count;
+                Entry[] entries = d.entries;
+                for (int i = 0; i < count; i++) {
+                    if (entries[i].hashCode >= 0) {
+                        Add(entries[i].key, entries[i].value);
+                    }
+                }
+                return;
+            }
+
             foreach (KeyValuePair<TKey,TValue> pair in dictionary) {
                 Add(pair.Key, pair.Value);
             }


### PR DESCRIPTION
Fast path to avoid the enumerator allocation and overhead when the passed-in `dictionary` is `Dictionary<TKey, TValue>`.