### PR TITLE
Remove new operator usage in PAL

### DIFF
--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -3701,7 +3701,7 @@ GetTempFileNameW(
         }
     }
     
-    tempfile_name = new char[MAX_LONGPATH];
+    tempfile_name = (char*)InternalMalloc(pThread, MAX_LONGPATH);
     if (tempfile_name == NULL)
     {
         pThread->SetLastError(ERROR_NOT_ENOUGH_MEMORY);
@@ -3717,7 +3717,7 @@ GetTempFileNameW(
         path_size = MultiByteToWideChar( CP_ACP, 0, tempfile_name, -1, 
                                            lpTempFileName, MAX_LONGPATH );
 
-        delete [] tempfile_name;
+        InternalFree(pThread, tempfile_name);
         tempfile_name = NULL;
         if (!path_size)
         {
@@ -4881,7 +4881,8 @@ Return value:
 BOOL FILEGetFileNameFromSymLink(char *source)
 {
     int ret;
-    char * sLinkData = new char[MAX_LONGPATH];
+    CPalThread* pThread = InternalGetCurrentThread();
+    char * sLinkData = (char*)InternalMalloc(pThread, MAX_LONGPATH);
 
     do
     {
@@ -4893,7 +4894,7 @@ BOOL FILEGetFileNameFromSymLink(char *source)
         }
     } while (ret > 0);
 
-    delete [] sLinkData;
+    InternalFree(pThread, sLinkData);
     return (errno == EINVAL);
 }
 

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1931,7 +1931,14 @@ MODSTRUCT *LOADGetPalLibrary()
         // Make sure it's terminated with a slash.
         if (g_szCoreCLRPath == NULL)
         {
-            g_szCoreCLRPath = new char[g_cbszCoreCLRPath/sizeof(char)];
+            CPalThread* pThread = InternalGetCurrentThread();
+            g_szCoreCLRPath = (char*) InternalMalloc(pThread, g_cbszCoreCLRPath);
+
+            if (g_szCoreCLRPath == NULL)
+            {
+                ERROR("LOADGetPalLibrary: InternalMalloc failed!");
+                goto exit;
+            }
         }
         
         if (strcpy_s(g_szCoreCLRPath, g_cbszCoreCLRPath, info.dli_fname) != SAFECRT_SUCCESS)

--- a/src/pal/src/misc/perftrace.cpp
+++ b/src/pal/src/misc/perftrace.cpp
@@ -663,7 +663,8 @@ void
 PERFLogFileName(PathCharString * destFileString, const char *fileName, const char *suffix, int max_length)
 {
     const char *dir_path;
-    char * destFileName = new char[max_length];
+    CPalThread* pThread = InternalGetCurrentThread();
+    char * destFileName = (char*)InternalMalloc(pThread, max_length);
     dir_path = (profile_log_path == NULL) ? "." : profile_log_path;
 
     if (fileName != NULL)
@@ -677,7 +678,7 @@ PERFLogFileName(PathCharString * destFileString, const char *fileName, const cha
     }
     
     destFileString.Set(destFileName);
-    delete [] destFileName;
+    InternalFree(pThread, destFileName);
     destFileName = NULL;
 }
 
@@ -1109,9 +1110,6 @@ PERFFlushLog(pal_perf_thread_info * local_info, BOOL output_header)
         ret = TRUE;
     }
     
-    delete [] fileName;
-    fileName = NULL;
-
     return ret;
 }
 

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -561,7 +561,7 @@ CorUnix::InternalCreateProcess(
     int iFdErr = -1;
     
     pid_t processId;
-    char * lpFileName = new char[MAX_LONGPATH];
+    char * lpFileName = (char*)InternalMalloc(pThread, MAX_LONGPATH);
     char **lppArgv = NULL;
     UINT nArg;
     int  iRet;


### PR DESCRIPTION
This change fixes an issue caused by recent change in filename buffers
allocations. It was using the operator new, but it should not be used
in PAL since it invokes overriden operator new in the coreclr.
The fix is to use InternalMalloc instead.