### PR TITLE
Implement LocalReAlloc in PAL

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -22,6 +22,7 @@ CloseHandle
 CoCreateGuid
 CopyFileW
 CoTaskMemAlloc
+CoTaskMemRealloc
 CoTaskMemFree
 CreateDirectoryW
 CreateEventW

--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -58,6 +58,7 @@ GetTempFileNameW
 GetTempPathW
 LeaveCriticalSection
 LocalAlloc
+LocalReAlloc
 LocalFree
 LockFile
 lstrlenA

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3944,6 +3944,7 @@ HeapSetInformation(
         IN SIZE_T HeapInformationLength);
 
 #define LMEM_FIXED          0x0000
+#define LMEM_MOVEABLE       0x0002
 #define LMEM_ZEROINIT       0x0040
 #define LPTR                (LMEM_FIXED | LMEM_ZEROINIT)
 
@@ -3953,6 +3954,14 @@ PALAPI
 LocalAlloc(
        IN UINT uFlags,
        IN SIZE_T uBytes);
+
+PALIMPORT
+HLOCAL
+PALAPI
+LocalReAlloc(
+       IN HLOCAL hMem,
+       IN SIZE_T uBytes,
+       IN UINT   uFlags);
 
 PALIMPORT
 HLOCAL

--- a/src/pal/inc/rt/palrt.h
+++ b/src/pal/inc/rt/palrt.h
@@ -437,6 +437,7 @@ typedef union _ULARGE_INTEGER {
 /******************* OLE, BSTR, VARIANT *************************/
 
 STDAPI_(LPVOID) CoTaskMemAlloc(SIZE_T cb);
+STDAPI_(LPVOID) CoTaskMemRealloc(LPVOID pv, SIZE_T cb);
 STDAPI_(void) CoTaskMemFree(LPVOID pv);
 
 typedef SHORT VARIANT_BOOL;

--- a/src/pal/src/memory/local.cpp
+++ b/src/pal/src/memory/local.cpp
@@ -79,6 +79,38 @@ done:
     return (HLOCAL) lpRetVal;
 }
 
+/*++
+Function:
+LocalReAlloc
+
+See MSDN doc.
+--*/
+HLOCAL
+PALAPI
+LocalReAlloc(
+       IN HLOCAL hMem,
+       IN SIZE_T uBytes,
+       IN UINT   uFlags)
+{
+    LPVOID lpRetVal = NULL;
+    PERF_ENTRY(LocalReAlloc);
+    ENTRY("LocalReAlloc (hMem=%p, uBytes=%u, uFlags=%#x)\n", hMem, uBytes, uFlags);
+
+    if (uFlags != LMEM_MOVEABLE) {
+        // Currently valid iff uFlags is LMEM_MOVEABLE
+        ASSERT("Invalid parameter uFlags=0x%x\n", uFlags);
+        SetLastError(ERROR_INVALID_PARAMETER);
+        goto done;
+    }
+    uFlags = 0;
+
+    lpRetVal = HeapReAlloc(GetProcessHeap(), uFlags, hMem, uBytes);
+
+done:
+    LOGEXIT("LocalReAlloc returning %p.\n", lpRetVal);
+    PERF_EXIT(LocalReAlloc);
+    return (HLOCAL)lpRetVal;
+}
 
 /*++
 Function:

--- a/src/palrt/comem.cpp
+++ b/src/palrt/comem.cpp
@@ -17,6 +17,11 @@ STDAPI_(LPVOID) CoTaskMemAlloc(SIZE_T cb)
     return LocalAlloc(LMEM_FIXED, cb);
 }
 
+STDAPI_(LPVOID) CoTaskMemRealloc(LPVOID pv, SIZE_T cb)
+{
+    return LocalReAlloc(pv, cb, LMEM_MOVEABLE);
+}
+
 STDAPI_(void) CoTaskMemFree(LPVOID pv)
 {
     LocalFree(pv);


### PR DESCRIPTION
Marshal.ReAllocHGlobal is failing because it's expecting to find a LocalReAlloc implementation in libcoreclr's PAL.  This commit adds one.

cc: @janvorli 