### PR TITLE
Update Linux and OS X build instructions

### DIFF
--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -1,5 +1,5 @@
-Cross Compilation
-=================
+Cross Compilation for ARM
+=========================
 
 Through cross compilation, on Linux it is possible to build CoreCLR for ARM or ARM64.
 
@@ -40,3 +40,48 @@ And with:
     ben@ubuntu ~/git/coreclr/ $ ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build.sh arm debug verbose clean cross
 
 As usual the resulting binaries will be found in `bin/Product/BuildOS.BuildArch.BuildType/`
+
+Cross Compilation for Linux, FreeBSD, or OS X
+=============================================
+
+It is also possible to use a Windows machine to build the managed components of CoreCLR or CoreFX for Linux or OS X.  This can be useful when the build on the target platform fails, for example due to Mono issues.
+
+Build mscorlib on Windows
+-------------------------
+The following instructions assume you are on a Windows machine with a clone of the CoreCLR repo that has a correctly configured [environment](https://github.com/dotnet/coreclr/wiki/Windows-instructions#environment).
+
+To build mscorlib for Linux, run the following command:
+
+```
+D:\git\coreclr> build.cmd linuxmscorlib
+```
+
+The arguments `freebsdmscorlib` and `osxmscorlib` can be used instead to build mscorlib for FreeBSD or OS X.
+
+The output is at bin\Product\<BuildOS>.x64.Debug\mscorlib.dll.
+
+The CoreCLR native components need to be built on the target platform.  This can be done with the following command:
+
+```
+ellismg@linux:~/git/coreclr$ ./build.sh skipmscorlib
+```
+
+Build the Framework Managed Components on Windows
+-------------------------------------------------
+The following instructions assume you are on a Windows machine with a clone of the CoreFX repo.
+
+To build the CoreFX managed components for Linux, run the following command:
+
+```
+D:\git\corefx> build.cmd /p:OSGroup=Linux /p:SkipTests=true
+```
+
+`FreeBSD` and `OSX` can be used instead for the `OSGroup`.
+
+The output is at bin\<BuildOS>.AnyCPU.Debug.
+
+The CoreFX native components need to be built on the target platform.  This can be done with the following command:
+
+```
+ellismg@linux:~/git/corefx$ ./build.sh native
+```

--- a/Documentation/building/freebsd-instructions.md
+++ b/Documentation/building/freebsd-instructions.md
@@ -85,7 +85,7 @@ Build the Framework Native Components
 ======================================
 
 ```sh
-janhenke@freebsd-frankfurt:~/git/corefx$ src/Native/build.sh
+janhenke@freebsd-frankfurt:~/git/corefx$ ./build.sh native
 janhenke@freebsd-frankfurt:~/git/corefx$ cp bin/FreeBSD.x64.Debug/Native/*.so ~/coreclr-demo/runtime
 ```
 

--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -84,52 +84,33 @@ ellismg@linux:~/git/coreclr$ mkdir -p ~/coreclr-demo/runtime
 ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/corerun ~/coreclr-demo/runtime
 ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/libcoreclr.so ~/coreclr-demo/runtime
 ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/mscorlib.dll ~/coreclr-demo/runtime
+ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/System.Globalization.Native.so ~/coreclr-demo/runtime
 ```
 
-(Alternative) Build the Microsoft Core Library on Windows
-=========================================================
-
-If the build fails (for example due to Mono issues), alternatively you can build it on Windows.
-You'll need a Windows machine with clone of the CoreCLR project.
-
-You will build mscorlib.dll out of the coreclr repository.
-From a regular command prompt window run:
+Build the Framework
+===================
 
 ```
-D:\git\coreclr> build.cmd linuxmscorlib
+ellismg@linux:~/git/corefx$ ./build.sh
 ```
 
-The output is placed in bin\Product\Linux.x64.Debug\mscorlib.dll. You'll want to copy this to the runtime folder on your Linux machine. (e.g. ~/coreclr-demo/runtime)
-
-Build the Framework Native Components
-======================================
+For the purposes of Hello World, you need to copy a few required files to the demo folder.
 
 ```
-ellismg@linux:~/git/corefx$ src/Native/build.sh
 ellismg@linux:~/git/corefx$ cp bin/Linux.x64.Debug/Native/*.so ~/coreclr-demo/runtime
+ellismg@linux:~/git/corefx$ cp bin/Linux.AnyCPU.Debug/System.Console/System.Console.dll ~/coreclr-demo/runtime
+ellismg@linux:~/git/corefx$ cp bin/Linux.AnyCPU.Debug/System.Diagnostics.Debug/System.Diagnostics.Debug.dll ~/coreclr-demo/runtime
 ```
 
-Build the Framework Managed Components
-======================================
-
-We don't _yet_ have support for building managed code on Linux, so you'll need a Windows machine with clones of CoreFX project.
-
-You will build the rest of the framework that out of the corefx repository.  
-You need to pass some special parameters to build.cmd when building out of the CoreFX repository.
-
-```
-D:\git\corefx> build.cmd /p:OSGroup=Linux /p:SkipTests=true
-```
-
-It's also possible to add `/t:rebuild` to the build.cmd to force it to delete the previously built assemblies.
-
-For the purposes of Hello World, you need to copy over both `bin\Linux.AnyCPU.Debug\System.Console\System.Console.dll` and `bin\Linux.AnyCPU.Debug\System.Diagnostics.Debug\System.Diagnostics.Debug.dll`  into the runtime folder on Linux. (e.g `~/coreclr-demo/runtime`).
-
-After you've done these steps, the runtime directory on Linux should look like this:
+The runtime directory should now look like the following:
 
 ```
 matell@linux:~$ ls ~/coreclr-demo/runtime/
-corerun  libcoreclr.so  mscorlib.dll  System.Console.dll  System.Diagnostics.Debug.dll System.Native.so
+corerun                       System.Globalization.Native.so
+libcoreclr.so                 System.Native.so
+mscorlib.dll                  System.Net.Http.Native.so
+System.Console.dll            System.Security.Cryptography.Native.so
+System.Diagnostics.Debug.dll
 ```
 
 Download Dependencies

--- a/Documentation/building/osx-instructions.md
+++ b/Documentation/building/osx-instructions.md
@@ -69,8 +69,8 @@ NuGet is required to acquire any .NET assembly dependency that is not built by t
 
     dotnet-mbp:coreclr-demo richlander$ curl -L -O https://nuget.org/nuget.exe
 
-Build CoreCLR
-=============
+Build the Runtime and Microsoft Core Library
+============================================
 
 To Build CoreCLR, run build.sh from the root of the coreclr repo.
 
@@ -92,64 +92,34 @@ You will see several files. The interesting ones are:
 
 - `corerun`: The command line host. This program loads and starts the CoreCLR runtime and passes the managed program you want to run to it.
 - `libcoreclr.dylib`: The CoreCLR runtime itself.
+- `mscorlib.dll`: Microsoft Core Library (requires Mono).
 
 Copy the runtime and corerun into the demo directory.
 
     dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/corerun ~/coreclr-demo/runtime/
     dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/libcoreclr.dylib ~/coreclr-demo/runtime/
+	dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/mscorlib.dll ~/coreclr-demo/runtime/
+	dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/System.Globalization.Native.dylib ~/coreclr-demo/runtime/
 
-Build the Framework Native Components
-=====================================
-
-    dotnet-mbp:corefx richlander$ src/Native/build.sh
-    dotnet-mbp:corefx richlander$ cp bin/OSX.x64.Debug/Native/*.dylib ~/coreclr-demo/runtime
-
-Build the Framework Managed Components
-======================================
-
-While CoreFX can be built on OS X, building mscorlib still requires Windows.
-
-Build mscorlb
--------------
-
-The following instructions assume you are on a Windows machine with a clone of the CoreCLR repo and that has a correctly configured [environment](https://github.com/dotnet/coreclr/wiki/Windows-instructions#environment).
-
-You will need to copy binaries built on Windows to your Mac. Use whatever copying method works for you, such as a thumbdrive, a sync program or a cloud drive. To make this easy, copy files to a demo directory on Windows, so that you can copy all of the files to your Mac together.
-
-    C:\git\coreclr>mkdir \coreclr-demo
-
-Build mscorlib.dll out of the coreclr repository:
-
-    C:\git\coreclr>build.cmd osxmscorlib
-
-The output is placed in `bin\obj\OSX.x64.Debug`. Copy to the demo folder.
-
-    C:\git\coreclr>copy bin\obj\OSX.x64.Debug\mscorlib.dll \coreclr-demo
-
-Copy mscorlib
--------------
-
-Copy the newly built mscorlib.dll from `C:\coreclr-demo` to your Mac, in the `~/coreclr-demo/runtime/` directory.
-
-Build CoreFX
-------------
-
-Build the rest of the Framework out of the corefx directory on your Mac.
+Build the Framework
+===================
 
     dotnet-mbp:corefx richlander$ ./build.sh
 
+For the purposes of this demo, you need to copy a few required files to the demo folder.
 
-For the purposes of this demo, you need to copy a few required assemblies to the demo folder.
-
+	dotnet-mbp:corefx richlander$ cp bin/OSX.x64.Debug/Native/*.dylib ~/coreclr-demo/runtime
     dotnet-mbp:corefx richlander$ cp bin/OSX.AnyCPU.Debug/System.Console/System.Console.dll ~/coreclr-demo/runtime
     dotnet-mbp:corefx richlander$ cp bin/OSX.AnyCPU.Debug/System.Diagnostics.Debug/System.Diagnostics.Debug.dll ~/coreclr-demo/runtime
 
 The runtime directory should now look like the following:
 
     dotnet-mbp:~ richlander$ ls ~/coreclr-demo/runtime/
-    System.Console.dll              libcoreclr.dylib
-    System.Diagnostics.Debug.dll    mscorlib.dll
-    corerun
+    System.Console.dll                 System.Security.Cryptography.Native.dylib
+    System.Diagnostics.Debug.dll       corerun
+	System.Globalization.Native.dylib  libcoreclr.dylib
+	System.Native.dylib                mscorlib.dll
+	System.Net.Http.Native.dylib
 
 Download NuGet Packages
 =======================


### PR DESCRIPTION
CoreClr (including mscorlib) and CoreFx can now be built using Mono on
both Linux and OS X; this change updates the instructions to reflect
that.  It also moves the instructions for the alternative option of
building the x-plat bits on Windows to cross-building.md.

This change also adds System.Globalization.Native, which is now
necessary.

At some point the FreeBSD documentation should also be updated to be
consistent with the Linux and OS X instructions; ideally, they should be
combined into one file, as discussed in https://github.com/dotnet/coreclr/issues/1590.