### PR TITLE
BinaryReader perf improvements on little-endian machines

### DIFF
--- a/src/mscorlib/src/System/IO/BinaryReader.cs
+++ b/src/mscorlib/src/System/IO/BinaryReader.cs
@@ -156,18 +156,52 @@ namespace System.IO {
             return (char)value;
         }
 
-        public virtual short ReadInt16() {
+        /*
+        PATTERN:
+            #if BIGENDIAN
+            ...
+            #else
+            ...
+            #endif
+
+        EXPLANATION:
+            When reading datatypes larger than a byte
+            (such as int) from the stream, we want to
+            make sure to read it in little-endian
+            format, even on big-endian platforms.
+
+            Thus, on little-endian machines we can
+            simply take a pointer to the buffer and
+            dereference it, while for big-endian
+            we have to manually do the bitshifting.
+        */
+
+        public virtual unsafe short ReadInt16() {
             FillBuffer(2);
-            return (short)(m_buffer[0] | m_buffer[1] << 8);
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                return (short)(ptr[0] | ptr[1] << 8);
+#else
+                return *(short*)ptr;
+#endif
+            }
         }
 
         [CLSCompliant(false)]
-        public virtual ushort ReadUInt16(){
+        public virtual unsafe ushort ReadUInt16(){
             FillBuffer(2);
-            return (ushort)(m_buffer[0] | m_buffer[1] << 8);
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                return (ushort)(ptr[0] | ptr[1] << 8);
+#else
+                return *(ushort*)ptr;
+#endif
+            }
         }
 
