### PR TITLE
Add [Out] to a couple of StringBuilders in DllImports

### DIFF
--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         internal static extern int GetCalendars(string localeName, CalendarId[] calendars, int calendarsCapacity);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
-        internal static extern CalendarDataResult GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, StringBuilder result, int resultCapacity);
+        internal static extern CalendarDataResult GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, [Out] StringBuilder result, int resultCapacity);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
@@ -11,15 +11,15 @@ internal static partial class Interop
     {
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal unsafe static extern bool GetLocaleName(string localeName, StringBuilder value, int valueLength);
+        internal unsafe static extern bool GetLocaleName(string localeName, [Out] StringBuilder value, int valueLength);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal unsafe static extern bool GetLocaleInfoString(string localeName, uint localeStringData, StringBuilder value, int valueLength);
+        internal unsafe static extern bool GetLocaleInfoString(string localeName, uint localeStringData, [Out] StringBuilder value, int valueLength);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal unsafe static extern bool GetLocaleTimeFormat(string localeName, bool shortFormat, StringBuilder value, int valueLength);
+        internal unsafe static extern bool GetLocaleTimeFormat(string localeName, bool shortFormat, [Out] StringBuilder value, int valueLength);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -10,6 +10,6 @@ internal static partial class Interop
     {
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi)] // readlink requires char*
         [return: MarshalAs(UnmanagedType.Bool)]
-        internal static extern bool ReadLink(string filePath, StringBuilder result, uint resultCapacity);
+        internal static extern bool ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
     }
 }

--- a/src/mscorlib/src/Microsoft/Win32/UnsafeNativeMethods.cs
+++ b/src/mscorlib/src/Microsoft/Win32/UnsafeNativeMethods.cs
@@ -45,14 +45,14 @@ namespace Microsoft.Win32 {
                                      [MarshalAs(UnmanagedType.LPWStr)]
                                      StringBuilder language,
                                      ref int languageLength,
-                                     [MarshalAs(UnmanagedType.LPWStr)]
+                                     [Out, MarshalAs(UnmanagedType.LPWStr)]
                                      StringBuilder fileMuiPath,
                                      ref int fileMuiPathLength,
                                      ref Int64 enumerator);
 
 
         [DllImport(Win32Native.USER32, EntryPoint="LoadStringW",  SetLastError=true, CharSet=CharSet.Unicode, ExactSpelling=true, CallingConvention=CallingConvention.StdCall)]
-        internal static extern int LoadString(SafeLibraryHandle handle, int id, StringBuilder buffer, int bufferLength);
+        internal static extern int LoadString(SafeLibraryHandle handle, int id, [Out] StringBuilder buffer, int bufferLength);
 
         [DllImport(Win32Native.KERNEL32, CharSet=System.Runtime.InteropServices.CharSet.Unicode, SetLastError=true)]
         internal static extern SafeLibraryHandle LoadLibraryEx(string libFilename, IntPtr reserved, int flags);        


### PR DESCRIPTION
I audited all of the StringBuilders being used in P/Invokes in mscorlib.  Almost all of them were correctly annotated as to their direction of needed marshaling.  Two weren't.

cc; @yizhang82