### PR TITLE
Implement Encodings on Linux

### DIFF
--- a/src/mscorlib/src/System/Globalization/EncodingDataItem.Unix.cs
+++ b/src/mscorlib/src/System/Globalization/EncodingDataItem.Unix.cs
@@ -1,72 +1,68 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace System.Globalization {
-    using System.Text;
-    using System.Runtime.Remoting;
-    using System;
-    using System.Security;
-
+namespace System.Globalization
+{
     [Serializable]
     internal class CodePageDataItem
     {
-        // TODO: Implement this fully.
-        private readonly string _webName;
+        private readonly int _codePage;
         private readonly int _uiFamilyCodePage;
-        private readonly string _headerName;
-        private readonly string _bodyName;
+        private readonly string _webName;
         private readonly uint _flags;
+        private string _displayNameResourceKey;
 
-        [SecurityCritical]
-        unsafe internal CodePageDataItem(
-            string webName, int uiFamilyCodePage, string headerName,
-            string bodyName, uint flags) {
-            // TODO: Implement this fully.
-            _webName = webName;
+        internal CodePageDataItem(int codePage, int uiFamilyCodePage, string webName, uint flags)
+        {
+            _codePage = codePage;
             _uiFamilyCodePage = uiFamilyCodePage;
-            _headerName = headerName;
-            _bodyName = bodyName;
+            _webName = webName;
             _flags = flags;
         }
 
-        unsafe public String WebName {
-            [System.Security.SecuritySafeCritical]  // auto-generated
-            get {
-                // TODO: Implement this fully.
-                return _webName;
-            }
+        public int CodePage
+        {
+            get { return _codePage; }
         }
-    
-        public virtual int UIFamilyCodePage {
-            get {
-                // TODO: Implement this fully.
-                return _uiFamilyCodePage;
-            }
-        }
-    
-        unsafe public String HeaderName {
-            [System.Security.SecuritySafeCritical]  // auto-generated
-            get {
-                // TODO: Implement this fully.
-                return _headerName;
-            }
-        }
-    
-        unsafe public String BodyName {
-            [System.Security.SecuritySafeCritical]  // auto-generated
-            get {
-                // TODO: Implement this fully.
-                return _bodyName;
-            }
-        }    
 
-        unsafe public uint Flags {
-            get {
-                // TODO: Implement this fully.
-                return _flags;
-            }
+        public int UIFamilyCodePage
+        {
+            get { return _uiFamilyCodePage; }
+        }
+
+        public String WebName
+        {
+            get { return _webName; }
+        }
+
+        public String HeaderName
+        {
+            get { return _webName; } // all the code pages used on unix only have a single name
+        }
+
+        public String BodyName
+        {
+            get { return _webName; } // all the code pages used on unix only have a single name
+        }
+
+        public uint Flags
+        {
+            get { return _flags; }
         }
 
         // PAL ends here
+
+        public string DisplayNameResourceKey
+        {
+            get
+            {
+                if (_displayNameResourceKey == null)
+                {
+                    _displayNameResourceKey = "Globalization.cp_" + CodePage;
+                }
+
+                return _displayNameResourceKey;
+            }
+        }
     }
 }

--- a/src/mscorlib/src/System/Text/Encoding.cs
+++ b/src/mscorlib/src/System/Text/Encoding.cs
@@ -107,10 +107,10 @@ namespace System.Text
         // The following values are from mlang.idl.  These values
         // should be in sync with those in mlang.idl.
         //
-        private const int MIMECONTF_MAILNEWS          = 0x00000001;
-        private const int MIMECONTF_BROWSER           = 0x00000002;
-        private const int MIMECONTF_SAVABLE_MAILNEWS  = 0x00000100;
-        private const int MIMECONTF_SAVABLE_BROWSER   = 0x00000200;
+        internal const int MIMECONTF_MAILNEWS          = 0x00000001;
+        internal const int MIMECONTF_BROWSER           = 0x00000002;
+        internal const int MIMECONTF_SAVABLE_MAILNEWS  = 0x00000100;
+        internal const int MIMECONTF_SAVABLE_BROWSER   = 0x00000200;
 
         // Special Case Code Pages
         private const int CodePageDefault       = 0;


### PR DESCRIPTION
Our current Encodings implementation on Linux is stubbed out and
needs to be fully implemented for CoreClr.

Fix https://github.com/dotnet/corefx/issues/2774.

@ellismg 