### PR TITLE
Correct comments on Array sorting methods

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -2047,7 +2047,7 @@ namespace System {
                     } while (i <= j);
 
                     // The next iteration of the while loop is to "recursively" sort the larger half of the array and the
-                    // following calls recrusively sort the smaller half.  So we subtrack one from depthLimit here so
+                    // following calls recursively sort the smaller half.  So we subtract one from depthLimit here so
                     // both sorts see the new value.
                     depthLimit--;
 
@@ -2364,7 +2364,7 @@ namespace System {
                     } while (i <= j);
 
                     // The next iteration of the while loop is to "recursively" sort the larger half of the array and the
-                    // following calls recrusively sort the smaller half.  So we subtrack one from depthLimit here so
+                    // following calls recursively sort the smaller half.  So we subtract one from depthLimit here so
                     // both sorts see the new value.
                     depthLimit--;
 

--- a/src/mscorlib/src/System/Collections/Generic/ArraySortHelper.cs
+++ b/src/mscorlib/src/System/Collections/Generic/ArraySortHelper.cs
@@ -270,7 +270,7 @@ namespace System.Collections.Generic
                 } while (i <= j);
 
                 // The next iteration of the while loop is to "recursively" sort the larger half of the array and the
-                // following calls recrusively sort the smaller half.  So we subtrack one from depthLimit here so
+                // following calls recursively sort the smaller half.  So we subtract one from depthLimit here so
                 // both sorts see the new value.
                 depthLimit--;
 
@@ -671,7 +671,7 @@ namespace System.Collections.Generic
                 } while (i <= j);
 
                 // The next iteration of the while loop is to "recursively" sort the larger half of the array and the
-                // following calls recrusively sort the smaller half.  So we subtrack one from depthLimit here so
+                // following calls recursively sort the smaller half.  So we subtract one from depthLimit here so
                 // both sorts see the new value.
                 depthLimit--;
 
@@ -1025,7 +1025,7 @@ namespace System.Collections.Generic
                 } while (i <= j);
 
                 // The next iteration of the while loop is to "recursively" sort the larger half of the array and the
-                // following calls recrusively sort the smaller half.  So we subtrack one from depthLimit here so
+                // following calls recursively sort the smaller half.  So we subtract one from depthLimit here so
                 // both sorts see the new value.
                 depthLimit--;
 
@@ -1382,7 +1382,7 @@ namespace System.Collections.Generic
                 } while (i <= j);
 
                 // The next iteration of the while loop is to "recursively" sort the larger half of the array and the
-                // following calls recrusively sort the smaller half.  So we subtrack one from depthLimit here so
+                // following calls recursively sort the smaller half.  So we subtract one from depthLimit here so
                 // both sorts see the new value.
                 depthLimit--;
 


### PR DESCRIPTION
Changed "recrusively" to "recursively" and "subtrack" to "subtract".

https://github.com/dotnet/coreclr/issues/1801