### PR TITLE
Fix DllImport search logic with respect to prefixes/suffixes

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6666,6 +6666,18 @@ public:
 #define MAKEDLLNAME(x) MAKEDLLNAME_A(x)
 #endif
 
+#define PAL_SHLIB_PREFIX "lib"
+
+#if __APPLE__
+#define PAL_SHLIB_SUFFIX ".dylib"
+#elif _AIX
+#define PAL_SHLIB_SUFFIX ".a"
+#elif _HPUX_
+#define PAL_SHLIB_SUFFIX ".sl"
+#else
+#define PAL_SHLIB_SUFFIX ".so"
+#endif
+
 #define DBG_EXCEPTION_HANDLED            ((DWORD   )0x00010001L)    
 #define DBG_CONTINUE                     ((DWORD   )0x00010002L)    
 #define DBG_EXCEPTION_NOT_HANDLED        ((DWORD   )0x80010001L)    

--- a/src/pal/src/include/pal/module.h
+++ b/src/pal/src/include/pal/module.h
@@ -26,18 +26,6 @@ extern "C"
 {
 #endif // __cplusplus
 
-#define PAL_SHLIB_PREFIX "lib"
-
-#if __APPLE__
-#define PAL_SHLIB_SUFFIX ".dylib"
-#elif _AIX
-#define PAL_SHLIB_SUFFIX ".a"
-#elif _HPUX_
-#define PAL_SHLIB_SUFFIX ".sl"
-#else
-#define PAL_SHLIB_SUFFIX ".so"
-#endif
-
 typedef BOOL (__stdcall *PDLLMAIN)(HINSTANCE, DWORD, LPVOID);   /* entry point of module */
 typedef HINSTANCE (PALAPI *PREGISTER_MODULE)(LPCSTR);           /* used to create the HINSTANCE for above DLLMain entry point */
 typedef VOID (PALAPI *PUNREGISTER_MODULE)(HINSTANCE);           /* used to cleanup the HINSTANCE for above DLLMain entry point */

--- a/src/vm/dllimport.h
+++ b/src/vm/dllimport.h
@@ -80,7 +80,7 @@ public:
     static LPVOID NDirectGetEntryPoint(NDirectMethodDesc *pMD, HINSTANCE hMod);
     static HMODULE LoadLibraryFromPath(LPCWSTR libraryPath);
     static HINSTANCE LoadLibraryModule(NDirectMethodDesc * pMD, LoadLibErrorTracker *pErrorTracker);
-    
+
 #ifndef FEATURE_CORECLR
     static VOID CheckUnificationList(NDirectMethodDesc * pMD, DWORD * pDllImportSearchPathFlag, BOOL * pSearchAssemblyDirectory);
 #endif // !FEATURE_CORECLR
@@ -132,6 +132,9 @@ public:
 
 private:
     NDirect() {LIMITED_METHOD_CONTRACT;};     // prevent "new"'s on this class
+
+    static HMODULE LoadFromNativeDllSearchDirectories(AppDomain* pDomain, LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker);
+    static HMODULE LoadFromPInvokeAssemblyDirectory(NDirectMethodDesc *pMD, LPCWSTR libName, DWORD flags, LoadLibErrorTracker *pErrorTracker);
 
 #if defined(FEATURE_HOST_ASSEMBLY_RESOLVER)
     static HMODULE LoadLibraryModuleViaHost(NDirectMethodDesc * pMD, AppDomain* pDomain, const wchar_t* wszLibName);

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -1,5 +1,4 @@
 Interop/ICastable/Castable.sh
-Interop/ReversePInvoke/Marshalling/MarshalBoolArray.sh
 JIT/Directed/lifetime/lifetime2.sh
 JIT/Directed/newarr/newarr.sh
 JIT/Directed/PREFIX/unaligned/1/arglist.sh


### PR DESCRIPTION
With this change, we will now attempt to add prefixes and suffixes (like 'lib' and '.so') to library names in the VM code (`LoadLibraryModule`) rather than in the PAL function `LOADLoadLibrary`.

The previous way of doing things caused problems because the code in dllimport has logic which probes several paths when trying to find a library, and the code in PAL was only able to add prefixes when given a library name rather than a path.

This change also fixes the test we have for ReversePInvoke, and I've removed it from the failing tests list.