### PR TITLE
Fix issue in the new exception handling

### DIFF
--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -302,12 +302,17 @@ public:
         return m_pInitialExplicitFrame;
     }
 
-    // Reset the range of explicit frames that covers already unwound frames.
-    void ResetUnwoundExplicitFramesRange()
+#ifdef FEATURE_PAL
+    // Reset the range of explicit frames, the limit frame and the scanned
+    // stack range before unwinding a sequence of native frames. These frames
+    // will be in the unwound part of the stack.
+    void CleanupBeforeNativeFramesUnwind()
     {
         m_pInitialExplicitFrame = NULL;
         m_pLimitFrame = NULL;
+        m_ScannedStackRange.Reset();
     }
+#endif // FEATURE_PAL
 
     // Determines if we have unwound to the specified parent method frame.
     // Currently this is only used for funclet skipping.


### PR DESCRIPTION
There was a problem with scanned stack range stored in an exception tracker.
After unwinding a sequence of native frames during the 2nd pass of unwinding,
the scanned stack range was not cleared and referenced stack frames that
were unwound. In some rare cases related to throwing an exception from
a catch handler, this was causing the exception handling to consider stack
frames that accidentally had the same range of addresses as already visited,
which resulted in a wrong exception handler being executed.