### PR TITLE
Enable Frame Pointers for UNIX Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,9 @@ add_compile_options(-fms-extensions )
 #-fms-compatibility      Enable full Microsoft Visual C++ compatibility
 #-fms-extensions         Accept some non-standard constructs supported by the Microsoft compiler
 
+# Disable frame pointer optimizations so profilers can get better call stacks
+add_compile_options(-fno-omit-frame-pointer)
+
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(src/debug/debug-pal)

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -522,7 +522,7 @@ PCODE MethodDesc::MakeJitWorker(COR_ILMETHOD_DECODER* ILHeader, DWORD flags, DWO
 
 #ifdef FEATURE_PERFMAP
                 // Save the JIT'd method information so that perf can resolve JIT'd call frames.
-                PerfMap::LogMethod(this, pCode, sizeOfCode);
+                PerfMap::LogJITCompiledMethod(this, pCode, sizeOfCode);
 #endif
                 
                 mcJitManager.GetMulticoreJitCodeStorage().StoreMethodCode(this, pCode);
@@ -606,7 +606,7 @@ GotNewCode:
 
 #ifdef FEATURE_PERFMAP
                 // Save the JIT'd method information so that perf can resolve JIT'd call frames.
-                PerfMap::LogMethod(this, pCode, sizeOfCode);
+                PerfMap::LogJITCompiledMethod(this, pCode, sizeOfCode);
 #endif
             }
  
@@ -1350,6 +1350,11 @@ PCODE MethodDesc::DoPrestub(MethodTable *pDispatchingMT)
                 END_PIN_PROFILER();
             }
 #endif // PROFILING_SUPPORTED
+
+#ifdef FEATURE_PERFMAP
+            // Log the pre-compiled method code to the perf map.
+            PerfMap::LogPreCompiledMethod(this, pCode);
+#endif  // FEATURE_PERFMAP
         }
 
         //

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -5074,6 +5074,12 @@ bool ZapImage::canIntraModuleDirectCall(
 
     // No direct calls at all under some circumstances
 
+#ifdef PLATFORM_LINUX
+    // On Linux always call via the prestub.  This ensures that the prestub can log method information
+    // for Linux profiling tools.
+    goto CALL_VIA_ENTRY_POINT;
+#endif
+
     if ((m_zapper->m_pOpt->m_compilerFlags & CORJIT_FLG_PROF_ENTERLEAVE)
         && !m_pPreloader->IsDynamicMethod(callerFtn))
     {


### PR DESCRIPTION
By default, frame pointers are disabled for optimized builds on UNIX platforms.  This results in partial, and worse, impossible call stacks to be collected by perf tools such as perf_event.

To resolve, this we should always compile with frame pointers.