### PR TITLE
Add new exports to get expression evaluator working in clrdbg

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -61,11 +61,13 @@ LockFile
 lstrlenA
 lstrlenW
 MapViewOfFile
+MetaDataGetDispenser
 MoveFileExW
 MultiByteToWideChar
 OpenEventW
 OpenMutexW
 OpenSemaphoreW
+OutputDebugStringW
 PAL_Random
 QueryPerformanceCounter  
 QueryPerformanceFrequency


### PR DESCRIPTION
Added MetaDataGetDispenser, OutputDebugStringW to unix exports. MetaDataGetDispenser is needed to get expression evaluation working for clr debugger. PAL OutputDebugStringW is needed to see the diagnostic messages during debugging.