### PR TITLE
code: Fix redefined macro warning

### DIFF
--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -74,8 +74,10 @@ extern "C" {
 
 // On ARM __fastcall is ignored and causes a compile error
 #if !defined(PAL_STDCPP_COMPAT) || defined(__arm__)
-#define __fastcall
-#define _fastcall
+#  undef __fastcall
+#  undef _fastcall
+#  define __fastcall
+#  define _fastcall
 #endif // !defined(PAL_STDCPP_COMPAT) || defined(__arm__)
 
 #endif  // !defined(__i386__)


### PR DESCRIPTION
For example, in this log:
https://dotnet-ci.cloudapp.net/job/dotnet_coreclr_freebsd_debug_prtest/1082/consoleFull
search for '-Wmacro-redefined'. All 26 occurences are pointing to this line.