### PR TITLE
Add native exception filter holder.

### DIFF
--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -1437,10 +1437,10 @@ void DECLSPEC_NORETURN EEPolicy::HandleFatalStackOverflow(EXCEPTION_POINTERS *pE
             param.pExceptionRecord = pExceptionInfo->ExceptionRecord;
             g_pDebugInterface->RequestFavor(ResetWatsonBucketsFavorWorker, reinterpret_cast<void *>(&param));
         }
+#endif // !FEATURE_PAL        
 
         WatsonLastChance(pThread, pExceptionInfo, 
             (fTreatAsNativeUnhandledException == FALSE)? TypeOfReportedError::UnhandledException: TypeOfReportedError::NativeThreadUnhandledException);
-#endif // !FEATURE_PAL        
     }
 
     TerminateProcess(GetCurrentProcess(), COR_E_STACKOVERFLOW);

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7885,7 +7885,6 @@ LONG WINAPI CLRVectoredExceptionHandlerPhase2(PEXCEPTION_POINTERS pExceptionInfo
     if ((pExceptionRecord->ExceptionCode == STATUS_BREAKPOINT) ||
         (pExceptionRecord->ExceptionCode == STATUS_SINGLE_STEP))
     {
-#ifndef FEATURE_PAL
         // A breakpoint outside managed code and outside the runtime will have to be handled by some
         //  other piece of code.
 
@@ -7910,7 +7909,6 @@ LONG WINAPI CLRVectoredExceptionHandlerPhase2(PEXCEPTION_POINTERS pExceptionInfo
             //  an unhandled exception.)
             return EXCEPTION_CONTINUE_SEARCH;
         }
-#endif // !FEATURE_PAL
 
         // The breakpoint was from managed or the runtime.  Handle it.  Or,
         //  this may be a Rotor build.


### PR DESCRIPTION
The problem is that the debugger unhandled managed exception notification is sent
because the proper filter function (InternalUnhandledExcpetionFilter) isn't called
and the filter can't be called currently during the first pass of managed exception
dispatch that it requires.

The NativeExceptionHolder is used to hold the filter handler for the
PAL_TRY/PAL_EXCEPT/PAL_EXCEPT_FILTER macros so managed exception dispatcher
can call them during the first pass like real SEH on Windows.