### PR TITLE
Remove OSX Homebrew ICU dependency

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -6,29 +6,7 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 add_definitions(-DPIC=1)
 add_definitions(-DBIT64=1)
 
-set(ICU_HOMEBREW_LIB_PATH "/usr/local/opt/icu4c/lib")
 set(ICU_HOMEBREW_INC_PATH "/usr/local/opt/icu4c/include")
-
-if(NOT CLR_CMAKE_PLATFORM_DARWIN)
-    find_library(ICUUC NAMES icuuc PATHS ${ICU_HOMEBREW_LIB_PATH})
-    if(ICUUC STREQUAL ICUUC-NOTFOUND)
-        message(FATAL_ERROR "Cannot find libicuuc, try installing libicu-dev (or the appropriate package for your platform)")
-        return()
-    endif()
-
-    find_library(ICUI18N NAMES icui18n PATHS ${ICU_HOMEBREW_LIB_PATH})
-        if(ICUI18N STREQUAL ICUI18N-NOTFOUND)
-        message(FATAL_ERROR "Cannot find libicui18n, try installing libicu-dev (or the appropriate package for your platform)")
-        return()
-    endif()
-
-else()
-    find_library(ICUCORE NAMES icucore)
-    if(ICUI18N STREQUAL ICUCORE-NOTFOUND)
-        message(FATAL_ERROR "Cannot find libicucore, skipping build for System.Globalization.Native. .NET globalization is not expected to function.")
-        return()
-    endif()
-endif()
 
 find_path(UTYPES_H "unicode/utypes.h" PATHS ${ICU_HOMEBREW_INC_PATH})
 if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)
@@ -36,15 +14,41 @@ if(UTYPES_H STREQUAL UTYPES_H-NOTFOUND)
     return()
 endif()
 
