### PR TITLE
Format native CoreFX code to follow conventions

### DIFF
--- a/src/corefx/.clang-format
+++ b/src/corefx/.clang-format
@@ -1,0 +1,18 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AlignEscapedNewlinesLeft: false
+AlignAfterOpenBracket: true
+AllowShortFunctionsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: false
+BinPackParameters: false
+BreakBeforeBraces: Allman
+ColumnLimit:     120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+IndentCaseLabels: true
+IndentWidth: 4
+PointerAlignment: Left
+TabWidth:    4
+...
+

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -30,33 +30,33 @@
 */
 enum CalendarId : int16_t
 {
-	UNINITIALIZED_VALUE = 0,
-	GREGORIAN = 1,     // Gregorian (localized) calendar
-	GREGORIAN_US = 2,     // Gregorian (U.S.) calendar
-	JAPAN = 3,     // Japanese Emperor Era calendar
-				   /* SSS_WARNINGS_OFF */
-	TAIWAN = 4,     // Taiwan Era calendar /* SSS_WARNINGS_ON */ 
-	KOREA = 5,     // Korean Tangun Era calendar
-	HIJRI = 6,     // Hijri (Arabic Lunar) calendar
-	THAI = 7,     // Thai calendar
-	HEBREW = 8,     // Hebrew (Lunar) calendar
-	GREGORIAN_ME_FRENCH = 9,     // Gregorian Middle East French calendar
-	GREGORIAN_ARABIC = 10,     // Gregorian Arabic calendar
-	GREGORIAN_XLIT_ENGLISH = 11,     // Gregorian Transliterated English calendar
-	GREGORIAN_XLIT_FRENCH = 12,
-	// Note that all calendars after this point are MANAGED ONLY for now.
-	JULIAN = 13,
-	JAPANESELUNISOLAR = 14,
-	CHINESELUNISOLAR = 15,
-	SAKA = 16,     // reserved to match Office but not implemented in our code
-	LUNAR_ETO_CHN = 17,     // reserved to match Office but not implemented in our code
-	LUNAR_ETO_KOR = 18,     // reserved to match Office but not implemented in our code
-	LUNAR_ETO_ROKUYOU = 19,     // reserved to match Office but not implemented in our code
-	KOREANLUNISOLAR = 20,
-	TAIWANLUNISOLAR = 21,
-	PERSIAN = 22,
-	UMALQURA = 23,
-	LAST_CALENDAR = 23      // Last calendar ID
+    UNINITIALIZED_VALUE = 0,
+    GREGORIAN = 1,               // Gregorian (localized) calendar
+    GREGORIAN_US = 2,            // Gregorian (U.S.) calendar
+    JAPAN = 3,                   // Japanese Emperor Era calendar
+                                 /* SSS_WARNINGS_OFF */
+    TAIWAN = 4,                  // Taiwan Era calendar /* SSS_WARNINGS_ON */
+    KOREA = 5,                   // Korean Tangun Era calendar
+    HIJRI = 6,                   // Hijri (Arabic Lunar) calendar
+    THAI = 7,                    // Thai calendar
+    HEBREW = 8,                  // Hebrew (Lunar) calendar
+    GREGORIAN_ME_FRENCH = 9,     // Gregorian Middle East French calendar
+    GREGORIAN_ARABIC = 10,       // Gregorian Arabic calendar
+    GREGORIAN_XLIT_ENGLISH = 11, // Gregorian Transliterated English calendar
+    GREGORIAN_XLIT_FRENCH = 12,
+    // Note that all calendars after this point are MANAGED ONLY for now.
+    JULIAN = 13,
+    JAPANESELUNISOLAR = 14,
+    CHINESELUNISOLAR = 15,
+    SAKA = 16,              // reserved to match Office but not implemented in our code
+    LUNAR_ETO_CHN = 17,     // reserved to match Office but not implemented in our code
+    LUNAR_ETO_KOR = 18,     // reserved to match Office but not implemented in our code
+    LUNAR_ETO_ROKUYOU = 19, // reserved to match Office but not implemented in our code
+    KOREANLUNISOLAR = 20,
+    TAIWANLUNISOLAR = 21,
+    PERSIAN = 22,
+    UMALQURA = 23,
+    LAST_CALENDAR = 23 // Last calendar ID
 };
 
 /*
@@ -64,35 +64,36 @@ enum CalendarId : int16_t
 */
 enum CalendarDataType : int32_t
 {
-	Uninitialized = 0,
-	NativeName = 1,
-	MonthDay = 2,
-	ShortDates = 3,
-	LongDates = 4,
-	YearMonths = 5,
-	DayNames = 6,
-	AbbrevDayNames = 7,
-	MonthNames = 8,
-	AbbrevMonthNames = 9,
-	SuperShortDayNames = 10,
-	MonthGenitiveNames = 11,
-	AbbrevMonthGenitiveNames = 12,
-	EraNames = 13,
-	AbbrevEraNames = 14,
+    Uninitialized = 0,
+    NativeName = 1,
+    MonthDay = 2,
+    ShortDates = 3,
+    LongDates = 4,
+    YearMonths = 5,
+    DayNames = 6,
+    AbbrevDayNames = 7,
+    MonthNames = 8,
+    AbbrevMonthNames = 9,
+    SuperShortDayNames = 10,
+    MonthGenitiveNames = 11,
+    AbbrevMonthGenitiveNames = 12,
+    EraNames = 13,
+    AbbrevEraNames = 14,
 };
 
 /*
-* These values should be kept in sync with System.Globalization.CalendarDataResult
+* These values should be kept in sync with
+* System.Globalization.CalendarDataResult
 */
 enum CalendarDataResult : int32_t
 {
-	Success = 0,
-	UnknownError = 1,
-	InsufficentBuffer = 2,
+    Success = 0,
+    UnknownError = 1,
+    InsufficentBuffer = 2,
 };
 
 // the function pointer definition for the callback used in EnumCalendarInfo
-typedef void(*EnumCalendarInfoCallback)(const UChar*, const void*);
+typedef void (*EnumCalendarInfoCallback)(const UChar*, const void*);
 
 /*
 Function:
@@ -102,17 +103,17 @@ Converts a UErrorCode to a CalendarDataResult.
 */
 CalendarDataResult GetCalendarDataResult(UErrorCode err)
 {
-	if (U_SUCCESS(err))
-	{
-		return Success;
-	}
+    if (U_SUCCESS(err))
+    {
+        return Success;
+    }
 
-	if (err == U_BUFFER_OVERFLOW_ERROR)
-	{
-		return InsufficentBuffer;
-	}
+    if (err == U_BUFFER_OVERFLOW_ERROR)
+    {
+        return InsufficentBuffer;
+    }
 
-	return UnknownError;
+    return UnknownError;
 }
 
 /*
@@ -123,44 +124,44 @@ Gets the associated ICU calendar name for the CalendarId.
 */
 const char* GetCalendarName(CalendarId calendarId)
 {
-	switch (calendarId)
-	{
-		case JAPAN:
-			return JAPANESE_NAME;
-		case THAI:
-			return BUDDHIST_NAME;
-		case HEBREW:
-			return HEBREW_NAME;
-		case KOREA:
-			return DANGI_NAME;
-		case PERSIAN:
-			return PERSIAN_NAME;
-		case HIJRI:
-			return ISLAMIC_NAME;
-		case UMALQURA:
-			return ISLAMIC_UMALQURA_NAME;
-		case TAIWAN:
-			return ROC_NAME;
-		case GREGORIAN:
-		case GREGORIAN_US:
-		case GREGORIAN_ARABIC:
-		case GREGORIAN_ME_FRENCH:
-		case GREGORIAN_XLIT_ENGLISH:
-		case GREGORIAN_XLIT_FRENCH:
-		case JULIAN:
-		case LUNAR_ETO_CHN:
-		case LUNAR_ETO_KOR:
-		case LUNAR_ETO_ROKUYOU:
-		case SAKA:
-		// don't support the lunisolar calendars until we have a solid understanding
-		// of how they map to the ICU/CLDR calendars
-		case CHINESELUNISOLAR:
-		case KOREANLUNISOLAR:
-		case JAPANESELUNISOLAR:
-		case TAIWANLUNISOLAR:
-		default:
-			return GREGORIAN_NAME;
-	}
+    switch (calendarId)
+    {
+        case JAPAN:
+            return JAPANESE_NAME;
+        case THAI:
+            return BUDDHIST_NAME;
+        case HEBREW:
+            return HEBREW_NAME;
+        case KOREA:
+            return DANGI_NAME;
+        case PERSIAN:
+            return PERSIAN_NAME;
+        case HIJRI:
+            return ISLAMIC_NAME;
+        case UMALQURA:
+            return ISLAMIC_UMALQURA_NAME;
+        case TAIWAN:
+            return ROC_NAME;
+        case GREGORIAN:
+        case GREGORIAN_US:
+        case GREGORIAN_ARABIC:
+        case GREGORIAN_ME_FRENCH:
+        case GREGORIAN_XLIT_ENGLISH:
+        case GREGORIAN_XLIT_FRENCH:
+        case JULIAN:
+        case LUNAR_ETO_CHN:
+        case LUNAR_ETO_KOR:
+        case LUNAR_ETO_ROKUYOU:
+        case SAKA:
+        // don't support the lunisolar calendars until we have a solid understanding
+        // of how they map to the ICU/CLDR calendars
+        case CHINESELUNISOLAR:
+        case KOREANLUNISOLAR:
+        case JAPANESELUNISOLAR:
+        case TAIWANLUNISOLAR:
+        default:
+            return GREGORIAN_NAME;
+    }
 }
 
 /*
@@ -171,27 +172,27 @@ Gets the associated CalendarId for the ICU calendar name.
 */
 CalendarId GetCalendarId(const char* calendarName)
 {
-	if (strcasecmp(calendarName, GREGORIAN_NAME) == 0)
-		//TODO: what about the other gregorian types?
-		return GREGORIAN;
-	else if (strcasecmp(calendarName, JAPANESE_NAME) == 0)
-		return JAPAN;
-	else if (strcasecmp(calendarName, BUDDHIST_NAME) == 0)
-		return THAI;
-	else if (strcasecmp(calendarName, HEBREW_NAME) == 0)
-		return HEBREW;
-	else if (strcasecmp(calendarName, DANGI_NAME) == 0)
-		return KOREA;
-	else if (strcasecmp(calendarName, PERSIAN_NAME) == 0)
-		return PERSIAN;
-	else if (strcasecmp(calendarName, ISLAMIC_NAME) == 0)
-		return HIJRI;
-	else if (strcasecmp(calendarName, ISLAMIC_UMALQURA_NAME) == 0)
-		return UMALQURA;
-	else if (strcasecmp(calendarName, ROC_NAME) == 0)
-		return TAIWAN;
-	else
-		return UNINITIALIZED_VALUE;
+    if (strcasecmp(calendarName, GREGORIAN_NAME) == 0)
+        // TODO: what about the other gregorian types?
+        return GREGORIAN;
+    else if (strcasecmp(calendarName, JAPANESE_NAME) == 0)
+        return JAPAN;
+    else if (strcasecmp(calendarName, BUDDHIST_NAME) == 0)
+        return THAI;
+    else if (strcasecmp(calendarName, HEBREW_NAME) == 0)
+        return HEBREW;
+    else if (strcasecmp(calendarName, DANGI_NAME) == 0)
+        return KOREA;
+    else if (strcasecmp(calendarName, PERSIAN_NAME) == 0)
+        return PERSIAN;
+    else if (strcasecmp(calendarName, ISLAMIC_NAME) == 0)
+        return HIJRI;
+    else if (strcasecmp(calendarName, ISLAMIC_UMALQURA_NAME) == 0)
+        return UMALQURA;
+    else if (strcasecmp(calendarName, ROC_NAME) == 0)
+        return TAIWAN;
+    else
+        return UNINITIALIZED_VALUE;
 }
 
 /*
@@ -202,37 +203,38 @@ Returns the list of CalendarIds that are available for the specified locale.
 */
 extern "C" int32_t GetCalendars(const UChar* localeName, CalendarId* calendars, int32_t calendarsCapacity)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-		return 0;
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+        return 0;
 
-	UErrorCode err = U_ZERO_ERROR;
-	LocalPointer<StringEnumeration> stringEnumerator(Calendar::getKeywordValuesForLocale("calendar", locale, TRUE, err));
+    UErrorCode err = U_ZERO_ERROR;
+    LocalPointer<StringEnumeration> stringEnumerator(
+        Calendar::getKeywordValuesForLocale("calendar", locale, TRUE, err));
 
-	if (stringEnumerator.isNull() || U_FAILURE(err))
-		return 0;
+    if (stringEnumerator.isNull() || U_FAILURE(err))
+        return 0;
 
-	int stringEnumeratorCount = stringEnumerator->count(err);
-	if (U_FAILURE(err))
-		return 0;
+    int stringEnumeratorCount = stringEnumerator->count(err);
+    if (U_FAILURE(err))
+        return 0;
 
-	int calendarsReturned = 0;
-	for (int i = 0; i < stringEnumeratorCount && calendarsReturned < calendarsCapacity; i++)
-	{
-		int32_t calendarNameLength = 0;
-		const char* calendarName = stringEnumerator->next(&calendarNameLength, err);
-		if (U_SUCCESS(err))
-		{
-			CalendarId calendarId = GetCalendarId(calendarName);
-			if (calendarId != UNINITIALIZED_VALUE)
-			{
-				calendars[calendarsReturned] = calendarId;
-				calendarsReturned++;
-			}
-		}
-	}
+    int calendarsReturned = 0;
+    for (int i = 0; i < stringEnumeratorCount && calendarsReturned < calendarsCapacity; i++)
+    {
+        int32_t calendarNameLength = 0;
+        const char* calendarName = stringEnumerator->next(&calendarNameLength, err);
+        if (U_SUCCESS(err))
+        {
+            CalendarId calendarId = GetCalendarId(calendarName);
+            if (calendarId != UNINITIALIZED_VALUE)
+            {
+                calendars[calendarsReturned] = calendarId;
+                calendarsReturned++;
+            }
+        }
+    }
 
