### PR TITLE
Expose ICustomMarshaler as public

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -10169,12 +10169,12 @@
       <Member Name="AddField(System.String)" /> <!-- EE -->
       <Member Name="RemoveMember(System.Reflection.MemberInfo)" /> <!-- EE -->
     </Type>
-    <Type Status="ImplRoot" Name="System.Runtime.InteropServices.ICustomMarshaler">
-      <Member Name="MarshalNativeToManaged(System.IntPtr)" /> <!-- EE -->
-      <Member Name="MarshalManagedToNative(System.Object)" /> <!-- EE -->
-      <Member Name="CleanUpNativeData(System.IntPtr)" /> <!-- EE -->
-      <Member Name="CleanUpManagedData(System.Object)" /> <!-- EE -->
-      <Member Name="GetNativeDataSize" /> <!-- EE -->
+    <Type Name="System.Runtime.InteropServices.ICustomMarshaler">
+      <Member Name="MarshalNativeToManaged(System.IntPtr)" />
+      <Member Name="MarshalManagedToNative(System.Object)" />
+      <Member Name="CleanUpNativeData(System.IntPtr)" />
+      <Member Name="CleanUpManagedData(System.Object)" />
+      <Member Name="GetNativeDataSize" />
     </Type>
     <Type Name="System.Runtime.InteropServices.InvalidOleVariantTypeException">
       <Member Name="#ctor" />


### PR DESCRIPTION
The ICustomMarshaler machinery exists in mscorlib, but the actual
interface has been marked internal. Let's make it public so that people
can use it.

There will also need to be a change in the corefx repo to add it to the
System.Runtime.InteropServices contract.

Fix #1767