### PR TITLE
fix ICU compile error on CentOS 

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -27,6 +27,16 @@ if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)
     return()
 endif()
 
+set(CMAKE_REQUIRED_INCLUDES ${ICU_HOMEBREW_INC_PATH})
+CHECK_CXX_SOURCE_COMPILES("
+ #include <unicode/dtfmtsym.h>
+ int main() { DateFormatSymbols::DtWidthType e = DateFormatSymbols::DtWidthType::SHORT; }
+" HAVE_DTWIDTHTYPE_SHORT) 
+
+if(HAVE_DTWIDTHTYPE_SHORT)
+    add_definitions(-DHAVE_DTWIDTHTYPE_SHORT=1)
+endif(HAVE_DTWIDTHTYPE_SHORT)
+
 add_compile_options(-fPIC)
 
 set(NATIVEGLOBALIZATION_SOURCES

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -498,7 +498,12 @@ extern "C" int32_t EnumCalendarInfo(
 		case AbbrevMonthNames:
 			return EnumMonths(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::ABBREVIATED, callback, context);
 		case SuperShortDayNames:
+#ifdef HAVE_DTWIDTHTYPE_SHORT
 			return EnumWeekdays(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::SHORT, callback, context);
+#else
+			// Currently CentOS-7 uses ICU-50 and ::SHORT was added in ICU-51, so use ::NARROW instead
+			return EnumWeekdays(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::NARROW, callback, context);
+#endif
 		case MonthGenitiveNames:
 			return EnumMonths(locale, calendarId, DateFormatSymbols::FORMAT, DateFormatSymbols::WIDE, callback, context);
 		case AbbrevMonthGenitiveNames:


### PR DESCRIPTION
Issue #1660

Use DateFormatSymbols::NARROW insead of ::SHORT for CentOS as ::SHORT is not defined in the version of ICU being used (50) by CentOS build. ::SHORT was added in ICU 51