### PR TITLE
Remove the need for the PKT to match when binding to an assembly on t…

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -1228,17 +1228,9 @@ namespace BINDER_SPACE
 #ifdef FEATURE_LEGACYNETCF
         fWindowsPhone7 = RuntimeIsLegacyNetCF(pApplicationContext->GetAppDomainId()) == TRUE;
 #endif
-        //
-        // Windows Phone 7 Quirk:
-        //
-        // NetCF allows partial binds to platform assemblies.  If we are running a
-        // Mango application, skip the PKT check if no Ref version is provided,
-        // since there are apps in the Marketplace that do Assembly.Load("System")
-        //
+
         if (!tpaListAssembly || (fWindowsPhone7 && tpaListAssembly))
         {
-            dwIncludeFlags |= AssemblyName::EXCLUDE_PUBLIC_KEY_TOKEN_IF_MISSING;
-
             //
             // On Windows Phone 7, exclude culture comparisons when requesting an uncultured
             // assembly for app compat reasons (there are main app assemblies with spurious cultures)

--- a/src/binder/assemblyname.cpp
+++ b/src/binder/assemblyname.cpp
@@ -568,10 +568,10 @@ Exit:
             {
                 fEquals = EqualsCaseInsensitive(GetNormalizedCulture(), pAssemblyName->GetNormalizedCulture());
             }
-            if (fEquals && ((dwIncludeFlags & EXCLUDE_PUBLIC_KEY_TOKEN_IF_MISSING) == 0 ||
-                (pAssemblyName->Have(AssemblyIdentity::IDENTITY_FLAG_PUBLIC_KEY_TOKEN))))
+
+            if (fEquals && (dwIncludeFlags & INCLUDE_PUBLIC_KEY_TOKEN) != 0)
             {
-                    fEquals = (GetPublicKeyTokenBLOB().Equals(pAssemblyName->GetPublicKeyTokenBLOB()));
+                fEquals = (GetPublicKeyTokenBLOB().Equals(pAssemblyName->GetPublicKeyTokenBLOB()));
             }
             
             if (fEquals && ((dwIncludeFlags & INCLUDE_ARCHITECTURE) != 0))

--- a/src/binder/inc/assemblyname.hpp
+++ b/src/binder/inc/assemblyname.hpp
@@ -31,7 +31,7 @@ namespace BINDER_SPACE
             INCLUDE_ARCHITECTURE                = 0x02,
             INCLUDE_RETARGETABLE                = 0x04, 
             INCLUDE_CONTENT_TYPE                = 0x08,
-            EXCLUDE_PUBLIC_KEY_TOKEN_IF_MISSING = 0x10,
+            INCLUDE_PUBLIC_KEY_TOKEN            = 0x10,
             EXCLUDE_CULTURE                     = 0x20
         } INCLUDE_FLAGS;
 


### PR DESCRIPTION
…he TPA list

There is some inconsistency in how binding works with and without a custom AssemblyLoadContext being active. By default, the binder allows binding to assemblies on the TPA list despite a PKT mismatch while searching app paths. This part is skipped when a custom AssemblyLoadContext is active.

It has been determined that generally, the binder shouldn't require the PKT to match, so disabling that check.

Fixes #1640