-	return calendarsReturned;
+    return calendarsReturned;
 }
 
 /*
@@ -243,18 +245,18 @@ Gets the Month-Day DateTime pattern for the specified locale.
 */
 CalendarDataResult GetMonthDayPattern(Locale& locale, UChar* sMonthDay, int32_t stringCapacity)
 {
-	UErrorCode err = U_ZERO_ERROR;
-	LocalPointer<DateTimePatternGenerator> generator(DateTimePatternGenerator::createInstance(locale, err));
-	if (U_FAILURE(err))
-		return GetCalendarDataResult(err);
+    UErrorCode err = U_ZERO_ERROR;
+    LocalPointer<DateTimePatternGenerator> generator(DateTimePatternGenerator::createInstance(locale, err));
+    if (U_FAILURE(err))
+        return GetCalendarDataResult(err);
 
-	UnicodeString monthDayPattern = generator->getBestPattern(UnicodeString(UDAT_MONTH_DAY), err);
-	if (U_FAILURE(err))
-		return GetCalendarDataResult(err);
+    UnicodeString monthDayPattern = generator->getBestPattern(UnicodeString(UDAT_MONTH_DAY), err);
+    if (U_FAILURE(err))
+        return GetCalendarDataResult(err);
 
-	monthDayPattern.extract(sMonthDay, stringCapacity, err);
+    monthDayPattern.extract(sMonthDay, stringCapacity, err);
 
-	return GetCalendarDataResult(err);
+    return GetCalendarDataResult(err);
 }
 
 /*
@@ -263,88 +265,99 @@ GetNativeCalendarName
 
 Gets the native calendar name.
 */
-CalendarDataResult GetNativeCalendarName(Locale& locale, CalendarId calendarId, UChar* nativeName, int32_t stringCapacity)
+CalendarDataResult
+GetNativeCalendarName(Locale& locale, CalendarId calendarId, UChar* nativeName, int32_t stringCapacity)
 {
-	LocalPointer<LocaleDisplayNames> displayNames(LocaleDisplayNames::createInstance(locale));
+    LocalPointer<LocaleDisplayNames> displayNames(LocaleDisplayNames::createInstance(locale));
 
-	UnicodeString calendarName;
-	displayNames->keyValueDisplayName("calendar", GetCalendarName(calendarId), calendarName);
+    UnicodeString calendarName;
+    displayNames->keyValueDisplayName("calendar", GetCalendarName(calendarId), calendarName);
 
-	UErrorCode err = U_ZERO_ERROR;
-	calendarName.extract(nativeName, stringCapacity, err);
+    UErrorCode err = U_ZERO_ERROR;
+    calendarName.extract(nativeName, stringCapacity, err);
 
-	return GetCalendarDataResult(err);
+    return GetCalendarDataResult(err);
 }
 
 /*
 Function:
 GetCalendarInfo
 
-Gets a single string of calendar information by filling the result parameter with the requested value.
+Gets a single string of calendar information by filling the result parameter
+with the requested value.
 */
-extern "C" CalendarDataResult GetCalendarInfo(const UChar* localeName, CalendarId calendarId, CalendarDataType dataType, UChar* result, int32_t resultCapacity)
+extern "C" CalendarDataResult GetCalendarInfo(
+    const UChar* localeName, CalendarId calendarId, CalendarDataType dataType, UChar* result, int32_t resultCapacity)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-		return UnknownError;
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+        return UnknownError;
 
-	switch (dataType)
-	{
-		case NativeName:
-			return GetNativeCalendarName(locale, calendarId, result, resultCapacity);
-		case MonthDay:
-			return GetMonthDayPattern(locale, result, resultCapacity);
-		default:
-			assert(false);
-			return UnknownError;
-	}
+    switch (dataType)
+    {
+        case NativeName:
+            return GetNativeCalendarName(locale, calendarId, result, resultCapacity);
+        case MonthDay:
+            return GetMonthDayPattern(locale, result, resultCapacity);
+        default:
+            assert(false);
+            return UnknownError;
+    }
 }
 
 /*
 Function:
 InvokeCallbackForDatePattern
 
-Gets the ICU date pattern for the specified locale and EStyle and invokes the callback with the result.
+Gets the ICU date pattern for the specified locale and EStyle and invokes the
+callback with the result.
 */
-bool InvokeCallbackForDatePattern(Locale& locale, DateFormat::EStyle style, EnumCalendarInfoCallback callback, const void* context)
+bool InvokeCallbackForDatePattern(Locale& locale,
+                                  DateFormat::EStyle style,
+                                  EnumCalendarInfoCallback callback,
+                                  const void* context)
 {
-	LocalPointer<DateFormat> dateFormat(DateFormat::createDateInstance(style, locale));
-	if (dateFormat.isNull())
-		return false;
+    LocalPointer<DateFormat> dateFormat(DateFormat::createDateInstance(style, locale));
+    if (dateFormat.isNull())
+        return false;
 
-	// cast to SimpleDateFormat so we can call toPattern()  
-	SimpleDateFormat* sdf = dynamic_cast<SimpleDateFormat*>(dateFormat.getAlias());
-	if (sdf == NULL)
-		return false;
+    // cast to SimpleDateFormat so we can call toPattern()
+    SimpleDateFormat* sdf = dynamic_cast<SimpleDateFormat*>(dateFormat.getAlias());
+    if (sdf == NULL)
+        return false;
 
-	UnicodeString pattern;
-	sdf->toPattern(pattern);
+    UnicodeString pattern;
+    sdf->toPattern(pattern);
 
-	callback(pattern.getTerminatedBuffer(), context);
-	return true;
+    callback(pattern.getTerminatedBuffer(), context);
+    return true;
 }
 
 /*
 Function:
 InvokeCallbackForDateTimePattern
 
-Gets the DateTime pattern for the specified skeleton and invokes the callback with the retrieved value.
+Gets the DateTime pattern for the specified skeleton and invokes the callback
+with the retrieved value.
 */
-bool InvokeCallbackForDateTimePattern(Locale& locale, const char* patternSkeleton, EnumCalendarInfoCallback callback, const void* context)
+bool InvokeCallbackForDateTimePattern(Locale& locale,
+                                      const char* patternSkeleton,
+                                      EnumCalendarInfoCallback callback,
+                                      const void* context)
 {
-	UErrorCode err = U_ZERO_ERROR;
-	LocalPointer<DateTimePatternGenerator> generator(DateTimePatternGenerator::createInstance(locale, err));
-	if (U_FAILURE(err))
-		return false;
+    UErrorCode err = U_ZERO_ERROR;
+    LocalPointer<DateTimePatternGenerator> generator(DateTimePatternGenerator::createInstance(locale, err));
+    if (U_FAILURE(err))
+        return false;
 
-	UnicodeString pattern = generator->getBestPattern(UnicodeString(patternSkeleton), err);
-	if (U_SUCCESS(err))
-	{
-		callback(pattern.getTerminatedBuffer(), context);
-		return true;
-	}
+    UnicodeString pattern = generator->getBestPattern(UnicodeString(patternSkeleton), err);
+    if (U_SUCCESS(err))
+    {
+        callback(pattern.getTerminatedBuffer(), context);
+        return true;
+    }
 
-	return false;
+    return false;
 }
 
 /*
@@ -353,168 +366,187 @@ EnumCalendarArray
 
 Enumerates an array of strings and invokes the callback for each value.
 */
-bool EnumCalendarArray(const UnicodeString* srcArray, int32_t srcArrayCount, EnumCalendarInfoCallback callback, const void* context)
+bool EnumCalendarArray(const UnicodeString* srcArray,
+                       int32_t srcArrayCount,
+                       EnumCalendarInfoCallback callback,
+                       const void* context)
 {
-	for (int i = 0; i < srcArrayCount; i++)
-	{
-		UnicodeString src = srcArray[i];
-		callback(src.getTerminatedBuffer(), context);
-	}
+    for (int i = 0; i < srcArrayCount; i++)
+    {
+        UnicodeString src = srcArray[i];
+        callback(src.getTerminatedBuffer(), context);
+    }
 
-	return true;
+    return true;
 }
 
 /*
 Function:
 EnumWeekdays
 
-Enumerates all the weekday names of the specified context and width, invoking the callback function
+Enumerates all the weekday names of the specified context and width, invoking
+the callback function
 for each weekday name.
 */
-bool EnumWeekdays(
-	Locale& locale,
-	CalendarId calendarId,
-	DateFormatSymbols::DtContextType dtContext,
-	DateFormatSymbols::DtWidthType dtWidth,
-	EnumCalendarInfoCallback callback,
-	const void* context)
+bool EnumWeekdays(Locale& locale,
+                  CalendarId calendarId,
+                  DateFormatSymbols::DtContextType dtContext,
+                  DateFormatSymbols::DtWidthType dtWidth,
+                  EnumCalendarInfoCallback callback,
+                  const void* context)
 {
-	UErrorCode err = U_ZERO_ERROR;
-	DateFormatSymbols dateFormatSymbols(locale, GetCalendarName(calendarId), err);
-	if (U_FAILURE(err))
-		return false;
+    UErrorCode err = U_ZERO_ERROR;
+    DateFormatSymbols dateFormatSymbols(locale, GetCalendarName(calendarId), err);
+    if (U_FAILURE(err))
+        return false;
 
-	int32_t daysCount;
-	const UnicodeString* dayNames = dateFormatSymbols.getWeekdays(daysCount, dtContext, dtWidth);
+    int32_t daysCount;
+    const UnicodeString* dayNames = dateFormatSymbols.getWeekdays(daysCount, dtContext, dtWidth);
 
-	// ICU returns an empty string for the first/zeroth element in the weekdays array.
-	// So skip the first element.
-	dayNames++;
-	daysCount--;
+    // ICU returns an empty string for the first/zeroth element in the weekdays
+    // array.
+    // So skip the first element.
+    dayNames++;
+    daysCount--;
 
-	return EnumCalendarArray(dayNames, daysCount, callback, context);
+    return EnumCalendarArray(dayNames, daysCount, callback, context);
 }
 
 /*
 Function:
 EnumMonths
 
-Enumerates all the month names of the specified context and width, invoking the callback function
+Enumerates all the month names of the specified context and width, invoking the
+callback function
 for each month name.
 */
-bool EnumMonths(
-	Locale& locale,
-	CalendarId calendarId,
-	DateFormatSymbols::DtContextType dtContext,
-	DateFormatSymbols::DtWidthType dtWidth,
-	EnumCalendarInfoCallback callback,
-	const void* context)
+bool EnumMonths(Locale& locale,
+                CalendarId calendarId,
+                DateFormatSymbols::DtContextType dtContext,
+                DateFormatSymbols::DtWidthType dtWidth,
+                EnumCalendarInfoCallback callback,
+                const void* context)
 {
-	UErrorCode err = U_ZERO_ERROR;
-	DateFormatSymbols dateFormatSymbols(locale, GetCalendarName(calendarId), err);
-	if (U_FAILURE(err))
-		return false;
+    UErrorCode err = U_ZERO_ERROR;
+    DateFormatSymbols dateFormatSymbols(locale, GetCalendarName(calendarId), err);
+    if (U_FAILURE(err))
+        return false;
 
-	int32_t monthsCount;
-	const UnicodeString* monthNames = dateFormatSymbols.getMonths(monthsCount, dtContext, dtWidth);
-	return EnumCalendarArray(monthNames, monthsCount, callback, context);
+    int32_t monthsCount;
+    const UnicodeString* monthNames = dateFormatSymbols.getMonths(monthsCount, dtContext, dtWidth);
+    return EnumCalendarArray(monthNames, monthsCount, callback, context);
 }
 
 /*
 Function:
 EnumEraNames
 
-Enumerates all the era names of the specified locale and calendar, invoking the callback function
+Enumerates all the era names of the specified locale and calendar, invoking the
+callback function
 for each era name.
 */
-bool EnumEraNames(Locale& locale, CalendarId calendarId, CalendarDataType dataType, EnumCalendarInfoCallback callback, const void* context)
+bool EnumEraNames(Locale& locale,
+                  CalendarId calendarId,
+                  CalendarDataType dataType,
+                  EnumCalendarInfoCallback callback,
+                  const void* context)
 {
-	UErrorCode err = U_ZERO_ERROR;
-	const char* calendarName = GetCalendarName(calendarId);
-	DateFormatSymbols dateFormatSymbols(locale, calendarName, err);
-	if (U_FAILURE(err))
-		return false;
+    UErrorCode err = U_ZERO_ERROR;
+    const char* calendarName = GetCalendarName(calendarId);
+    DateFormatSymbols dateFormatSymbols(locale, calendarName, err);
+    if (U_FAILURE(err))
+        return false;
 
-	int32_t eraNameCount;
-	const UnicodeString* eraNames;
+    int32_t eraNameCount;
+    const UnicodeString* eraNames;
 
-	if (dataType == EraNames)
-	{
-		eraNames = dateFormatSymbols.getEras(eraNameCount);
-	}
-	else if (dataType == AbbrevEraNames)
-	{
-		eraNames = dateFormatSymbols.getNarrowEras(eraNameCount);
-	}
-	else
-	{
-		assert(false);
-		return false;
-	}
+    if (dataType == EraNames)
+    {
+        eraNames = dateFormatSymbols.getEras(eraNameCount);
+    }
+    else if (dataType == AbbrevEraNames)
+    {
+        eraNames = dateFormatSymbols.getNarrowEras(eraNameCount);
+    }
+    else
+    {
+        assert(false);
+        return false;
+    }
 
-	return EnumCalendarArray(eraNames, eraNameCount, callback, context);
+    return EnumCalendarArray(eraNames, eraNameCount, callback, context);
 }
 
 /*
 Function:
 EnumCalendarInfo
 
-Retrieves a collection of calendar string data specified by the locale, calendar, and data type.
+Retrieves a collection of calendar string data specified by the locale,
+calendar, and data type.
 Allows for a collection of calendar string data to be retrieved by invoking
 the callback for each value in the collection.
 The context parameter is passed through to the callback along with each string.
 */
-extern "C" int32_t EnumCalendarInfo(
-	EnumCalendarInfoCallback callback,
-	const UChar* localeName,
-	CalendarId calendarId,
-	CalendarDataType dataType,
-	const void* context)
+extern "C" int32_t EnumCalendarInfo(EnumCalendarInfoCallback callback,
+                                    const UChar* localeName,
+                                    CalendarId calendarId,
+                                    CalendarDataType dataType,
+                                    const void* context)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-		return false;
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+        return false;
 
