### PR TITLE
Add EnterCriticalSection / LeaveCriticalSection exports to libcoreclr

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -30,6 +30,7 @@ CreateMutexW
 CreateSemaphoreW
 DeleteFileW
 DuplicateHandle
+EnterCriticalSection
 FindClose
 FindFirstFileW
 FindNextFileW
@@ -55,6 +56,7 @@ GetStdHandle
 GetSystemInfo
 GetTempFileNameW
 GetTempPathW
+LeaveCriticalSection
 LocalAlloc
 LocalFree
 LockFile


### PR DESCRIPTION
Added exports from libcoreclr as needed by the clr debugger on linux