### PR TITLE
Remove stack allocations of MAX_LONGPATH strings and use PathString for heap alloc

### DIFF
--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -6631,7 +6631,7 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
 {
     DWORD imageTimestamp, imageSize, dataSize;
     void* buffer = NULL;
-    WCHAR uniPath[MAX_LONGPATH] = {0};
+    NewArrayHolder<WCHAR> uniPath = new WCHAR[MAX_LONGPATH];
     bool isAlt = false;
     bool isNGEN = false;
     DAC_INSTANCE* inst = NULL;
@@ -6664,7 +6664,7 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
             ulRvaHint,
             isNGEN,
             uniPath,
-            NumItems(uniPath)))
+            MAX_LONGPATH))
     {
         return NULL;
     }
@@ -6728,26 +6728,26 @@ ClrDataAccess::GetMetaDataFromHost(PEFile* peFile,
                 imageTimestamp,
                 imageSize,
                 uniPath,
-                NumItems(uniPath)))
+                MAX_LONGPATH))
         {
             goto ErrExit;
         }
         
 #if defined(FEATURE_CORESYSTEM)
         const WCHAR* ilExtension[] = {W("dll"), W("winmd")};
-        WCHAR ngenImageName[MAX_LONGPATH] = {0};
-        if (wcscpy_s(ngenImageName, NumItems(ngenImageName), uniPath) != 0)
+        NewArrayHolder<WCHAR> ngenImageName = new WCHAR[MAX_LONGPATH];
+        if (wcscpy_s(ngenImageName, MAX_LONGPATH, uniPath) != 0)
         {
             goto ErrExit;
         }
         for (unsigned i = 0; i < COUNTOF(ilExtension); i++)
         {
-            if (wcscpy_s(uniPath, NumItems(uniPath), ngenImageName) != 0)
+            if (wcscpy_s(uniPath, MAX_LONGPATH, ngenImageName) != 0)
             {
                 goto ErrExit;
             }
             // Transform NGEN image name into IL Image name
-            if (!GetILImageNameFromNgenImage(ilExtension[i], uniPath, NumItems(uniPath)))
+            if (!GetILImageNameFromNgenImage(ilExtension[i], uniPath, MAX_LONGPATH))
             {
                 goto ErrExit;
             }

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -1247,7 +1247,7 @@ bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
     if (pPEFile == NULL)
         return false;
 
-    WCHAR wszFilePath[MAX_LONGPATH] = {0};
+    WCHAR * wszFilePath = new WCHAR[MAX_LONGPATH];
     DWORD cchFilePath = MAX_LONGPATH;
     bool ret = ClrDataAccess::GetMetaDataFileInfoFromPEFile(pPEFile,
                                                             dwTimeStamp,
@@ -1259,6 +1259,8 @@ bool DacDbiInterfaceImpl::GetMetaDataFileInfoFromPEFile(VMPTR_PEFile vmPEFile,
                                                             cchFilePath);
 
     pStrFilename->AssignCopy(wszFilePath);
+    delete [] wszFilePath;
+    wszFilePath = NULL;
     return ret;
 #endif // !defined(FEATURE_PREJIT)
 }
@@ -1284,7 +1286,7 @@ bool DacDbiInterfaceImpl::GetILImageInfoFromNgenPEFile(VMPTR_PEFile vmPEFile,
         return false;
     }
 
-    WCHAR wszFilePath[MAX_LONGPATH] = {0};
+    WCHAR * wszFilePath = new WCHAR[MAX_LONGPATH];
     DWORD cchFilePath = MAX_LONGPATH;
     bool ret = ClrDataAccess::GetILImageInfoFromNgenPEFile(pPEFile,
                                                            dwTimeStamp,
@@ -1293,6 +1295,8 @@ bool DacDbiInterfaceImpl::GetILImageInfoFromNgenPEFile(VMPTR_PEFile vmPEFile,
                                                            cchFilePath);
 
     pStrFilename->AssignCopy(wszFilePath);
+    delete [] wszFilePath;
+    wszFilePath = NULL;
     return ret;
 #endif // !defined(FEATURE_PREJIT)
 }

--- a/src/debug/daccess/request.cpp
+++ b/src/debug/daccess/request.cpp
@@ -1269,10 +1269,10 @@ ClrDataAccess::GetMethodDescName(CLRDATA_ADDRESS methodDesc, unsigned int count,
             Module* pModule = pMD->GetModule();
             if (pModule)
             {
-                WCHAR path[MAX_LONGPATH];
+                WCHAR * path = new WCHAR[MAX_LONGPATH];
                 COUNT_T nChars = 0;
-                if (pModule->GetPath().DacGetUnicode(NumItems(path), path, &nChars) &&
-                    nChars > 0 && nChars <= NumItems(path))
+                if (pModule->GetPath().DacGetUnicode(MAX_LONGPATH, path, &nChars) &&
+                    nChars > 0 && nChars <= MAX_LONGPATH)
                 {
                     WCHAR* pFile = path + nChars - 1;
                     while ((pFile >= path) && (*pFile != W('\\')))
@@ -1287,6 +1287,9 @@ ClrDataAccess::GetMethodDescName(CLRDATA_ADDRESS methodDesc, unsigned int count,
                         hr = S_OK;
                     }
                 }
+
+                delete [] path;
+                path = NULL;
             }
 #ifdef FEATURE_MINIMETADATA_IN_TRIAGEDUMPS
             }

--- a/src/debug/di/process.cpp
+++ b/src/debug/di/process.cpp
@@ -7592,8 +7592,11 @@ void CordbProcess::VerifyControlBlock()
     }
 
 #ifdef _DEBUG
