### PR TITLE
Remove use of ICU C++ Calendar class

### DIFF
--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include "unicode/ucal.h"
+#include "unicode/uenum.h"
+
+// IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
+// time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
+// pointer and UErrorCode to manage the lifetime.  When the holder goes out of scope, the coresponding close method is
+// called on the pointer.
+template <typename T, typename Closer>
+class IcuHolder
+{
+  public:
+    IcuHolder(T* p, UErrorCode err)
+    {
+        m_p = U_SUCCESS(err) ? p : nullptr;
+    }
+
+    ~IcuHolder()
+    {
+        if (m_p != nullptr)
+        {
+            Closer()(m_p);
+        }
+    }
+
+  private:
+    T* m_p;
+    IcuHolder(const IcuHolder&);
+    IcuHolder operator=(const IcuHolder&);
+};
+
+struct UCalendarCloser
+{
+  public:
+    void operator()(UCalendar* pCal) const
+    {
+        ucal_close(pCal);
+    }
+};
+
+struct UEnumerationCloser
+{
+  public:
+    void operator()(UEnumeration* pEnum) const
+    {
+        uenum_close(pEnum);
+    }
+};
+
+typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
+typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "locale.hpp"
+#include "holders.h"
 
 #include "unicode/calendar.h"
 #include "unicode/decimfmt.h"
@@ -442,11 +443,13 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
         case FirstWeekOfYear:
         {
             // corresponds to DateTimeFormat.CalendarWeekRule
-            LocalPointer<Calendar> calendar(Calendar::createInstance(locale, status));
+            UCalendar* pCal = ucal_open(nullptr, 0, locale.getName(), UCAL_TRADITIONAL, &status);
+            UCalendarHolder calHolder(pCal, status);
+
             if (U_SUCCESS(status))
             {
                 // values correspond to LOCALE_IFIRSTWEEKOFYEAR
-                int minDaysInWeek = calendar->getMinimalDaysInFirstWeek();
+                int minDaysInWeek = ucal_getAttribute(pCal, UCAL_MINIMAL_DAYS_IN_FIRST_WEEK);
                 if (minDaysInWeek == 1)
                 {
                     *value = CalendarWeekRule::FirstDay;
@@ -483,10 +486,12 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
         }
         case FirstDayofWeek:
         {
-            LocalPointer<Calendar> pcalendar(Calendar::createInstance(locale, status));
+            UCalendar* pCal = ucal_open(nullptr, 0, locale.getName(), UCAL_TRADITIONAL, &status);
+            UCalendarHolder calHolder(pCal, status);
+
             if (U_SUCCESS(status))
             {
-                *value = pcalendar->getFirstDayOfWeek(status) - 1; // .NET is 0-based and ICU is 1-based
+                *value = ucal_getAttribute(pCal, UCAL_FIRST_DAY_OF_WEEK) - 1; // .NET is 0-based and ICU is 1-based
             }
             break;
         }


### PR DESCRIPTION
We would like to be able to link against versions of ICU installed as a
"operating system level library" which means we can't take a dependency
on any C++ APIs.

This change moves away from icu::Calendar in favor of UCalendar. I also
introduce a small helper template to manage the lifetime of ICU
resources.