### PR TITLE
Fixed an issue with getting event size not working for custom notific…

### DIFF
--- a/src/debug/shared/dbgtransportsession.cpp
+++ b/src/debug/shared/dbgtransportsession.cpp
@@ -2403,7 +2403,11 @@ DWORD DbgTransportSession::GetEventSize(DebuggerIPCEvent *pEvent)
     case DB_IPCE_GET_GCHANDLE_INFO:
         cbAdditionalSize = sizeof(pEvent->GetGCHandleInfo);
         break;
-
+    
+    case DB_IPCE_CUSTOM_NOTIFICATION:
+        cbAdditionalSize = sizeof(pEvent->CustomNotification);
+        break;
+            
     default:
         printf("Unknown debugger event type: 0x%x\n", (pEvent->type & DB_IPCE_TYPE_MASK));
         _ASSERTE(!"Unknown debugger event type");


### PR DESCRIPTION
Ran into this issue while debugging an ASP.NET app with clrdbg. The debuggee rans into an "unknown debugger event type" assert for a custom notification event. Added code for this missing case in GetEventSize function.