-	switch (dataType)
-	{
-		case ShortDates:
-			// ShortDates to map kShort and kMedium in ICU, but also adding the "yMd" skeleton as well, as this
-			// closely matches what is used on Windows
-			return InvokeCallbackForDateTimePattern(locale, UDAT_YEAR_NUM_MONTH_DAY, callback, context) &&
-				InvokeCallbackForDatePattern(locale, DateFormat::kShort, callback, context) &&
-				InvokeCallbackForDatePattern(locale, DateFormat::kMedium, callback, context);
-		case LongDates:
-			// LongDates map to kFull and kLong in ICU.
-			return InvokeCallbackForDatePattern(locale, DateFormat::kFull, callback, context) &&
-				InvokeCallbackForDatePattern(locale, DateFormat::kLong, callback, context);
-		case YearMonths:
-			return InvokeCallbackForDateTimePattern(locale, UDAT_YEAR_MONTH, callback, context);
-		case DayNames:
-			return EnumWeekdays(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::WIDE, callback, context);
-		case AbbrevDayNames:
-			return EnumWeekdays(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::ABBREVIATED, callback, context);
-		case MonthNames:
-			return EnumMonths(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::WIDE, callback, context);
-		case AbbrevMonthNames:
-			return EnumMonths(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::ABBREVIATED, callback, context);
-		case SuperShortDayNames:
+    switch (dataType)
+    {
+        case ShortDates:
+            // ShortDates to map kShort and kMedium in ICU, but also adding the "yMd"
+            // skeleton as well, as this
+            // closely matches what is used on Windows
+            return InvokeCallbackForDateTimePattern(locale, UDAT_YEAR_NUM_MONTH_DAY, callback, context) &&
+                   InvokeCallbackForDatePattern(locale, DateFormat::kShort, callback, context) &&
+                   InvokeCallbackForDatePattern(locale, DateFormat::kMedium, callback, context);
+        case LongDates:
+            // LongDates map to kFull and kLong in ICU.
+            return InvokeCallbackForDatePattern(locale, DateFormat::kFull, callback, context) &&
+                   InvokeCallbackForDatePattern(locale, DateFormat::kLong, callback, context);
+        case YearMonths:
+            return InvokeCallbackForDateTimePattern(locale, UDAT_YEAR_MONTH, callback, context);
+        case DayNames:
+            return EnumWeekdays(
+                locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::WIDE, callback, context);
+        case AbbrevDayNames:
+            return EnumWeekdays(
+                locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::ABBREVIATED, callback, context);
+        case MonthNames:
+            return EnumMonths(
+                locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::WIDE, callback, context);
+        case AbbrevMonthNames:
+            return EnumMonths(
+                locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::ABBREVIATED, callback, context);
+        case SuperShortDayNames:
 #ifdef HAVE_DTWIDTHTYPE_SHORT
-			return EnumWeekdays(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::SHORT, callback, context);
+            return EnumWeekdays(
+                locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::SHORT, callback, context);
 #else
-			// Currently CentOS-7 uses ICU-50 and ::SHORT was added in ICU-51, so use ::NARROW instead
-			return EnumWeekdays(locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::NARROW, callback, context);
+            // Currently CentOS-7 uses ICU-50 and ::SHORT was added in ICU-51, so use
+            // ::NARROW instead
+            return EnumWeekdays(
+                locale, calendarId, DateFormatSymbols::STANDALONE, DateFormatSymbols::NARROW, callback, context);
 #endif
-		case MonthGenitiveNames:
-			return EnumMonths(locale, calendarId, DateFormatSymbols::FORMAT, DateFormatSymbols::WIDE, callback, context);
-		case AbbrevMonthGenitiveNames:
-			return EnumMonths(locale, calendarId, DateFormatSymbols::FORMAT, DateFormatSymbols::ABBREVIATED, callback, context);
-		case EraNames:
-		case AbbrevEraNames:
-			return EnumEraNames(locale, calendarId, dataType, callback, context);
-		default:
-			assert(false);
-			return false;
-	}
+        case MonthGenitiveNames:
+            return EnumMonths(
+                locale, calendarId, DateFormatSymbols::FORMAT, DateFormatSymbols::WIDE, callback, context);
+        case AbbrevMonthGenitiveNames:
+            return EnumMonths(
+                locale, calendarId, DateFormatSymbols::FORMAT, DateFormatSymbols::ABBREVIATED, callback, context);
+        case EraNames:
+        case AbbrevEraNames:
+            return EnumEraNames(locale, calendarId, dataType, callback, context);
+        default:
+            assert(false);
+            return false;
+    }
 }
 
 /*
@@ -525,14 +557,14 @@ Gets the latest era in the Japanese calendar.
 */
 extern "C" int32_t GetLatestJapaneseEra()
 {
-	UErrorCode err = U_ZERO_ERROR;
-	Locale japaneseLocale(JAPANESE_LOCALE_AND_CALENDAR);
-	LocalPointer<Calendar> calendar(Calendar::createInstance(japaneseLocale, err));
+    UErrorCode err = U_ZERO_ERROR;
+    Locale japaneseLocale(JAPANESE_LOCALE_AND_CALENDAR);
+    LocalPointer<Calendar> calendar(Calendar::createInstance(japaneseLocale, err));
 
-	if (U_FAILURE(err))
-		return 0;
+    if (U_FAILURE(err))
+        return 0;
 
-	return calendar->getMaximum(UCAL_ERA);
+    return calendar->getMaximum(UCAL_ERA);
 }
 
 /*
@@ -541,79 +573,76 @@ GetJapaneseEraInfo
 
 Gets the starting Gregorian date of the specified Japanese Era.
 */
-extern "C" int32_t GetJapaneseEraStartDate(
-	int32_t era,
-	int32_t* startYear,
-	int32_t* startMonth,
-	int32_t* startDay)
+extern "C" int32_t GetJapaneseEraStartDate(int32_t era, int32_t* startYear, int32_t* startMonth, int32_t* startDay)
 {
-	*startYear = -1;
-	*startMonth = -1;
-	*startDay = -1;
+    *startYear = -1;
+    *startMonth = -1;
+    *startDay = -1;
 
-	UErrorCode err = U_ZERO_ERROR;
-	Locale japaneseLocale(JAPANESE_LOCALE_AND_CALENDAR);
-	LocalPointer<Calendar> calendar(Calendar::createInstance(japaneseLocale, err));
-	if (U_FAILURE(err))
-		return false;
+    UErrorCode err = U_ZERO_ERROR;
+    Locale japaneseLocale(JAPANESE_LOCALE_AND_CALENDAR);
+    LocalPointer<Calendar> calendar(Calendar::createInstance(japaneseLocale, err));
+    if (U_FAILURE(err))
+        return false;
 
-	calendar->set(UCAL_ERA, era);
-	calendar->set(UCAL_YEAR, 1);
+    calendar->set(UCAL_ERA, era);
+    calendar->set(UCAL_YEAR, 1);
 
-	// UCAL_EXTENDED_YEAR is the gregorian year for the JapaneseCalendar
-	*startYear = calendar->get(UCAL_EXTENDED_YEAR, err);
-	if (U_FAILURE(err))
-		return false;
+    // UCAL_EXTENDED_YEAR is the gregorian year for the JapaneseCalendar
+    *startYear = calendar->get(UCAL_EXTENDED_YEAR, err);
+    if (U_FAILURE(err))
+        return false;
 
-	// set the date to Jan 1
-	calendar->set(UCAL_MONTH, 0);
-	calendar->set(UCAL_DATE, 1);
+    // set the date to Jan 1
+    calendar->set(UCAL_MONTH, 0);
+    calendar->set(UCAL_DATE, 1);
 
-	int32_t currentEra;
-	for (int i = 0; i <= 12; i++)
-	{
-		currentEra = calendar->get(UCAL_ERA, err);
-		if (U_FAILURE(err))
-			return false;
+    int32_t currentEra;
+    for (int i = 0; i <= 12; i++)
+    {
+        currentEra = calendar->get(UCAL_ERA, err);
+        if (U_FAILURE(err))
+            return false;
 
-		if (currentEra == era)
-		{
-			for (int i = 0; i < 31; i++)
-			{
-				// subtract 1 day at a time until we get out of the specified Era
-				calendar->add(Calendar::DATE, -1, err);
-				if (U_FAILURE(err))
-					return false;
+        if (currentEra == era)
+        {
+            for (int i = 0; i < 31; i++)
+            {
+                // subtract 1 day at a time until we get out of the specified Era
+                calendar->add(Calendar::DATE, -1, err);
+                if (U_FAILURE(err))
+                    return false;
 
-				currentEra = calendar->get(UCAL_ERA, err);
-				if (U_FAILURE(err))
-					return false;
+                currentEra = calendar->get(UCAL_ERA, err);
+                if (U_FAILURE(err))
+                    return false;
 
-				if (currentEra != era)
-				{
-					// add back 1 day to get back into the specified Era
-					calendar->add(UCAL_DATE, 1, err);
-					if (U_FAILURE(err))
-						return false;
+                if (currentEra != era)
+                {
+                    // add back 1 day to get back into the specified Era
+                    calendar->add(UCAL_DATE, 1, err);
+                    if (U_FAILURE(err))
+                        return false;
 
-					*startMonth = calendar->get(UCAL_MONTH, err) + 1;  // ICU Calendar months are 0-based, but .NET is 1-based
-					if (U_FAILURE(err))
-						return false;
+                    *startMonth =
+                        calendar->get(UCAL_MONTH, err) + 1; // ICU Calendar months are 0-based, but .NET is 1-based
+                    if (U_FAILURE(err))
+                        return false;
 
-					*startDay = calendar->get(UCAL_DATE, err);
-					if (U_FAILURE(err))
-						return false;
+                    *startDay = calendar->get(UCAL_DATE, err);
+                    if (U_FAILURE(err))
+                        return false;
 
-					return true;
-				}
-			}
-		}
+                    return true;
+                }
+            }
+        }
 
-		// add 1 month at a time until we get into the specified Era
-		calendar->add(UCAL_MONTH, 1, err);
-		if (U_FAILURE(err))
-			return false;
-	}
+        // add 1 month at a time until we get into the specified Era
+        calendar->add(UCAL_MONTH, 1, err);
+        if (U_FAILURE(err))
+            return false;
+    }
 
-	return false;
+    return false;
 }

--- a/src/corefx/System.Globalization.Native/casing.cpp
+++ b/src/corefx/System.Globalization.Native/casing.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <assert.h>
@@ -12,9 +13,15 @@
 Function:
 ChangeCase
 
-Performs upper or lower casing of a string into a new buffer, performing special casing for Turkish, if needed.
+Performs upper or lower casing of a string into a new buffer, performing special
+casing for Turkish, if needed.
 */
