### PR TITLE
Impossible implicit downcast in assignment operator

### DIFF
--- a/src/jit/jitstd/unordered_set.h
+++ b/src/jit/jitstd/unordered_set.h
@@ -150,7 +150,8 @@ template <typename Value, typename Hash, typename Pred, typename Alloc>
 unordered_set<Value, Hash, Pred, Alloc>&
     unordered_set<Value, Hash, Pred, Alloc>::operator=(unordered_set const& other)
 {
-    return base_type::operator=(other);
+    base_type::operator=(other);
+    return *this;
 }
 
 } // end of namespace jitstd.


### PR DESCRIPTION
This code only compiles because the member function is never instantiated. It cannot compile because `base::operator=()` returns `base&` which cannot be implicitly upcast to `derived&`.

This defect was found with Cppcheck.