### PR TITLE
change coreconsole to use _get_wpgmptr

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -597,27 +597,22 @@ void showHelp() {
 
 int __cdecl wmain(const int argc, const wchar_t* argv[])
 {
-    auto programPath = _wcsdup(argv[0]);
+    wchar_t* wpgmptr;
+    if (_get_wpgmptr(&wpgmptr) != 0) {
+        ::wprintf(W("Failed to get the path to the current executable"));
+        return -1;
+    }
+    auto programPath = _wcsdup(wpgmptr);
     auto extension = wcsrchr(programPath, '.');
-    if (extension == NULL) {
-        // We were called without the extension so need a bigger buffer
-        size_t pathLen = wcslen(programPath);
-        size_t bufLen = pathLen + 5;
-        wchar_t *newPath = new wchar_t[bufLen];
-        wcscpy_s(newPath, bufLen, programPath);
-        wcscat_s(newPath, bufLen, W(".dll"));
-        programPath = newPath;
+    if (extension == NULL || (wcscmp(extension, L".exe") != 0)) {
+        ::wprintf(W("This executable needs to have 'exe' extension"));
+        return -1;
     }
-    else {
-        extension += 1;
-        if (wcscmp(extension, L"exe") != 0) {
-            ::wprintf(W("This executable needs to have 'exe' extension"));
-            return -1;
-        }
-        extension[0] = 'd';
-        extension[1] = 'l';
-        extension[2] = 'l';
-    }
+
+	// Change the extension from ".exe" to ".dll"
+	extension[1] = 'd';
+	extension[2] = 'l';
+	extension[3] = 'l';
 
     // Parse the options from the command line
     bool verbose = false;


### PR DESCRIPTION
Fixes #1771 by using [`_get_wpgmptr`](https://msdn.microsoft.com/en-us/library/z2zbk054.aspx) instead of `argv[0]` to get the path to the currently running executable in CoreConsole (on Windows).

As far as I could tell, this is the quickest and cleanest way to do this. [MSDN says](https://msdn.microsoft.com/en-us/library/z2zbk054.aspx):

> The _wpgmptr global variable contains the full path to the executable associated with the process as a wide-character string.

I tested this in app I originally reproed #1771 and verified that with this new version of CoreConsole it no longer occurs. I wasn't able to find any test infrastructure for CoreConsole, so I didn't add a test, but feel free to let me know if there's something I missed :).

Also, now that we are getting the full path to the executable, we shouldn't need to worry about reallocating the buffer if the value doesn't have the extension since `_get_wpgmptr` should return the full path (extension included)