-extern "C" void ChangeCase(const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength, int32_t bToUpper, int32_t bTurkishCasing)
+extern "C" void ChangeCase(const UChar* lpSrc,
+                           int32_t cwSrcLength,
+                           UChar* lpDst,
+                           int32_t cwDstLength,
+                           int32_t bToUpper,
+                           int32_t bTurkishCasing)
 {
     int32_t srcIdx = 0;
     int32_t dstIdx = 0;
@@ -23,12 +30,17 @@ extern "C" void ChangeCase(const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst
     UChar32 srcCodepoint;
     UChar32 dstCodepoint;
 
-    // Iterate through the string, decoding the next one or two UTF-16 code units into a codepoint 
-    // and updating srcIdx to point to the next UTF-16 code unit to decode.  Then upper or lower
+    // Iterate through the string, decoding the next one or two UTF-16 code units
+    // into a codepoint
+    // and updating srcIdx to point to the next UTF-16 code unit to decode.  Then
+    // upper or lower
     // case it, write dstCodepoint into lpDst at offset dstIdx, and update dstIdx.
-    // (The loop here has been manually cloned for each of the four cases, rather than having a 
-    // single loop that internally branched based on bToUpper and bTurkishCasing, as the compiler 
-    // wasn't doing that optimization, and it results in an ~15-20% perf improvement on longer strings.)
+    // (The loop here has been manually cloned for each of the four cases, rather
+    // than having a
+    // single loop that internally branched based on bToUpper and bTurkishCasing,
+    // as the compiler
+    // wasn't doing that optimization, and it results in an ~15-20% perf
+    // improvement on longer strings.)
 
     if (bToUpper)
     {
@@ -37,7 +49,8 @@ extern "C" void ChangeCase(const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst
             // bToUpper && bTurkishCasing
             while (srcIdx < cwSrcLength)
             {
-                // In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130).
+                // In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN
+                // CAPITAL LETTER I WITH DOT ABOVE (U+0130).
                 U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
                 dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
                 U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
@@ -63,7 +76,8 @@ extern "C" void ChangeCase(const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst
             // !bToUpper && bTurkishCasing
             while (srcIdx < cwSrcLength)
             {
-                // In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to LATIN SMALL LETTER DOTLESS I (U+0131).
+                // In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to
+                // LATIN SMALL LETTER DOTLESS I (U+0131).
                 U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
                 dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
                 U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);

--- a/src/corefx/System.Globalization.Native/collation.cpp
+++ b/src/corefx/System.Globalization.Native/collation.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <assert.h>
@@ -18,7 +19,8 @@ const int32_t CompareOptionsIgnoreCase = 1;
 // const int32_t CompareOptionsStringSort = 0x20000000;
 
 /*
- * To collator returned by this function is owned by the callee and must be closed when this method returns
+ * To collator returned by this function is owned by the callee and must be
+ *closed when this method returns
  * with a U_SUCCESS UErrorCode.
  *
  * On error, the return value is undefined.
@@ -37,12 +39,16 @@ UCollator* GetCollatorForLocaleAndOptions(const char* lpLocaleName, int32_t opti
     return pColl;
 }
 
-
 /*
 Function:
 CompareString
 */
-extern "C" int32_t CompareString(const char* lpLocaleName, const UChar* lpStr1, int32_t cwStr1Length, const UChar* lpStr2, int32_t cwStr2Length, int32_t options)
+extern "C" int32_t CompareString(const char* lpLocaleName,
+                                 const UChar* lpStr1,
+                                 int32_t cwStr1Length,
+                                 const UChar* lpStr2,
+                                 int32_t cwStr2Length,
+                                 int32_t options)
 {
     static_assert(UCOL_EQUAL == 0, "managed side requires 0 for equal strings");
     static_assert(UCOL_LESS < 0, "managed side requires less than zero for a < b");
@@ -65,7 +71,8 @@ extern "C" int32_t CompareString(const char* lpLocaleName, const UChar* lpStr1, 
 Function:
 IndexOf
 */
-extern "C" int32_t IndexOf(const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t
+IndexOf(const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
 {
     static_assert(USEARCH_DONE == -1, "managed side requires -1 for not found");
 
@@ -93,7 +100,8 @@ extern "C" int32_t IndexOf(const char* lpLocaleName, const UChar* lpTarget, cons
 Function:
 LastIndexOf
 */
-extern "C" int32_t LastIndexOf(const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t LastIndexOf(
+    const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
 {
     static_assert(USEARCH_DONE == -1, "managed side requires -1 for not found");
 
@@ -120,7 +128,8 @@ extern "C" int32_t LastIndexOf(const char* lpLocaleName, const UChar* lpTarget, 
 /*
  Return value is a "Win32 BOOL" (1 = true, 0 = false)
  */
-extern "C" int32_t StartsWith(const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t StartsWith(
+    const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
 {
     int32_t result = FALSE;
     UErrorCode err = U_ZERO_ERROR;
@@ -149,11 +158,12 @@ extern "C" int32_t StartsWith(const char* lpLocaleName, const UChar* lpTarget, c
 
                     result = TRUE;
 
-                    while((curCollElem = ucol_next(pCollElem, &err)) != UCOL_NULLORDER)
+                    while ((curCollElem = ucol_next(pCollElem, &err)) != UCOL_NULLORDER)
                     {
                         if (curCollElem != 0)
                         {
-                            // Non ignorable collation element found between start of the string and the first match for lpTarget.
+                            // Non ignorable collation element found between start of the
+                            // string and the first match for lpTarget.
                             result = FALSE;
                             break;
                         }
@@ -180,7 +190,8 @@ extern "C" int32_t StartsWith(const char* lpLocaleName, const UChar* lpTarget, c
 /*
  Return value is a "Win32 BOOL" (1 = true, 0 = false)
  */
-extern "C" int32_t EndsWith(const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t EndsWith(
+    const char* lpLocaleName, const UChar* lpTarget, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
 {
     int32_t result = FALSE;
     UErrorCode err = U_ZERO_ERROR;
@@ -202,7 +213,8 @@ extern "C" int32_t EndsWith(const char* lpLocaleName, const UChar* lpTarget, con
                     result = TRUE;
                 }
 
-                // TODO (dotnet/corefx#3467): We should do something similar to what StartsWith does where we can ignore
+                // TODO (dotnet/corefx#3467): We should do something similar to what
+                // StartsWith does where we can ignore
                 // some collation elements at the end of te string if they are zero.
             }
 
@@ -215,7 +227,12 @@ extern "C" int32_t EndsWith(const char* lpLocaleName, const UChar* lpTarget, con
     return result;
 }
 
-extern "C" int32_t GetSortKey(const char* lpLocaleName, const UChar* lpStr, int32_t cwStrLength, uint8_t* sortKey, int32_t cbSortKeyLength, int32_t options)
+extern "C" int32_t GetSortKey(const char* lpLocaleName,
+                              const UChar* lpStr,
+                              int32_t cwStrLength,
+                              uint8_t* sortKey,
+                              int32_t cbSortKeyLength,
+                              int32_t options)
 {
     UErrorCode err = U_ZERO_ERROR;
     UCollator* pColl = GetCollatorForLocaleAndOptions(lpLocaleName, options, &err);
@@ -231,7 +248,8 @@ extern "C" int32_t GetSortKey(const char* lpLocaleName, const UChar* lpStr, int3
     return result;
 }
 
-extern "C" int32_t CompareStringOrdinalIgnoreCase(const UChar* lpStr1, int32_t cwStr1Length, const UChar* lpStr2, int32_t cwStr2Length)
+extern "C" int32_t
+CompareStringOrdinalIgnoreCase(const UChar* lpStr1, int32_t cwStr1Length, const UChar* lpStr2, int32_t cwStr2Length)
 {
     assert(lpStr1 != nullptr);
     assert(cwStr1Length >= 0);

--- a/src/corefx/System.Globalization.Native/idna.cpp
+++ b/src/corefx/System.Globalization.Native/idna.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <stdint.h>
@@ -30,7 +31,8 @@ uint32_t GetOptions(uint32_t flags)
 Function:
 ToASCII
 
-Used by System.Globalization.IdnMapping.GetAsciiCore to convert an Unicode domain name to ASCII
+Used by System.Globalization.IdnMapping.GetAsciiCore to convert an Unicode
+domain name to ASCII
 
 Return values:
 0: internal error during conversion.
@@ -54,7 +56,8 @@ extern "C" int32_t ToAscii(uint32_t flags, const UChar* lpSrc, int32_t cwSrcLeng
 Function:
 ToUnicode
 
-Used by System.Globalization.IdnMapping.GetUnicodeCore to convert an ASCII name to Unicode
+Used by System.Globalization.IdnMapping.GetUnicodeCore to convert an ASCII name
+to Unicode
 
 Return values:
 0: internal error during conversion.

--- a/src/corefx/System.Globalization.Native/locale.cpp
+++ b/src/corefx/System.Globalization.Native/locale.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <assert.h>
@@ -14,123 +15,125 @@
 #include "unicode/localpointer.h"
 #include "unicode/ulocdata.h"
 
-int32_t UErrorCodeToBool(UErrorCode status) 
-{ 
-	if (U_SUCCESS(status))
-	{
-		return 1;
-	}
+int32_t UErrorCodeToBool(UErrorCode status)
+{
+    if (U_SUCCESS(status))
+    {
+        return 1;
+    }
 
-	// assert errors that should never occur
-	assert(status != U_BUFFER_OVERFLOW_ERROR);
-	assert(status != U_INTERNAL_PROGRAM_ERROR);
+    // assert errors that should never occur
+    assert(status != U_BUFFER_OVERFLOW_ERROR);
+    assert(status != U_INTERNAL_PROGRAM_ERROR);
 
-	// add possible SetLastError support here
+    // add possible SetLastError support here
 
-	return 0;
+    return 0;
 }
 
 Locale GetLocale(const UChar* localeName, bool canonize)
 {
-	char localeNameTemp[ULOC_FULLNAME_CAPACITY];
+    char localeNameTemp[ULOC_FULLNAME_CAPACITY];
 
-	if (localeName != NULL)
-	{
-		// use UnicodeString.extract instead of u_UCharsToChars; u_UCharsToChars considers '@' a variant and stops
-		UnicodeString str(localeName, -1, ULOC_FULLNAME_CAPACITY);
-		str.extract(0, str.length(), localeNameTemp);
-	}
+    if (localeName != NULL)
+    {
+        // use UnicodeString.extract instead of u_UCharsToChars; u_UCharsToChars
+        // considers '@' a variant and stops
+        UnicodeString str(localeName, -1, ULOC_FULLNAME_CAPACITY);
+        str.extract(0, str.length(), localeNameTemp);
+    }
 
-	Locale loc;
-	if (canonize)
-	{
-		loc = Locale::createCanonical(localeName == NULL ? NULL : localeNameTemp);
-	}
-	else
-	{
-		loc = Locale::createFromName(localeName == NULL ? NULL : localeNameTemp);
-	}
+    Locale loc;
+    if (canonize)
+    {
+        loc = Locale::createCanonical(localeName == NULL ? NULL : localeNameTemp);
+    }
+    else
+    {
+        loc = Locale::createFromName(localeName == NULL ? NULL : localeNameTemp);
+    }
 
-	return loc;
+    return loc;
 }
 
-UErrorCode u_charsToUChars_safe(const char *str, UChar* value, int32_t valueLength)
+UErrorCode u_charsToUChars_safe(const char* str, UChar* value, int32_t valueLength)
 {
-	int len = strlen(str);
-	if (len >= valueLength)
-	{
-		return U_BUFFER_OVERFLOW_ERROR;
-	}
-	u_charsToUChars(str, value, len + 1);
-	return U_ZERO_ERROR;
+    int len = strlen(str);
+    if (len >= valueLength)
+    {
+        return U_BUFFER_OVERFLOW_ERROR;
+    }
+    u_charsToUChars(str, value, len + 1);
+    return U_ZERO_ERROR;
 }
 
 int FixupLocaleName(UChar* value, int32_t valueLength)
 {
-	int i = 0;
-	for (; i < valueLength; i++)
-	{
-		if (value[i] == (UChar)'\0')
-		{
-			break;
-		}
-		else if (value[i] == (UChar)'_')
-		{
-			value[i] = (UChar)'-';
-		}
-	}
+    int i = 0;
+    for (; i < valueLength; i++)
+    {
+        if (value[i] == (UChar)'\0')
+        {
+            break;
+        }
+        else if (value[i] == (UChar)'_')
+        {
+            value[i] = (UChar)'-';
+        }
+    }
 
-	return i;
+    return i;
 }
 
 extern "C" int32_t GetLocaleName(const UChar* localeName, UChar* value, int32_t valueLength)
 {
-	Locale locale = GetLocale(localeName, true);
+    Locale locale = GetLocale(localeName, true);
 
-	if (locale.isBogus())
-	{
-		// localeName not properly formatted
-		return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
-	}
+    if (locale.isBogus())
+    {
+        // localeName not properly formatted
+        return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
+    }
 
-	// other validation done on managed side
+    // other validation done on managed side
 
-	UErrorCode status = u_charsToUChars_safe(locale.getName(), value, valueLength);
-	if (U_SUCCESS(status))
-	{
-		FixupLocaleName(value, valueLength);
-	}
+    UErrorCode status = u_charsToUChars_safe(locale.getName(), value, valueLength);
+    if (U_SUCCESS(status))
+    {
+        FixupLocaleName(value, valueLength);
+    }
 
-	return UErrorCodeToBool(status);
+    return UErrorCodeToBool(status);
 }
 
 extern "C" int32_t GetDefaultLocaleName(UChar* value, int32_t valueLength)
 {
-	Locale locale = GetLocale(NULL);
-	if (locale.isBogus())
-	{
-		// ICU should be able to get default locale
-		return UErrorCodeToBool(U_INTERNAL_PROGRAM_ERROR);
-	}
+    Locale locale = GetLocale(NULL);
+    if (locale.isBogus())
+    {
+        // ICU should be able to get default locale
+        return UErrorCodeToBool(U_INTERNAL_PROGRAM_ERROR);
+    }
 
-	UErrorCode status = u_charsToUChars_safe(locale.getBaseName(), value, valueLength);
-	if (U_SUCCESS(status))
-	{
-		int localeNameLen = FixupLocaleName(value, valueLength);
+    UErrorCode status = u_charsToUChars_safe(locale.getBaseName(), value, valueLength);
+    if (U_SUCCESS(status))
+    {
+        int localeNameLen = FixupLocaleName(value, valueLength);
 
-		// if collation is present, return that to managed side
-		char collationValueTemp[ULOC_KEYWORDS_CAPACITY];
-		if (locale.getKeywordValue("collation", collationValueTemp, ULOC_KEYWORDS_CAPACITY, status) > 0)
-		{
-			// copy the collation; managed uses a "_" to represent collation (not "@collation=")
-			status = u_charsToUChars_safe("_", &value[localeNameLen], valueLength - localeNameLen);
-			if (U_SUCCESS(status))
-			{
-				status = u_charsToUChars_safe(collationValueTemp, &value[localeNameLen + 1], valueLength - localeNameLen - 1);
-			}
-		}
-	}
+        // if collation is present, return that to managed side
+        char collationValueTemp[ULOC_KEYWORDS_CAPACITY];
+        if (locale.getKeywordValue("collation", collationValueTemp, ULOC_KEYWORDS_CAPACITY, status) > 0)
+        {
+            // copy the collation; managed uses a "_" to represent collation (not
+            // "@collation=")
+            status = u_charsToUChars_safe("_", &value[localeNameLen], valueLength - localeNameLen);
+            if (U_SUCCESS(status))
+            {
+                status = u_charsToUChars_safe(
+                    collationValueTemp, &value[localeNameLen + 1], valueLength - localeNameLen - 1);
+            }
+        }
+    }
 
-	return UErrorCodeToBool(status);
+    return UErrorCodeToBool(status);
 }
-

--- a/src/corefx/System.Globalization.Native/locale.hpp
+++ b/src/corefx/System.Globalization.Native/locale.hpp
@@ -37,7 +37,7 @@ u_charsToUChars_safe
 
 Copies the given null terminated char* to UChar with error checking. Replacement for ICU u_charsToUChars
 */
-UErrorCode u_charsToUChars_safe(const char *str, UChar* value, int32_t valueLength);
+UErrorCode u_charsToUChars_safe(const char* str, UChar* value, int32_t valueLength);
 
 /*
 Function:

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <assert.h>
@@ -15,171 +16,177 @@
 #include "unicode/ulocdata.h"
 
 // invariant character definitions used by ICU
-#define UCHAR_CURRENCY             ((UChar)0x00A4) // international currency
-#define UCHAR_SPACE                ((UChar)0x0020) // space 
-#define UCHAR_NBSPACE              ((UChar)0x00A0) // space
-#define UCHAR_DIGIT                ((UChar)0x0023) // '#'
-#define UCHAR_SEMICOLON            ((UChar)0x003B) // ';'
-#define UCHAR_MINUS                ((UChar)0x002D) // '-'
-#define UCHAR_PERCENT              ((UChar)0x0025) // '%'
-#define UCHAR_OPENPAREN            ((UChar)0x0028) // '(' 
-#define UCHAR_CLOSEPAREN           ((UChar)0x0029) // ')'
+#define UCHAR_CURRENCY ((UChar)0x00A4)   // international currency
+#define UCHAR_SPACE ((UChar)0x0020)      // space
+#define UCHAR_NBSPACE ((UChar)0x00A0)    // space
+#define UCHAR_DIGIT ((UChar)0x0023)      // '#'
+#define UCHAR_SEMICOLON ((UChar)0x003B)  // ';'
+#define UCHAR_MINUS ((UChar)0x002D)      // '-'
+#define UCHAR_PERCENT ((UChar)0x0025)    // '%'
+#define UCHAR_OPENPAREN ((UChar)0x0028)  // '('
+#define UCHAR_CLOSEPAREN ((UChar)0x0029) // ')'
 
-#define ARRAY_LENGTH(array) (sizeof(array)/sizeof(array[0]))
+#define ARRAY_LENGTH(array) (sizeof(array) / sizeof(array[0]))
 
 // Enum that corresponds to managed enum CultureData.LocaleNumberData.
-// The numeric values of the enum members match their Win32 counterparts. 
+// The numeric values of the enum members match their Win32 counterparts.
 enum LocaleNumberData : int32_t
 {
-	LanguageId = 0x00000001,
-	MeasurementSystem = 0x0000000D,
-	FractionalDigitsCount = 0x00000011,
-	NegativeNumberFormat = 0x00001010,
-	MonetaryFractionalDigitsCount = 0x00000019,
-	PositiveMonetaryNumberFormat = 0x0000001B,
-	NegativeMonetaryNumberFormat = 0x0000001C,
-	FirstDayofWeek = 0x0000100C,
-	FirstWeekOfYear = 0x0000100D,
-	ReadingLayout = 0x00000070,
-	NegativePercentFormat = 0x00000074,
-	PositivePercentFormat = 0x00000075,
-	Digit = 0x00000010,
-	Monetary = 0x00000018
+    LanguageId = 0x00000001,
+    MeasurementSystem = 0x0000000D,
+    FractionalDigitsCount = 0x00000011,
+    NegativeNumberFormat = 0x00001010,
+    MonetaryFractionalDigitsCount = 0x00000019,
+    PositiveMonetaryNumberFormat = 0x0000001B,
+    NegativeMonetaryNumberFormat = 0x0000001C,
+    FirstDayofWeek = 0x0000100C,
+    FirstWeekOfYear = 0x0000100D,
+    ReadingLayout = 0x00000070,
+    NegativePercentFormat = 0x00000074,
+    PositivePercentFormat = 0x00000075,
+    Digit = 0x00000010,
+    Monetary = 0x00000018
 };
 
 // Enum that corresponds to managed enum System.Globalization.CalendarWeekRule
 enum CalendarWeekRule : int32_t
 {
-	FirstDay = 0,
-	FirstFullWeek = 1,
-	FirstFourDayWeek = 2
+    FirstDay = 0,
+    FirstFullWeek = 1,
+    FirstFourDayWeek = 2
 };
 
 /*
 Function:
 NormalizeNumericPattern
 
-Returns a numeric string pattern in a format that we can match against the appropriate managed pattern.
+Returns a numeric string pattern in a format that we can match against the
+appropriate managed pattern.
 */
-void NormalizeNumericPattern(const UnicodeString *srcPattern, UnicodeString *destPattern, bool isNegative)
+void NormalizeNumericPattern(const UnicodeString* srcPattern, UnicodeString* destPattern, bool isNegative)
 {
-	// A srcPattern example: "#,##0.00 C;(#,##0.00 C)" but where C is the international currency symbol (UCHAR_CURRENCY)
-	// The positive pattern comes first, then an optional negative pattern separated by a semicolon
-	// A destPattern example: "(C n)" where C represents the currency symbol, and n is the number
-	destPattern->remove();
+    // A srcPattern example: "#,##0.00 C;(#,##0.00 C)" but where C is the
+    // international currency symbol (UCHAR_CURRENCY)
+    // The positive pattern comes first, then an optional negative pattern
+    // separated by a semicolon
+    // A destPattern example: "(C n)" where C represents the currency symbol, and
+    // n is the number
+    destPattern->remove();
 
-	int iStart = 0;
-	int iEnd = srcPattern->length() - 1;
-	int32_t iNegativePatternStart = srcPattern->indexOf(UCHAR_SEMICOLON);
-	if (iNegativePatternStart >= 0)
-	{
-		if (isNegative)
-		{
-			iStart = iNegativePatternStart + 1;
-		}
-		else
-		{
-			iEnd = iNegativePatternStart - 1;
-		}
-	}
+    int iStart = 0;
+    int iEnd = srcPattern->length() - 1;
+    int32_t iNegativePatternStart = srcPattern->indexOf(UCHAR_SEMICOLON);
+    if (iNegativePatternStart >= 0)
+    {
+        if (isNegative)
+        {
+            iStart = iNegativePatternStart + 1;
+        }
+        else
+        {
+            iEnd = iNegativePatternStart - 1;
+        }
+    }
 
-	bool minusAdded = false;
-	bool digitAdded = false;
-	bool currencyAdded = false;
-	bool spaceAdded = false;
+    bool minusAdded = false;
+    bool digitAdded = false;
+    bool currencyAdded = false;
+    bool spaceAdded = false;
 
-	for (int i = iStart; i <= iEnd; i++)
-	{
-		UChar ch = srcPattern->charAt(i);
-		switch (ch)
-		{
-		case UCHAR_DIGIT:
-			if (!digitAdded)
-			{
-				digitAdded = true;
-				destPattern->append('n');
-			}
-			break;
+    for (int i = iStart; i <= iEnd; i++)
+    {
+        UChar ch = srcPattern->charAt(i);
+        switch (ch)
+        {
+            case UCHAR_DIGIT:
+                if (!digitAdded)
+                {
+                    digitAdded = true;
+                    destPattern->append('n');
+                }
+                break;
 
-		case UCHAR_CURRENCY:
-			if (!currencyAdded)
-			{
-				currencyAdded = true;
-				destPattern->append('C');
-			}
-			break;
+            case UCHAR_CURRENCY:
+                if (!currencyAdded)
+                {
+                    currencyAdded = true;
+                    destPattern->append('C');
+                }
+                break;
 
-		case UCHAR_SPACE:
-		case UCHAR_NBSPACE:
-			if (!spaceAdded)
-			{
-				spaceAdded = true;
-				destPattern->append(UCHAR_SPACE);
-			}
-			else
-			{
-				assert(false);
-			}
-			break;
+            case UCHAR_SPACE:
+            case UCHAR_NBSPACE:
+                if (!spaceAdded)
+                {
+                    spaceAdded = true;
+                    destPattern->append(UCHAR_SPACE);
+                }
+                else
+                {
+                    assert(false);
+                }
+                break;
 
-		case UCHAR_MINUS:
-		case UCHAR_OPENPAREN:
-		case UCHAR_CLOSEPAREN:
-			minusAdded = true;
-			destPattern->append(ch);
-			break;
+            case UCHAR_MINUS:
+            case UCHAR_OPENPAREN:
+            case UCHAR_CLOSEPAREN:
+                minusAdded = true;
+                destPattern->append(ch);
+                break;
 
-		case UCHAR_PERCENT:
-			destPattern->append(ch);
-			break;
-		}
-	}
+            case UCHAR_PERCENT:
+                destPattern->append(ch);
+                break;
+        }
+    }
 
-	// if there is no negative subpattern, the ICU convention is to prefix the minus sign
-	if (isNegative && !minusAdded)
-	{
-		destPattern->insert(0, UCHAR_MINUS);
-	}
+    // if there is no negative subpattern, the ICU convention is to prefix the
+    // minus sign
+    if (isNegative && !minusAdded)
+    {
+        destPattern->insert(0, UCHAR_MINUS);
+    }
 }
 
 /*
 Function:
 GetNumericPattern
 
-Determines the pattern from the decimalFormat and returns the matching pattern's index from patterns[].
+Determines the pattern from the decimalFormat and returns the matching pattern's
+index from patterns[].
 Returns index -1 if no pattern is found.
 */
-int GetNumericPattern(DecimalFormat *decimalFormat, const char* patterns[], int patternsCount, bool isNegative)
+int GetNumericPattern(DecimalFormat* decimalFormat, const char* patterns[], int patternsCount, bool isNegative)
 {
-	const int INVALID_FORMAT = -1;
-	const int MAX_DOTNET_NUMERIC_PATTERN_LENGTH = 6; // example: "(C n)" plus terminator
-	char charPattern[MAX_DOTNET_NUMERIC_PATTERN_LENGTH] = { 0 };
+    const int INVALID_FORMAT = -1;
+    const int MAX_DOTNET_NUMERIC_PATTERN_LENGTH = 6; // example: "(C n)" plus terminator
+    char charPattern[MAX_DOTNET_NUMERIC_PATTERN_LENGTH] = {0};
 
-	UnicodeString icuPattern;
-	decimalFormat->toPattern(icuPattern);
+    UnicodeString icuPattern;
+    decimalFormat->toPattern(icuPattern);
 
-	UnicodeString normalizedPattern;
-	NormalizeNumericPattern(&icuPattern, &normalizedPattern, isNegative);
+    UnicodeString normalizedPattern;
+    NormalizeNumericPattern(&icuPattern, &normalizedPattern, isNegative);
 
-	assert(normalizedPattern.length() > 0);
-	assert(normalizedPattern.length() < MAX_DOTNET_NUMERIC_PATTERN_LENGTH);
-	if (normalizedPattern.length() == 0 || normalizedPattern.length() >= MAX_DOTNET_NUMERIC_PATTERN_LENGTH)
-	{
-		return INVALID_FORMAT;
-	}
+    assert(normalizedPattern.length() > 0);
+    assert(normalizedPattern.length() < MAX_DOTNET_NUMERIC_PATTERN_LENGTH);
+    if (normalizedPattern.length() == 0 || normalizedPattern.length() >= MAX_DOTNET_NUMERIC_PATTERN_LENGTH)
+    {
+        return INVALID_FORMAT;
+    }
 
-	u_UCharsToChars(normalizedPattern.getTerminatedBuffer(), charPattern, normalizedPattern.length() + 1);
+    u_UCharsToChars(normalizedPattern.getTerminatedBuffer(), charPattern, normalizedPattern.length() + 1);
 
-	for (int i = 0; i < patternsCount; i++)
-	{
-		if (strcmp(charPattern, patterns[i]) == 0)
-		{
-			return i;
-		}
-	};
+    for (int i = 0; i < patternsCount; i++)
+    {
+        if (strcmp(charPattern, patterns[i]) == 0)
+        {
+            return i;
+        }
+    };
 
-	assert(false); // should have found a valid pattern
-	return INVALID_FORMAT;
+    assert(false); // should have found a valid pattern
+    return INVALID_FORMAT;
 }
 
 /*
@@ -189,29 +196,44 @@ GetCurrencyNegativePattern
 Implementation of NumberFormatInfo.CurrencyNegativePattern.
 Returns the pattern index.
 */
-int GetCurrencyNegativePattern(const Locale &locale)
+int GetCurrencyNegativePattern(const Locale& locale)
 {
-	const int DEFAULT_VALUE = 0;
-	static const char* Patterns[] = { "(Cn)", "-Cn", "C-n", "Cn-", "(nC)", "-nC", "n-C", "nC-", "-n C", "-C n", "n C-", "C n-", "C -n", "n- C", "(C n)", "(n C)" };
-	UErrorCode status = U_ZERO_ERROR;
+    const int DEFAULT_VALUE = 0;
+    static const char* Patterns[] = {"(Cn)",
+                                     "-Cn",
+                                     "C-n",
+                                     "Cn-",
+                                     "(nC)",
+                                     "-nC",
+                                     "n-C",
+                                     "nC-",
+                                     "-n C",
+                                     "-C n",
+                                     "n C-",
+                                     "C n-",
+                                     "C -n",
+                                     "n- C",
+                                     "(C n)",
+                                     "(n C)"};
+    UErrorCode status = U_ZERO_ERROR;
 
-	LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_CURRENCY, status));
-	assert(U_SUCCESS(status));
-	if (U_SUCCESS(status))
-	{
-		DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
-		assert(decimalFormat != NULL);
-		if (decimalFormat != NULL)
-		{
-			int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), true);
-			if (value >= 0)
-			{
-				return value;
-			}
-		}
-	}
+    LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_CURRENCY, status));
+    assert(U_SUCCESS(status));
+    if (U_SUCCESS(status))
+    {
+        DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
+        assert(decimalFormat != NULL);
+        if (decimalFormat != NULL)
+        {
+            int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), true);
+            if (value >= 0)
+            {
+                return value;
+            }
+        }
+    }
 
-	return DEFAULT_VALUE;
+    return DEFAULT_VALUE;
 }
 
 /*
@@ -221,29 +243,29 @@ GetCurrencyPositivePattern
 Implementation of NumberFormatInfo.CurrencyPositivePattern.
 Returns the pattern index.
 */
-int GetCurrencyPositivePattern(const Locale &locale)
+int GetCurrencyPositivePattern(const Locale& locale)
 {
-	const int DEFAULT_VALUE = 0;
-	static const char* Patterns[] = { "Cn", "nC", "C n", "n C" };
-	UErrorCode status = U_ZERO_ERROR;
+    const int DEFAULT_VALUE = 0;
+    static const char* Patterns[] = {"Cn", "nC", "C n", "n C"};
+    UErrorCode status = U_ZERO_ERROR;
 
-	LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_CURRENCY, status));
-	assert(U_SUCCESS(status));
-	if (U_SUCCESS(status))
-	{
-		DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
-		assert(decimalFormat != NULL);
-		if (decimalFormat != NULL)
-		{
-			int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), false);
-			if (value >= 0)
-			{
-				return value;
-			}
-		}
-	}
+    LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_CURRENCY, status));
+    assert(U_SUCCESS(status));
+    if (U_SUCCESS(status))
+    {
+        DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
+        assert(decimalFormat != NULL);
+        if (decimalFormat != NULL)
+        {
+            int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), false);
+            if (value >= 0)
+            {
+                return value;
+            }
+        }
+    }
 
-	return DEFAULT_VALUE;
+    return DEFAULT_VALUE;
 }
 
 /*
@@ -253,29 +275,29 @@ GetNumberNegativePattern
 Implementation of NumberFormatInfo.NumberNegativePattern.
 Returns the pattern index.
 */
-int GetNumberNegativePattern(const Locale &locale)
+int GetNumberNegativePattern(const Locale& locale)
 {
-	const int DEFAULT_VALUE = 1;
-	static const char* Patterns[] = { "(n)", "-n", "- n", "n-", "n -" };
-	UErrorCode status = U_ZERO_ERROR;
+    const int DEFAULT_VALUE = 1;
+    static const char* Patterns[] = {"(n)", "-n", "- n", "n-", "n -"};
+    UErrorCode status = U_ZERO_ERROR;
 
-	LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_DECIMAL, status));
-	assert(U_SUCCESS(status));
-	if (U_SUCCESS(status))
-	{
-		DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
-		assert(decimalFormat != NULL);
-		if (decimalFormat != NULL)
-		{
-			int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), true);
-			if (value >= 0)
-			{
-				return value;
-			}
-		}
-	}
+    LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_DECIMAL, status));
+    assert(U_SUCCESS(status));
+    if (U_SUCCESS(status))
+    {
+        DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
+        assert(decimalFormat != NULL);
+        if (decimalFormat != NULL)
+        {
+            int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), true);
+            if (value >= 0)
+            {
+                return value;
+            }
+        }
+    }
 
-	return DEFAULT_VALUE;
+    return DEFAULT_VALUE;
 }
 
 /*
@@ -285,29 +307,30 @@ GetPercentNegativePattern
 Implementation of NumberFormatInfo.PercentNegativePattern.
 Returns the pattern index.
 */
-int GetPercentNegativePattern(const Locale &locale)
+int GetPercentNegativePattern(const Locale& locale)
 {
-	const int DEFAULT_VALUE = 0;
-	static const char* Patterns[] = { "-n %", "-n%", "-%n", "%-n", "%n-", "n-%", "n%-", "-% n", "n %-", "% n-", "% -n", "n- %" };
-	UErrorCode status = U_ZERO_ERROR;
+    const int DEFAULT_VALUE = 0;
+    static const char* Patterns[] = {
+        "-n %", "-n%", "-%n", "%-n", "%n-", "n-%", "n%-", "-% n", "n %-", "% n-", "% -n", "n- %"};
+    UErrorCode status = U_ZERO_ERROR;
 
-	LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_PERCENT, status));
-	assert(U_SUCCESS(status));
-	if (U_SUCCESS(status))
-	{
-		DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
-		assert(decimalFormat != NULL);
-		if (decimalFormat != NULL)
-		{
-			int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), true);
-			if (value >= 0)
-			{
-				return value;
-			}
-		}
-	}
+    LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_PERCENT, status));
+    assert(U_SUCCESS(status));
+    if (U_SUCCESS(status))
+    {
+        DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
+        assert(decimalFormat != NULL);
+        if (decimalFormat != NULL)
+        {
+            int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), true);
+            if (value >= 0)
+            {
+                return value;
+            }
+        }
+    }
 
