### PR TITLE
Ensure each test has its own unique directory

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -1,10 +1,7 @@
 <Project DefaultTargets = "GetListOfTestCmds"
     xmlns="http://schemas.microsoft.com/developer/msbuild/2003" >
     <ItemGroup Condition="'$(XunitTestBinBase)' != ''">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\newarr\newarr.cmd" >
-             <Issue>1036</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\lifetime\lifetime2.cmd" >
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\lifetime\**\lifetime2.cmd" >
              <Issue>1037</Issue>
         </ExcludeList>
     </ItemGroup>

--- a/tests/src/Interop/ReversePInvoke/Marshalling/MarshalBoolArray.csproj
+++ b/tests/src/Interop/ReversePInvoke/Marshalling/MarshalBoolArray.csproj
@@ -41,8 +41,7 @@
       <Project>{c8c0dc74-fac4-45b1-81fe-70c4808366e0}</Project>
       <Name>CoreCLRTestLibrary</Name>
     </ProjectReference>
-    <ProjectReference Include="CMakeLists.txt">
-    </ProjectReference>
+    <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/Loader/NativeLibs/FromNativePaths.csproj
+++ b/tests/src/Loader/NativeLibs/FromNativePaths.csproj
@@ -19,6 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+    <ProjectReference Include="CMakeLists.txt" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -36,7 +36,7 @@
     <BaseIntermediateOutputPath Condition="'$(__ManagedTestIntermediatesDir)' != ''">$(__ManagedTestIntermediatesDir)\</BaseIntermediateOutputPath>
     <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\obj\$(BuildOS).$(Platform).$(Configuration)\))</__NativeTestIntermediatesDir>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
-    <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))</BuildProjectRelativeDir>
+    <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))\$(MSBuildProjectName)</BuildProjectRelativeDir>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPathWithConfig)$(BuildProjectRelativeDir)\</OutputPath>
   </PropertyGroup>

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -134,19 +134,29 @@
   </Target>
 
   <Target Name="ConsolidateNativeProjectReference"
-          Condition="'@(ProjectReference)' != ''"
+          Condition="'@(NativeProjectReferenceNormalized)' != ''"
           BeforeTargets="Build" >
      <ItemGroup>
         <NativeProjectOutputFoldersToCopy Include="$([System.String]::Copy('%(NativeProjectReferenceNormalized.RelativeDir)').Replace($(SourceDir),$(__NativeTestIntermediatesDir)\src\))$(Configuration)\"/>
      </ItemGroup>
 
-    <Message Text= "Project files are :$([System.String]::Copy(%(ProjectReference.FileName)).ToUpper()) " />
-    <Message Text= "Project references are :%(ProjectReference.Identity)" />
-    <Message Text= "Native project references are :%(NativeProjectReference.Identity)" />
     <Message Text= "Full native project references are :%(NativeProjectReferenceNormalized.Identity)" />
     <Message Text= "Native binaries will be copied from :%(NativeProjectOutputFoldersToCopy.Identity)" />
    <MSBuild Projects="$(MSBuildProjectFile)" Targets="CopyNativeProjectBinaries" Properties="NativeProjectOutputFolder=%(NativeProjectOutputFoldersToCopy.Identity)" Condition="'@(NativeProjectReference)' != ''" />
 
   </Target>
+
+  <PropertyGroup>
+     <PrepareForRunDependsOn>$(PrepareForRunDependsOn);ResetReferenceCopyLocalPaths</PrepareForRunDependsOn>
+  </PropertyGroup>
+
+  <Target Name="ResetReferenceCopyLocalPaths"
+          Condition="'@(ReferenceCopyLocalPaths)' != ''"
+          BeforeTargets="_CopyFilesMarkedCopyLocal">
+    <ItemGroup>
+       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)" Condition="'%(ReferenceCopyLocalPaths.CopyLocal)' != 'true'"/>
+    </ItemGroup>
+  </Target>
+
 </Project>
 


### PR DESCRIPTION
This change ensures each test has its own unique directory
And avoids copying the facades to the test  build

@mmitche @jkotas  @bryanar can you take a look