### PR TITLE
Managed unhandled exceptions for debugging and other fixes

### DIFF
--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -1316,7 +1316,6 @@ CThreadSuspensionInfo::InitializeSignalSets()
 #endif
     sigaddset(&smDefaultmask, SIGSYS); 
     sigaddset(&smDefaultmask, SIGALRM); 
-    sigaddset(&smDefaultmask, SIGTERM);     
     sigaddset(&smDefaultmask, SIGURG); 
     sigaddset(&smDefaultmask, SIGTSTP); 
     sigaddset(&smDefaultmask, SIGCONT);   

--- a/src/vm/eepolicy.cpp
+++ b/src/vm/eepolicy.cpp
@@ -573,6 +573,14 @@ void SafeExitProcess(UINT exitCode, BOOL fAbort = FALSE, ShutdownCompleteAction 
         // disabled because if we fault in this code path we will trigger our
         // Watson code via EntryPointFilter which is THROWS (see Dev11 317016)
         CONTRACT_VIOLATION(ThrowsViolation);
+
+#ifdef FEATURE_PAL
+        if (fAbort)
+        {
+            TerminateProcess(GetCurrentProcess(), exitCode);
+        }
+#endif
+
         EEPolicy::ExitProcessViaShim(exitCode);
     }
 }

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4623,8 +4623,11 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex)
 
             if (controlPc == 0)
             {
-                // The unhandled exceptions should be caught by the high level exception filter
-                _ASSERTE(!"UnwindManagedExceptionPass1: Exception escaped the stack");
+                if (!GetThread()->HasThreadStateNC(Thread::TSNC_ProcessedUnhandledException))
+                {
+                    LONG disposition = InternalUnhandledExceptionFilter_Worker(&ex.ExceptionPointers);
+                    _ASSERTE(disposition == EXCEPTION_CONTINUE_SEARCH);
+                }
                 EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);                    
             }
 

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -340,23 +340,21 @@ VOID DECLSPEC_NORETURN DispatchManagedException(PAL_SEHException& ex);
         }
 
 // Install trap that catches unhandled managed exception and dumps its stack
-#define INSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP                                                    \
-        try {                                                                                       \
-            auto exceptionFilter = [](PAL_SEHException& ex)                                         \
-            {                                                                                       \
-                return EXCEPTION_EXECUTE_HANDLER;                                                   \
-            };                                                                                      \
-            auto __exceptionHolder = NativeExceptionHolderFactory::CreateHolder(&exceptionFilter);  \
-            __exceptionHolder.Push();
+#define INSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP                                            \
+        try {                                                                                   
 
 // Uninstall trap that catches unhandled managed exception and dumps its stack
-#define UNINSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP                                              \
-        }                                                                                       \
-        catch (PAL_SEHException& ex)                                                            \
-        {                                                                                       \
-            LONG disposition = InternalUnhandledExceptionFilter_Worker(&ex.ExceptionPointers);  \
-            _ASSERTE(disposition == EXCEPTION_CONTINUE_SEARCH);                                 \
-            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);                                 \
+#define UNINSTALL_UNHANDLED_MANAGED_EXCEPTION_TRAP                                          \
+        }                                                                                   \
+        catch (PAL_SEHException& ex)                                                        \
+        {                                                                                   \
+            DefaultCatchHandler(NULL /*pExceptionInfo*/,                                    \
+                                NULL /*Throwable*/,                                         \
+                                TRUE /*useLastThrownObject*/,                               \
+                                TRUE /*isTerminating*/,                                     \
+                                FALSE /*isThreadBaseFIlter*/,                               \
+                                FALSE /*sendAppDomainEvents*/);                             \
+            EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);                             \
         }
 
 #else


### PR DESCRIPTION
Fix assert when unhandled exception is unwound and restored some previous code in the first pass dispatcher so the managed debugger notification is sent at the right time (during the first pass instead after everything is unwound).

Fixed issue #1799 by not masking SIGTERM anymore.

Fix issue #1782 unhanded exceptions don't generate core dumps by changing HandleFatalError to end up calling TerminateProcess (which calls the unix abort()) instead of ExitProcess.