-	return DEFAULT_VALUE;
+    return DEFAULT_VALUE;
 }
 
 /*
@@ -317,29 +340,29 @@ GetPercentPositivePattern
 Implementation of NumberFormatInfo.PercentPositivePattern.
 Returns the pattern index.
 */
-int GetPercentPositivePattern(const Locale &locale)
+int GetPercentPositivePattern(const Locale& locale)
 {
-	const int DEFAULT_VALUE = 0;
-	static const char* Patterns[] = { "n %", "n%", "%n", "% n" };
-	UErrorCode status = U_ZERO_ERROR;
+    const int DEFAULT_VALUE = 0;
+    static const char* Patterns[] = {"n %", "n%", "%n", "% n"};
+    UErrorCode status = U_ZERO_ERROR;
 
-	LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_PERCENT, status));
-	assert(U_SUCCESS(status));
-	if (U_SUCCESS(status))
-	{
-		DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
-		assert(decimalFormat != NULL);
-		if (decimalFormat != NULL)
-		{
-			int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), false);
-			if (value >= 0)
-			{
-				return value;
-			}
-		}
-	}
+    LocalPointer<NumberFormat> format(NumberFormat::createInstance(locale, UNUM_PERCENT, status));
+    assert(U_SUCCESS(status));
+    if (U_SUCCESS(status))
+    {
+        DecimalFormat* decimalFormat = dynamic_cast<DecimalFormat*>(format.getAlias());
+        assert(decimalFormat != NULL);
+        if (decimalFormat != NULL)
+        {
+            int value = GetNumericPattern(decimalFormat, Patterns, ARRAY_LENGTH(Patterns), false);
+            if (value >= 0)
+            {
+                return value;
+            }
+        }
+    }
 
