### PR TITLE
Using DotNetCore version of BclRewriter in mscorlib build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -102,6 +102,9 @@ build_mscorlib()
         return
     fi
 
+    # Temporary hack to make dnu restore more reliable. This is specifically for dnu beta 5 since this issue should already be addressed in later versions of dnu.
+    export MONO_THREADS_PER_CPU=2000
+
     echo "Commencing build of mscorlib components for $__BuildOS.$__BuildArch.$__BuildType"
 
     # Pull NuGet.exe down if we don't have it already
@@ -135,8 +138,21 @@ build_mscorlib()
         fi
     fi
 
+    # Set _ToolNugetRuntimeId
+    case $__BuildOS in
+        Linux)
+            _ToolNugetRuntimeId=ubuntu.14.04-x64
+            ;;
+        OSX)
+            _ToolNugetRuntimeId=osx.10.10-x64
+            ;;
+        *)
+            _ToolNugetRuntimeId=ubuntu.14.04-x64
+            ;;
+    esac
+
     # Invoke MSBuild
-    mono "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__MSBuildBuildArch /p:__BuildType=$__BuildType /p:UseRoslynCompiler=true /p:BuildNugetPackage=false
+    mono "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__MSBuildBuildArch /p:__BuildType=$__BuildType /p:UseRoslynCompiler=true /p:BuildNugetPackage=false /p:ToolNugetRuntimeId=$_ToolNugetRuntimeId
 
     if [ $? -ne 0 ]; then
         echo "Failed to build mscorlib."

--- a/dir.props
+++ b/dir.props
@@ -9,7 +9,7 @@
   
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00079</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00105</BuildToolsVersion>
     <BuildToolsCoreCLRVersion>1.0.3-prerelease</BuildToolsCoreCLRVersion>
     <DnxVersion Condition="'$(OsEnvironment)'!='Unix'">1.0.0-beta5-12101</DnxVersion>
     <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta5-12101</DnxVersion>
@@ -51,6 +51,8 @@
     <BinDir>$(__BinDir)\</BinDir>
     <BinDir Condition="'$(__BinDir)'==''">$(RootBinDir)Product\$(BuildOS).$(BuildArch).$(BuildType)\</BinDir>
 
+    <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(__IntermediatesDir)\</IntermediateOutputRootPath>
+
     <!-- We don't append back slash because this path is used by nuget.exe as output directory and it
          fails to write packages to it if the path contains the forward slash.
     -->
@@ -58,6 +60,7 @@
     <PackagesBinDir Condition="'$(__PackagesBinDir)'==''">$(BinDir).nuget</PackagesBinDir>
     
     <ToolsDir Condition="'$(ToolsDir)'==''">$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)/lib/</ToolsDir>
+    <BuildToolsSemaphore Condition="'$(BuildToolsSemaphore)' == ''">$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll</BuildToolsSemaphore>
     <!-- Directory for the CoreCLR tools (BCLRewriter, etc.) -->
     <CoreCLRToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.CoreCLR.$(BuildToolsCoreCLRVersion)/</CoreCLRToolsDir>
     

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00079" />
-  <package id="Microsoft.DotNet.BuildTools.CoreCLR" version="1.0.3-prerelease" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00105" />
   <package id="dnx-mono" version="1.0.0-beta5-12101" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />
 </packages>

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00079" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00105" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
-  <package id="Microsoft.DotNet.BuildTools.CoreCLR" version="1.0.3-prerelease" />
 </packages>

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -6,6 +6,7 @@
   <packageSources>
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="myget.org dotnet-core" value="https://www.myget.org/F/dotnet-core/" />
   </packageSources>
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />

--- a/src/mscorlib/Tools/BclRewriter/BclRewriter.targets
+++ b/src/mscorlib/Tools/BclRewriter/BclRewriter.targets
@@ -5,26 +5,26 @@
   <!-- ********************************************************************************************* -->
 
   <PropertyGroup>
-    <BclRewriterCommand Condition="'$(BclRewriterCommand)'==''">$(CoreCLRToolsDir)\BclRewriter.exe</BclRewriterCommand>
     <BclRewriterModelFile>$(MscorlibDir)model.xml</BclRewriterModelFile>
     <BclRewriterWorkDir>$(IntermediateOutputPath)\BclRewriter</BclRewriterWorkDir>
     <BclRewriterSymbolOutput>$(IntermediateOutputPath)\BclRewriter\$(TargetName).pdb</BclRewriterSymbolOutput>
     <BclRewriterOutput>$(IntermediateOutputPath)\BclRewriter\$(TargetName)$(TargetExt)</BclRewriterOutput>
   </PropertyGroup>
