### PR TITLE
Disable DEBUG_MESSAGES in release build of CoreCLR PAL

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -1,8 +1,6 @@
 #ifndef _PAL_CONFIG_H_INCLUDED
 #define _PAL_CONFIG_H_INCLUDED 1
 
-#define _NO_DEBUG_MESSAGES_ 0
-
 #cmakedefine01 HAVE_IEEEFP_H
 #cmakedefine01 HAVE_ALLOCA_H
 #cmakedefine01 HAVE_SYS_VMPARAM_H

--- a/src/pal/src/cruntime/misc.cpp
+++ b/src/pal/src/cruntime/misc.cpp
@@ -334,19 +334,19 @@ PAL_qsort(void *base, size_t nmemb, size_t size,
 
 /* reset ENTRY nesting level back to zero, qsort will invoke app-defined 
    callbacks and we want their entry traces... */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
 {
     int old_level;
     old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
     qsort(base,nmemb,size,compar);
 
 /* ...and set nesting level back to what it was */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
     DBG_change_entrylevel(old_level);
 }
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
     LOGEXIT("qsort returns\n");
     PERF_EXIT(qsort);
@@ -365,19 +365,19 @@ PAL_bsearch(const void *key, const void *base, size_t nmemb, size_t size,
 
 /* reset ENTRY nesting level back to zero, bsearch will invoke app-defined 
    callbacks and we want their entry traces... */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
 {
     int old_level;
     old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
     retval = bsearch(key,base,nmemb,size,compar);
 
 /* ...and set nesting level back to what it was */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
     DBG_change_entrylevel(old_level);
 }
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
     LOGEXIT("bsearch returns %p\n",retval);
     PERF_EXIT(bsearch);

--- a/src/pal/src/exception/console.cpp
+++ b/src/pal/src/exception/console.cpp
@@ -340,19 +340,19 @@ void SEHHandleControlEvent(DWORD event, LPVOID eip)
         BOOL handler_retval;
 
 /* reset ENTRY nesting level back to zero while inside the callback... */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
     {
         int old_level;
         old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
         handler_retval = handler->handler(event);
 
 /* ...and set nesting level back to what it was */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
         DBG_change_entrylevel(old_level);
     }
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
         if(handler_retval)
         {

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -737,9 +737,9 @@ static void FILEEscapeSquareBrackets(char *pattern, char *escaped_pattern)
     TRACE("Entering FILEEscapeSquareBrackets: [%p (%s)][%p]\n",
           pattern,pattern,escaped_pattern);
 
-#if !_NO_DEBUG_MESSAGES_          
+#if _ENABLE_DEBUG_MESSAGES_
     char *escaped_pattern_base = escaped_pattern;
-#endif // !_NO_DEBUG_MESSAGES
+#endif // _ENABLE_DEBUG_MESSAGES_
 
     while(*pattern)
     {

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -148,6 +148,12 @@ function_name() to call the system's implementation
    compiling PAL implementation files. */
 #include "config.h"
 
+#ifdef DEBUG
+#define _ENABLE_DEBUG_MESSAGES_ 1
+#else
+#define _ENABLE_DEBUG_MESSAGES_ 0
+#endif
+
 #ifdef PAL_PERF
 #include "pal_perf.h"
 #endif

--- a/src/pal/src/init/sxs.cpp
+++ b/src/pal/src/init/sxs.cpp
@@ -230,7 +230,7 @@ PAL_ReenterForEH()
     }
     else if (!pThread->IsInPal())
     {
-#if !_NO_DEBUG_MESSAGES_                
+#if _ENABLE_DEBUG_MESSAGES_
         DBG_PRINTF(DLI_ENTRY, defdbgchan, TRUE)("PAL_ReenterForEH()\n");
 #endif
 

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -540,11 +540,11 @@ FreeLibrary(
                 module->lib_name ? module->lib_name : W16_NULLSTRING);
 
 /* reset ENTRY nesting level back to zero while inside the callback... */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
     {
         int old_level;
         old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
     
         {
             // This module may be foreign to our PAL, so leave our PAL.
@@ -562,10 +562,10 @@ FreeLibrary(
             }
         }
 /* ...and set nesting level back to what it was */
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
         DBG_change_entrylevel(old_level);
     }
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
     }
 
     if (module->dl_handle && 0 != dlclose(module->dl_handle))
@@ -1137,11 +1137,11 @@ void LOADCallDllMain(DWORD dwReason, LPVOID lpReserved)
         {
             if (module->pDllMain)
             {
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
                 /* reset ENTRY nesting level back to zero while inside the callback... */
                 int old_level;
                 old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
                 {
                     // This module may be foreign to our PAL, so leave our PAL.
@@ -1150,10 +1150,10 @@ void LOADCallDllMain(DWORD dwReason, LPVOID lpReserved)
                     module->pDllMain(module->hinstance, dwReason, lpReserved);
                 }
 
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
                 /* ...and set nesting level back to what it was */
                 DBG_change_entrylevel(old_level);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
             }
         }
 
@@ -1541,11 +1541,11 @@ static HMODULE LOADRegisterLibraryDirect(HMODULE dl_handle, LPCSTR libraryNameOr
 
         BOOL dllMainRetVal;
         {
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
             /* reset ENTRY nesting level back to zero while inside the callback... */
             int old_level;
             old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
             {
                 // This module may be foreign to our PAL, so leave our PAL.
@@ -1554,10 +1554,10 @@ static HMODULE LOADRegisterLibraryDirect(HMODULE dl_handle, LPCSTR libraryNameOr
                 dllMainRetVal = module->pDllMain(module->hinstance, DLL_PROCESS_ATTACH, fDynamic ? NULL : (LPVOID)-1);
             }
 
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
             /* ...and set nesting level back to what it was */
             DBG_change_entrylevel(old_level);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
         }
 
         // If DlMain(DLL_PROCESS_ATTACH) returns FALSE, we must immediately unload the module
@@ -1696,10 +1696,10 @@ we're terminating anyway.
 */
 static void LOAD_SEH_CallDllMain(MODSTRUCT *module, DWORD dwReason, LPVOID lpReserved)
 {
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
     /* reset ENTRY nesting level back to zero while inside the callback... */
     int old_level = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
     
     struct Param
     {
@@ -1731,10 +1731,10 @@ static void LOAD_SEH_CallDllMain(MODSTRUCT *module, DWORD dwReason, LPVOID lpRes
     }
     PAL_ENDTRY
 
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
     /* ...and set nesting level back to what it was */
     DBG_change_entrylevel(old_level);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 }
 
 /*++

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -1423,11 +1423,11 @@ namespace CorUnix
                 ptainNode = ptainLocalHead;
                 ptainLocalHead = ptainNode->pNext;
 
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
                 // reset ENTRY nesting level back to zero while 
                 // inside the callback ... 
                 int iOldLevel = DBG_change_entrylevel(0);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
                 TRACE("Calling APC %p with parameter %#x\n",
                       ptainNode->pfnAPC, ptainNode->pfnAPC);
@@ -1435,10 +1435,10 @@ namespace CorUnix
                 // Actual APC call
                 ptainNode->pfnAPC(ptainNode->pAPCData);
 
-#if !_NO_DEBUG_MESSAGES_
+#if _ENABLE_DEBUG_MESSAGES_
                 // ... and set nesting level back to what it was
                 DBG_change_entrylevel(iOldLevel);
-#endif /* !_NO_DEBUG_MESSAGES_ */
+#endif /* _ENABLE_DEBUG_MESSAGES_ */
 
                 iAPCsCalled++;
                 m_cacheThreadApcInfoNodes.Add(pthrCurrent, ptainNode);


### PR DESCRIPTION
This reduces the size of libcoreclr by 1.3MB and improves performace results by a few percent on some benchmarks.
_NO_DEBUG_MESSAGES_ has been renamed to _ENABLE_DEBUG_MESSAGES_ to improve readability of the code.