-	return DEFAULT_VALUE;
+    return DEFAULT_VALUE;
 }
 
 /*
@@ -349,17 +372,17 @@ GetMeasurementSystem
 Obtains the measurement system for the local, determining if US or metric.
 Returns 1 for US, 0 otherwise.
 */
-UErrorCode GetMeasurementSystem(const char *localeId, int32_t *value)
+UErrorCode GetMeasurementSystem(const char* localeId, int32_t* value)
 {
-	UErrorCode status = U_ZERO_ERROR;
+    UErrorCode status = U_ZERO_ERROR;
 
-	UMeasurementSystem measurementSystem = ulocdata_getMeasurementSystem(localeId, &status);
-	if (U_SUCCESS(status))
-	{
-		*value = (measurementSystem == UMeasurementSystem::UMS_US) ? 1 : 0;
-	}
+    UMeasurementSystem measurementSystem = ulocdata_getMeasurementSystem(localeId, &status);
+    if (U_SUCCESS(status))
+    {
+        *value = (measurementSystem == UMeasurementSystem::UMS_US) ? 1 : 0;
+    }
 
-	return status;
+    return status;
 }
 
 /*
@@ -371,113 +394,115 @@ Returns 1 for success, 0 otherwise
 */
 extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData localeNumberData, int32_t* value)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-	{
-		return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
-	}
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+    {
+        return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
+    }
 
-	UErrorCode status = U_ZERO_ERROR;
+    UErrorCode status = U_ZERO_ERROR;
 
-	switch (localeNumberData)
-	{
-	case LanguageId:
-		*value = locale.getLCID();
-		break;
-	case MeasurementSystem:
-		status = GetMeasurementSystem(locale.getName(), value);
-		break;
-	case FractionalDigitsCount:
-	{
-		UNumberFormat* numformat = unum_open(UNUM_DECIMAL, NULL, 0, locale.getName(), NULL, &status);
-		if (U_SUCCESS(status))
-		{
-			*value = unum_getAttribute(numformat, UNUM_MAX_FRACTION_DIGITS);
-			unum_close(numformat);
-		}
-		break;
-	}
-	case NegativeNumberFormat:
-		*value = GetNumberNegativePattern(locale);
-		break;
-	case MonetaryFractionalDigitsCount:
-	{
-		UNumberFormat* numformat = unum_open(UNUM_CURRENCY, NULL, 0, locale.getName(), NULL, &status);
-		if (U_SUCCESS(status))
-		{
-			*value = unum_getAttribute(numformat, UNUM_MAX_FRACTION_DIGITS);
-			unum_close(numformat);
-		}
-		break;
-	}
-	case PositiveMonetaryNumberFormat:
-		*value = GetCurrencyPositivePattern(locale);
-		break;
-	case NegativeMonetaryNumberFormat:
-		*value = GetCurrencyNegativePattern(locale);
-		break;
-	case FirstWeekOfYear:
-	{
-		// corresponds to DateTimeFormat.CalendarWeekRule
-		LocalPointer<Calendar> calendar(Calendar::createInstance(locale, status));
-		if (U_SUCCESS(status))
-		{
-			// values correspond to LOCALE_IFIRSTWEEKOFYEAR
-			int minDaysInWeek = calendar->getMinimalDaysInFirstWeek();
-			if (minDaysInWeek == 1)
-			{
-				*value = CalendarWeekRule::FirstDay;
-			}
-			else if (minDaysInWeek == 7)
-			{
-				*value = CalendarWeekRule::FirstFullWeek;
-			}
-			else if (minDaysInWeek >= 4)
-			{
-				*value = CalendarWeekRule::FirstFourDayWeek;
-			}
-			else
-			{
-				status = U_UNSUPPORTED_ERROR;
-			}
-		}
-		break;
-	}
-	case ReadingLayout:
-	{
-		// coresponds to values 0 and 1 in LOCALE_IREADINGLAYOUT (values 2 and 3 not used in coreclr)
-		//  0 - Left to right (such as en-US)
-		//  1 - Right to left (such as arabic locales)
-		ULayoutType orientation = uloc_getCharacterOrientation(locale.getName(), &status);
-		// alternative implementation in ICU 54+ is Locale.isRightToLeft() which also supports script tags in locale
-		if (U_SUCCESS(status))
-		{
-			*value = (orientation == ULOC_LAYOUT_RTL) ? 1 : 0;
-		}
-		break;
-	}
-	case FirstDayofWeek:
-	{
-		LocalPointer<Calendar> pcalendar(Calendar::createInstance(locale, status));
-		if (U_SUCCESS(status))
-		{
-			*value = pcalendar->getFirstDayOfWeek(status) - 1; // .NET is 0-based and ICU is 1-based
-		}
-		break;
-	}
-	case NegativePercentFormat:
-		*value = GetPercentNegativePattern(locale);
-		break;
-	case PositivePercentFormat:
-		*value = GetPercentPositivePattern(locale);
-		break;
-	default:
-		status = U_UNSUPPORTED_ERROR;
-		assert(false);
-		break;
-	}
+    switch (localeNumberData)
+    {
+        case LanguageId:
+            *value = locale.getLCID();
+            break;
+        case MeasurementSystem:
+            status = GetMeasurementSystem(locale.getName(), value);
+            break;
+        case FractionalDigitsCount:
+        {
+            UNumberFormat* numformat = unum_open(UNUM_DECIMAL, NULL, 0, locale.getName(), NULL, &status);
+            if (U_SUCCESS(status))
+            {
+                *value = unum_getAttribute(numformat, UNUM_MAX_FRACTION_DIGITS);
+                unum_close(numformat);
+            }
+            break;
+        }
+        case NegativeNumberFormat:
+            *value = GetNumberNegativePattern(locale);
+            break;
+        case MonetaryFractionalDigitsCount:
+        {
+            UNumberFormat* numformat = unum_open(UNUM_CURRENCY, NULL, 0, locale.getName(), NULL, &status);
+            if (U_SUCCESS(status))
+            {
+                *value = unum_getAttribute(numformat, UNUM_MAX_FRACTION_DIGITS);
+                unum_close(numformat);
+            }
+            break;
+        }
+        case PositiveMonetaryNumberFormat:
+            *value = GetCurrencyPositivePattern(locale);
+            break;
+        case NegativeMonetaryNumberFormat:
+            *value = GetCurrencyNegativePattern(locale);
+            break;
+        case FirstWeekOfYear:
+        {
+            // corresponds to DateTimeFormat.CalendarWeekRule
+            LocalPointer<Calendar> calendar(Calendar::createInstance(locale, status));
+            if (U_SUCCESS(status))
+            {
+                // values correspond to LOCALE_IFIRSTWEEKOFYEAR
+                int minDaysInWeek = calendar->getMinimalDaysInFirstWeek();
+                if (minDaysInWeek == 1)
+                {
+                    *value = CalendarWeekRule::FirstDay;
+                }
+                else if (minDaysInWeek == 7)
+                {
+                    *value = CalendarWeekRule::FirstFullWeek;
+                }
+                else if (minDaysInWeek >= 4)
+                {
+                    *value = CalendarWeekRule::FirstFourDayWeek;
+                }
+                else
+                {
+                    status = U_UNSUPPORTED_ERROR;
+                }
+            }
+            break;
+        }
+        case ReadingLayout:
+        {
+            // coresponds to values 0 and 1 in LOCALE_IREADINGLAYOUT (values 2 and 3 not
+            // used in coreclr)
+            //  0 - Left to right (such as en-US)
+            //  1 - Right to left (such as arabic locales)
+            ULayoutType orientation = uloc_getCharacterOrientation(locale.getName(), &status);
+            // alternative implementation in ICU 54+ is Locale.isRightToLeft() which
+            // also supports script tags in locale
+            if (U_SUCCESS(status))
+            {
+                *value = (orientation == ULOC_LAYOUT_RTL) ? 1 : 0;
+            }
+            break;
+        }
+        case FirstDayofWeek:
+        {
+            LocalPointer<Calendar> pcalendar(Calendar::createInstance(locale, status));
+            if (U_SUCCESS(status))
+            {
+                *value = pcalendar->getFirstDayOfWeek(status) - 1; // .NET is 0-based and ICU is 1-based
+            }
+            break;
+        }
+        case NegativePercentFormat:
+            *value = GetPercentNegativePattern(locale);
+            break;
+        case PositivePercentFormat:
+            *value = GetPercentPositivePattern(locale);
+            break;
+        default:
+            status = U_UNSUPPORTED_ERROR;
+            assert(false);
+            break;
+    }
 
-	return UErrorCodeToBool(status);
+    return UErrorCodeToBool(status);
 }
 
 /*
@@ -487,35 +512,38 @@ GetLocaleInfoGroupingSizes
 Obtains grouping sizes for decimal and currency
 Returns 1 for success, 0 otherwise
 */
-extern "C" int32_t GetLocaleInfoGroupingSizes(const UChar* localeName, LocaleNumberData localeGroupingData, int32_t* primaryGroupSize, int32_t* secondaryGroupSize)
+extern "C" int32_t GetLocaleInfoGroupingSizes(const UChar* localeName,
+                                              LocaleNumberData localeGroupingData,
+                                              int32_t* primaryGroupSize,
+                                              int32_t* secondaryGroupSize)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-	{
-		return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
-	}
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+    {
+        return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
+    }
 
-	UNumberFormatStyle style;
-	switch (localeGroupingData)
-	{
-		case Digit:
-			style = UNUM_DECIMAL;
-			break;
-		case Monetary:
-			style = UNUM_CURRENCY;
-			break;
-		default:
-			return UErrorCodeToBool(U_UNSUPPORTED_ERROR);
-	}
+    UNumberFormatStyle style;
+    switch (localeGroupingData)
+    {
+        case Digit:
+            style = UNUM_DECIMAL;
+            break;
+        case Monetary:
+            style = UNUM_CURRENCY;
+            break;
+        default:
+            return UErrorCodeToBool(U_UNSUPPORTED_ERROR);
+    }
 
