### PR TITLE
Remove assert found in internal testing

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3408,8 +3408,6 @@ bool Lowering::IndirsAreEquivalent(GenTreePtr candidate, GenTreePtr storeInd)
     if (pTreeA->OperGet() != pTreeB->OperGet())
         return false;
 
-    assert(genActualType(candidate->gtType) == genActualType(storeInd->gtType));
-
     if (genTypeSize(candidate->gtType) != genTypeSize(storeInd->gtType))
         return false;
 


### PR DESCRIPTION
This assert was introduced with the fix for #1323 as a sanity check that truly incompatible types couldn't enter this function.  However, there are at least some cases where the types could be different.  In the case found, REF and LONG were the types and the operand was a GT_LEA, which is handled later in the function.
This assert was introduced with the fix for #1323 as a sanity check that truly incompatible types couldn't enter this function.  However, there are at least some cases where the types could be different.  In the case found, REF and LONG were the types and the operand was a GT_LEA, which is handled later in the function.