### PR TITLE
Fix wrong register with module address in crossgen on Unix

### DIFF
--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1948,10 +1948,15 @@ DWORD ZapLazyHelperThunk::SaveWorker(ZapWriter * pZapWriter)
         pImage->WriteReloc(buffer, (int)(p - buffer), m_pTarget, 0, IMAGE_REL_BASED_REL32);
     p += 4;
 #elif defined(_TARGET_AMD64_)
-    // lea rdx, module
     *p++ = 0x48;
     *p++ = 0x8D;
+#ifdef UNIX_AMD64_ABI
+    // lea rsi, module
+    *p++ = 0x35;
+#else
+    // lea rdx, module
     *p++ = 0x15;
+#endif
     if (pImage != NULL)
         pImage->WriteReloc(buffer, (int)(p - buffer), m_pArg, 0, IMAGE_REL_BASED_REL32);
     p += 4;

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -1995,10 +1995,15 @@ DWORD ZapIndirectHelperThunk::SaveWorker(ZapWriter * pZapWriter)
     else
     if (IsLazyHelper())
     {
-        // mov rdx, [module]
         *p++ = 0x48;
         *p++ = 0x8B;
+#ifdef UNIX_AMD64_ABI
+        // mov rsi, [module]
+        *p++ = 0x35;
+#else
+        // mov rdx, [module]
         *p++ = 0x15;
+#endif
         if (pImage != NULL)
             pImage->WriteReloc(buffer, (int) (p - buffer), pImage->GetImportTable()->GetHelperImport(READYTORUN_HELPER_Module), 0, IMAGE_REL_BASED_REL32);
         p += 4;


### PR DESCRIPTION
This change fixes a crossgen bug when the module pointer as a parameter to
JIT_StrCns was incorrectly placed into RDX both on Windows and on Unix.
Since it is the second parameter to the function, the calling convention
on Unix requires it to be in RSI.