### PR TITLE
Add chmod +x to individual test scripts in runtest.sh

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -311,7 +311,7 @@ function create_core_overlay {
         rm -f -r "$coreOverlayDir"
     fi
     mkdir "$coreOverlayDir"
-    find "$coreFxBinDir" -iname '*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' -exec cp -f -u '{}' "$coreOverlayDir/" \;
+    (cd $coreFxBinDir && find . -iname '*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' -exec cp -f -u '{}' "$coreOverlayDir/" \;)
     cp -f "$coreFxNativeBinDir/Native/"*.so "$coreOverlayDir/" 2>/dev/null
     cp -f "$coreClrBinDir/"* "$coreOverlayDir/" 2>/dev/null
     cp -f "$mscorlibDir/mscorlib.dll" "$coreOverlayDir/"

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -420,6 +420,9 @@ function run_test {
     # Convert DOS line endings to Unix if needed
     sed -i 's/\r$//' "$scriptFileName"
 
+    # Add executable file mode bit if needed
+    chmod +x "$scriptFileName"
+
     "./$scriptFileName" >"$outputFileName" 2>&1
     return $?
 }


### PR DESCRIPTION
Do a `chmod +x` in runtest.sh before trying to run each test script. This hasn't been needed when running tests locally after copying the scripts (and binaries) from a mounted Windows share, because doing so automatically sets the executable bit on the scripts. However, we need it now because these scripts will be run as part of the CI process, which doesn't involve directly copying files from Windows shares.