### PR TITLE
Clarify code with unobvious precedence

### DIFF
--- a/src/debug/di/rsthread.cpp
+++ b/src/debug/di/rsthread.cpp
@@ -8915,8 +8915,13 @@ HRESULT CordbJITILFrame::GetReturnValueForILOffsetImpl(ULONG32 ILoffset, ICorDeb
     bool found = false;
     ULONG32 currentOffset = m_nativeFrame->GetIPOffset();
     for (ULONG32 i = 0; i < count; ++i)
-        if ((found = currentOffset == offsets[i]))
+    {
+        if (currentOffset == offsets[i])
+        {
+            found = true;
             break;
+        }
+    }
 
     if (!found)
         return E_UNEXPECTED;


### PR DESCRIPTION
The original code contains a construct where operation precedence is not immediately clear.

This was found with Cppcheck.