### PR TITLE
Fix managed breakpoints on OSX

### DIFF
--- a/src/debug/di/shimremotedatatarget.cpp
+++ b/src/debug/di/shimremotedatatarget.cpp
@@ -130,6 +130,7 @@ void ShimRemoteDataTarget::Dispose()
         m_pProxy->ReleaseTransport(m_pTransport);
     }
 
+    m_pTransport = NULL;
     m_hr = CORDBG_E_OBJECT_NEUTERED;
 }
 

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -2054,6 +2054,9 @@ HRESULT Debugger::Startup(void)
     }
 #endif
 
+#ifdef FEATURE_PAL
+    PAL_InitializeDebug();
+#endif // FEATURE_PAL
 
     // Lazily initialize the interop-safe heap
 

--- a/src/pal/src/exception/machexception.cpp
+++ b/src/pal/src/exception/machexception.cpp
@@ -133,9 +133,20 @@ static exception_mask_t GetExceptionMask()
 
     if (exMode == MachException_Uninitialized)
     {
+        exMode = MachException_Default;
+
         const char * exceptionSettings = getenv(PAL_MACH_EXCEPTION_MODE);
-        exMode = exceptionSettings
-            ? (MachExceptionMode)atoi(exceptionSettings) : MachException_Default;
+        if (exceptionSettings)
+        {
+            exMode = (MachExceptionMode)atoi(exceptionSettings);
+        }
+        else
+        {
+            if (PAL_IsDebuggerPresent())
+            {
+                exMode = MachException_SuppressDebugging;
+            }
+        }
     }
 
     exception_mask_t machExceptionMask = 0;

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -164,6 +164,7 @@ PAL_SetHardwareExceptionHandler(
     IN PHARDWARE_EXCEPTION_HANDLER exceptionHandler)
 
 {
+    //TRACE("Hardware exception installed: %p\n", exceptionHandler);
     g_hardwareExceptionHandler = exceptionHandler;
 }
 
@@ -194,7 +195,8 @@ SEHProcessException(PEXCEPTION_POINTERS pointers)
         throw exception;
     }
 
-    TRACE("Unhandled hardware exception %08x\n", pointers->ExceptionRecord->ExceptionCode);
+    TRACE("Unhandled hardware exception %08x at %p\n", 
+        pointers->ExceptionRecord->ExceptionCode, pointers->ExceptionRecord->ExceptionAddress);
 }
 
 /*++

--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -137,13 +137,7 @@ HeapCreate(
     }
     else
     {
-        malloc_zone_t *pZone = malloc_create_zone(dwInitialSize, 0 /* flags */);
-        ret = (HANDLE)pZone;
-#ifdef CACHE_HEAP_ZONE
-        _ASSERT_MSG(s_pExecutableHeap == NULL, "PAL currently only handles the creation of one executable heap.");
-        s_pExecutableHeap = pZone;
-        TRACE("s_pExecutableHeap is %p.\n", s_pExecutableHeap);
-#endif // CACHE_HEAP_ZONE
+        ret = (HANDLE)malloc_create_zone(dwInitialSize, 0 /* flags */);
     }
     
 #else // __APPLE__
@@ -176,7 +170,15 @@ GetProcessHeap(
 #if HEAP_HANDLES_ARE_REAL_HANDLES
 #error
 #else
-    ret = (HANDLE) malloc_default_zone();
+    malloc_zone_t *pZone = malloc_default_zone();
+    ret = (HANDLE)pZone;
+#ifdef CACHE_HEAP_ZONE
+    if (s_pExecutableHeap == NULL)
+    {
+        s_pExecutableHeap = pZone;
+        TRACE("s_pExecutableHeap is %p (process heap).\n", s_pExecutableHeap);
+    }
+#endif // CACHE_HEAP_ZONE
 #endif // HEAP_HANDLES_ARE_REAL_HANDLES
 #else
     ret = (HANDLE) DUMMY_HEAP;

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -894,12 +894,14 @@ CONTEXT_GetThreadContextFromPort(
         lpContext->R13 = State.__r13;
         lpContext->R14 = State.__r14;
         lpContext->R15 = State.__r15;
-//        lpContext->SegSs = State.ss; // no such state?
         lpContext->EFlags = State.__rflags;
         lpContext->Rip = State.__rip;
         lpContext->SegCs = State.__cs;
-//        lpContext->SegDs_PAL_Undefined = State.ds; // no such state?
-//        lpContext->SegEs_PAL_Undefined = State.es; // no such state?
+        // RtlRestoreContext uses the actual ss instead of this one
+        // to build the iret frame so just set it zero.
+        lpContext->SegSs = 0;
+        lpContext->SegDs = 0;
+        lpContext->SegEs = 0;
         lpContext->SegFs = State.__fs;
         lpContext->SegGs = State.__gs;
 #else


### PR DESCRIPTION
Changed the OSX exception initialization to enable breakpoints/stepping.

Fix problem with faults and breakpoints in coreclr code not being forwarded to
native debugger (if being debugged).

Fix debugger shutdown where we release the transport too many times and assert in debug.

When building the register context for an exception don't save/restore the debug
registers because they cause an priviledged instruction fault.

Fixed the PAL's TRACE formatting by merging the printfcpp.cpp formatting into
silent_printf.cpp. "%p" wasn't being formatted correctly in a PAL TRACE statement.

The executable heap zone wasn't being set because the process heap
is used instead of creating a new heap.
