### PR TITLE
Expose Module.ModuleVersionId

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -5384,6 +5384,7 @@
       <Member Status="ApiFxInternal" Name="get_FullyQualifiedName" Condition="not FEATURE_LEGACYNETCF" />
       <Member Name="get_FullyQualifiedName" Condition="FEATURE_LEGACYNETCF" />
       <Member Name="get_MetadataToken" />
+      <Member Name="get_ModuleVersionId" />
       <Member Name="get_Name" />
       <Member Name="GetCustomAttributes(System.Boolean)" />
       <Member Name="GetCustomAttributes(System.Type,System.Boolean)" />
@@ -5417,6 +5418,7 @@
       <Member MemberType="Property" Name="CustomAttributes" />            
       <Member MemberType="Property" Name="FullyQualifiedName" Condition="FEATURE_LEGACYNETCF" />
       <Member MemberType="Property" Name="MetadataToken" />
+      <Member MemberType="Property" Name="ModuleVersionId" />
       <Member MemberType="Property" Name="Name" />
     </Type>
     <Type Status="ImplRoot" Name="System.Reflection.RuntimeModule">

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -497,8 +497,8 @@ FCFuncStart(gMetaDataImport)
     FCFuncElement("_GetDefaultValue", MetaDataImport::GetDefaultValue) 
     FCFuncElement("_GetName", MetaDataImport::GetName) 
     FCFuncElement("_GetUserString", MetaDataImport::GetUserString) 
-#ifndef FEATURE_CORECLR
     FCFuncElement("_GetScopeProps", MetaDataImport::GetScopeProps)  
+#ifndef FEATURE_CORECLR
     FCFuncElement("_GetClassLayout", MetaDataImport::GetClassLayout) 
     FCFuncElement("_GetSignatureFromToken", MetaDataImport::GetSignatureFromToken) 
 #endif // FEATURE_CORECLR


### PR DESCRIPTION
This is in support of dotnet/corefx#2375

The POR is not to expose it directly on Module in the core reflection contract but via a TryGet extension that is allowed to simply return false on platforms without this capability. The CoreCLR implementation of that extension will call Module.ModuleVersionId in mscorlib.

cc @jkotas @weshaggard 


