### PR TITLE
Fix floatingpoint register offsets in TransitionBlock for Unix

### DIFF
--- a/src/vm/argdestination.h
+++ b/src/vm/argdestination.h
@@ -57,7 +57,7 @@ public:
     {
         LIMITED_METHOD_CONTRACT;
         _ASSERTE(IsStructPassedInRegs());
-        int offset = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_argLocDescForStructInRegs->m_idxFloatReg * 8;
+        int offset = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_argLocDescForStructInRegs->m_idxFloatReg * 16;
         return dac_cast<PTR_VOID>(dac_cast<TADDR>(m_base) + offset);
     }
 

--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -611,7 +611,7 @@ public:
         if (TransitionBlock::IsFloatArgumentRegisterOffset(argOffset))
         {
             // Dividing by 8 as size of each register in FloatArgumentRegisters is 8 bytes.
-            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / 8;
+            pLoc->m_idxFloatReg = (argOffset - TransitionBlock::GetOffsetOfFloatArgumentRegisters()) / 16;
             pLoc->m_cFloatReg = 1;
         }
         else if (!TransitionBlock::IsStackArgumentOffset(argOffset))
@@ -1032,7 +1032,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
 
     if ((cFPRegs > 0) && (cFPRegs + m_idxFPReg <= NUM_FLOAT_ARGUMENT_REGISTERS))
     {
-        int argOfs = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 8;
+        int argOfs = TransitionBlock::GetOffsetOfFloatArgumentRegisters() + m_idxFPReg * 16;
         m_idxFPReg += cFPRegs;
         return argOfs;
     }


### PR DESCRIPTION
The conversion between floating point register index and offset was incorrectly
multiplying the the index by 8 instead of 16. The xmm registers in the
TransitionBlock on Unix take 16 bytes each, not 8.