### PR TITLE
Add allocation fast path for arrays of value type elements outside Wi…

### DIFF
--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -454,10 +454,11 @@ public:
         // SIMPLIFY:  only use allocation contexts
         return true;
 #else
-#ifdef _TARGET_ARM_
-        return TRUE;
-#endif
+#if defined(_TARGET_ARM_) || defined(FEATURE_PAL)
+        return true;
+#else
         return ((IsServerHeap() ? true : (g_SystemInfo.dwNumberOfProcessors >= 2)));
+#endif
 #endif 
     }
 

--- a/src/inc/sbuffer.h
+++ b/src/inc/sbuffer.h
@@ -50,7 +50,7 @@
     (( (size^(size-1)) >> 1) +1)
 
 #define ALIGN(size, align) \
-    (((size)+(align)-1) & ~((align)-1))
+    (((size)+((align)-1)) & ~((align)-1))
 
 #define PAD(size, align) \
     (ALIGN((size), (align)) - (size))

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -200,6 +200,9 @@ EXTERN_C FCDECL2(Object*, JIT_IsInstanceOfInterface_Portable, MethodTable* pMT, 
 EXTERN_C FCDECL1(Object*, JIT_NewCrossContext, CORINFO_CLASS_HANDLE typeHnd_);
 EXTERN_C FCDECL1(Object*, JIT_NewCrossContext_Portable, CORINFO_CLASS_HANDLE typeHnd_);
 
+extern FCDECL2(Object*, JIT_NewArr1VC_MP_FastPortable, CORINFO_CLASS_HANDLE typeHnd_, INT_PTR size);
+extern FCDECL2(Object*, JIT_NewArr1, CORINFO_CLASS_HANDLE typeHnd_, INT_PTR size);
+
 #ifndef JIT_Stelem_Ref
 #define JIT_Stelem_Ref JIT_Stelem_Ref_Portable
 #endif
@@ -1614,7 +1617,6 @@ FCDECL1(StringObject*, UnframedAllocateString, DWORD stringLength);
 OBJECTHANDLE ConstructStringLiteral(CORINFO_MODULE_HANDLE scopeHnd, mdToken metaTok);
 
 FCDECL1(Object*, JIT_New, CORINFO_CLASS_HANDLE typeHnd_);
-FCDECL2(Object*, JIT_NewArr1, CORINFO_CLASS_HANDLE typeHnd_, INT_PTR size);
 FCDECL2(Object*, JIT_Box, CORINFO_CLASS_HANDLE type, void* data);
 FCDECL0(VOID, JIT_PollGC);
 #ifdef ENABLE_FAST_GCPOLL_HELPER

--- a/src/vm/object.h
+++ b/src/vm/object.h
@@ -745,6 +745,7 @@ class ArrayBase : public Object
     friend class Object;
     friend OBJECTREF AllocateArrayEx(TypeHandle arrayClass, INT32 *pArgs, DWORD dwNumArgs, BOOL bAllocateInLargeHeap DEBUG_ARG(BOOL bDontSetAppDomain)); 
     friend OBJECTREF FastAllocatePrimitiveArray(MethodTable* arrayType, DWORD cElements, BOOL bAllocateInLargeHeap);
+    friend Object *JIT_NewArr1VC_MP_FastPortable(CORINFO_CLASS_HANDLE arrayTypeHnd_, INT_PTR size);
     friend class JIT_TrialAlloc;
     friend class CheckAsmOffsets;
     friend struct _DacGlobals;


### PR DESCRIPTION
…ndows

- A microbenchmark involving byte array allocation was about 200% faster on Windows compared to Linux
- On Windows, using the portable version of the fast path is about 5% slower than using the asm version on the microbenchmark
- On Linux, using the portable fast path improves the microbenchmark perf by 160%
- With the fast path enabled on Linux, the microbenchmark on Windows (with asm fast path) is now about 17% faster than on Linux.