### PR TITLE
Enable Frame Pointers for UNIX Builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,9 @@ add_compile_options(-fms-extensions )
 #-fms-compatibility      Enable full Microsoft Visual C++ compatibility
 #-fms-extensions         Accept some non-standard constructs supported by the Microsoft compiler
 
+# Disable frame pointer optimizations so profilers can get better call stacks
+add_compile_options(-fno-omit-frame-pointer)
+
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(src/debug/debug-pal)


### PR DESCRIPTION
By default, frame pointers are disabled for optimized builds on UNIX platforms. This results in partial, and worse, impossible call stacks to be collected by perf tools such as perf_event.

To resolve, this we should always compile with frame pointers.