### PR TITLE
Fix OSX hardware exception handling

### DIFF
--- a/src/pal/src/arch/i386/activationhandlerwrapper.S
+++ b/src/pal/src/arch/i386/activationhandlerwrapper.S
@@ -16,8 +16,8 @@ C_FUNC(ActivationHandlerReturnOffset):
 NESTED_ENTRY ActivationHandlerWrapper, _TEXT, NoHandler
     push_nonvol_reg rbp
     mov     rbp, rsp
-    set_cfa_register rbp, 0
     alloc_stack (CONTEXT_Size)
+    set_cfa_register rbp, (2*8)
     mov     rdi, rsp
     int3
     call    C_FUNC(ActivationHandler)

--- a/src/pal/src/arch/i386/dispatchexceptionwrapper.S
+++ b/src/pal/src/arch/i386/dispatchexceptionwrapper.S
@@ -47,7 +47,7 @@ C_FUNC(PAL_DispatchExceptionReturnOffset):
 NESTED_ENTRY PAL_DispatchExceptionWrapper, _TEXT, NoHandler
     push_nonvol_reg rbp
     mov     rbp, rsp
-    set_cfa_register rbp, 0
+    set_cfa_register rbp, (2*8)
     int3
     call    PAL_DISPATCHEXCEPTION
 LOCAL_LABEL(PAL_DispatchExceptionReturn):

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -294,8 +294,7 @@ BOOL PAL_VirtualUnwind(CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextP
     // Check if the frame we have unwound to is a frame that caused
     // synchronous signal, like a hardware exception and record it
     // in the context flags.
-    st = unw_is_signal_frame(&cursor); 
-    if (st > 0)
+    if (unw_is_signal_frame(&cursor) > 0)
     {
         context->ContextFlags |= CONTEXT_EXCEPTION_ACTIVE;
     }


### PR DESCRIPTION
In my recent change that has added the runtime suspension for OSX,
I have also added a fix for the unwind info of the PAL_DispatchExceptionWrapper
function. It turns out that I've made a mistake in the offset in the set_cfa_register
and it has broken hardware exception handling on OSX since the unwinder was not
able to unwind correctly through the wrapper.
It also turns out that the same wrong offset in set_cfa_register is in the
ActivationHelperWrapper.S, but in that function, the unwinding still works correctly.
I've actually verified that with both the wrong and the correct offset, the unwinder
gets the same correct RSP / RBP at the time of the exception. So I believe linked ignored
the DWARF unwind info and used compact unwind info instead that it was able to
derive correctly on its own.
Also, the allocate_stack was incorrectly placed before the set_cfa_register, which again
didn't cause a problem due to the DWARF info being ignored. The issue with this one was
that it updates the CFA, but the CFA offset is relative to RBP at that point and
RBP didn't change.
As an additional fix, there was a problem in PAL_VirtualUnwind that @sergiy-k has
spotted. The return value of the recently added unw_is_signal_frame call was
overwriting the status code returned by the unw_step that we use on OSX to
detect walking out of stack.