### PR TITLE
Clean up cleanup code in PAL

### DIFF
--- a/src/pal/src/include/pal/init.h
+++ b/src/pal/src/include/pal/init.h
@@ -38,15 +38,6 @@ Utility function to force PAL to shutdown state
 --*/
 void PALShutdown( void );
 
-typedef enum
-{
-    PALCLEANUP_STEP_ONE, /* enum MUST start from 0 */
-    PALCLEANUP_STEP_TWO,
-    PALCLEANUP_ALL_STEPS,
-    PALCLEANUP_STEP_INVALID          /* This const MUST be the last entry
-                                        in the enum */
-} PALCLEANUP_STEP;
-
 /*++
 Function:
   PALCommonCleanup
@@ -54,12 +45,11 @@ Function:
 Utility function to free any resource used by the PAL. 
 
 Parameters :
-    step:          selects the desired cleanup step
     full_cleanup:  TRUE: cleanup only what's needed and leave the rest 
                          to the OS process cleanup
                    FALSE: full cleanup 
 --*/
-void PALCommonCleanup( PALCLEANUP_STEP step, BOOL full_cleanup );
+void PALCommonCleanup( BOOL full_cleanup );
 
 extern Volatile<INT> init_count;
 

--- a/src/pal/src/include/pal/init.h
+++ b/src/pal/src/include/pal/init.h
@@ -42,14 +42,10 @@ void PALShutdown( void );
 Function:
   PALCommonCleanup
 
-Utility function to free any resource used by the PAL. 
+Utility function to prepare for shutdown.
 
-Parameters :
-    full_cleanup:  TRUE: cleanup only what's needed and leave the rest 
-                         to the OS process cleanup
-                   FALSE: full cleanup 
 --*/
-void PALCommonCleanup( BOOL full_cleanup );
+void PALCommonCleanup();
 
 extern Volatile<INT> init_count;
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -756,11 +756,11 @@ Parameters :
 void 
 PALCommonCleanup(BOOL full_cleanup)
 {
-    static bool done = false;
+    static bool cleanupDone = false;
 
-    if (!done)
+    if (!cleanupDone)
     {
-        done = true;
+        cleanupDone = true;
 
         PALSetShutdownIntent();
 
@@ -773,15 +773,6 @@ PALCommonCleanup(BOOL full_cleanup)
 #ifdef _DEBUG
         PROCDumpThreadList();
 #endif
-
-        TRACE("About to suspend every other thread\n");
-
-        /* prevent other threads from acquiring signaled objects */
-        PROCCondemnOtherThreads();
-        /* prevent other threads from using services we're shutting down */
-        PROCSuspendOtherThreads();
-
-        TRACE("Every other thread suspended until exit\n");
     }
 }
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -754,128 +754,35 @@ Parameters :
                    TRUE:  full cleanup 
 --*/
 void 
