### PR TITLE
Modify Platform ID of Linux NIs (issue #1035)

### DIFF
--- a/src/inc/pedecoder.h
+++ b/src/inc/pedecoder.h
@@ -84,12 +84,24 @@ inline CHECK CheckOverflow(RVA value1, COUNT_T value2)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_I386
 #elif defined(_TARGET_AMD64_)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_AMD64
+#if defined(__LINUX__)
+#define IMAGE_FILE_MACHINE_NATIVE_NI   0x9664
+#elif defined(__APPLE__)
+#define IMAGE_FILE_MACHINE_NATIVE_NI   0xa664
+#elif defined(__FreeBSD__)
+#define IMAGE_FILE_MACHINE_NATIVE_NI   0xb664
+#endif
 #elif defined(_TARGET_ARM_)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_ARMNT
 #elif defined(_TARGET_ARM64_)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_ARM64
 #else
 #error "port me"
+#endif
+
+// Machine code for native images
+#ifndef IMAGE_FILE_MACHINE_NATIVE_NI
+#define IMAGE_FILE_MACHINE_NATIVE_NI IMAGE_FILE_MACHINE_NATIVE
 #endif
 
 // --------------------------------------------------------------------------------

--- a/src/inc/pedecoder.inl
+++ b/src/inc/pedecoder.inl
@@ -962,8 +962,11 @@ inline BOOL PEDecoder::IsNativeMachineFormat() const
     if (!HasContents() || !HasNTHeaders() )
         return FALSE;
     _ASSERTE(m_pNTHeaders);
+    WORD expectedFormat = (HasNativeHeader() || HasReadyToRunHeader()) ?
+        IMAGE_FILE_MACHINE_NATIVE_NI :
+        IMAGE_FILE_MACHINE_NATIVE;
     //do not call GetNTHeaders as we do not want to bother with PE32->PE32+ conversion
-    return m_pNTHeaders->FileHeader.Machine==IMAGE_FILE_MACHINE_NATIVE;
+    return m_pNTHeaders->FileHeader.Machine==expectedFormat;
 }
 
 inline BOOL PEDecoder::IsI386() const

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -3279,7 +3279,7 @@ void DomainAssembly::GetCurrentVersionInfo(CORCOMPILE_VERSION_INFO *pNativeVersi
     // pNativeVersionInfo->wOSMajorVersion = (WORD) osInfo.dwMajorVersion;
     pNativeVersionInfo->wOSMajorVersion = 4;
 
-    pNativeVersionInfo->wMachine = IMAGE_FILE_MACHINE_NATIVE;
+    pNativeVersionInfo->wMachine = IMAGE_FILE_MACHINE_NATIVE_NI;
 
     pNativeVersionInfo->wVersionMajor = VER_MAJORVERSION;
     pNativeVersionInfo->wVersionMinor = VER_MINORVERSION;

--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -2146,7 +2146,7 @@ BOOL RuntimeVerifyNativeImageVersion(const CORCOMPILE_VERSION_INFO *info, Loggab
     // Check processor
     //
 
-    if (info->wMachine != IMAGE_FILE_MACHINE_NATIVE)
+    if (info->wMachine != IMAGE_FILE_MACHINE_NATIVE_NI)
     {
         RuntimeVerifyLog(LL_ERROR, pLogAsm, W("Processor type recorded in native image doesn't match this machine's processor."));
         return FALSE;

--- a/src/zap/zapwriter.h
+++ b/src/zap/zapwriter.h
@@ -330,7 +330,7 @@ class ZapWriter : public IStream
 
     USHORT GetMachine()
     {
-        return IMAGE_FILE_MACHINE_NATIVE;
+        return IMAGE_FILE_MACHINE_NATIVE_NI;
     }
 
     void SaveDosHeader();


### PR DESCRIPTION
Modify the platform IDs embedded in the PE header for native images on Linux and other UNIX platforms, to make them different from the platform ID used on Windows. This makes it easier to detect accidentally using native images from a different platform.