### PR TITLE
Add support for BSTRs on Unix

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -87,6 +87,9 @@ SetEvent
 SetFileAttributesW
 SetFilePointer
 SetFileTime
+SysAllocStringLen
+SysFreeString
+SysStringLen
 UnlockFile
 UnmapViewOfFile
 VirtualAlloc

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -696,13 +696,14 @@ namespace Microsoft.Win32 {
         internal const String KERNEL32 = "kernel32.dll";
         internal const String USER32   = "user32.dll";
         internal const String OLE32    = "ole32.dll";
+        internal const String OLEAUT32 = "oleaut32.dll";
 #else //FEATURE_PAL
         internal const String KERNEL32 = "libcoreclr";
         internal const String USER32   = "libcoreclr";
         internal const String OLE32    = "libcoreclr";
+        internal const String OLEAUT32 = "libcoreclr";
 #endif //FEATURE_PAL         
         internal const String ADVAPI32 = "advapi32.dll";
-        internal const String OLEAUT32 = "oleaut32.dll";
         internal const String SHELL32  = "shell32.dll";
         internal const String SHIM     = "mscoree.dll";
         internal const String CRYPT32  = "crypt32.dll";
@@ -829,11 +830,19 @@ namespace Microsoft.Win32 {
         [DllImport(KERNEL32, CharSet=CharSet.Unicode, ExactSpelling=true, EntryPoint="lstrlenW")]
         internal static extern int lstrlenW(IntPtr ptr);
 
-#if FEATURE_COMINTEROP
-        [DllImport(Win32Native.OLEAUT32, CharSet=CharSet.Unicode)]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]            
+        [DllImport(Win32Native.OLEAUT32, CharSet = CharSet.Unicode)]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
         internal static extern IntPtr SysAllocStringLen(String src, int len);  // BSTR
 
+        [DllImport(Win32Native.OLEAUT32)]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        internal static extern uint SysStringLen(IntPtr bstr);
+
+        [DllImport(Win32Native.OLEAUT32)]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        internal static extern void SysFreeString(IntPtr bstr);
+
+#if FEATURE_COMINTEROP
         [DllImport(Win32Native.OLEAUT32)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]            
         internal static extern IntPtr SysAllocStringByteLen(byte[] str, uint len);  // BSTR
@@ -844,15 +853,7 @@ namespace Microsoft.Win32 {
 
         [DllImport(Win32Native.OLEAUT32)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        internal static extern uint SysStringLen(IntPtr bstr);
-
-        [DllImport(Win32Native.OLEAUT32)]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         internal static extern uint SysStringLen(SafeBSTRHandle bstr);
-
-        [DllImport(Win32Native.OLEAUT32)]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        internal static extern void SysFreeString(IntPtr bstr);
 #endif
 
         [DllImport(KERNEL32)]

--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -1869,6 +1869,40 @@ namespace System.Runtime.InteropServices
             return pNewMem;
         }
 
+        //====================================================================
+        // BSTR allocation and dealocation.
+        //====================================================================      
+        [System.Security.SecurityCritical]  // auto-generated_required
+        public static void FreeBSTR(IntPtr ptr)
+        {
+            if (IsNotWin32Atom(ptr))
+            {
+                Win32Native.SysFreeString(ptr);
+            }
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated_required
+        public static IntPtr StringToBSTR(String s)
+        {
+            if (s == null)
+                return IntPtr.Zero;
+
+            // Overflow checking
+            if (s.Length + 1 < s.Length)
+                throw new ArgumentOutOfRangeException("s");
+
+            IntPtr bstr = Win32Native.SysAllocStringLen(s, s.Length);
+            if (bstr == IntPtr.Zero)
+                throw new OutOfMemoryException();
+
+            return bstr;
+        }
+
+        [System.Security.SecurityCritical]  // auto-generated_required
+        public static String PtrToStringBSTR(IntPtr ptr)
+        {
+            return PtrToStringUni(ptr, (int)Win32Native.SysStringLen(ptr));
+        }
 
 #if FEATURE_COMINTEROP
         //====================================================================
@@ -2094,40 +2128,6 @@ namespace System.Runtime.InteropServices
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public static extern int /* ULONG */ Release(IntPtr /* IUnknown */ pUnk );
-
-        //====================================================================
-        // BSTR allocation and dealocation.
-        //====================================================================      
-        [System.Security.SecurityCritical]  // auto-generated_required
-        public static void FreeBSTR(IntPtr ptr)
-        {
-            if (IsNotWin32Atom(ptr)) {
-                Win32Native.SysFreeString(ptr);
-            }
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated_required
-        public static IntPtr StringToBSTR(String s)
-        {
-            if (s == null) 
-                return IntPtr.Zero;
-
-            // Overflow checking
-            if (s.Length+1 < s.Length)
-                throw new ArgumentOutOfRangeException("s");
-
-            IntPtr bstr = Win32Native.SysAllocStringLen(s, s.Length);
-            if (bstr == IntPtr.Zero)
-                throw new OutOfMemoryException();
-
-            return bstr;
-        }
-
-        [System.Security.SecurityCritical]  // auto-generated_required
-        public static String PtrToStringBSTR(IntPtr ptr)
-        {
-            return PtrToStringUni(ptr, (int)Win32Native.SysStringLen(ptr));
-        }
 
         [System.Security.SecurityCritical]  // auto-generated_required
         [MethodImplAttribute(MethodImplOptions.InternalCall)]

--- a/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/NonPortable.cs
@@ -50,12 +50,6 @@ namespace System.Runtime.InteropServices
         }
 
         [System.Security.SecurityCriticalAttribute]
-        public static void FreeBSTR(System.IntPtr ptr)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        [System.Security.SecurityCriticalAttribute]
         public static System.IntPtr GetComInterfaceForObject(object o, System.Type T)
         {
             throw new PlatformNotSupportedException();
@@ -150,12 +144,6 @@ namespace System.Runtime.InteropServices
         }
 
         [System.Security.SecurityCriticalAttribute]
-        public static string PtrToStringBSTR(System.IntPtr ptr)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        [System.Security.SecurityCriticalAttribute]
         public static int QueryInterface(System.IntPtr pUnk, ref System.Guid iid, out System.IntPtr ppv)
         {
             throw new PlatformNotSupportedException();
@@ -169,12 +157,6 @@ namespace System.Runtime.InteropServices
 
         [System.Security.SecurityCriticalAttribute]
         public static int ReleaseComObject(object o)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        [System.Security.SecurityCriticalAttribute]
-        public static System.IntPtr StringToBSTR(string s)
         {
             throw new PlatformNotSupportedException();
         }


### PR DESCRIPTION
Made FreeBSTR, StringToBSTR, PtrToStringBSTR functions in marshal class available on unix by exporting the necessary functions from libcoreclr and using them. This was needed by clr debugger on linux.