### PR TITLE
Fix a CrossGen assert on Linux

### DIFF
--- a/src/utilcode/sstring_com.cpp
+++ b/src/utilcode/sstring_com.cpp
@@ -39,7 +39,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
 
     HRESULT hr = E_FAIL;
 
-#ifndef FEATURE_UTILCODE_NO_DEPENDENCIES
+#if !defined(FEATURE_UTILCODE_NO_DEPENDENCIES) && !(defined(CROSSGEN_COMPILE) && defined(PLATFORM_UNIX))
     if (pResourceDLL == NULL) 
     {
         pResourceDLL = CCompRC::GetDefaultResourceDll();


### PR DESCRIPTION
Resource string loading during CrossGen doesn't work on Linux.
Disable it for now. In many cases the loaded string isn't even used.