### PR TITLE
Fix some documentation typos

### DIFF
--- a/Documentation/project-docs/contributing.md
+++ b/Documentation/project-docs/contributing.md
@@ -101,7 +101,7 @@ DOs and DON'Ts
 Contributor License Agreement
 =============================
 
-You must sign a [.NET Foundation Contribution License Agreement (CLA)](http://cla2.dotnetfoundation.org) before your PR will be merged. This a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on wikipedia.
+You must sign a [.NET Foundation Contribution License Agreement (CLA)](http://cla2.dotnetfoundation.org) before your PR will be merged. This a one-time requirement for projects in the .NET Foundation. You can read more about [Contribution License Agreements (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) on Wikipedia.
 
 However, you don't have to do this up-front. You can simply clone, fork, and submit your pull-request as usual.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The [.NET Core Libraries][corefx] repo contains the base class libraries, which 
 Engage, Contribute and Provide Feedback
 ---------------------------------------
 
-Some of the best ways to contribute are to try things out, file bugs, and join in design conversations. You are encouraged to start a discussion by filing an issue, or starting a thread in the [.NET Foundation forums].
+Some of the best ways to contribute are to try things out, file bugs, and join in design conversations. You are encouraged to start a discussion by filing an issue, or starting a thread in the [.NET Foundation forums](http://forums.dotnetfoundation.org/).
 
 Looking for something to work on? The list of [up-for-grabs issues](https://github.com/dotnet/coreclr/issues?q=is%3Aopen+is%3Aissue+label%3Aup-for-grabs) is a great place to start.
 


### PR DESCRIPTION
Missing links right on the repo frontpage look quite strange, as do uncapitalized proper nouns.