### PR TITLE
String.StartsWith ordinal optimization

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2556,10 +2556,12 @@ namespace System {
                     return CultureInfo.InvariantCulture.CompareInfo.IsPrefix(this, value, CompareOptions.IgnoreCase);                    
 
                 case StringComparison.Ordinal:
-                    if( this.Length < value.Length) {
+                    if( this.Length < value.Length || m_firstChar != value.m_firstChar) {
                         return false;
                     }
-                    return (nativeCompareOrdinalEx(this, 0, value, 0, value.Length) == 0);
+                    return (value.Length == 1) ?
+                            true :                 // First char is the same and thats all there is to compare
+                            (nativeCompareOrdinalEx(this, 0, value, 0, value.Length) == 0);
 
                 case StringComparison.OrdinalIgnoreCase:
                     if( this.Length < value.Length) {


### PR DESCRIPTION
Optimization for when the first character is different, and for single length compare values.

While it might be unlikely that we get StartsWith(char) and [EndsWith(char)](https://github.com/dotnet/coreclr/issues/1463) overloads we can at least make that faster for the existing `StartsWith(string, StringComparison.Ordinal)` and single length strings. Bonus is that this also improves any length comparisons where the first char is different.
Single length compare values are common in url processing and text processing (eg quoted strings).

By the time we get to the first character comparison we have already confirmed that `value.Length >=1` and that `this.Length >= value.Length` which means both `m_firstChar` instances have valid values.

Testing against "abc".StartsWith(value, StringComparison.Ordinal), Release mode, 10M iterations.

| Test value | Before | After | Faster |
| ---------- | -----: | ----: | -----: |
| "a" (char match, single length) | 173 | 73 | 137% |
| "ab" (match, multi-length) | 178 | 172 | 4% |
| "X" (no-match, first char) | 183 | 74 | 148% |
| "aX" (no-match, secondary char) | 179 | 172 | 4% |

Unit tests https://github.com/dotnet/corefx/pull/3478. Because this change uses internals it can be confirmed though the System.Runtime.Tests project in Corefx using this [gist](https://gist.github.com/bbowyersmyth/099c572ab8fdd5fc48cb#file-startswith) and checking the testResults.xml file.