### PR TITLE
Improve String.ToLower/ToUpper throughput on Unix

### DIFF
--- a/src/corefx/System.Globalization.Native/casing.cpp
+++ b/src/corefx/System.Globalization.Native/casing.cpp
@@ -12,7 +12,7 @@
 Function:
 ChangeCase
 
-Preforms upper or lower casing of a string into a new buffer, preforming special casing for turkish, if needed.
+Performs upper or lower casing of a string into a new buffer, performing special casing for Turkish, if needed.
 */
 extern "C" void ChangeCase(const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength, int32_t bToUpper, int32_t bTurkishCasing)
 {
@@ -20,46 +20,66 @@ extern "C" void ChangeCase(const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst
     int32_t dstIdx = 0;
 
     UBool isError = FALSE;
+    UChar32 srcCodepoint;
+    UChar32 dstCodepoint;
 
-    while (srcIdx < cwSrcLength)
+    // Iterate through the string, decoding the next one or two UTF-16 code units into a codepoint 
+    // and updating srcIdx to point to the next UTF-16 code unit to decode.  Then upper or lower
+    // case it, write dstCodepoint into lpDst at offset dstIdx, and update dstIdx.
+    // (The loop here has been manually cloned for each of the four cases, rather than having a 
+    // single loop that internally branched based on bToUpper and bTurkishCasing, as the compiler 
+    // wasn't doing that optimization, and it results in an ~15-20% perf improvement on longer strings.)
+
+    if (bToUpper)
     {
-        UChar32 srcCodepoint;
-        UChar32 dstCodepoint;
-
-        // Decode the next one or two UTF-16 code units into a codepoint and update srcIdx to point to the next UTF-16 code unit to decode.
-        U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-
-        if (bToUpper)
+        if (bTurkishCasing)
         {
-            if (!bTurkishCasing)
-            {
-                dstCodepoint = u_toupper(srcCodepoint);
-            }
-            else
+            // bToUpper && bTurkishCasing
+            while (srcIdx < cwSrcLength)
             {
                 // In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130).
+                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
                 dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
+                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+                assert(isError == FALSE && srcIdx == dstIdx);
             }
         }
         else
         {
-            if (!bTurkishCasing)
+            // bToUpper && !bTurkishCasing
+            while (srcIdx < cwSrcLength)
             {
-                dstCodepoint = u_tolower(srcCodepoint);
-            }
-            else
-            {
-                // In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to LATIN SMALL LETTER DOTLESS I (U+0131).
-                dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
+                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+                dstCodepoint = u_toupper(srcCodepoint);
+                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+                assert(isError == FALSE && srcIdx == dstIdx);
             }
         }
-
-        // Write dstCodepoint into lpDst at offset dstIdx and update dstIdx.
-        U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-
-        // Ensure that we wrote the data and the source codepoint when encoded in UTF16 is the same
-        // number of code units as the cased codepoint.
-        assert(isError == FALSE && srcIdx == dstIdx);
+    }
+    else
+    {
+        if (bTurkishCasing)
+        {
+            // !bToUpper && bTurkishCasing
+            while (srcIdx < cwSrcLength)
+            {
+                // In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to LATIN SMALL LETTER DOTLESS I (U+0131).
+                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+                dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
+                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+                assert(isError == FALSE && srcIdx == dstIdx);
+            }
+        }
+        else
+        {
+            // !bToUpper && !bTurkishCasing
+            while (srcIdx < cwSrcLength)
+            {
+                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+                dstCodepoint = u_tolower(srcCodepoint);
+                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+                assert(isError == FALSE && srcIdx == dstIdx);
+            }
+        }
     }
 }
-


### PR DESCRIPTION
Our Unix implementation of changing case is currently slower than our implementation on Windows.  In our Unix ChangeCase implementation in System.Globalization.Native that uses ICU, we have a loop that reads each code point, processes it, and writes out the result.  That processing involves branching into four cases based on whether we're going to upper or to lower, and whether we're using Turkish or not.  By manually hoisting the invariants and loop cloning in order to remove the branches from the inner loop (an optimization the compiler appears to either miss or dismiss), we can improve the performance of this routine by ~15-20%.

Contributes to https://github.com/dotnet/corefx/issues/3574
cc: @ellismg, @nguerrera, @steveharter, @eerhardt 

(@ellismg, I also tried using U16_NEXT_UNSAFE and U16_APPEND_UNSAFE instead of U16_NEXT and U16_APPEND.  Doing so gave an additional ~25% perf improvement.  But I've not included that change here as I don't know if we can assume that the input UTF16 is well-formed... if we can, we should do that change as a follow-up.)