### PR TITLE
Fix instructions for building framework native components

### DIFF
--- a/Documentation/building/freebsd-instructions.md
+++ b/Documentation/building/freebsd-instructions.md
@@ -85,7 +85,7 @@ Build the Framework Native Components
 ======================================
 
 ```sh
-janhenke@freebsd-frankfurt:~/git/corefx$ src/Native/build.sh
+janhenke@freebsd-frankfurt:~/git/corefx$ ./build.sh native
 janhenke@freebsd-frankfurt:~/git/corefx$ cp bin/FreeBSD.x64.Debug/Native/*.so ~/coreclr-demo/runtime
 ```
 

--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -105,7 +105,7 @@ Build the Framework Native Components
 ======================================
 
 ```
-ellismg@linux:~/git/corefx$ src/Native/build.sh
+ellismg@linux:~/git/corefx$ ./build.sh native
 ellismg@linux:~/git/corefx$ cp bin/Linux.x64.Debug/Native/*.so ~/coreclr-demo/runtime
 ```
 

--- a/Documentation/building/osx-instructions.md
+++ b/Documentation/building/osx-instructions.md
@@ -101,7 +101,7 @@ Copy the runtime and corerun into the demo directory.
 Build the Framework Native Components
 =====================================
 
-    dotnet-mbp:corefx richlander$ src/Native/build.sh
+    dotnet-mbp:corefx richlander$ ./build.sh native
     dotnet-mbp:corefx richlander$ cp bin/OSX.x64.Debug/Native/*.dylib ~/coreclr-demo/runtime
 
 Build the Framework Managed Components


### PR DESCRIPTION
src/Native/build.sh was removed from corefx as of commit [425d47f](https://github.com/dotnet/corefx/commit/425d47f8494b2c2a4414efd799e65fb6b58cc9f7). This updates our instructions.