-set(CMAKE_REQUIRED_INCLUDES ${ICU_HOMEBREW_INC_PATH})
-CHECK_CXX_SOURCE_COMPILES("
- #include <unicode/dtfmtsym.h>
- int main() { DateFormatSymbols::DtWidthType e = DateFormatSymbols::DtWidthType::SHORT; }
-" HAVE_DTWIDTHTYPE_SHORT) 
+if(NOT CLR_CMAKE_PLATFORM_DARWIN)
+    find_library(ICUUC icuuc)
+    if(ICUUC STREQUAL ICUUC-NOTFOUND)
+        message(FATAL_ERROR "Cannot find libicuuc, try installing libicu-dev (or the appropriate package for your platform)")
+        return()
+    endif()
 
-if(HAVE_DTWIDTHTYPE_SHORT)
-    add_definitions(-DHAVE_DTWIDTHTYPE_SHORT=1)
-endif(HAVE_DTWIDTHTYPE_SHORT)
+    find_library(ICUI18N icui18n)
+        if(ICUI18N STREQUAL ICUI18N-NOTFOUND)
+        message(FATAL_ERROR "Cannot find libicui18n, try installing libicu-dev (or the appropriate package for your platform)")
+        return()
+    endif()
+
+    set(CMAKE_REQUIRED_INCLUDES ${ICU_HOMEBREW_INC_PATH})
+    CHECK_CXX_SOURCE_COMPILES("
+     #include <unicode/udat.h>
+     int main() { UDateFormatSymbolType e = UDAT_STANDALONE_SHORTER_WEEKDAYS; }
+    " HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
+
+    if(HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
+        add_definitions(-DHAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS=1)
+    endif(HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
+
+else()
+
+    find_library(ICUCORE icucore)
+    if(ICUI18N STREQUAL ICUCORE-NOTFOUND)
+        message(FATAL_ERROR "Cannot find libicucore, skipping build for System.Globalization.Native. .NET globalization is not expected to function.")
+        return()
+    endif()
+
+    # libicucore supports UDAT_STANDALONE_SHORTER_WEEKDAYS
+    add_definitions(-DHAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS=1)
+
+endif()
 
 add_compile_options(-fPIC)
 

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -9,16 +9,25 @@ add_definitions(-DBIT64=1)
 set(ICU_HOMEBREW_LIB_PATH "/usr/local/opt/icu4c/lib")
 set(ICU_HOMEBREW_INC_PATH "/usr/local/opt/icu4c/include")
 
-find_library(ICUUC NAMES icuuc PATHS ${ICU_HOMEBREW_LIB_PATH})
-if(ICUUC STREQUAL ICUUC-NOTFOUND)
-    message(FATAL_ERROR "Cannot find libicuuc, try installing libicu-dev (or the appropriate package for your platform)")
-    return()
-endif()
+if(NOT CLR_CMAKE_PLATFORM_DARWIN)
+    find_library(ICUUC NAMES icuuc PATHS ${ICU_HOMEBREW_LIB_PATH})
+    if(ICUUC STREQUAL ICUUC-NOTFOUND)
+        message(FATAL_ERROR "Cannot find libicuuc, try installing libicu-dev (or the appropriate package for your platform)")
+        return()
+    endif()
 
-find_library(ICUI18N NAMES icui18n PATHS ${ICU_HOMEBREW_LIB_PATH})
-if(ICUI18N STREQUAL ICUI18N-NOTFOUND)
-    message(FATAL_ERROR "Cannot find libicui18n, try installing libicu-dev (or the appropriate package for your platform)")
-    return()
+    find_library(ICUI18N NAMES icui18n PATHS ${ICU_HOMEBREW_LIB_PATH})
+        if(ICUI18N STREQUAL ICUI18N-NOTFOUND)
+        message(FATAL_ERROR "Cannot find libicui18n, try installing libicu-dev (or the appropriate package for your platform)")
+        return()
+    endif()
+
+else()
+    find_library(ICUCORE NAMES icucore)
+    if(ICUI18N STREQUAL ICUCORE-NOTFOUND)
+        message(FATAL_ERROR "Cannot find libicucore, skipping build for System.Globalization.Native. .NET globalization is not expected to function.")
+        return()
+    endif()
 endif()
 
 find_path(UTYPES_H "unicode/utypes.h" PATHS ${ICU_HOMEBREW_INC_PATH})
@@ -61,9 +70,17 @@ add_library(System.Globalization.Native
 # Disable the "lib" prefix.
 set_target_properties(System.Globalization.Native PROPERTIES PREFIX "")
 
-target_link_libraries(System.Globalization.Native
-  ${ICUUC}
-  ${ICUI18N}
-)
+if(NOT CLR_CMAKE_PLATFORM_DARWIN)
+    target_link_libraries(System.Globalization.Native
+        ${ICUUC}
+        ${ICUI18N}
+    )
+else()
+    target_link_libraries(System.Globalization.Native
+        ${ICUCORE}
+    )
+
+    add_definitions(-DU_DISABLE_RENAMING=1)
+endif()
 
 install (TARGETS System.Globalization.Native DESTINATION .)

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -576,7 +576,10 @@ extern "C" int32_t EnumCalendarInfo(EnumCalendarInfoCallback callback,
         case AbbrevMonthNames:
             return EnumSymbols(locale, calendarId, UDAT_STANDALONE_SHORT_MONTHS, 0, callback, context);
         case SuperShortDayNames:
-#ifdef HAVE_DTWIDTHTYPE_SHORT
+            // UDAT_STANDALONE_SHORTER_WEEKDAYS was added in ICU 51, and CentOS 7 currently uses ICU 50.
+            // fallback to UDAT_STANDALONE_NARROW_WEEKDAYS in that case.
+
+#ifdef HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS
             return EnumSymbols(locale, calendarId, UDAT_STANDALONE_SHORTER_WEEKDAYS, 1, callback, context);
 #else
             return EnumSymbols(locale, calendarId, UDAT_STANDALONE_NARROW_WEEKDAYS, 1, callback, context);

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -10,11 +10,6 @@
 #include "locale.hpp"
 #include "holders.h"
 
-#include <unicode/dtfmtsym.h>
-#include <unicode/smpdtfmt.h>
-#include <unicode/dtptngen.h>
-#include <unicode/locdspnm.h>
-
 #define GREGORIAN_NAME "gregorian"
 #define JAPANESE_NAME "japanese"
 #define BUDDHIST_NAME "buddhist"

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -379,7 +379,7 @@ bool InvokeCallbackForDateTimePattern(const char* locale,
 Function:
 EnumSymbols
 
-Enumerates of of the symbols of a type for a locale and calendar and invokes a callback
+Enumerates all of the symbols of a type for a locale and calendar and invokes a callback
 for each value.
 */
 bool EnumSymbols(const char* locale,
@@ -404,7 +404,7 @@ bool EnumSymbols(const char* locale,
         return false;
 
     UCalendar* pCalendar = ucal_open(nullptr, 0, localeWithCalendarName, UCAL_DEFAULT, &err);
-    UCalendarHolder calenderHolder(pCalendar, err);
+    UCalendarHolder calendarHolder(pCalendar, err);
 
     if (U_FAILURE(err))
         return false;

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -329,19 +329,14 @@ bool InvokeCallbackForDatePattern(const char* locale,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udat_toPattern(pFormat, false, nullptr, 0, &ignore);
 
-    UChar* pattern = (UChar*)calloc(patternLen + 1, sizeof(UChar));
+    std::vector<UChar> pattern(patternLen + 1, '\0');
 
-    if (pattern == nullptr)
-        return false;
-
-    udat_toPattern(pFormat, false, pattern, patternLen + 1, &err);
+    udat_toPattern(pFormat, false, pattern.data(), patternLen + 1, &err);
 
     if (U_SUCCESS(err))
     {
-        callback(pattern, context);
+        callback(pattern.data(), context);
     }
-
-    free(pattern);
 
     return U_SUCCESS(err);
 }
@@ -368,21 +363,14 @@ bool InvokeCallbackForDateTimePattern(const char* locale,
     UErrorCode ignore = U_ZERO_ERROR;
     int32_t patternLen = udatpg_getBestPattern(pGenerator, patternSkeleton, -1, nullptr, 0, &ignore);
 
-    UChar* bestPattern = (UChar*)calloc(patternLen + 1, sizeof(UChar));
+    std::vector<UChar> bestPattern(patternLen + 1, '\0');
 
-    if (bestPattern == nullptr)
-    {
-        return false;
-    }
-
-    udatpg_getBestPattern(pGenerator, patternSkeleton, -1, bestPattern, patternLen + 1, &err);
+    udatpg_getBestPattern(pGenerator, patternSkeleton, -1, bestPattern.data(), patternLen + 1, &err);
 
     if (U_SUCCESS(err))
     {
-        callback(bestPattern, context);
+        callback(bestPattern.data(), context);
     }
-
-    free(bestPattern);
 
     return U_SUCCESS(err);
 }

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -271,13 +271,11 @@ Gets the native calendar name.
 CalendarDataResult
 GetNativeCalendarName(Locale& locale, CalendarId calendarId, UChar* nativeName, int32_t stringCapacity)
 {
-    LocalPointer<LocaleDisplayNames> displayNames(LocaleDisplayNames::createInstance(locale));
-
-    UnicodeString calendarName;
-    displayNames->keyValueDisplayName("calendar", GetCalendarName(calendarId), calendarName);
-
     UErrorCode err = U_ZERO_ERROR;
-    calendarName.extract(nativeName, stringCapacity, err);
+    ULocaleDisplayNames* pDisplayNames = uldn_open(locale.getName(), ULDN_STANDARD_NAMES, &err);
+    ULocaleDisplayNamesHolder displayNamesHolder(pDisplayNames, err);
+
+    uldn_keyValueDisplayName(pDisplayNames, "calendar", GetCalendarName(calendarId), nativeName, stringCapacity, &err);
 
     return GetCalendarDataResult(err);
 }

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -408,13 +408,14 @@ bool EnumSymbols(Locale& locale,
     if (U_FAILURE(err))
         return false;
 
-    Locale localeWithCalendar(locale);
-    localeWithCalendar.setKeywordValue("calendar", GetCalendarName(calendarId), err);
+    char localeWithCalendarName[ULOC_FULLNAME_CAPACITY];
+    strncpy(localeWithCalendarName, locale.getName(), ULOC_FULLNAME_CAPACITY);
+    uloc_setKeywordValue("calendar", GetCalendarName(calendarId), localeWithCalendarName, ULOC_FULLNAME_CAPACITY, &err);
 
     if (U_FAILURE(err))
         return false;
 
-    UCalendar* pCalendar = ucal_open(nullptr, 0, localeWithCalendar.getName(), UCAL_DEFAULT, &err);
+    UCalendar* pCalendar = ucal_open(nullptr, 0, localeWithCalendarName, UCAL_DEFAULT, &err);
     UCalendarHolder calenderHolder(pCalendar, err);
 
     if (U_FAILURE(err))

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -7,6 +7,7 @@
 #include "unicode/uenum.h"
 #include "unicode/udatpg.h"
 #include "unicode/udat.h"
+#include "unicode/unum.h"
 
 // IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
 // time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
@@ -71,7 +72,16 @@ struct UDateFormatCloser
     }
 };
 
+struct UNumberFormatCloser
+{
+    void operator()(UNumberFormat* pNumberFormat) const
+    {
+        udat_close(pNumberFormat);
+    }
+};
+
 typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
 typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;
 typedef IcuHolder<UDateTimePatternGenerator, UDateTimePatternGeneratorCloser> UDateTimePatternGeneratorHolder;
 typedef IcuHolder<UDateFormat, UDateFormatCloser> UDateFormatHolder;
+typedef IcuHolder<UNumberFormat, UNumberFormatCloser> UNumberFormatHolder;

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -6,6 +6,7 @@
 #include "unicode/ucal.h"
 #include "unicode/uenum.h"
 #include "unicode/udatpg.h"
+#include "unicode/udat.h"
 
 // IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
 // time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
@@ -61,6 +62,16 @@ struct UDateTimePatternGeneratorCloser
     }
 };
 
+struct UDateFormatCloser
+{
+  public:
+    void operator()(UDateFormat* pDateFormat) const
+    {
+        udat_close(pDateFormat);
+    }
+};
+
 typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
 typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;
 typedef IcuHolder<UDateTimePatternGenerator, UDateTimePatternGeneratorCloser> UDateTimePatternGeneratorHolder;
+typedef IcuHolder<UDateFormat, UDateFormatCloser> UDateFormatHolder;

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -5,6 +5,7 @@
 
 #include "unicode/ucal.h"
 #include "unicode/uenum.h"
+#include "unicode/udatpg.h"
 
 // IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
 // time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
@@ -51,5 +52,15 @@ struct UEnumerationCloser
     }
 };
 
+struct UDateTimePatternGeneratorCloser
+{
+  public:
+    void operator()(UDateTimePatternGenerator* pGenerator) const
+    {
+        udatpg_close(pGenerator);
+    }
+};
+
 typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
 typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;
+typedef IcuHolder<UDateTimePatternGenerator, UDateTimePatternGeneratorCloser> UDateTimePatternGeneratorHolder;

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -74,7 +74,7 @@ struct UNumberFormatCloser
 {
     void operator()(UNumberFormat* pNumberFormat) const
     {
-        udat_close(pNumberFormat);
+        unum_close(pNumberFormat);
     }
 };
 

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -8,6 +8,7 @@
 #include "unicode/udatpg.h"
 #include "unicode/udat.h"
 #include "unicode/unum.h"
+#include "unicode/uldnames.h"
 
 // IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
 // time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
@@ -80,8 +81,17 @@ struct UNumberFormatCloser
     }
 };
 
+struct ULocaleDisplayNamesCloser
+{
+    void operator()(ULocaleDisplayNames* pLocaleDisplayNames) const
+    {
+        uldn_close(pLocaleDisplayNames);
+    }
+};
+
 typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
 typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;
 typedef IcuHolder<UDateTimePatternGenerator, UDateTimePatternGeneratorCloser> UDateTimePatternGeneratorHolder;
 typedef IcuHolder<UDateFormat, UDateFormatCloser> UDateFormatHolder;
 typedef IcuHolder<UNumberFormat, UNumberFormatCloser> UNumberFormatHolder;
+typedef IcuHolder<ULocaleDisplayNames, ULocaleDisplayNamesCloser> ULocaleDisplayNamesHolder;

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -34,13 +34,12 @@ class IcuHolder
 
   private:
     T* m_p;
-    IcuHolder(const IcuHolder&);
-    IcuHolder operator=(const IcuHolder&);
+    IcuHolder(const IcuHolder&) = delete;
+    IcuHolder operator=(const IcuHolder&) = delete;
 };
 
 struct UCalendarCloser
 {
-  public:
     void operator()(UCalendar* pCal) const
     {
         ucal_close(pCal);
@@ -49,7 +48,6 @@ struct UCalendarCloser
 
 struct UEnumerationCloser
 {
-  public:
     void operator()(UEnumeration* pEnum) const
     {
         uenum_close(pEnum);
@@ -58,7 +56,6 @@ struct UEnumerationCloser
 
 struct UDateTimePatternGeneratorCloser
 {
-  public:
     void operator()(UDateTimePatternGenerator* pGenerator) const
     {
         udatpg_close(pGenerator);
@@ -67,7 +64,6 @@ struct UDateTimePatternGeneratorCloser
 
 struct UDateFormatCloser
 {
-  public:
     void operator()(UDateFormat* pDateFormat) const
     {
         udat_close(pDateFormat);

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -9,6 +9,7 @@
 #include "unicode/udat.h"
 #include "unicode/unum.h"
 #include "unicode/uldnames.h"
+#include "unicode/ures.h"
 
 // IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
 // time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
@@ -89,9 +90,18 @@ struct ULocaleDisplayNamesCloser
     }
 };
 
+struct UResourceBundleCloser
+{
+    void operator()(UResourceBundle* pResourceBundle) const
+    {
+        ures_close(pResourceBundle);
+    }
+};
+
 typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
 typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;
 typedef IcuHolder<UDateTimePatternGenerator, UDateTimePatternGeneratorCloser> UDateTimePatternGeneratorHolder;
 typedef IcuHolder<UDateFormat, UDateFormatCloser> UDateFormatHolder;
 typedef IcuHolder<UNumberFormat, UNumberFormatCloser> UNumberFormatHolder;
 typedef IcuHolder<ULocaleDisplayNames, ULocaleDisplayNamesCloser> ULocaleDisplayNamesHolder;
+typedef IcuHolder<UResourceBundle, UResourceBundleCloser> UResourceBundleHolder;

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -3,13 +3,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 
-#include "unicode/ucal.h"
-#include "unicode/uenum.h"
-#include "unicode/udatpg.h"
-#include "unicode/udat.h"
-#include "unicode/unum.h"
-#include "unicode/uldnames.h"
-#include "unicode/ures.h"
+#include <unicode/ucal.h>
+#include <unicode/uenum.h>
+#include <unicode/udatpg.h>
+#include <unicode/udat.h>
+#include <unicode/unum.h>
+#include <unicode/uldnames.h>
+#include <unicode/ures.h>
 
 // IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
 // time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the

--- a/src/corefx/System.Globalization.Native/holders.h
+++ b/src/corefx/System.Globalization.Native/holders.h
@@ -1,0 +1,55 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include "unicode/ucal.h"
+#include "unicode/uenum.h"
+
+// IcuHolder is a template that can manage the lifetime of a raw pointer to ensure that it is cleaned up at the correct
+// time.  The general usage pattern is to aquire some ICU resource via an _open call, then construct a holder using the
+// pointer and UErrorCode to manage the lifetime.  When the holder goes out of scope, the coresponding close method is
+// called on the pointer.
+template <typename T, typename Closer>
+class IcuHolder
+{
+  public:
+    IcuHolder(T* p, UErrorCode err)
+    {
+        m_p = U_SUCCESS(err) ? p : nullptr;
+    }
+
+    ~IcuHolder()
+    {
+        if (m_p != nullptr)
+        {
+            Closer()(m_p);
+        }
+    }
+
+  private:
+    T* m_p;
+    IcuHolder(const IcuHolder&);
+    IcuHolder operator=(const IcuHolder&);
+};
+
+struct UCalendarCloser
+{
+  public:
+    void operator()(UCalendar* pCal) const
+    {
+        ucal_close(pCal);
+    }
+};
+
+struct UEnumerationCloser
+{
+  public:
+    void operator()(UEnumeration* pEnum) const
+    {
+        uenum_close(pEnum);
+    }
+};
+
+typedef IcuHolder<UCalendar, UCalendarCloser> UCalendarHolder;
+typedef IcuHolder<UEnumeration, UEnumerationCloser> UEnumerationHolder;

--- a/src/corefx/System.Globalization.Native/locale.cpp
+++ b/src/corefx/System.Globalization.Native/locale.cpp
@@ -10,11 +10,6 @@
 
 #include "locale.hpp"
 
-#include "unicode/dcfmtsym.h" //decimal
-#include "unicode/dtfmtsym.h" //date
-#include "unicode/localpointer.h"
-#include "unicode/ulocdata.h"
-
 int32_t UErrorCodeToBool(UErrorCode status)
 {
     if (U_SUCCESS(status))

--- a/src/corefx/System.Globalization.Native/locale.hpp
+++ b/src/corefx/System.Globalization.Native/locale.hpp
@@ -27,9 +27,13 @@ int32_t UErrorCodeToBool(UErrorCode code);
 Function:
 GetLocale
 
-Returns a locale given the locale name
+Converts a managed localeName into something ICU understands and can use as a localeName.
 */
-Locale GetLocale(const UChar* localeName, bool canonize = false);
+int32_t GetLocale(const UChar* localeName,
+                  char* localeNameResult,
+                  int32_t localeNameResultLength,
+                  bool canonicalize,
+                  UErrorCode* err);
 
 /*
 Function:

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -402,25 +402,26 @@ Returns 1 for success, 0 otherwise
 */
 extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData localeNumberData, int32_t* value)
 {
-    Locale locale = GetLocale(localeName);
-    if (locale.isBogus())
+    UErrorCode status = U_ZERO_ERROR;
+    char locale[ULOC_FULLNAME_CAPACITY];
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
+
+    if (U_FAILURE(status))
     {
         return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
     }
 
-    UErrorCode status = U_ZERO_ERROR;
-
     switch (localeNumberData)
     {
         case LanguageId:
-            *value = uloc_getLCID(locale.getName());
+            *value = uloc_getLCID(locale);
             break;
         case MeasurementSystem:
-            status = GetMeasurementSystem(locale.getName(), value);
+            status = GetMeasurementSystem(locale, value);
             break;
         case FractionalDigitsCount:
         {
-            UNumberFormat* numformat = unum_open(UNUM_DECIMAL, NULL, 0, locale.getName(), NULL, &status);
+            UNumberFormat* numformat = unum_open(UNUM_DECIMAL, NULL, 0, locale, NULL, &status);
             if (U_SUCCESS(status))
             {
                 *value = unum_getAttribute(numformat, UNUM_MAX_FRACTION_DIGITS);
@@ -429,11 +430,11 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             break;
         }
         case NegativeNumberFormat:
-            *value = GetNumberNegativePattern(locale.getName());
+            *value = GetNumberNegativePattern(locale);
             break;
         case MonetaryFractionalDigitsCount:
         {
-            UNumberFormat* numformat = unum_open(UNUM_CURRENCY, NULL, 0, locale.getName(), NULL, &status);
+            UNumberFormat* numformat = unum_open(UNUM_CURRENCY, NULL, 0, locale, NULL, &status);
             if (U_SUCCESS(status))
             {
                 *value = unum_getAttribute(numformat, UNUM_MAX_FRACTION_DIGITS);
@@ -442,15 +443,15 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             break;
         }
         case PositiveMonetaryNumberFormat:
-            *value = GetCurrencyPositivePattern(locale.getName());
+            *value = GetCurrencyPositivePattern(locale);
             break;
         case NegativeMonetaryNumberFormat:
-            *value = GetCurrencyNegativePattern(locale.getName());
+            *value = GetCurrencyNegativePattern(locale);
             break;
         case FirstWeekOfYear:
         {
             // corresponds to DateTimeFormat.CalendarWeekRule
-            UCalendar* pCal = ucal_open(nullptr, 0, locale.getName(), UCAL_TRADITIONAL, &status);
+            UCalendar* pCal = ucal_open(nullptr, 0, locale, UCAL_TRADITIONAL, &status);
             UCalendarHolder calHolder(pCal, status);
 
             if (U_SUCCESS(status))
@@ -482,7 +483,7 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             // used in coreclr)
             //  0 - Left to right (such as en-US)
             //  1 - Right to left (such as arabic locales)
-            ULayoutType orientation = uloc_getCharacterOrientation(locale.getName(), &status);
+            ULayoutType orientation = uloc_getCharacterOrientation(locale, &status);
             // alternative implementation in ICU 54+ is uloc_isRightToLeft() which
             // also supports script tags in locale
             if (U_SUCCESS(status))
@@ -493,7 +494,7 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
         }
         case FirstDayofWeek:
         {
-            UCalendar* pCal = ucal_open(nullptr, 0, locale.getName(), UCAL_TRADITIONAL, &status);
+            UCalendar* pCal = ucal_open(nullptr, 0, locale, UCAL_TRADITIONAL, &status);
             UCalendarHolder calHolder(pCal, status);
 
             if (U_SUCCESS(status))
@@ -503,10 +504,10 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             break;
         }
         case NegativePercentFormat:
-            *value = GetPercentNegativePattern(locale.getName());
+            *value = GetPercentNegativePattern(locale);
             break;
         case PositivePercentFormat:
-            *value = GetPercentPositivePattern(locale.getName());
+            *value = GetPercentPositivePattern(locale);
             break;
         default:
             status = U_UNSUPPORTED_ERROR;
@@ -529,8 +530,11 @@ extern "C" int32_t GetLocaleInfoGroupingSizes(const UChar* localeName,
                                               int32_t* primaryGroupSize,
                                               int32_t* secondaryGroupSize)
 {
-    Locale locale = GetLocale(localeName);
-    if (locale.isBogus())
+    UErrorCode status = U_ZERO_ERROR;
+    char locale[ULOC_FULLNAME_CAPACITY];
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
+
+    if (U_FAILURE(status))
     {
         return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
     }
@@ -548,8 +552,7 @@ extern "C" int32_t GetLocaleInfoGroupingSizes(const UChar* localeName,
             return UErrorCodeToBool(U_UNSUPPORTED_ERROR);
     }
 
-    UErrorCode status = U_ZERO_ERROR;
-    UNumberFormat* numformat = unum_open(style, NULL, 0, locale.getName(), NULL, &status);
+    UNumberFormat* numformat = unum_open(style, NULL, 0, locale, NULL, &status);
     if (U_SUCCESS(status))
     {
         *primaryGroupSize = unum_getAttribute(numformat, UNUM_GROUPING_SIZE);

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -8,6 +8,7 @@
 #include <string.h>
 
 #include "locale.hpp"
+#include "holders.h"
 
 #include "unicode/calendar.h"
 #include "unicode/decimfmt.h"
@@ -442,11 +443,13 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
         case FirstWeekOfYear:
         {
             // corresponds to DateTimeFormat.CalendarWeekRule
-            LocalPointer<Calendar> calendar(Calendar::createInstance(locale, status));
+            UCalendar* pCal = ucal_open(nullptr, 0, locale.getName(), UCAL_TRADITIONAL, &status);
+            UCalendarHolder calHolder(pCal, status);
+
             if (U_SUCCESS(status))
             {
                 // values correspond to LOCALE_IFIRSTWEEKOFYEAR
-                int minDaysInWeek = calendar->getMinimalDaysInFirstWeek();
+                int minDaysInWeek = ucal_getAttribute(pCal, UCAL_MINIMAL_DAYS_IN_FIRST_WEEK);
                 if (minDaysInWeek == 1)
                 {
                     *value = CalendarWeekRule::FirstDay;
@@ -483,10 +486,12 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
         }
         case FirstDayofWeek:
         {
-            LocalPointer<Calendar> pcalendar(Calendar::createInstance(locale, status));
+            UCalendar* pCal = ucal_open(nullptr, 0, locale.getName(), UCAL_TRADITIONAL, &status);
+            UCalendarHolder calHolder(pCal, status);
+
             if (U_SUCCESS(status))
             {
-                *value = pcalendar->getFirstDayOfWeek(status) - 1; // .NET is 0-based and ICU is 1-based
+                *value = ucal_getAttribute(pCal, UCAL_FIRST_DAY_OF_WEEK) - 1; // .NET is 0-based and ICU is 1-based
             }
             break;
         }

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -8,14 +8,10 @@
 #include <string.h>
 #include <vector>
 
+#include <unicode/ulocdata.h>
+
 #include "locale.hpp"
 #include "holders.h"
-
-#include "unicode/calendar.h"
-#include "unicode/decimfmt.h"
-#include "unicode/localpointer.h"
-#include "unicode/numfmt.h"
-#include "unicode/ulocdata.h"
 
 // invariant character definitions used by ICU
 #define UCHAR_CURRENCY ((UChar)0x00A4)   // international currency

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -214,7 +214,7 @@ GetCurrencyNegativePattern
 Implementation of NumberFormatInfo.CurrencyNegativePattern.
 Returns the pattern index.
 */
-int GetCurrencyNegativePattern(const Locale& locale)
+int GetCurrencyNegativePattern(const char* locale)
 {
     const int DEFAULT_VALUE = 0;
     static const char* Patterns[] = {"(Cn)",
@@ -235,7 +235,7 @@ int GetCurrencyNegativePattern(const Locale& locale)
                                      "(n C)"};
     UErrorCode status = U_ZERO_ERROR;
 
-    UNumberFormat* pFormat = unum_open(UNUM_CURRENCY, nullptr, 0, locale.getName(), nullptr, &status);
+    UNumberFormat* pFormat = unum_open(UNUM_CURRENCY, nullptr, 0, locale, nullptr, &status);
     UNumberFormatHolder formatHolder(pFormat, status);
 
     assert(U_SUCCESS(status));
@@ -259,13 +259,13 @@ GetCurrencyPositivePattern
 Implementation of NumberFormatInfo.CurrencyPositivePattern.
 Returns the pattern index.
 */
-int GetCurrencyPositivePattern(const Locale& locale)
+int GetCurrencyPositivePattern(const char* locale)
 {
     const int DEFAULT_VALUE = 0;
     static const char* Patterns[] = {"Cn", "nC", "C n", "n C"};
     UErrorCode status = U_ZERO_ERROR;
 
-    UNumberFormat* pFormat = unum_open(UNUM_CURRENCY, nullptr, 0, locale.getName(), nullptr, &status);
+    UNumberFormat* pFormat = unum_open(UNUM_CURRENCY, nullptr, 0, locale, nullptr, &status);
     UNumberFormatHolder formatHolder(pFormat, status);
 
     assert(U_SUCCESS(status));
@@ -289,13 +289,13 @@ GetNumberNegativePattern
 Implementation of NumberFormatInfo.NumberNegativePattern.
 Returns the pattern index.
 */
-int GetNumberNegativePattern(const Locale& locale)
+int GetNumberNegativePattern(const char* locale)
 {
     const int DEFAULT_VALUE = 1;
     static const char* Patterns[] = {"(n)", "-n", "- n", "n-", "n -"};
     UErrorCode status = U_ZERO_ERROR;
 
-    UNumberFormat* pFormat = unum_open(UNUM_DECIMAL, nullptr, 0, locale.getName(), nullptr, &status);
+    UNumberFormat* pFormat = unum_open(UNUM_DECIMAL, nullptr, 0, locale, nullptr, &status);
     UNumberFormatHolder formatHolder(pFormat, status);
 
     assert(U_SUCCESS(status));
@@ -319,14 +319,14 @@ GetPercentNegativePattern
 Implementation of NumberFormatInfo.PercentNegativePattern.
 Returns the pattern index.
 */
-int GetPercentNegativePattern(const Locale& locale)
+int GetPercentNegativePattern(const char* locale)
 {
     const int DEFAULT_VALUE = 0;
     static const char* Patterns[] = {
         "-n %", "-n%", "-%n", "%-n", "%n-", "n-%", "n%-", "-% n", "n %-", "% n-", "% -n", "n- %"};
     UErrorCode status = U_ZERO_ERROR;
 
-    UNumberFormat* pFormat = unum_open(UNUM_PERCENT, nullptr, 0, locale.getName(), nullptr, &status);
+    UNumberFormat* pFormat = unum_open(UNUM_PERCENT, nullptr, 0, locale, nullptr, &status);
     UNumberFormatHolder formatHolder(pFormat, status);
 
     assert(U_SUCCESS(status));
@@ -350,13 +350,13 @@ GetPercentPositivePattern
 Implementation of NumberFormatInfo.PercentPositivePattern.
 Returns the pattern index.
 */
-int GetPercentPositivePattern(const Locale& locale)
+int GetPercentPositivePattern(const char* locale)
 {
     const int DEFAULT_VALUE = 0;
     static const char* Patterns[] = {"n %", "n%", "%n", "% n"};
     UErrorCode status = U_ZERO_ERROR;
 
-    UNumberFormat* pFormat = unum_open(UNUM_PERCENT, nullptr, 0, locale.getName(), nullptr, &status);
+    UNumberFormat* pFormat = unum_open(UNUM_PERCENT, nullptr, 0, locale, nullptr, &status);
     UNumberFormatHolder formatHolder(pFormat, status);
 
     assert(U_SUCCESS(status));
@@ -380,11 +380,11 @@ GetMeasurementSystem
 Obtains the measurement system for the local, determining if US or metric.
 Returns 1 for US, 0 otherwise.
 */
-UErrorCode GetMeasurementSystem(const char* localeId, int32_t* value)
+UErrorCode GetMeasurementSystem(const char* locale, int32_t* value)
 {
     UErrorCode status = U_ZERO_ERROR;
 
-    UMeasurementSystem measurementSystem = ulocdata_getMeasurementSystem(localeId, &status);
+    UMeasurementSystem measurementSystem = ulocdata_getMeasurementSystem(locale, &status);
     if (U_SUCCESS(status))
     {
         *value = (measurementSystem == UMeasurementSystem::UMS_US) ? 1 : 0;
@@ -413,7 +413,7 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
     switch (localeNumberData)
     {
         case LanguageId:
-            *value = locale.getLCID();
+            *value = uloc_getLCID(locale.getName());
             break;
         case MeasurementSystem:
             status = GetMeasurementSystem(locale.getName(), value);
@@ -429,7 +429,7 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             break;
         }
         case NegativeNumberFormat:
-            *value = GetNumberNegativePattern(locale);
+            *value = GetNumberNegativePattern(locale.getName());
             break;
         case MonetaryFractionalDigitsCount:
         {
@@ -442,10 +442,10 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             break;
         }
         case PositiveMonetaryNumberFormat:
-            *value = GetCurrencyPositivePattern(locale);
+            *value = GetCurrencyPositivePattern(locale.getName());
             break;
         case NegativeMonetaryNumberFormat:
-            *value = GetCurrencyNegativePattern(locale);
+            *value = GetCurrencyNegativePattern(locale.getName());
             break;
         case FirstWeekOfYear:
         {
@@ -483,7 +483,7 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             //  0 - Left to right (such as en-US)
             //  1 - Right to left (such as arabic locales)
             ULayoutType orientation = uloc_getCharacterOrientation(locale.getName(), &status);
-            // alternative implementation in ICU 54+ is Locale.isRightToLeft() which
+            // alternative implementation in ICU 54+ is uloc_isRightToLeft() which
             // also supports script tags in locale
             if (U_SUCCESS(status))
             {
@@ -503,10 +503,10 @@ extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData lo
             break;
         }
         case NegativePercentFormat:
-            *value = GetPercentNegativePattern(locale);
+            *value = GetPercentNegativePattern(locale.getName());
             break;
         case PositivePercentFormat:
-            *value = GetPercentPositivePattern(locale);
+            *value = GetPercentPositivePattern(locale.getName());
             break;
         default:
             status = U_UNSUPPORTED_ERROR;

--- a/src/corefx/System.Globalization.Native/localeStringData.cpp
+++ b/src/corefx/System.Globalization.Native/localeStringData.cpp
@@ -173,96 +173,95 @@ Returns 1 for success, 0 otherwise
 extern "C" int32_t
 GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, UChar* value, int32_t valueLength)
 {
-    Locale locale = GetLocale(localeName);
-    if (locale.isBogus())
+    UErrorCode status = U_ZERO_ERROR;
+    char locale[ULOC_FULLNAME_CAPACITY];
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &status);
+
+    if (U_FAILURE(status))
     {
         return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
     }
 
-    UErrorCode status = U_ZERO_ERROR;
     switch (localeStringData)
     {
         case LocalizedDisplayName:
-            uloc_getDisplayName(locale.getName(), uloc_getDefault(), value, valueLength, &status);
+            uloc_getDisplayName(locale, uloc_getDefault(), value, valueLength, &status);
             break;
         case EnglishDisplayName:
-            uloc_getDisplayName(locale.getName(), ULOC_ENGLISH, value, valueLength, &status);
+            uloc_getDisplayName(locale, ULOC_ENGLISH, value, valueLength, &status);
             break;
         case NativeDisplayName:
-            uloc_getDisplayName(locale.getName(), locale.getName(), value, valueLength, &status);
+            uloc_getDisplayName(locale, locale, value, valueLength, &status);
             break;
         case LocalizedLanguageName:
-            uloc_getDisplayLanguage(locale.getName(), uloc_getDefault(), value, valueLength, &status);
+            uloc_getDisplayLanguage(locale, uloc_getDefault(), value, valueLength, &status);
             break;
         case EnglishLanguageName:
-            uloc_getDisplayLanguage(locale.getName(), ULOC_ENGLISH, value, valueLength, &status);
+            uloc_getDisplayLanguage(locale, ULOC_ENGLISH, value, valueLength, &status);
             break;
         case NativeLanguageName:
-            uloc_getDisplayLanguage(locale.getName(), locale.getName(), value, valueLength, &status);
+            uloc_getDisplayLanguage(locale, locale, value, valueLength, &status);
             break;
         case EnglishCountryName:
-            uloc_getDisplayCountry(locale.getName(), ULOC_ENGLISH, value, valueLength, &status);
+            uloc_getDisplayCountry(locale, ULOC_ENGLISH, value, valueLength, &status);
             break;
         case NativeCountryName:
-            uloc_getDisplayCountry(locale.getName(), locale.getName(), value, valueLength, &status);
+            uloc_getDisplayCountry(locale, locale, value, valueLength, &status);
             break;
         case ListSeparator:
         // fall through
         case ThousandSeparator:
-            status =
-                GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
             break;
         case DecimalSeparator:
-            status =
-                GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_DECIMAL_SEPARATOR_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_DECIMAL_SEPARATOR_SYMBOL, value, valueLength);
             break;
         case Digits:
-            status = GetDigitSymbol(locale.getName(), status, UNUM_ZERO_DIGIT_SYMBOL, 0, value, valueLength);
+            status = GetDigitSymbol(locale, status, UNUM_ZERO_DIGIT_SYMBOL, 0, value, valueLength);
             // symbols UNUM_ONE_DIGIT to UNUM_NINE_DIGIT are contiguous
             for (int32_t symbol = UNUM_ONE_DIGIT_SYMBOL; symbol <= UNUM_NINE_DIGIT_SYMBOL; symbol++)
             {
                 int charIndex = symbol - UNUM_ONE_DIGIT_SYMBOL + 1;
                 status = GetDigitSymbol(
-                    locale.getName(), status, static_cast<UNumberFormatSymbol>(symbol), charIndex, value, valueLength);
+                    locale, status, static_cast<UNumberFormatSymbol>(symbol), charIndex, value, valueLength);
             }
             break;
         case MonetarySymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_CURRENCY_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_CURRENCY_SYMBOL, value, valueLength);
             break;
         case Iso4217MonetarySymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_INTL_CURRENCY_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INTL_CURRENCY_SYMBOL, value, valueLength);
             break;
         case MonetaryDecimalSeparator:
-            status =
-                GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_MONETARY_SEPARATOR_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_SEPARATOR_SYMBOL, value, valueLength);
             break;
         case MonetaryThousandSeparator:
-            status = GetLocaleInfoDecimalFormatSymbol(
-                locale.getName(), UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
+            status =
+                GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MONETARY_GROUPING_SEPARATOR_SYMBOL, value, valueLength);
             break;
         case AMDesignator:
-            status = GetLocaleInfoAmPm(locale.getName(), true, value, valueLength);
+            status = GetLocaleInfoAmPm(locale, true, value, valueLength);
             break;
         case PMDesignator:
-            status = GetLocaleInfoAmPm(locale.getName(), false, value, valueLength);
+            status = GetLocaleInfoAmPm(locale, false, value, valueLength);
             break;
         case PositiveSign:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_PLUS_SIGN_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PLUS_SIGN_SYMBOL, value, valueLength);
             break;
         case NegativeSign:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_MINUS_SIGN_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_MINUS_SIGN_SYMBOL, value, valueLength);
             break;
         case Iso639LanguageName:
-            status = GetLocaleIso639LanguageName(locale.getName(), value, valueLength);
+            status = GetLocaleIso639LanguageName(locale, value, valueLength);
             break;
         case Iso3166CountryName:
-            status = GetLocaleIso3166CountryName(locale.getName(), value, valueLength);
+            status = GetLocaleIso3166CountryName(locale, value, valueLength);
             break;
         case NaNSymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_NAN_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_NAN_SYMBOL, value, valueLength);
             break;
         case PositiveInfinitySymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_INFINITY_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_INFINITY_SYMBOL, value, valueLength);
             break;
         case ParentName:
         {
@@ -270,7 +269,7 @@ GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, 
             // including invariant locale
             char localeNameTemp[ULOC_FULLNAME_CAPACITY];
 
-            uloc_getParent(locale.getName(), localeNameTemp, ULOC_FULLNAME_CAPACITY, &status);
+            uloc_getParent(locale, localeNameTemp, ULOC_FULLNAME_CAPACITY, &status);
             if (U_SUCCESS(status))
             {
                 status = u_charsToUChars_safe(localeNameTemp, value, valueLength);
@@ -282,10 +281,10 @@ GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, 
             break;
         }
         case PercentSymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_PERCENT_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PERCENT_SYMBOL, value, valueLength);
             break;
         case PerMilleSymbol:
-            status = GetLocaleInfoDecimalFormatSymbol(locale.getName(), UNUM_PERMILL_SYMBOL, value, valueLength);
+            status = GetLocaleInfoDecimalFormatSymbol(locale, UNUM_PERMILL_SYMBOL, value, valueLength);
             break;
         default:
             status = U_UNSUPPORTED_ERROR;
@@ -304,15 +303,17 @@ Returns 1 for success, 0 otherwise
 */
 extern "C" int32_t GetLocaleTimeFormat(const UChar* localeName, int shortFormat, UChar* value, int32_t valueLength)
 {
-    Locale locale = GetLocale(localeName);
-    if (locale.isBogus())
+    UErrorCode err = U_ZERO_ERROR;
+    char locale[ULOC_FULLNAME_CAPACITY];
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
+
+    if (U_FAILURE(err))
     {
         return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
     }
 
-    UErrorCode err = U_ZERO_ERROR;
     UDateFormatStyle style = (shortFormat != 0) ? UDAT_SHORT : UDAT_MEDIUM;
-    UDateFormat* pFormat = udat_open(style, UDAT_NONE, locale.getName(), nullptr, 0, nullptr, 0, &err);
+    UDateFormat* pFormat = udat_open(style, UDAT_NONE, locale, nullptr, 0, nullptr, 0, &err);
     UDateFormatHolder formatHolder(pFormat, err);
 
     if (U_FAILURE(err))

--- a/src/corefx/System.Globalization.Native/localeStringData.cpp
+++ b/src/corefx/System.Globalization.Native/localeStringData.cpp
@@ -11,11 +11,6 @@
 #include "locale.hpp"
 #include "holders.h"
 
-#include "unicode/dcfmtsym.h" //decimal symbols
-#include "unicode/dtfmtsym.h" //date symbols
-#include "unicode/smpdtfmt.h" //date format
-#include "unicode/localpointer.h"
-
 // Enum that corresponds to managed enum CultureData.LocaleStringData.
 // The numeric values of the enum members match their Win32 counterparts.
 enum LocaleStringData : int32_t

--- a/src/corefx/System.Globalization.Native/localeStringData.cpp
+++ b/src/corefx/System.Globalization.Native/localeStringData.cpp
@@ -102,31 +102,21 @@ UErrorCode GetDigitSymbol(const Locale& locale,
 Function:
 GetLocaleInfoAmPm
 
-Obtains the value of a DateFormatSymbols Am or Pm string
+Obtains the value of the AM or PM string for a locale.
 */
 UErrorCode GetLocaleInfoAmPm(const Locale& locale, bool am, UChar* value, int32_t valueLength)
 {
     UErrorCode status = U_ZERO_ERROR;
-    LocalPointer<DateFormatSymbols> dateFormatSymbols(new DateFormatSymbols(locale, status));
-    if (dateFormatSymbols == NULL)
-    {
-        status = U_MEMORY_ALLOCATION_ERROR;
-    }
+    UDateFormat* pFormat = udat_open(UDAT_DEFAULT, UDAT_DEFAULT, locale.getName(), nullptr, 0, nullptr, 0, &status);
+    UDateFormatHolder formatHolder(pFormat, status);
 
     if (U_FAILURE(status))
     {
         return status;
     }
 
-    int32_t count = 0;
-    const UnicodeString* tempStr = dateFormatSymbols->getAmPmStrings(count);
-    int offset = am ? 0 : 1;
-    if (offset >= count)
-    {
-        return U_INTERNAL_PROGRAM_ERROR;
-    }
+    udat_getSymbols(pFormat, UDAT_AM_PMS, am ? 0 : 1, value, valueLength, &status);
 
-    tempStr[offset].extract(value, valueLength, status);
     return status;
 }
 

--- a/src/corefx/System.Globalization.Native/localeStringData.cpp
+++ b/src/corefx/System.Globalization.Native/localeStringData.cpp
@@ -8,15 +8,12 @@
 #include <string.h>
 
 #include "locale.hpp"
+#include "holders.h"
 
 #include "unicode/dcfmtsym.h" //decimal symbols
 #include "unicode/dtfmtsym.h" //date symbols
 #include "unicode/smpdtfmt.h" //date format
 #include "unicode/localpointer.h"
-
-// invariant character definitions used by ICU
-#define UCHAR_SPACE ((UChar)0x0020)   // space
-#define UCHAR_NBSPACE ((UChar)0x00A0) // space
 
 // Enum that corresponds to managed enum CultureData.LocaleStringData.
 // The numeric values of the enum members match their Win32 counterparts.
@@ -284,53 +281,10 @@ GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, 
 }
 
 /*
-Function:
-NormalizeTimePattern
-
-Convert an ICU non-localized time pattern to .NET format
-*/
-void NormalizeTimePattern(const UnicodeString* srcPattern, UnicodeString* destPattern)
-{
-    // An srcPattern example: "h:mm:ss a"
-    // A destPattern example: "h:mm:ss tt"
-    destPattern->remove();
-
-    bool amPmAdded = false;
-    for (int i = 0; i <= srcPattern->length() - 1; i++)
-    {
-        UChar ch = srcPattern->charAt(i);
-        switch (ch)
-        {
-            case ':':
-            case '.':
-            case 'H':
-            case 'h':
-            case 'm':
-            case 's':
-                destPattern->append(ch);
-                break;
-
-            case UCHAR_SPACE:
-            case UCHAR_NBSPACE:
-                destPattern->append(UCHAR_SPACE);
-                break;
-
-            case 'a': // AM/PM
-                if (!amPmAdded)
-                {
-                    amPmAdded = true;
-                    destPattern->append("tt");
-                }
-                break;
-        }
-    }
-}
-
-/*
 PAL Function:
 GetLocaleTimeFormat
 
-Obtains time format information.
+Obtains time format information (in ICU format, it needs to be coverted to .NET Format).
 Returns 1 for success, 0 otherwise
 */
 extern "C" int32_t GetLocaleTimeFormat(const UChar* localeName, int shortFormat, UChar* value, int32_t valueLength)
@@ -341,28 +295,15 @@ extern "C" int32_t GetLocaleTimeFormat(const UChar* localeName, int shortFormat,
         return UErrorCodeToBool(U_ILLEGAL_ARGUMENT_ERROR);
     }
 
-    DateFormat::EStyle style = (shortFormat != 0) ? DateFormat::kShort : DateFormat::kMedium;
-    LocalPointer<DateFormat> dateFormat(DateFormat::createTimeInstance(style, locale));
-    if (dateFormat == NULL || !dateFormat.isValid())
-    {
-        return UErrorCodeToBool(U_MEMORY_ALLOCATION_ERROR);
-    }
+    UErrorCode err = U_ZERO_ERROR;
+    UDateFormatStyle style = (shortFormat != 0) ? UDAT_SHORT : UDAT_MEDIUM;
+    UDateFormat* pFormat = udat_open(style, UDAT_NONE, locale.getName(), nullptr, 0, nullptr, 0, &err);
+    UDateFormatHolder formatHolder(pFormat, err);
 
-    // cast to SimpleDateFormat so we can call toPattern()
-    SimpleDateFormat* sdf = dynamic_cast<SimpleDateFormat*>(dateFormat.getAlias());
-    if (sdf == NULL)
-    {
-        return UErrorCodeToBool(U_INTERNAL_PROGRAM_ERROR);
-    }
+    if (U_FAILURE(err))
+        return UErrorCodeToBool(err);
 
-    UnicodeString icuPattern;
-    sdf->toPattern(icuPattern);
+    udat_toPattern(pFormat, false, value, valueLength, &err);
 
-    UnicodeString dotnetPattern;
-    NormalizeTimePattern(&icuPattern, &dotnetPattern);
-
-    UErrorCode status = U_ZERO_ERROR;
-    dotnetPattern.extract(value, valueLength, status);
-
-    return UErrorCodeToBool(status);
+    return UErrorCodeToBool(err);
 }


### PR DESCRIPTION
This change converts the System.Globalization.Native shim to use the ICU C API (instead of C++).  Once that is done, we are able to link against the version of ICU that OSX uses for all of their locale APIs.

Please take a look @stephentoub @ericeil

The individual commits have some duplicated work, I did it this way so I could make progress incrementally, continue to test and slowly make progress driving towards C.  I'm not sure if it is easier to review the 8 files or the 15 commits.

I ran all of the corefx tests locally on both Ubuntu and OSX. 