-PALCommonCleanup(PALCLEANUP_STEP step, BOOL full_cleanup)
+PALCommonCleanup(BOOL full_cleanup)
 {
     CPalThread *pThread = InternalGetCurrentThread();
-    static int step_done[PALCLEANUP_STEP_INVALID] = { 0 };
+    static bool done = false;
 
-    switch (step)
+    if (!done)
     {
-    case PALCLEANUP_ALL_STEPS:
-    case PALCLEANUP_STEP_ONE:
-        /* Note: in order to work correctly, this step should be executed with 
-           init_count > 0
-         */
-        if (!step_done[PALCLEANUP_STEP_ONE])
-        {
-            step_done[PALCLEANUP_STEP_ONE] = 1;
+        done = true;
 
-            PALSetShutdownIntent();
+        PALSetShutdownIntent();
 
-            //
-            // Let the synchronization manager know we're about to shutdown
-            //
+        //
+        // Let the synchronization manager know we're about to shutdown
+        //
 
-            CPalSynchMgrController::PrepareForShutdown();
+        CPalSynchMgrController::PrepareForShutdown();
 
 #ifdef _DEBUG
-            PROCDumpThreadList();
+        PROCDumpThreadList();
 #endif
 
-            TRACE("About to suspend every other thread\n");
+        TRACE("About to suspend every other thread\n");
 
-            /* prevent other threads from acquiring signaled objects */
-            PROCCondemnOtherThreads();
-            /* prevent other threads from using services we're shutting down */
-            PROCSuspendOtherThreads();
+        /* prevent other threads from acquiring signaled objects */
+        PROCCondemnOtherThreads();
+        /* prevent other threads from using services we're shutting down */
+        PROCSuspendOtherThreads();
 
-            TRACE("Every other thread suspended until exit\n");
-        }
-
-        /* Fall down for PALCLEANUP_ALL_STEPS */
-        if (PALCLEANUP_ALL_STEPS != step)
-            break;
-
-    case PALCLEANUP_STEP_TWO:
-        if (!step_done[PALCLEANUP_STEP_TWO])
-        {
-            step_done[PALCLEANUP_STEP_TWO] = 1;
-
-            /* LOADFreeeModules needs to be called before unitializing the rest
-               of the PAL since it could result in calling DllMain for loaded
-               libraries. For the user DllMain, all PAL APIs should still be
-               functional. */
-            LOADFreeModules(FALSE);
-
-#ifdef PAL_PERF
-            PERFDisableProcessProfile();
-            PERFDisableThreadProfile(FALSE);
-            PERFTerminate();  
-#endif
-
-            if (full_cleanup)
-            {
-                /* close primary handles of standard file objects */
-                FILECleanupStdHandles();
-                VIRTUALCleanup();
-                /* SEH requires information from the process structure to work;
-                   LOADFreeModules requires SEH to be functional when calling DllMain.
-                   Therefore SEHCleanup must go between LOADFreeModules and
-                   PROCCleanupInitialProcess */
-                SEHCleanup();
-                PROCCleanupInitialProcess();
-            }
-
-            // Object manager shutdown may cause all CPalThread objects
-            // to be deleted. Since the CPalThread of the shutdown thread
-            // needs to be available for reference by the thread suspension unsafe
-            // operations, the reference of CPalThread is incremented here
-            // to keep it alive until PAL finishes cleanup.
-            pThread->AddThreadReference();
-
-            //
-            // Shutdown object manager -- this needs to happen before the
-            // synch manager shutdown since it will call into the synch
-            // manager to free object synch data
-            // 
-            static_cast<CSharedMemoryObjectManager*>(g_pObjectManager)->Shutdown(pThread);
-
-            //
-            // Final synch manager shutdown
-            //
-            CPalSynchMgrController::Shutdown(pThread, full_cleanup);
-
-            if (full_cleanup)
-            {
-                /* It needs to be done after stopping the handle manager, because
-                   the cleanup will delete the critical section which is used
-                   when closing the handle of a file mapping */
-                MAPCleanup();
-                // MutexCleanup();
-
-                MiscCleanup();
-
-                TLSCleanup();
-            }
-
-            // The thread object will no longer be available after the shutdown thread
-            // releases the thread reference.
-            g_fThreadDataAvailable = FALSE;
-            pThread->ReleaseThreadReference();
-            pthread_setspecific(thObjKey, NULL); // Make sure any TLS entry is removed.
-
-            // Since thread object is no longer available here,
-            // the code path from here should stop using any functions
-            // that reference thread object.
-            SHMCleanup();
-
-            TRACE("PAL Terminated.\n");
-        }
-        break;
-
-    default:
-        ASSERT("Unknown final cleanup step %d", step);
-        break;
+        TRACE("Every other thread suspended until exit\n");
     }
 }
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -745,16 +745,11 @@ done:
 Function:
   PALCommonCleanup
 
-Utility function to free any resource used by the PAL. 
+Utility function to prepare for shutdown.
 
-Parameters :
-    step: selects the desired cleanup step
-    full_cleanup:  FALSE: cleanup only what's needed and leave the rest 
-                          to the OS process cleanup
-                   TRUE:  full cleanup 
 --*/
 void 
