### PR TITLE
Improve frame destructor performance

### DIFF
--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -477,18 +477,22 @@ VOID Frame::Pop(Thread *pThread)
              (*m_Next->GetGSCookiePtr() == GetProcessGSCookie()));
 
     pThread->SetFrame(m_Next);
+    m_Next = NULL;
 }
 
 #ifdef FEATURE_PAL     
 Frame::~Frame()        
 {      
-    // When the frame is destroyed, make sure it is no longer in the       
-    // frame chain managed by the Thread.      
-    Thread* pThread = GetThread();     
-    if (pThread != NULL && pThread->GetFrame() == this)        
-    {      
-        Pop(pThread);      
-    }      
+    if (m_Next != NULL)
+    {
+        // When the frame is destroyed, make sure it is no longer in the
+        // frame chain managed by the Thread.
+        Thread* pThread = GetThread();
+        if (pThread != NULL && pThread->GetFrame() == this)
+        {
+            Pop(pThread);
+        }
+    }
 }      
 #endif // FEATURE_PAL
 

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -845,6 +845,7 @@ protected:
     // Frame is considered an abstract class: this protected constructor
     // causes any attempt to instantiate one to fail at compile-time.
     Frame()
+    : m_Next(dac_cast<PTR_Frame>(nullptr))
     { 
         LIMITED_METHOD_CONTRACT;
     }


### PR DESCRIPTION
This change makes the Frame destructor access thread local storage much less often,
only in rare case when the Frame was not popped before the destructor is called.