### PR TITLE
Fix Turkish i casing with invariant culture on Unix

### DIFF
--- a/src/corefx/System.Globalization.Native/casing.cpp
+++ b/src/corefx/System.Globalization.Native/casing.cpp
@@ -13,87 +13,140 @@
 Function:
 ChangeCase
 
-Performs upper or lower casing of a string into a new buffer, performing special
-casing for Turkish, if needed.
+Performs upper or lower casing of a string into a new buffer.
+No special casing is performed beyond that provided by ICU.
 */
 extern "C" void ChangeCase(const UChar* lpSrc,
                            int32_t cwSrcLength,
                            UChar* lpDst,
                            int32_t cwDstLength,
-                           int32_t bToUpper,
-                           int32_t bTurkishCasing)
+                           int32_t bToUpper)
 {
-    int32_t srcIdx = 0;
-    int32_t dstIdx = 0;
+	// Iterate through the string, decoding the next one or two UTF-16 code units
+	// into a codepoint and updating srcIdx to point to the next UTF-16 code unit 
+	// to decode.  Then upper or lower case it, write dstCodepoint into lpDst at 
+	// offset dstIdx, and update dstIdx.
 
-    UBool isError = FALSE;
-    UChar32 srcCodepoint;
-    UChar32 dstCodepoint;
+	// (The loop here has been manually cloned for each of the four cases, rather
+	// than having a single loop that internally branched based on bToUpper as the 
+	// compiler wasn't doing that optimization, and it results in an ~15-20% perf
+	// improvement on longer strings.)
 
-    // Iterate through the string, decoding the next one or two UTF-16 code units
-    // into a codepoint
-    // and updating srcIdx to point to the next UTF-16 code unit to decode.  Then
-    // upper or lower
-    // case it, write dstCodepoint into lpDst at offset dstIdx, and update dstIdx.
-    // (The loop here has been manually cloned for each of the four cases, rather
-    // than having a
-    // single loop that internally branched based on bToUpper and bTurkishCasing,
-    // as the compiler
-    // wasn't doing that optimization, and it results in an ~15-20% perf
-    // improvement on longer strings.)
+	UBool isError = FALSE;
+	int32_t srcIdx = 0, dstIdx = 0;
+	UChar32 srcCodepoint, dstCodepoint;
 
-    if (bToUpper)
-    {
-        if (bTurkishCasing)
-        {
-            // bToUpper && bTurkishCasing
-            while (srcIdx < cwSrcLength)
-            {
-                // In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN
-                // CAPITAL LETTER I WITH DOT ABOVE (U+0130).
-                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-                dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
-                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-                assert(isError == FALSE && srcIdx == dstIdx);
-            }
-        }
-        else
-        {
-            // bToUpper && !bTurkishCasing
-            while (srcIdx < cwSrcLength)
-            {
-                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-                dstCodepoint = u_toupper(srcCodepoint);
-                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-                assert(isError == FALSE && srcIdx == dstIdx);
-            }
-        }
-    }
-    else
-    {
-        if (bTurkishCasing)
-        {
-            // !bToUpper && bTurkishCasing
-            while (srcIdx < cwSrcLength)
-            {
-                // In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to
-                // LATIN SMALL LETTER DOTLESS I (U+0131).
-                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-                dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
-                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-                assert(isError == FALSE && srcIdx == dstIdx);
-            }
-        }
-        else
-        {
-            // !bToUpper && !bTurkishCasing
-            while (srcIdx < cwSrcLength)
-            {
-                U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-                dstCodepoint = u_tolower(srcCodepoint);
-                U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-                assert(isError == FALSE && srcIdx == dstIdx);
-            }
-        }
-    }
+	if (bToUpper)
+	{
+		while (srcIdx < cwSrcLength)
+		{
+			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+			dstCodepoint = u_toupper(srcCodepoint);
+			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+			assert(isError == FALSE && srcIdx == dstIdx);
+		}
+	}
+	else
+	{
+		while (srcIdx < cwSrcLength)
+		{
+			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+			dstCodepoint = u_tolower(srcCodepoint);
+			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+			assert(isError == FALSE && srcIdx == dstIdx);
+		}
+	}
+}
+
+/*
+Function:
+ChangeCaseInvariant
+
+Performs upper or lower casing of a string into a new buffer.
+Special casing is performed to ensure that invariant casing 
+matches that of Windows in certain situations, e.g. Turkish i's.
+*/
+extern "C" void ChangeCaseInvariant(const UChar* lpSrc,
+                                    int32_t cwSrcLength,
+                                    UChar* lpDst,
+                                    int32_t cwDstLength,
+                                    int32_t bToUpper)
+{
+	// See algorithmic comment in ChangeCase.
+
+	UBool isError = FALSE;
+	int32_t srcIdx = 0, dstIdx = 0;
+	UChar32 srcCodepoint, dstCodepoint;
+
+	if (bToUpper)
+	{
+		while (srcIdx < cwSrcLength)
+		{
+			// On Windows with InvariantCulture, the LATIN SMALL LETTER DOTLESS I (U+0131)
+			// capitalizes to itself, whereas with ICU it capitalizes to LATIN CAPITAL LETTER I (U+0049).
+			// We special case it to match the Windows invariant behavior.
+			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+			dstCodepoint = ((srcCodepoint == (UChar32)0x0131) ? (UChar32)0x0131 : u_toupper(srcCodepoint));
+			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+			assert(isError == FALSE && srcIdx == dstIdx);
+		}
+	}
+	else
+	{
+		while (srcIdx < cwSrcLength)
+		{
+			// On Windows with InvariantCulture, the LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130)
+			// lower cases to itself, whereas with ICU it lower cases to LATIN SMALL LETTER I (U+0069).
+			// We special case it to match the Windows invariant behavior.
+			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+			dstCodepoint = ((srcCodepoint == (UChar32)0x0130) ? (UChar32)0x0130 : u_tolower(srcCodepoint));
+			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+			assert(isError == FALSE && srcIdx == dstIdx);
+		}
+	}
+}
+
+/*
+Function:
+ChangeCaseTurkish
+
+Performs upper or lower casing of a string into a new buffer, performing special
+casing for Turkish.
+*/
+extern "C" void ChangeCaseTurkish(const UChar* lpSrc,
+								  int32_t cwSrcLength,
+								  UChar* lpDst,
+								  int32_t cwDstLength,
+								  int32_t bToUpper)
+{
+	// See algorithmic comment in ChangeCase.
+
+	UBool isError = FALSE;
+	int32_t srcIdx = 0, dstIdx = 0;
+	UChar32 srcCodepoint, dstCodepoint;
+
+	if (bToUpper)
+	{
+		while (srcIdx < cwSrcLength)
+		{
+			// In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN
+			// CAPITAL LETTER I WITH DOT ABOVE (U+0130).
+			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+			dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
+			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+			assert(isError == FALSE && srcIdx == dstIdx);
+		}
+	}
+	else
+	{
+		while (srcIdx < cwSrcLength)
+		{
+			// In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to
+			// LATIN SMALL LETTER DOTLESS I (U+0131).
+			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+			dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
+			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+			assert(isError == FALSE && srcIdx == dstIdx);
+		}
+	}
 }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
@@ -10,9 +10,12 @@ internal static partial class Interop
     internal static partial class GlobalizationInterop
     {
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
-        internal unsafe static extern void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper, bool bTurkishCasing);
+        internal unsafe static extern void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
-        internal unsafe static extern void ChangeCase(string src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper, bool bTurkishCasing);
+        internal unsafe static extern void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
+
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        internal unsafe static extern void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
     }
 }


### PR DESCRIPTION
It turns out there are some differences in the casing data used by Windows and ICU for our invariant culture.  In particular, Turkish 'i' is handled differently.

This change splits the shim ChangeCase function into three: ChangeCaseTurkish (used for Turkish culture), ChangeCaseInvariant (used for Invariant culture), and ChangeCase (used for everything else.  ChangeCaseInvariant includes the new special cases.  Call sites in the  managed code are localized to a single function that determines which native function to invoke.

cc: @ellismg, @tarekgh 