-PALCommonCleanup(BOOL full_cleanup)
+PALCommonCleanup()
 {
     static bool cleanupDone = false;
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -756,7 +756,6 @@ Parameters :
 void 
 PALCommonCleanup(BOOL full_cleanup)
 {
-    CPalThread *pThread = InternalGetCurrentThread();
     static bool done = false;
 
     if (!done)

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -120,21 +120,8 @@ namespace CorUnix
     needs to be carried out when core PAL subsystems are still active
     --*/
     PAL_ERROR CPalSynchMgrController::PrepareForShutdown()
-    {        
+    {
         return CPalSynchronizationManager::PrepareForShutdown();
-    }
-
-    /*++
-    Method:
-      CPalSynchMgrController::Shutdown
-
-    Synchronization Manager's final shutdown step
-    --*/
-    PAL_ERROR CPalSynchMgrController::Shutdown(
-        CPalThread *pthrCurrent,
-        bool fFullCleanup)
-    {        
-        return CPalSynchronizationManager::Shutdown(pthrCurrent, fFullCleanup);
     }
 
     //////////////////////////////////
@@ -1823,56 +1810,6 @@ namespace CorUnix
             s_lInitStatus = SynchMgrStatusReadyForProcessShutDown;
         }
             
-        return palErr;
-    }
-
-    /*++
-    Method:
-      CPalSynchronizationManager::Shutdown
-
-    Synchronization Manager's final shutdown step.
-    Private method, it is called only by CPalSynchMgrController.
-    --*/
-    PAL_ERROR CPalSynchronizationManager::Shutdown(
-        CPalThread *pthrCurrent,
-        bool fFullCleanup)
-    {
-        PAL_ERROR palErr = NO_ERROR;
-        CPalSynchronizationManager * pSynchManager = GetInstance();
-
-        if ((LONG)SynchMgrStatusReadyForProcessShutDown != s_lInitStatus)
-        {
-            _ASSERT_MSG((LONG)SynchMgrStatusRunning != s_lInitStatus,
-                        "Synchronization Manager: Shutdown called with no "
-                        "prior PrepareForShutdown call");
-
-            ERROR("Unexpected initialization status found "
-                  "in Shutdown [expected=%d current=%d]\n", 
-                  (int)SynchMgrStatusShuttingDown, s_lInitStatus.Load());
-            palErr = ERROR_INTERNAL_ERROR;
-            goto S_exit;
-        }
-
-        pSynchManager->m_cacheSHRSynchData.Flush(pthrCurrent);
-        pSynchManager->m_cacheSHRWTListNodes.Flush(pthrCurrent);
-
-        if (fFullCleanup)
-        {
-            pSynchManager->m_cacheWaitCtrlrs.Flush(pthrCurrent);
-            pSynchManager->m_cacheStateCtrlrs.Flush(pthrCurrent);
-            pSynchManager->m_cacheSynchData.Flush(pthrCurrent);
-            pSynchManager->m_cacheWTListNodes.Flush(pthrCurrent);
-            pSynchManager->m_cacheThreadApcInfoNodes.Flush(pthrCurrent);
-            pSynchManager->m_cacheOwnedObjectsListNodes.Flush(pthrCurrent);
-
-            InternalDeleteCriticalSection(&s_csSynchProcessLock);
-            InternalDeleteCriticalSection(&s_csMonitoredProcessesLock);
-        }
-
-        s_lInitStatus = (LONG)SynchMgrStatusIdle;
-        s_pObjSynchMgr = NULL;
-
-    S_exit:
         return palErr;
     }
 

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -1836,7 +1836,7 @@ namespace CorUnix
     PAL_ERROR CPalSynchronizationManager::Shutdown(
         CPalThread *pthrCurrent,
         bool fFullCleanup)
-    {        
+    {
         PAL_ERROR palErr = NO_ERROR;
         CPalSynchronizationManager * pSynchManager = GetInstance();
 
@@ -1845,7 +1845,7 @@ namespace CorUnix
             _ASSERT_MSG((LONG)SynchMgrStatusRunning != s_lInitStatus,
                         "Synchronization Manager: Shutdown called with no "
                         "prior PrepareForShutdown call");
-            
+
             ERROR("Unexpected initialization status found "
                   "in Shutdown [expected=%d current=%d]\n", 
                   (int)SynchMgrStatusShuttingDown, s_lInitStatus.Load());
@@ -1865,14 +1865,14 @@ namespace CorUnix
             pSynchManager->m_cacheThreadApcInfoNodes.Flush(pthrCurrent);
             pSynchManager->m_cacheOwnedObjectsListNodes.Flush(pthrCurrent);
 
-            InternalDeleteCriticalSection(&s_csSynchProcessLock);            
-            InternalDeleteCriticalSection(&s_csMonitoredProcessesLock);            
+            InternalDeleteCriticalSection(&s_csSynchProcessLock);
+            InternalDeleteCriticalSection(&s_csMonitoredProcessesLock);
         }
-                   
+
         s_lInitStatus = (LONG)SynchMgrStatusIdle;
         s_pObjSynchMgr = NULL;
-        
-    S_exit:        
+
+    S_exit:
         return palErr;
     }
 

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -605,7 +605,6 @@ namespace CorUnix
             CPalThread * pthrCurrent);
         static PAL_ERROR StartWorker(CPalThread * pthrCurrent);
         static PAL_ERROR PrepareForShutdown(void);
-        static PAL_ERROR Shutdown(CPalThread *pthrCurrent, bool fFullCleanup);
 
     public:
         virtual ~CPalSynchronizationManager();

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1401,7 +1401,7 @@ void PROCCleanupProcess(BOOL bTerminateUnconditionally)
     /* Declare the beginning of shutdown */
     PALSetShutdownIntent();
 
-    PALCommonCleanup(FALSE);
+    PALCommonCleanup();
 
     /* This must be called after PALCommonCleanup */
     PALShutdown();

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1401,10 +1401,9 @@ void PROCCleanupProcess(BOOL bTerminateUnconditionally)
     /* Declare the beginning of shutdown */
     PALSetShutdownIntent();
 
-    PALCommonCleanup(PALCLEANUP_STEP_ONE, FALSE);
+    PALCommonCleanup(FALSE);
 
-    /* This must be called after PALCommonCleanup(PALCLEANUP_STEP_ONE, ...)
-     */
+    /* This must be called after PALCommonCleanup */
     PALShutdown();
 }
 


### PR DESCRIPTION
This changes removes some of the unused codepaths in the PAL cleanup logic. It also removes the calls to `PROCCondemnOtherThreads` and `PROCSuspendOtherThreads` that we were doing in `PALCommonCleanup` since they should no longer be necessary.

I left some things in `PALCommonCleanup` alone without modifying the logic since there may be risk involved in removing them (for example, there is code in `CPalSynchMgrController::PrepareForShutdown` that is intended to prevent us from leaking shared memory when the process exits).

This change helps us achieve #1795.

@jkotas @janvorli @sergiy-k