-	UErrorCode status = U_ZERO_ERROR;
-	UNumberFormat* numformat = unum_open(style, NULL, 0, locale.getName(), NULL, &status);
-	if (U_SUCCESS(status))
-	{
-		*primaryGroupSize = unum_getAttribute(numformat, UNUM_GROUPING_SIZE);
-		*secondaryGroupSize = unum_getAttribute(numformat, UNUM_SECONDARY_GROUPING_SIZE);
-		unum_close(numformat);
-	}
+    UErrorCode status = U_ZERO_ERROR;
+    UNumberFormat* numformat = unum_open(style, NULL, 0, locale.getName(), NULL, &status);
+    if (U_SUCCESS(status))
+    {
+        *primaryGroupSize = unum_getAttribute(numformat, UNUM_GROUPING_SIZE);
+        *secondaryGroupSize = unum_getAttribute(numformat, UNUM_SECONDARY_GROUPING_SIZE);
+        unum_close(numformat);
+    }
 
-	return UErrorCodeToBool(status);
+    return UErrorCodeToBool(status);
 }

--- a/src/corefx/System.Globalization.Native/localeStringData.cpp
+++ b/src/corefx/System.Globalization.Native/localeStringData.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <assert.h>
@@ -14,40 +15,40 @@
 #include "unicode/localpointer.h"
 
 // invariant character definitions used by ICU
-#define UCHAR_SPACE                ((UChar)0x0020) // space 
-#define UCHAR_NBSPACE              ((UChar)0x00A0) // space
+#define UCHAR_SPACE ((UChar)0x0020)   // space
+#define UCHAR_NBSPACE ((UChar)0x00A0) // space
 
 // Enum that corresponds to managed enum CultureData.LocaleStringData.
-// The numeric values of the enum members match their Win32 counterparts. 
+// The numeric values of the enum members match their Win32 counterparts.
 enum LocaleStringData : int32_t
 {
-	LocalizedDisplayName = 0x00000002,
-	EnglishDisplayName = 0x00000072,
-	NativeDisplayName = 0x00000073,
-	LocalizedLanguageName = 0x0000006f,
-	EnglishLanguageName = 0x00001001,
-	NativeLanguageName = 0x00000004,
-	EnglishCountryName = 0x00001002,
-	NativeCountryName = 0x00000008,
-	ListSeparator = 0x0000000C,
-	DecimalSeparator = 0x0000000E,
-	ThousandSeparator = 0x0000000F,
-	Digits = 0x00000013,
-	MonetarySymbol = 0x00000014,
-	Iso4217MonetarySymbol = 0x00000015,
-	MonetaryDecimalSeparator = 0x00000016,
-	MonetaryThousandSeparator = 0x00000017,
-	AMDesignator = 0x00000028,
-	PMDesignator = 0x00000029,
-	PositiveSign = 0x00000050,
-	NegativeSign = 0x00000051,
-	Iso639LanguageName = 0x00000059,
-	Iso3166CountryName = 0x0000005A,
-	NaNSymbol = 0x00000069,
-	PositiveInfinitySymbol = 0x0000006a,
-	ParentName = 0x0000006d,
-	PercentSymbol = 0x00000076,
-	PerMilleSymbol = 0x00000077
+    LocalizedDisplayName = 0x00000002,
+    EnglishDisplayName = 0x00000072,
+    NativeDisplayName = 0x00000073,
+    LocalizedLanguageName = 0x0000006f,
+    EnglishLanguageName = 0x00001001,
+    NativeLanguageName = 0x00000004,
+    EnglishCountryName = 0x00001002,
+    NativeCountryName = 0x00000008,
+    ListSeparator = 0x0000000C,
+    DecimalSeparator = 0x0000000E,
+    ThousandSeparator = 0x0000000F,
+    Digits = 0x00000013,
+    MonetarySymbol = 0x00000014,
+    Iso4217MonetarySymbol = 0x00000015,
+    MonetaryDecimalSeparator = 0x00000016,
+    MonetaryThousandSeparator = 0x00000017,
+    AMDesignator = 0x00000028,
+    PMDesignator = 0x00000029,
+    PositiveSign = 0x00000050,
+    NegativeSign = 0x00000051,
+    Iso639LanguageName = 0x00000059,
+    Iso3166CountryName = 0x0000005A,
+    NaNSymbol = 0x00000069,
+    PositiveInfinitySymbol = 0x0000006a,
+    ParentName = 0x0000006d,
+    PercentSymbol = 0x00000076,
+    PerMilleSymbol = 0x00000077
 };
 
 /*
@@ -56,24 +57,27 @@ GetLocaleInfoDecimalFormatSymbol
 
 Obtains the value of a DecimalFormatSymbols
 */
-UErrorCode GetLocaleInfoDecimalFormatSymbol(const Locale &locale, DecimalFormatSymbols::ENumberFormatSymbol symbol, UChar* value, int32_t valueLength)
+UErrorCode GetLocaleInfoDecimalFormatSymbol(const Locale& locale,
+                                            DecimalFormatSymbols::ENumberFormatSymbol symbol,
+                                            UChar* value,
+                                            int32_t valueLength)
 {
-	UErrorCode status = U_ZERO_ERROR;
-	LocalPointer<DecimalFormatSymbols> decimalsymbols(new DecimalFormatSymbols(locale, status));
-	if (decimalsymbols == NULL)
-	{
-		status = U_MEMORY_ALLOCATION_ERROR;
-	}
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<DecimalFormatSymbols> decimalsymbols(new DecimalFormatSymbols(locale, status));
+    if (decimalsymbols == NULL)
+    {
+        status = U_MEMORY_ALLOCATION_ERROR;
+    }
 
-	if (U_FAILURE(status))
-	{
-		return status;
-	}
+    if (U_FAILURE(status))
+    {
+        return status;
+    }
 
-	UnicodeString s = decimalsymbols->getSymbol(symbol);
+    UnicodeString s = decimalsymbols->getSymbol(symbol);
 
-	s.extract(value, valueLength, status);
-	return status;
+    s.extract(value, valueLength, status);
+    return status;
 }
 
 /*
@@ -82,14 +86,19 @@ GetDigitSymbol
 
 Obtains the value of a Digit DecimalFormatSymbols
 */
-UErrorCode GetDigitSymbol(const Locale &locale, UErrorCode previousStatus, DecimalFormatSymbols::ENumberFormatSymbol symbol, int digit, UChar* value, int32_t valueLength)
+UErrorCode GetDigitSymbol(const Locale& locale,
+                          UErrorCode previousStatus,
+                          DecimalFormatSymbols::ENumberFormatSymbol symbol,
+                          int digit,
+                          UChar* value,
+                          int32_t valueLength)
 {
-	if (U_FAILURE(previousStatus))
-	{
-		return previousStatus;
-	}
+    if (U_FAILURE(previousStatus))
+    {
+        return previousStatus;
+    }
 
-	return GetLocaleInfoDecimalFormatSymbol(locale, symbol, value + digit, valueLength - digit);
+    return GetLocaleInfoDecimalFormatSymbol(locale, symbol, value + digit, valueLength - digit);
 }
 
 /*
@@ -98,30 +107,30 @@ GetLocaleInfoAmPm
 
 Obtains the value of a DateFormatSymbols Am or Pm string
 */
-UErrorCode GetLocaleInfoAmPm(const Locale &locale, bool am, UChar* value, int32_t valueLength)
+UErrorCode GetLocaleInfoAmPm(const Locale& locale, bool am, UChar* value, int32_t valueLength)
 {
-	UErrorCode status = U_ZERO_ERROR;
-	LocalPointer<DateFormatSymbols> dateFormatSymbols(new DateFormatSymbols(locale, status));
-	if (dateFormatSymbols == NULL)
-	{
-		status = U_MEMORY_ALLOCATION_ERROR;
-	}
+    UErrorCode status = U_ZERO_ERROR;
+    LocalPointer<DateFormatSymbols> dateFormatSymbols(new DateFormatSymbols(locale, status));
+    if (dateFormatSymbols == NULL)
+    {
+        status = U_MEMORY_ALLOCATION_ERROR;
+    }
 
-	if (U_FAILURE(status))
-	{
-		return status;
-	}
+    if (U_FAILURE(status))
+    {
+        return status;
+    }
 
-	int32_t count = 0;
-	const UnicodeString *tempStr = dateFormatSymbols->getAmPmStrings(count);
-	int offset = am ? 0 : 1;
-	if (offset >= count)
-	{
-		return U_INTERNAL_PROGRAM_ERROR;
-	}
+    int32_t count = 0;
+    const UnicodeString* tempStr = dateFormatSymbols->getAmPmStrings(count);
+    int offset = am ? 0 : 1;
+    if (offset >= count)
+    {
+        return U_INTERNAL_PROGRAM_ERROR;
+    }
 
-	tempStr[offset].extract(value, valueLength, status);
-	return status;
+    tempStr[offset].extract(value, valueLength, status);
+    return status;
 }
 
 /*
@@ -131,132 +140,147 @@ GetLocaleInfoString
 Obtains string locale information.
 Returns 1 for success, 0 otherwise
 */
-extern "C" int32_t GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, UChar* value, int32_t valueLength)
+extern "C" int32_t
+GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, UChar* value, int32_t valueLength)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-	{
-		return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
-	}
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+    {
+        return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
+    }
 
-	UnicodeString str;
-	UErrorCode status = U_ZERO_ERROR;
-	switch (localeStringData)
-	{
-		case LocalizedDisplayName:
-			locale.getDisplayName(str);
-			str.extract(value, valueLength, status);
-			break;
-		case EnglishDisplayName:
-			locale.getDisplayName(Locale::getEnglish(), str);
-			str.extract(value, valueLength, status);
-			break;
-		case NativeDisplayName:
-			locale.getDisplayName(locale, str);
-			str.extract(value, valueLength, status);
-			break;
-		case LocalizedLanguageName:
-			locale.getDisplayLanguage(str);
-			str.extract(value, valueLength, status);
-			break;
-		case EnglishLanguageName:
-			locale.getDisplayLanguage(Locale::getEnglish(), str);
-			str.extract(value, valueLength, status);
-			break;
-		case NativeLanguageName:
-			locale.getDisplayLanguage(locale, str);
-			str.extract(value, valueLength, status);
-			break;
-		case EnglishCountryName:
-			locale.getDisplayCountry(Locale::getEnglish(), str);
-			str.extract(value, valueLength, status);
-			break;
-		case NativeCountryName:
-			locale.getDisplayCountry(locale, str);
-			str.extract(value, valueLength, status);
-			break;
-		case ListSeparator:
-			// fall through
-		case ThousandSeparator:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kGroupingSeparatorSymbol, value, valueLength);
-			break;
-		case DecimalSeparator:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kDecimalSeparatorSymbol, value, valueLength);
-			break;
-		case Digits:
-			status = GetDigitSymbol(locale, status, DecimalFormatSymbols::kZeroDigitSymbol, 0, value, valueLength);
-			// symbols kOneDigitSymbol to kNineDigitSymbol are contiguous
-			for (int32_t symbol = DecimalFormatSymbols::kOneDigitSymbol; symbol <= DecimalFormatSymbols::kNineDigitSymbol; symbol++)
-			{
-				int charIndex = symbol - DecimalFormatSymbols::kOneDigitSymbol + 1;
-				status = GetDigitSymbol(locale, status, (DecimalFormatSymbols::ENumberFormatSymbol)symbol, charIndex, value, valueLength);
-			}
-			break;
-		case MonetarySymbol:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kCurrencySymbol, value, valueLength);
-			break;
-		case Iso4217MonetarySymbol:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kIntlCurrencySymbol, value, valueLength);
-			break;
-		case MonetaryDecimalSeparator:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kMonetarySeparatorSymbol, value, valueLength);
-			break;
-		case MonetaryThousandSeparator:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kMonetaryGroupingSeparatorSymbol, value, valueLength);
-			break;
-		case AMDesignator:
-			status = GetLocaleInfoAmPm(locale, true, value, valueLength);
-			break;
-		case PMDesignator:
-			status = GetLocaleInfoAmPm(locale, false, value, valueLength);
-			break;
-		case PositiveSign:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kPlusSignSymbol, value, valueLength);
-			break;
-		case NegativeSign:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kMinusSignSymbol, value, valueLength);
-			break;
-		case Iso639LanguageName:
-			status = u_charsToUChars_safe(locale.getLanguage(), value, valueLength);
-			break;
-		case Iso3166CountryName:
-			// coreclr expects 2-character version, not 3 (3 would correspond to LOCALE_SISO3166CTRYNAME2 and locale.getISO3Country)
-			status = u_charsToUChars_safe(locale.getCountry(), value, valueLength);
-			break;
-		case NaNSymbol:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kNaNSymbol, value, valueLength);
-			break;
-		case PositiveInfinitySymbol:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kInfinitySymbol, value, valueLength);
-			break;
-		case ParentName:
-		{
-			// ICU supports lang[-script][-region][-variant] so up to 4 parents including invariant locale
-			char localeNameTemp[ULOC_FULLNAME_CAPACITY];
+    UnicodeString str;
+    UErrorCode status = U_ZERO_ERROR;
+    switch (localeStringData)
+    {
+        case LocalizedDisplayName:
+            locale.getDisplayName(str);
+            str.extract(value, valueLength, status);
+            break;
+        case EnglishDisplayName:
+            locale.getDisplayName(Locale::getEnglish(), str);
+            str.extract(value, valueLength, status);
+            break;
+        case NativeDisplayName:
+            locale.getDisplayName(locale, str);
+            str.extract(value, valueLength, status);
+            break;
+        case LocalizedLanguageName:
+            locale.getDisplayLanguage(str);
+            str.extract(value, valueLength, status);
+            break;
+        case EnglishLanguageName:
+            locale.getDisplayLanguage(Locale::getEnglish(), str);
+            str.extract(value, valueLength, status);
+            break;
+        case NativeLanguageName:
+            locale.getDisplayLanguage(locale, str);
+            str.extract(value, valueLength, status);
+            break;
+        case EnglishCountryName:
+            locale.getDisplayCountry(Locale::getEnglish(), str);
+            str.extract(value, valueLength, status);
+            break;
+        case NativeCountryName:
+            locale.getDisplayCountry(locale, str);
+            str.extract(value, valueLength, status);
+            break;
+        case ListSeparator:
+        // fall through
+        case ThousandSeparator:
+            status = GetLocaleInfoDecimalFormatSymbol(
+                locale, DecimalFormatSymbols::kGroupingSeparatorSymbol, value, valueLength);
+            break;
+        case DecimalSeparator:
+            status = GetLocaleInfoDecimalFormatSymbol(
+                locale, DecimalFormatSymbols::kDecimalSeparatorSymbol, value, valueLength);
+            break;
+        case Digits:
+            status = GetDigitSymbol(locale, status, DecimalFormatSymbols::kZeroDigitSymbol, 0, value, valueLength);
+            // symbols kOneDigitSymbol to kNineDigitSymbol are contiguous
+            for (int32_t symbol = DecimalFormatSymbols::kOneDigitSymbol;
+                 symbol <= DecimalFormatSymbols::kNineDigitSymbol;
+                 symbol++)
+            {
+                int charIndex = symbol - DecimalFormatSymbols::kOneDigitSymbol + 1;
+                status = GetDigitSymbol(
+                    locale, status, (DecimalFormatSymbols::ENumberFormatSymbol)symbol, charIndex, value, valueLength);
+            }
+            break;
+        case MonetarySymbol:
+            status =
+                GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kCurrencySymbol, value, valueLength);
+            break;
+        case Iso4217MonetarySymbol:
+            status =
+                GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kIntlCurrencySymbol, value, valueLength);
+            break;
+        case MonetaryDecimalSeparator:
+            status = GetLocaleInfoDecimalFormatSymbol(
+                locale, DecimalFormatSymbols::kMonetarySeparatorSymbol, value, valueLength);
+            break;
+        case MonetaryThousandSeparator:
+            status = GetLocaleInfoDecimalFormatSymbol(
+                locale, DecimalFormatSymbols::kMonetaryGroupingSeparatorSymbol, value, valueLength);
+            break;
+        case AMDesignator:
+            status = GetLocaleInfoAmPm(locale, true, value, valueLength);
+            break;
+        case PMDesignator:
+            status = GetLocaleInfoAmPm(locale, false, value, valueLength);
+            break;
+        case PositiveSign:
+            status =
+                GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kPlusSignSymbol, value, valueLength);
+            break;
+        case NegativeSign:
+            status =
+                GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kMinusSignSymbol, value, valueLength);
+            break;
+        case Iso639LanguageName:
+            status = u_charsToUChars_safe(locale.getLanguage(), value, valueLength);
+            break;
+        case Iso3166CountryName:
+            // coreclr expects 2-character version, not 3 (3 would correspond to
+            // LOCALE_SISO3166CTRYNAME2 and locale.getISO3Country)
+            status = u_charsToUChars_safe(locale.getCountry(), value, valueLength);
+            break;
+        case NaNSymbol:
+            status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kNaNSymbol, value, valueLength);
+            break;
+        case PositiveInfinitySymbol:
+            status =
+                GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kInfinitySymbol, value, valueLength);
+            break;
+        case ParentName:
+        {
+            // ICU supports lang[-script][-region][-variant] so up to 4 parents
+            // including invariant locale
+            char localeNameTemp[ULOC_FULLNAME_CAPACITY];
 
-			uloc_getParent(locale.getName(), localeNameTemp, ULOC_FULLNAME_CAPACITY, &status);
-			if (U_SUCCESS(status))
-			{
-				status = u_charsToUChars_safe(localeNameTemp, value, valueLength);
-				if (U_SUCCESS(status))
-				{
-					FixupLocaleName(value, valueLength);
-				}
-			}
-			break;
-		}
-		case PercentSymbol:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kPercentSymbol, value, valueLength);
-			break;
-		case PerMilleSymbol:
-			status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kPerMillSymbol, value, valueLength);
-			break;
-		default:
-			status = U_UNSUPPORTED_ERROR;
-			break;
-	};
+            uloc_getParent(locale.getName(), localeNameTemp, ULOC_FULLNAME_CAPACITY, &status);
+            if (U_SUCCESS(status))
+            {
+                status = u_charsToUChars_safe(localeNameTemp, value, valueLength);
+                if (U_SUCCESS(status))
+                {
+                    FixupLocaleName(value, valueLength);
+                }
+            }
+            break;
+        }
+        case PercentSymbol:
+            status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kPercentSymbol, value, valueLength);
+            break;
+        case PerMilleSymbol:
+            status = GetLocaleInfoDecimalFormatSymbol(locale, DecimalFormatSymbols::kPerMillSymbol, value, valueLength);
+            break;
+        default:
+            status = U_UNSUPPORTED_ERROR;
+            break;
+    };
 