-    char buf[MAX_LONGPATH];
-    DWORD len = GetEnvironmentVariableA("CORDBG_NotCompatibleTest", buf, sizeof(buf));
+    char * buf;
+    PathString bufPS;
+    buf = bufPS.OpenANSIBuffer(MAX_LONGPATH);
+    DWORD len = GetEnvironmentVariableA("CORDBG_NotCompatibleTest", buf, MAX_LONGPATH);
+    bufPS.CloseBuffer(len);
     _ASSERTE(len < sizeof(buf));
 
     if (len > 0)

--- a/src/debug/di/publish.cpp
+++ b/src/debug/di/publish.cpp
@@ -494,12 +494,14 @@ CorpubProcess::CorpubProcess(DWORD dwProcessId,
             // MSDN is very confused about whether the lenght is in bytes (MSDN 2002) or chars (MSDN 2004).
             // We err on the safe side by having buffer that's twice as large, and ignoring
             // the units on the return value.
-            WCHAR szName[MAX_LONGPATH * sizeof(WCHAR)];
+            PathString szNamePS;
+            WCHAR * szName = szNamePS.OpenUnicodeBuffer(MAX_LONGPATH * sizeof(WCHAR));
 
             DWORD lenInCharsOrBytes = MAX_LONGPATH*sizeof(WCHAR);
 
             // Pass NULL module handle to get "Main Module", which will give us the process name.
             DWORD ret = (*fpGetModuleFileNameEx) (hProcess, NULL, szName, lenInCharsOrBytes);
+            szNamePS.CloseBuffer();
             if (ret > 0)
             {
                 // Recompute string length because we don't know if 'ret' is in bytes or char.

--- a/src/debug/di/shimprocess.cpp
+++ b/src/debug/di/shimprocess.cpp
@@ -1834,20 +1834,21 @@ HRESULT ShimProcess::FindLoadedCLR(CORDB_ADDRESS * pClrInstanceId)
 HMODULE ShimProcess::GetDacModule()
 {
     
-    HModuleHolder hDacDll;
+    HModuleHolder hDacDll;    
 
 #ifdef FEATURE_PAL
     // For now on Unix we'll just search for DAC in the default location.
     // Debugger can always control it by setting LD_LIBRARY_PATH env var.
-    WCHAR wszAccessDllPath[MAX_LONGPATH] = MAKEDLLNAME_W(W("mscordaccore"));
+    
+    WCHAR wszAccessDllPath[50] = MAKEDLLNAME_W(W("mscordaccore"));
 
-#else    
-    WCHAR wszAccessDllPath[MAX_LONGPATH];
+#else
+    NewArrayHolder<WCHAR> wszAccessDllPath = new WCHAR[MAX_LONGPATH];
     //
     // Load the access DLL from the same directory as the the current CLR Debugging Services DLL.
     //
 
-    if (!WszGetModuleFileName(GetModuleInst(), wszAccessDllPath, NumItems(wszAccessDllPath)))
+    if (!WszGetModuleFileName(GetModuleInst(), wszAccessDllPath, MAX_LONGPATH))
     {
         ThrowLastError();
     }
@@ -1870,8 +1871,8 @@ HMODULE ShimProcess::GetDacModule()
 #endif
 
     if (_snwprintf_s(pPathTail, 
-                     _countof(wszAccessDllPath) + (wszAccessDllPath - pPathTail),
-                     NumItems(wszAccessDllPath) - (pPathTail - wszAccessDllPath),
+                     MAX_LONGPATH + (wszAccessDllPath - pPathTail),
+                     MAX_LONGPATH - (pPathTail - wszAccessDllPath),
                      MAKEDLLNAME_W(W("mscordac%s")), 
                      eeFlavor) <= 0)
     {

--- a/src/dlls/dbgshim/dbgshim.cpp
+++ b/src/dlls/dbgshim/dbgshim.cpp
@@ -370,7 +370,7 @@ bool IsCoreClrWithGoodHeader(HANDLE hProcess, HMODULE hModule)
 {
     HRESULT hr = S_OK;
 
-    WCHAR modulePath[MAX_LONGPATH];
+    NewArrayHolder<WCHAR> modulePath = new WCHAR[MAX_LONGPATH];
     modulePath[0] = W('\0');
     if(0 == GetModuleFileNameEx(hProcess, hModule, modulePath, MAX_LONGPATH))
     {
@@ -618,7 +618,7 @@ BYTE* GetRemoteModuleBaseAddress(DWORD dwPID, LPCWSTR szFullModulePath)
     DWORD countModules = min(cbNeeded, sizeof(modules)) / sizeof(HMODULE);
     for(DWORD i = 0; i < countModules; i++)
     {
-        WCHAR modulePath[MAX_LONGPATH];
+        NewArrayHolder<WCHAR> modulePath = new WCHAR[MAX_LONGPATH];
         if(0 == GetModuleFileNameEx(hProcess, modules[i], modulePath, MAX_LONGPATH))
         {
             continue;
@@ -814,7 +814,7 @@ void GetDbiFilenameNextToRuntime(DWORD pidDebuggee, HMODULE hmodTargetCLR, SStri
     // Step 1: (pid, hmodule) --> full path
     // 
     HandleHolder hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pidDebuggee);
-    WCHAR modulePath[MAX_LONGPATH];
+    NewArrayHolder<WCHAR> modulePath = new WCHAR[MAX_LONGPATH];
     if(0 == GetModuleFileNameEx(hProcess, hmodTargetCLR, modulePath, MAX_LONGPATH))
     {
         ThrowHR(E_FAIL);

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -9409,19 +9409,19 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
             FILE_ATTRIBUTE_NORMAL,
             NULL);
 #else // FEATURE_REDHAWK
-        char logfile_name[MAX_LONGPATH+1];
+        char * logfile_name = new (nothrow) char[MAX_LONGPATH+1];
         if (temp_logfile_name != 0)
         {
             int ret;
-            ret = WszWideCharToMultiByte(CP_ACP, 0, temp_logfile_name, -1, logfile_name, sizeof(logfile_name)-1, NULL, NULL);
+            ret = WszWideCharToMultiByte(CP_ACP, 0, temp_logfile_name, -1, logfile_name, MAX_LONGPATH, NULL, NULL);
             _ASSERTE(ret != 0);
             delete temp_logfile_name;
         }
 
         char szPid[20];
         sprintf_s(szPid, _countof(szPid), ".%d", GetCurrentProcessId());
-        strcat_s(logfile_name, _countof(logfile_name), szPid);
-        strcat_s(logfile_name, _countof(logfile_name), ".log");
+        strcat_s(logfile_name, MAX_LONGPATH, szPid);
+        strcat_s(logfile_name, MAX_LONGPATH, ".log");
 
         gc_log = CreateFileA(
             logfile_name,
@@ -9431,6 +9431,9 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
             CREATE_ALWAYS,
             FILE_ATTRIBUTE_NORMAL,
             NULL);
+
+		delete [] logfile_name;
+		logfile_name = NULL;
 #endif // FEATURE_REDHAWK
 
         if (gc_log == INVALID_HANDLE_VALUE)

--- a/src/inc/zapper.h
+++ b/src/inc/zapper.h
@@ -103,7 +103,7 @@ class Zapper
     CORINFO_ASSEMBLY_HANDLE m_hAssembly;
     IMDInternalImport      *m_pAssemblyImport;
 
-    WCHAR                   m_outputPath[MAX_LONGPATH]; // Temp folder for creating the output file
+    PathString m_outputPath; // Temp folder for creating the output file
 
     IMetaDataAssemblyEmit  *m_pAssemblyEmit;
     IMetaDataAssemblyEmit  *CreateAssemblyEmitter();

--- a/src/strongname/api/strongname.cpp
+++ b/src/strongname/api/strongname.cpp
@@ -2631,8 +2631,8 @@ BOOLEAN RehashModules (SN_LOAD_CTX *pLoadCtx, LPCWSTR wszFilePath) {
     DWORD               cbNewFileHash = 0;
     DWORD               cchDirectory;
     DWORD               cchFullFile;
-    CHAR                szFullFile[MAX_LONGPATH + 1];
-    WCHAR               wszFullFile[MAX_LONGPATH + 1];
+    NewArrayHolder<CHAR> szFullFile = new CHAR[MAX_LONGPATH + 1];
+    NewArrayHolder<WCHAR> wszFullFile = new WCHAR[MAX_LONGPATH + 1];
     LPCWSTR             pszSlash;
     DWORD               cchFile;
     IMDInternalImport  *pMetaDataImport = NULL;

--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1112,17 +1112,21 @@ HANDLE ZapImage::GenerateFile(LPCWSTR wszOutputFileName, CORCOMPILE_NGEN_SIGNATU
         memcpy(&rsds.signature.Data4, &asBytes[8], 8);
 
         _ASSERTE(!m_pdbFileName.IsEmpty());
-        ZeroMemory(&rsds.path[0], sizeof(rsds.path));
-        if (WideCharToMultiByte(CP_UTF8, 
+        
+		int len = WideCharToMultiByte(CP_UTF8, 
                                 0, 
                                 m_pdbFileName.GetUnicode(),
                                 m_pdbFileName.GetCount(), 
                                 &rsds.path[0], 
                                 sizeof(rsds.path) - 1, // -1 to keep the buffer zero terminated
                                 NULL, 
-                                NULL) == 0)
+                                NULL);
+		
+        if (len == 0)
+        {
             ThrowHR(E_FAIL);
-        
+        }	
+
         ULONG cbWritten = 0;
         filePos.QuadPart = m_pTextSection->GetFilePos() + (m_pNGenPdbDebugData->GetRVA() - m_pTextSection->GetRVA());
         IfFailThrow(outputStream.Seek(filePos, STREAM_SEEK_SET, NULL));


### PR DESCRIPTION
These changes are in the non-linux path, replaced all occurences except utilcode, vm, tools and Toolbox - PR to follow.

cc @JeremyKuhne @janvorli @jkotas 