### PR TITLE
Fix Windows CoreConsole property list

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -456,8 +456,8 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         W("TRUSTED_PLATFORM_ASSEMBLIES"),
         W("APP_PATHS"),
         W("APP_NI_PATHS"),
-        W("NATIVE_DLL_SEARCH_DIRECTORIES")
-		W("AppDomainCompatSwitch"),
+        W("NATIVE_DLL_SEARCH_DIRECTORIES"),
+        W("AppDomainCompatSwitch")
     };
     const wchar_t *property_values[] = { 
         // TRUSTED_PLATFORM_ASSEMBLIES
@@ -468,6 +468,8 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
         appNiPath,
         // NATIVE_DLL_SEARCH_DIRECTORIES
         nativeDllSearchDirs,
+        // AppDomainCompatSwitch
+        W("UseLatestBehaviorWhenTFMNotSpecified")
     };
 
 


### PR DESCRIPTION
The property list was broken - the keys list was missing a comma between two entries,
so they got merged into one string. And the values list was missing one value too.