-        public virtual int ReadInt32() {
+        public virtual unsafe int ReadInt32() {
             if (m_isMemoryStream) {
                 if (m_stream==null) __Error.FileNotOpen();
                 // read directly from MemoryStream buffer
@@ -179,63 +213,144 @@ namespace System.IO {
             else
             {
                 FillBuffer(4);
-                return (int)(m_buffer[0] | m_buffer[1] << 8 | m_buffer[2] << 16 | m_buffer[3] << 24);
+                fixed (byte* ptr = m_buffer)
+                {
+#if BIGENDIAN
+                    return (int)(ptr[0] | ptr[1] << 8 | ptr[2] << 16 | ptr[3] << 24);
+#else
+                    return *(int*)ptr;
+#endif
+                }
             }
         }
 
         [CLSCompliant(false)]
-        public virtual uint ReadUInt32() {
+        public virtual unsafe uint ReadUInt32() {
             FillBuffer(4);
-            return (uint)(m_buffer[0] | m_buffer[1] << 8 | m_buffer[2] << 16 | m_buffer[3] << 24);
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                return (uint)(ptr[0] | ptr[1] << 8 | ptr[2] << 16 | ptr[3] << 24);
+#else
+                return *(uint*)ptr;
+#endif
+            }
         }
 
-        public virtual long ReadInt64() {
+        // For 64-bit types, it is necessary to
+        // read the buffer 2 [u]ints at a time.
+        // For more information, refer to:
+        // https://github.com/jamesqo/coreclr/commit/7351159#commitcomment-13684755
+
+        public virtual unsafe long ReadInt64() {
             FillBuffer(8);
-            uint lo = (uint)(m_buffer[0] | m_buffer[1] << 8 |
-                             m_buffer[2] << 16 | m_buffer[3] << 24);
-            uint hi = (uint)(m_buffer[4] | m_buffer[5] << 8 |
-                             m_buffer[6] << 16 | m_buffer[7] << 24);
-            return (long) ((ulong)hi) << 32 | lo;
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                uint lo = (uint)(ptr[0] | ptr[1] << 8 |
+                                 ptr[2] << 16 | ptr[3] << 24);
+                uint hi = (uint)(ptr[4] | ptr[5] << 8 |
+                                 ptr[6] << 16 | ptr[7] << 24);
+#else
+                uint* pBuffer = (uint*)ptr;
+
+                uint lo = pBuffer[0];
+                uint hi = pBuffer[1];
+#endif
+                return (long)((ulong)hi) << 32 | lo;
+            }
         }
 
         [CLSCompliant(false)]
-        public virtual ulong ReadUInt64() {
+        public virtual unsafe ulong ReadUInt64() {
             FillBuffer(8);
-            uint lo = (uint)(m_buffer[0] | m_buffer[1] << 8 |
-                             m_buffer[2] << 16 | m_buffer[3] << 24);
-            uint hi = (uint)(m_buffer[4] | m_buffer[5] << 8 |
-                             m_buffer[6] << 16 | m_buffer[7] << 24);
-            return ((ulong)hi) << 32 | lo;
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                uint lo = (uint)(ptr[0] | ptr[1] << 8 |
+                                 ptr[2] << 16 | ptr[3] << 24);
+                uint hi = (uint)(ptr[4] | ptr[5] << 8 |
+                                 ptr[6] << 16 | ptr[7] << 24);
+#else
+                uint* pBuffer = (uint*)ptr;
+
+                uint lo = pBuffer[0];
+                uint hi = pBuffer[1];
+#endif
+                return ((ulong)hi) << 32 | lo;
+            }
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public virtual unsafe float ReadSingle() {
             FillBuffer(4);
-            uint tmpBuffer = (uint)(m_buffer[0] | m_buffer[1] << 8 | m_buffer[2] << 16 | m_buffer[3] << 24);
-            return *((float*)&tmpBuffer);
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                uint tmpBuffer = (uint)(ptr[0] | ptr[1] << 8 | ptr[2] << 16 | ptr[3] << 24);
+                return *((float*)&tmpBuffer);
+#else
+                return *(float*)ptr;
+#endif
+            }
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public virtual unsafe double ReadDouble() {
             FillBuffer(8);
-            uint lo = (uint)(m_buffer[0] | m_buffer[1] << 8 |
-                m_buffer[2] << 16 | m_buffer[3] << 24);
-            uint hi = (uint)(m_buffer[4] | m_buffer[5] << 8 |
-                m_buffer[6] << 16 | m_buffer[7] << 24);
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                uint lo = (uint)(ptr[0] | ptr[1] << 8 |
+                    ptr[2] << 16 | ptr[3] << 24);
+                uint hi = (uint)(ptr[4] | ptr[5] << 8 |
+                    ptr[6] << 16 | ptr[7] << 24);
+#else
+                uint* pBuffer = (uint*)ptr;
 
-            ulong tmpBuffer = ((ulong)hi) << 32 | lo;
-            return *((double*)&tmpBuffer);
+                uint lo = pBuffer[0];
+                uint hi = pBuffer[1];
+#endif
+                ulong tmpBuffer = ((ulong)hi) << 32 | lo;
+                return *((double*)&tmpBuffer);
+            }
         }
 
-        public virtual decimal ReadDecimal() {
+        public virtual unsafe decimal ReadDecimal()
+        {
+            const int SignMask = unchecked((int)0x80000000);
+            const int ScaleMask = 0x00FF0000;
+
             FillBuffer(16);
-            try {
-                return Decimal.ToDecimal(m_buffer);
+            decimal d;
+            int* pDec = (int*)&d;
+            fixed (byte* ptr = m_buffer)
+            {
+#if BIGENDIAN
+                int flags = ptr[12] | ptr[13] << 8 | ptr[14] << 16 | ptr[15] << 24;
+#else
+                int* pBuffer = (int*)ptr;
+                int flags = pBuffer[3];
+#endif
+                // This logic mirrors the code in Decimal(int[]) ctor.
+                if (!((flags & ~(SignMask | ScaleMask)) == 0 && (flags & ScaleMask) <= (28 << 16)))
+                {
+                    // Invalid decimal
+                    throw new IOException(Environment.GetResourceString("Arg_DecBitCtor"));
+                }
+#if BIGENDIAN
+                pDec[0] = ptr[4] | ptr[5] << 8 | ptr[6] << 16 | ptr[7] << 24; // mid
+                pDec[1] = ptr[0] | ptr[1] << 8 | ptr[2] << 16 | ptr[3] << 24; // lo
+                pDec[2] = ptr[8] | ptr[9] << 8 | ptr[10] << 16 | ptr[11] << 24; // hi
+                pDec[3] = flags;
+#else
+                pDec[0] = flags;
+                pDec[1] = pBuffer[2]; // hi
+                pDec[2] = pBuffer[0]; // lo
+                pDec[3] = pBuffer[1]; // mid
+#endif
             }
-            catch (ArgumentException e) {
-                // ReadDecimal cannot leak out ArgumentException
-                throw new IOException(Environment.GetResourceString("Arg_DecBitCtor"), e);
-            }
+            return d;
         }
 
         public virtual String ReadString() {


### PR DESCRIPTION
Created from #1618.

Changes:

- use pointers instead of manual bitshifting if the target machine is already little-endian

Can someone verify the changes to `ReadDecimal` are correct? I got somewhat confused because the old implementation (`decimal.ToDecimal`) seems to interpret it differently than the actual layout of the decimal (if you casted the pointer to a `decimal*` and dereferenced that). Did I overlook something in the changes?