-
+  
   <ItemGroup>
     <RewrittenAssembly Include="$(BclRewriterOutput)" />
   </ItemGroup>
   
   <Target Name="RewriteWithBclRewriter" 
-          Inputs="@(AnnotatedAssembly)" Outputs="@(RewrittenAssembly)">
+          Inputs="@(AnnotatedAssembly)" Outputs="@(RewrittenAssembly)" DependsOnTargets="$(BclRewriterDependencyTargets)">
 
     <PropertyGroup>
       <OSPlatform Condition="'$(TargetsWindows)' == 'true'">win</OSPlatform>
       <OSPlatform Condition="'$(TargetsWindows)' != 'true'">unix</OSPlatform>
+      <BclRewriterCommand Condition="'$(BclRewriterCommand)'==''">"$(ToolRuntimePath)$(ToolHost)" "$(ToolsDir)BclRewriter.exe"</BclRewriterCommand>
     </PropertyGroup>
    
-    <Exec Command="&quot;$(BclRewriterCommand)&quot; -in:&quot;@(AnnotatedAssembly)&quot; -out:&quot;$(BclRewriterOutput)&quot; -include:&quot;$(BclRewriterModelFile)&quot; -platform:$(OSPlatform) -architecture:$(Platform) -flavor:$(_BuildType) -define:&quot;$(DefineConstants)&quot; -keepTempFiles+" StandardOutputImportance="Normal" />
+    <Exec Command="$(BclRewriterCommand) -in:&quot;@(AnnotatedAssembly)&quot; -out:&quot;$(BclRewriterOutput)&quot; -include:&quot;$(BclRewriterModelFile)&quot; -platform:$(OSPlatform) -architecture:$(Platform) -flavor:$(_BuildType) -define:&quot;$(DefineConstants)&quot; -keepTempFiles+" StandardOutputImportance="Normal" />
 
     <!-- Update the location of the symbol file-->
     <PropertyGroup>

--- a/src/mscorlib/Tools/PostProcessingTools.targets
+++ b/src/mscorlib/Tools/PostProcessingTools.targets
@@ -7,10 +7,13 @@
     <Clean Include="@(RewrittenAssembly->'$(FinalOutputPath)\%(Filename)%(Extension)')" />
     <Clean Include="$(FinalOutputPath)\$(TargetName).pdb" />
   </ItemGroup>
+  
+  <Import Project="$(ToolsDir)toolruntime.targets" />
 
   <PropertyGroup>
     <CurrentAssemblyPdb>$(IntermediateOutputPath)$(TargetName).pdb</CurrentAssemblyPdb>
     <PostProcessingTargets>RewriteWithBclRewriter</PostProcessingTargets>
+    <BclRewriterDependencyTargets>EnsureBuildToolsRuntime</BclRewriterDependencyTargets>
   </PropertyGroup>
 
   <Target Name="AfterBuild" DependsOnTargets="$(PostProcessingTargets)"

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -9,7 +9,7 @@
   
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00079</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00105</BuildToolsVersion>
     <BuildToolsCoreCLRVersion>1.0.2-prerelease</BuildToolsCoreCLRVersion>
     <DnxVersion Condition="'$(OsEnvironment)'!='Unix'">1.0.0-beta5-12101</DnxVersion>
     <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-beta5-12101</DnxVersion>

--- a/tests/src/.nuget/packages.Windows_NT.config
+++ b/tests/src/.nuget/packages.Windows_NT.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00079" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00105" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-beta5-12101" />
 </packages>

--- a/tests/xunitwrapper.targets
+++ b/tests/xunitwrapper.targets
@@ -5,7 +5,7 @@
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Target Name="ResolveNuGetPackages">
-
+ 
     <PrereleaseResolveNuGetPackageAssets Condition="Exists($(ProjectLockJson))"
                                          AllowFallbackOnTargetSelection="true"
                                          IncludeFrameworkReferences="false"
@@ -13,7 +13,7 @@
                                          RuntimeIdentifier="dotnet"
                                          ProjectLanguage="$(Language)"
                                          ProjectLockFile="$(ProjectLockJson)"
-                                         TargetMonikers="$(NugetTargetFrameworkMoniker)">
+                                         TargetMonikers="$(TargetFrameworkMoniker)">
       <Output TaskParameter="ResolvedAnalyzers" ItemName="Analyzer" />
       <Output TaskParameter="ResolvedReferences" ItemName="Reference" />
       <Output TaskParameter="ResolvedCopyLocalItems" ItemName="CopyLocal" />


### PR DESCRIPTION
Since we have updated the buildtools package to contain a .Net Core version of BclRewriter, now we can use that to build mscorlib 