### PR TITLE
Fix Unix CoreConsole to correctly determine the path to the entrypoint executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
       
   endif(CLR_CMAKE_PLATFORM_LINUX)
 
+  if(CLR_CMAKE_PLATFORM_DARWIN)
+    message("Detected OSX x86_64")
+  endif(CLR_CMAKE_PLATFORM_DARWIN)
+
   if(CLR_CMAKE_PLATFORM_FREEBSD)
     message("Detected FreeBSD amd64")
   endif(CLR_CMAKE_PLATFORM_FREEBSD)
@@ -472,7 +476,6 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   endif(IS_64BIT_BUILD)
   
   if(CLR_CMAKE_PLATFORM_DARWIN)
-    message("Detected OSX x86_64")
     add_definitions(-D_XOPEN_SOURCE)
   endif(CLR_CMAKE_PLATFORM_DARWIN)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,11 +225,37 @@ if (CLR_CMAKE_PLATFORM_LINUX)
     add_definitions(-DFEATURE_EVENTSOURCE_XPLAT=1)
 endif (CLR_CMAKE_PLATFORM_LINUX)
 
+if (CLR_CMAKE_PLATFORM_UNIX)
+  add_definitions(-DPLATFORM_UNIX=1)
+  
+  if(CLR_CMAKE_PLATFORM_LINUX)
+    add_definitions(-D__LINUX__=1)
+    if(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64)
+      message("Detected Linux x86_64")
+      add_definitions(-DLINUX64)
+    elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
+      message("Detected Linux ARM")
+      add_definitions(-DLINUX32)
+    elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
+      message("Detected Linux ARM64")
+      add_definitions(-DLINUX64)
+    else()
+      clr_unknown_arch()
+    endif()
+      
+  endif(CLR_CMAKE_PLATFORM_LINUX)
+
+  if(CLR_CMAKE_PLATFORM_FREEBSD)
+    message("Detected FreeBSD amd64")
+  endif(CLR_CMAKE_PLATFORM_FREEBSD)
+
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
 if(CLR_CMAKE_PLATFORM_UNIX)
     add_subdirectory(src/ToolBox/SOS/lldbplugin)
     add_subdirectory(src/pal)
-    add_subdirectory(src/coreclr/hosts/unixcorerun)
     add_subdirectory(src/corefx)
+    add_subdirectory(src/coreclr/hosts/unixcorerun)
     add_subdirectory(src/coreclr/hosts/unixcoreconsole)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
@@ -237,7 +263,6 @@ endif(CLR_CMAKE_PLATFORM_UNIX)
 if(CLR_CMAKE_PLATFORM_DARWIN)
     add_subdirectory(src/coreclr/hosts/osxbundlerun)
 endif(CLR_CMAKE_PLATFORM_DARWIN)
-
 
 # Add this subdir. We install the headers for the jit.
 
@@ -438,39 +463,19 @@ endif(WIN32)
 
 
 if (CLR_CMAKE_PLATFORM_UNIX)
-  add_definitions(-DPLATFORM_UNIX=1)
   add_definitions(-DFEATURE_PAL_SXS)
   add_definitions(-DFEATURE_COREFX_GLOBALIZATION)
+  add_definitions(-DFEATURE_PAL)
 
   if(IS_64BIT_BUILD)
     add_definitions(-DBIT64=1)
   endif(IS_64BIT_BUILD)
-
-  add_definitions(-DFEATURE_PAL)
-    
-  if(CLR_CMAKE_PLATFORM_LINUX)
-    add_definitions(-D__LINUX__=1)
-    if(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64)
-      message("Detected Linux x86_64")
-      add_definitions(-DLINUX64)
-    elseif(CLR_CMAKE_PLATFORM_ARCH_ARM)
-      message("Detected Linux ARM")
-      add_definitions(-DLINUX32)
-    elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
-      message("Detected Linux ARM64")
-      add_definitions(-DLINUX64)
-    else()
-      clr_unknown_arch()
-    endif()
-      
-  endif(CLR_CMAKE_PLATFORM_LINUX)
+  
   if(CLR_CMAKE_PLATFORM_DARWIN)
     message("Detected OSX x86_64")
     add_definitions(-D_XOPEN_SOURCE)
   endif(CLR_CMAKE_PLATFORM_DARWIN)
-  if(CLR_CMAKE_PLATFORM_FREEBSD)
-    message("Detected FreeBSD amd64")
-  endif(CLR_CMAKE_PLATFORM_FREEBSD)
+
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 

--- a/src/coreclr/hosts/unixcoreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/unixcoreconsole/coreconsole.cpp
@@ -95,9 +95,17 @@ int main(const int argc, const char* argv[])
 {
     // Make sure we have a full path for argv[0].
     std::string argv0AbsolutePath;
-    if (!GetAbsolutePath(argv[0], argv0AbsolutePath))
+    std::string entryPointExecutablePath;
+
+    if (!GetEntrypointExecutableAbsolutePath(entryPointExecutablePath))
     {
         perror("Could not get full path to current executable");
+        return -1;
+    }
+
+    if (!GetAbsolutePath(entryPointExecutablePath.c_str(), argv0AbsolutePath))
+    {
+        perror("Could not normalize full path to current executable");
         return -1;
     }
 

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.h
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.h
@@ -5,6 +5,9 @@
 
 #include <string>
 
+// Get the path to entrypoint executable
+bool GetEntrypointExecutableAbsolutePath(std::string& entrypointExecutable);
+
 // Get absolute path from the specified path.
 // Return true in case of a success, false otherwise.
 bool GetAbsolutePath(const char* path, std::string& absolutePath);


### PR DESCRIPTION
CoreConsole would use argv[0] to determine the entrypoint executable path that would return incorrect path information if the executable was invoked from a folder different from where it exists, with the latter being in the PATH environment variable.

@janvorli Could you please take a look?