### PR TITLE
Be explicit about exposing Assembly.Location in model.xml

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -3569,6 +3569,7 @@
       <Member Name="get_FullName" />
       <Member Name="get_ImageRuntimeVersion" Condition="FEATURE_LEGACYNETCF" />
       <Member Name="get_IsDynamic" />
+      <Member Name="get_Location" />
       <Member Name="get_ManifestModule" />
       <Member Name="get_CustomAttributes" />
       <Member Name="get_Modules" />
@@ -3614,6 +3615,7 @@
       <Member MemberType="Property" Name="EntryPoint" Condition="FEATURE_LEGACYNETCF" />
       <Member MemberType="Property" Name="FullName" />
       <Member MemberType="Property" Name="ImageRuntimeVersion" Condition="FEATURE_LEGACYNETCF" />
+      <Member MemberType="Property" Name="Location" />
       <Member MemberType="Property" Name="ManifestModule" />
       <Member Status="ImplRoot" MemberType="Event" Name="ModuleResolve" />
     </Type>


### PR DESCRIPTION
Assembly.Location was already being pulled in via "ApiClosure", but now that we'll expose it in the contract, we should be explicit about it.

This is the diff to the implClosure.xml and apiClosure.xml files in obj\

``` diff
-      <Member Status="ApiClosure" Name="get_Location" />
+      <Member Name="get_Location" />

-      <Member Status="ApiClosure" MemberType="Property" Name="Location" />
+      <Member MemberType="Property" Name="Location" />
```

cc @ellismg @weshaggard @jkotas 