-	return UErrorCodeToBool(status);
+    return UErrorCodeToBool(status);
 }
 
 /*
@@ -265,41 +289,41 @@ NormalizeTimePattern
 
 Convert an ICU non-localized time pattern to .NET format
 */
-void NormalizeTimePattern(const UnicodeString *srcPattern, UnicodeString *destPattern)
+void NormalizeTimePattern(const UnicodeString* srcPattern, UnicodeString* destPattern)
 {
-	// An srcPattern example: "h:mm:ss a"
-	// A destPattern example: "h:mm:ss tt"
-	destPattern->remove();
+    // An srcPattern example: "h:mm:ss a"
+    // A destPattern example: "h:mm:ss tt"
+    destPattern->remove();
 
-	bool amPmAdded = false;
-	for (int i = 0; i <= srcPattern->length() - 1; i++)
-	{
-		UChar ch = srcPattern->charAt(i);
-		switch (ch)
-		{
-		case ':':
-		case '.':
-		case 'H':
-		case 'h':
-		case 'm':
-		case 's':
-			destPattern->append(ch);
-			break;
+    bool amPmAdded = false;
+    for (int i = 0; i <= srcPattern->length() - 1; i++)
+    {
+        UChar ch = srcPattern->charAt(i);
+        switch (ch)
+        {
+            case ':':
+            case '.':
+            case 'H':
+            case 'h':
+            case 'm':
+            case 's':
+                destPattern->append(ch);
+                break;
 
-		case UCHAR_SPACE:
-		case UCHAR_NBSPACE:
-			destPattern->append(UCHAR_SPACE);
-			break;
+            case UCHAR_SPACE:
+            case UCHAR_NBSPACE:
+                destPattern->append(UCHAR_SPACE);
+                break;
 
-		case 'a': // AM/PM
-			if (!amPmAdded)
-			{
-				amPmAdded = true;
-				destPattern->append("tt"); 
-			}
-			break;
-		}
-	}
+            case 'a': // AM/PM
+                if (!amPmAdded)
+                {
+                    amPmAdded = true;
+                    destPattern->append("tt");
+                }
+                break;
+        }
+    }
 }
 
 /*
@@ -311,34 +335,34 @@ Returns 1 for success, 0 otherwise
 */
 extern "C" int32_t GetLocaleTimeFormat(const UChar* localeName, int shortFormat, UChar* value, int32_t valueLength)
 {
-	Locale locale = GetLocale(localeName);
-	if (locale.isBogus())
-	{
-		return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
-	}
+    Locale locale = GetLocale(localeName);
+    if (locale.isBogus())
+    {
+        return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
+    }
 
-	DateFormat::EStyle style = (shortFormat != 0) ? DateFormat::kShort : DateFormat::kMedium;
-	LocalPointer<DateFormat> dateFormat(DateFormat::createTimeInstance(style, locale));
-	if (dateFormat == NULL || !dateFormat.isValid())
-	{
-		return UErrorCodeToBool(U_MEMORY_ALLOCATION_ERROR);
-	}
+    DateFormat::EStyle style = (shortFormat != 0) ? DateFormat::kShort : DateFormat::kMedium;
+    LocalPointer<DateFormat> dateFormat(DateFormat::createTimeInstance(style, locale));
+    if (dateFormat == NULL || !dateFormat.isValid())
+    {
+        return UErrorCodeToBool(U_MEMORY_ALLOCATION_ERROR);
+    }
 
-	// cast to SimpleDateFormat so we can call toPattern()
-	SimpleDateFormat* sdf = dynamic_cast<SimpleDateFormat*>(dateFormat.getAlias());
-	if (sdf == NULL)
-	{
-		return UErrorCodeToBool(U_INTERNAL_PROGRAM_ERROR);
-	}
+    // cast to SimpleDateFormat so we can call toPattern()
+    SimpleDateFormat* sdf = dynamic_cast<SimpleDateFormat*>(dateFormat.getAlias());
+    if (sdf == NULL)
+    {
+        return UErrorCodeToBool(U_INTERNAL_PROGRAM_ERROR);
+    }
 
-	UnicodeString icuPattern;
-	sdf->toPattern(icuPattern);
+    UnicodeString icuPattern;
+    sdf->toPattern(icuPattern);
 
-	UnicodeString dotnetPattern;
-	NormalizeTimePattern(&icuPattern, &dotnetPattern);
+    UnicodeString dotnetPattern;
+    NormalizeTimePattern(&icuPattern, &dotnetPattern);
 
-	UErrorCode status = U_ZERO_ERROR;
-	dotnetPattern.extract(value, valueLength, status);
+    UErrorCode status = U_ZERO_ERROR;
+    dotnetPattern.extract(value, valueLength, status);
 
-	return UErrorCodeToBool(status);
+    return UErrorCodeToBool(status);
 }

--- a/src/corefx/System.Globalization.Native/normalization.cpp
+++ b/src/corefx/System.Globalization.Native/normalization.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <stdint.h>
@@ -9,7 +10,8 @@
 /*
  * These values should be kept in sync with System.Text.NormalizationForm
  */
-enum class NormalizationForm : int32_t {
+enum class NormalizationForm : int32_t
+{
     C = 0x1,
     D = 0x2,
     KC = 0x5,
@@ -18,16 +20,16 @@ enum class NormalizationForm : int32_t {
 
 const UNormalizer2* GetNormalizerForForm(NormalizationForm normalizationForm, UErrorCode* pErrorCode)
 {
-    switch(normalizationForm)
+    switch (normalizationForm)
     {
-    case NormalizationForm::C:
-        return unorm2_getNFCInstance(pErrorCode);
-    case NormalizationForm::D:
-        return unorm2_getNFDInstance(pErrorCode);
-    case NormalizationForm::KC:
-        return unorm2_getNFKCInstance(pErrorCode);
-    case NormalizationForm::KD:
-        return unorm2_getNFKDInstance(pErrorCode);
+        case NormalizationForm::C:
+            return unorm2_getNFCInstance(pErrorCode);
+        case NormalizationForm::D:
+            return unorm2_getNFDInstance(pErrorCode);
+        case NormalizationForm::KC:
+            return unorm2_getNFKCInstance(pErrorCode);
+        case NormalizationForm::KD:
+            return unorm2_getNFKDInstance(pErrorCode);
     }
 
     *pErrorCode = U_ILLEGAL_ARGUMENT_ERROR;
@@ -38,7 +40,8 @@ const UNormalizer2* GetNormalizerForForm(NormalizationForm normalizationForm, UE
 Function:
 IsNormalized
 
-Used by System.StringNormalizationExtensions.IsNormalized to detect if a string is in a certain
+Used by System.StringNormalizationExtensions.IsNormalized to detect if a string
+is in a certain
 Unicode Normalization Form.
 
 Return values:
@@ -66,14 +69,16 @@ extern "C" int32_t IsNormalized(NormalizationForm normalizationForm, const UChar
 Function:
 NormalizeString
 
-Used by System.StringNormalizationExtensions.Normalize to normalize a string into a certain
+Used by System.StringNormalizationExtensions.Normalize to normalize a string
+into a certain
 Unicode Normalization Form.
 
 Return values:
 0: internal error during normalization.
 >0: the length of the normalized string (not counting the null terminator).
 */
-extern "C" int32_t NormalizeString(NormalizationForm normalizationForm, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+extern "C" int32_t NormalizeString(
+    NormalizationForm normalizationForm, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
 {
     UErrorCode err = U_ZERO_ERROR;
     const UNormalizer2* pNormalizer = GetNormalizerForForm(normalizationForm, &err);

--- a/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
+++ b/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
@@ -1,6 +1,7 @@
 //
 // Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed under the MIT license. See LICENSE file in the project root for full
+// license information.
 //
 
 #include <stdint.h>
@@ -14,11 +15,11 @@ Gets the symlink value for the path.
 */
 extern "C" int32_t ReadLink(const char* path, char* result, size_t resultCapacity)
 {
-	ssize_t r = readlink(path, result, resultCapacity - 1); // subtract one to make room for the NULL character
+    ssize_t r = readlink(path, result, resultCapacity - 1); // subtract one to make room for the NULL character
 
-	if (r < 1 || r >= resultCapacity)
-		return false;
+    if (r < 1 || r >= resultCapacity)
+        return false;
 
-	result[r] = '\0';
-	return true;
+    result[r] = '\0';
+    return true;
 }

--- a/src/corefx/format-code.sh
+++ b/src/corefx/format-code.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# OS X names clang-format as clang-format; Ubuntu uses
+# clang-format-version so check for the right one
+if which "clang-format-3.6" > /dev/null 2>&1 ; then
+   export CF="$(which clang-format-3.6)"
+elif which "clang-format" > /dev/null 2>&1 ; then
+   export CF="$(which clang-format)"
+else
+   echo "Unable to find clang-format"
+   exit 1
+fi
+
+cd $(dirname "$0")
+
+for D in */; do
+    for file in "${D}"*.cpp; do
+        if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+        fi
+    done
+   
+    for file in "${D}"*.h ; do
+        if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+        fi
+    done
+
+    for file in "${D}"*.hpp ; do
+        if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+        fi
+    done
+
+   for file in "${D}"*.in ; do
+       if [ -e $file ] ; then
+            $CF -style=file -i "$file"
+       fi
+   done
+done


### PR DESCRIPTION
In CoreFX we have this nice little format-code.sh script which runs clang-format to format the code in a predefined format.

Pull the script into CoreCLR and then run it over all the Globalization native code in `src\corefx`.