### PR TITLE
Make GC stress tests cross platform

### DIFF
--- a/tests/src/GC/Stress/Framework/RFLogging.cs
+++ b/tests/src/GC/Stress/Framework/RFLogging.cs
@@ -141,12 +141,15 @@ internal class RFLogging
         {
             try
             {
-                string logFilename = logDirectory + "\\instrmentation.log";
+                string logFilename = Path.Combine (logDirectory, "instrmentation.log");
                 while (File.Exists(logFilename))
                 {
-                    logFilename = logDirectory + "\\instrmentation.log-" + DateTime.Now.ToString().Replace('/', '-').Replace(':', '.');
+                    logFilename = Path.Combine (logDirectory, "instrmentation.log-" + DateTime.Now.ToString().Replace('/', '-').Replace(':', '.'));
                 }
 
+                string logDirname = Path.GetDirectoryName (logFilename);
+                if (!Directory.Exists (logDirname))
+                    Directory.CreateDirectory (logDirname);
                 _instrumentationLogFile = File.Open(logFilename, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
             }
             catch
@@ -183,7 +186,7 @@ internal class RFLogging
             {
                 fRetry = false;
 
-                string safeName = logDirectory + "\\" + name.Replace('\\', ' ').Replace('*', ' ').Replace('?', ' ').Replace('>', ' ').Replace('<', ' ').Replace('|', ' ').Replace(':', ' ').Replace('/', ' ').Replace('"', ' ');
+                string safeName = Path.Combine (logDirectory, name.Replace('\\', ' ').Replace('*', ' ').Replace('?', ' ').Replace('>', ' ').Replace('<', ' ').Replace('|', ' ').Replace(':', ' ').Replace('/', ' ').Replace('"', ' '));
                 filename = safeName + ".log";
                 if (File.Exists(filename))
                 {
@@ -191,6 +194,9 @@ internal class RFLogging
                 }
                 try
                 {
+                    string dirname = Path.GetDirectoryName (filename);
+                    if (!Directory.Exists (dirname))
+                        Directory.CreateDirectory (dirname);
                     _logFile = File.Open(filename, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.ReadWrite);
                 }
                 catch (IOException e)

--- a/tests/src/GC/Stress/Framework/ReliabilityConfiguration.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityConfiguration.cs
@@ -1004,13 +1004,13 @@ public class ReliabilityConfig : IEnumerable, IEnumerator
         }
 
 
-        if (basepath.LastIndexOf("\\") == (basepath.Length - 1))
+        if (basepath.LastIndexOf(Path.PathSeparator) == (basepath.Length - 1))
         {
             return (basepath + trimmedPath);
         }
         else
         {
-            return (basepath + "\\" + trimmedPath);
+            return Path.Combine(basepath, trimmedPath);
         }
     }
 

--- a/tests/src/GC/Stress/Framework/ReliabilityFramework.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityFramework.cs
@@ -40,9 +40,9 @@ internal class CustomAssemblyResolver : AssemblyLoadContext
 
         string strBVTRoot = Environment.GetEnvironmentVariable("BVT_ROOT");
         if (String.IsNullOrEmpty(strBVTRoot))
-            strBVTRoot = Directory.GetCurrentDirectory() + "\\Tests";
+            strBVTRoot = Path.Combine(Directory.GetCurrentDirectory(), "Tests");
 
-        string strPath = strBVTRoot + "\\" + assemblyName.Name + ".exe";
+        string strPath = Path.Combine(strBVTRoot, assemblyName.Name + ".exe");
 
         Console.WriteLine("Incoming AssemblyName: {0}\n", assemblyName.ToString());
         Console.WriteLine("Trying to Load: {0}\n", strPath);
@@ -636,9 +636,9 @@ public class ReliabilityFramework
         if (myProcessName == null)
         {
             myProcessName = System.Windows.Forms.Application.ExecutablePath;
-            if (myProcessName.LastIndexOf("\\") != -1)
+            if (myProcessName.LastIndexOf(Path.PathSeparator) != -1)
             {
-                myProcessName = myProcessName.Substring(myProcessName.LastIndexOf("\\") + 1);
+                myProcessName = myProcessName.Substring(myProcessName.LastIndexOf(Path.PathSeparator) + 1);
                 if (myProcessName.LastIndexOf(".") != -1)
                 {
                     myProcessName = myProcessName.Substring(0, myProcessName.LastIndexOf("."));

--- a/tests/src/GC/Stress/Framework/ReliabilityTest.cs
+++ b/tests/src/GC/Stress/Framework/ReliabilityTest.cs
@@ -285,7 +285,7 @@ public class ReliabilityTest
 #if PROJECTK_BUILD
                 string strBVTRoot = Environment.GetEnvironmentVariable("BVT_ROOT");
                 if (String.IsNullOrEmpty(strBVTRoot))
-                    return (Directory.GetCurrentDirectory() + "\\Tests");
+                    return Path.Combine(Directory.GetCurrentDirectory(), "Tests");
                 else
                     return strBVTRoot;
 #else
@@ -295,9 +295,9 @@ public class ReliabilityTest
 
             if (_basePath.Length > 0)
             {
-                if (_basePath[_basePath.Length - 1] != '\\')
+                if (_basePath[_basePath.Length - 1] != Path.PathSeparator)
                 {
-                    _basePath = _basePath + "\\";
+                    _basePath = _basePath + Path.PathSeparator;
                 }
             }
             return (_basePath);
@@ -323,7 +323,7 @@ public class ReliabilityTest
             // first, check the current directory
             string curDir = Directory.GetCurrentDirectory();
             string theAnswer;
-            if (File.Exists(theAnswer = String.Format("{0}\\{1}", curDir, _debugger)))
+            if (File.Exists(theAnswer = Path.Combine (curDir, _debugger)))
             {
                 return (theAnswer);
             }
@@ -338,7 +338,7 @@ public class ReliabilityTest
             string[] splitPath = path.Split(new char[] { ';' });
             foreach (string curPath in splitPath)
             {
-                if (File.Exists(theAnswer = String.Format("{0}\\{1}", curPath, _debugger)))
+                if (File.Exists(theAnswer = Path.Combine (curPath, _debugger)))
                 {
                     return (theAnswer);
                 }


### PR DESCRIPTION
Use .NET provided path facilities, instead of using hardcoded values, such as path separator.