### PR TITLE
GetStaticFieldAddrNoCreate() returns data offset instead of NULL

### DIFF
--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -10640,8 +10640,10 @@ TADDR Thread::GetStaticFieldAddrNoCreate(FieldDesc *pFD, PTR_AppDomain pDomain)
     if (pFD->IsByValue())
     {
         _ASSERTE(result != NULL);
-        result = dac_cast<TADDR>
-            ((* PTR_UNCHECKED_OBJECTREF(result))->GetData());
+        PTR_Object obj = *PTR_UNCHECKED_OBJECTREF(result);
+        if (obj == NULL)
+            return NULL;
+        result = dac_cast<TADDR>(obj->GetData());
     }
 
     return result;


### PR DESCRIPTION
Fix clr!Thread::GetStaticFieldAddrNoCreate() to avoid returning data offset (0x4) instead of NULL for thread static fields when fields are a structure. The issue appears only when clr!MethodTable::GetGCThreadStaticsBasePointer() returns the pointer to the element of static object array and the element is zero. This bug was detected in desktop CLR v4.6.00079 x86/x64, but also present in CoreCLR.

struct DataCollector
{
  [ThreadStatic]
  static DataCollector ThreadInstance;
  ...
}

P.S. Detailed information about this issue is in JetBrains issue tracker: https://youtrack.jetbrains.com/issue/DMRY-2965