### PR TITLE
Producing standalone Jit for testing

### DIFF
--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
@@ -24,6 +24,7 @@
     <file src="..\corerun.exe" target="lib\aspnetcore50\corerun.exe" />
     <file src="..\mscorlib.dll" target="lib\aspnetcore50\mscorlib.dll" />
     <file src="..\sos.dll" target="lib\aspnetcore50\sos.dll" />
+    <file src="..\protojit.dll" target="lib\aspnetcore50\protojit.dll" />
     <file src="..\PDB\clretwrc.pdb" target="lib\aspnetcore50\clretwrc.pdb" />
     <file src="..\PDB\coreclr.pdb" target="lib\aspnetcore50\coreclr.pdb" />
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
@@ -34,6 +35,7 @@
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
     <file src="..\PDB\sos.pdb" target="lib\aspnetcore50\sos.pdb" />
     <file src="..\PDB\mscorlib.pdb" target="lib\aspnetcore50\mscorlib.pdb" />
+    <file src="..\PDB\protojit.pdb" target="lib\aspnetcore50\protojit.pdb" />
     <file src="..\inc\cor.h" target="inc\cor.h" />
     <file src="..\inc\corerror.h" target="inc\corerror.h" />
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
@@ -24,6 +24,7 @@
     <file src="..\corerun.exe" target="lib\aspnetcore50\corerun.exe" />
     <file src="..\mscorlib.dll" target="lib\aspnetcore50\mscorlib.dll" />
     <file src="..\sos.dll" target="lib\aspnetcore50\sos.dll" />
+    <file src="..\protojit.dll" target="lib\aspnetcore50\protojit.dll" />
     <file src="..\PDB\clretwrc.pdb" target="lib\aspnetcore50\clretwrc.pdb" />
     <file src="..\PDB\coreclr.pdb" target="lib\aspnetcore50\coreclr.pdb" />
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
@@ -34,6 +35,7 @@
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
     <file src="..\PDB\sos.pdb" target="lib\aspnetcore50\sos.pdb" />
     <file src="..\PDB\mscorlib.pdb" target="lib\aspnetcore50\mscorlib.pdb" />
+    <file src="..\PDB\protojit.pdb" target="lib\aspnetcore50\protojit.pdb" />
     <file src="..\inc\cor.h" target="inc\cor.h" />
     <file src="..\inc\corerror.h" target="inc\corerror.h" />
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -133,3 +133,4 @@ set(CLR_EXPORTED_SYMBOL_FILE ${CLRJIT_EXPORTS_DEF})
 
 add_subdirectory(dll)
 add_subdirectory(crossgen)
+add_subdirectory(standalone)

--- a/src/jit/ee_il_dll.cpp
+++ b/src/jit/ee_il_dll.cpp
@@ -94,6 +94,7 @@ HINSTANCE GetModuleInst()
     return (g_hInst);
 }
 
+extern "C"
 void __stdcall sxsJitStartup(CoreClrCallbacks const & cccallbacks)
 {
 #ifndef SELF_NO_HOST

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -1,0 +1,48 @@
+project(protojit)
+add_definitions(-DFEATURE_NO_HOST)
+add_definitions(-DSELF_NO_HOST)
+add_definitions(-DFEATURE_READYTORUN_COMPILER)
+remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
+
+add_library(protojit
+   SHARED
+   ${SHARED_LIB_SOURCES}
+)
+
+set(PROTOJIT_LINK_LIBRARIES
+   utilcodestaticnohost
+   gcinfo
+)
+
+if(CLR_CMAKE_PLATFORM_UNIX)
+    list(APPEND PROTOJIT_LINK_LIBRARIES
+       mscorrc_debug
+       coreclrpal
+       palrt
+    )
+else()
+    list(APPEND PROTOJIT_LINK_LIBRARIES
+       msvcrt.lib
+       kernel32.lib
+       advapi32.lib
+       ole32.lib
+       oleaut32.lib
+       uuid.lib
+       user32.lib
+       version.lib
+       shlwapi.lib
+       bcrypt.lib
+       crypt32.lib
+       RuntimeObject.lib
+    )
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
+target_link_libraries(protojit
+   ${PROTOJIT_LINK_LIBRARIES}
+)
+
+# add the install targets
+install (TARGETS protojit DESTINATION .)
+if(WIN32)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/protojit.pdb DESTINATION PDB)
+endif(WIN32)


### PR DESCRIPTION
protojit.dll (Windows) / libprotojit.so (*nix) is produced in addition, which is a standalone Jit that is not attached to CoreCLR.
Note CoreCLR still embeds such Jit by default same as before to not disrupt the existing clients.
This (same) standalone Jit can be used for other testing purpose and also this can be specified as an altjit as well in CoreCLR.