### PR TITLE
Fix incorrect runtime contract for FailedAssembly::Initialize

### DIFF
--- a/src/vm/appdomain.hpp
+++ b/src/vm/appdomain.hpp
@@ -1857,7 +1857,7 @@ struct FailedAssembly {
         CONTRACTL
         {
             THROWS;
-            GC_NOTRIGGER;
+            GC_TRIGGERS;
             MODE_ANY;
         }
         CONTRACTL_END;


### PR DESCRIPTION
FailedAssembly::Initialize may call CLRException::GetHR.
CLRException::GetHR is marked GC_TRIGGERS.
FailedAssembly::Initialize has to be marked GC_TRIGGERS
as well.