### PR TITLE
Fix putarg_stk for tail call functions.

### DIFF
--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -40,6 +40,7 @@
     void                genMathIntrinsic(GenTreePtr treeNode);
 
     void                genPutArgStk(GenTreePtr treeNode);
+    unsigned            getBaseVarForPutArgStk(GenTreePtr treeNode);
 
 #ifdef FEATURE_SIMD
     instruction         getOpForSIMDIntrinsic(SIMDIntrinsicID intrinsicId, var_types baseType, unsigned *ival = nullptr);
@@ -104,7 +105,7 @@
     void                genConsumeBlockOp(GenTreeBlkOp* blkNode, regNumber dstReg, regNumber srcReg, regNumber sizeReg);
 
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
-    void                genConsumePutArgStk(GenTreePutArgStk* putArgStkNode, regNumber dstReg, regNumber srcReg, regNumber sizeReg);
+    void                genConsumePutStructArgStk(GenTreePutArgStk* putArgStkNode, regNumber dstReg, regNumber srcReg, regNumber sizeReg, unsigned baseVarNum);
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
     void                genConsumeRegs(GenTree* tree);
@@ -131,8 +132,11 @@
     void                genCodeForCpBlkUnroll    (GenTreeCpBlk* cpBlkNode);
 
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
-    void                genCodeForPutArgRepMovs(GenTreePutArgStk* putArgStkNode);
-    void                genCodeForPutArgUnroll(GenTreePutArgStk* putArgStkNode);
+    void                genPutStructArgStk(GenTreePtr treeNode
+                                           FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(unsigned baseVarNum));
+
+    void                genStructPutArgRepMovs(GenTreePutArgStk* putArgStkNode, unsigned baseVarNum);
+    void                genStructPutArgUnroll(GenTreePutArgStk* putArgStkNode, unsigned baseVarNum);
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
     void                genCodeForLoadOffset(instruction ins, emitAttr size, regNumber dst, GenTree* base, unsigned offset);

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3368,6 +3368,12 @@ struct GenTreePutArgStk: public GenTreeUnOp
     }
 #endif // FEATURE_FASTTAILCALL
 
+    unsigned getArgOffset() { return gtSlotNum * TARGET_POINTER_SIZE; }
+
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    unsigned getArgSize() { return gtNumSlots * TARGET_POINTER_SIZE; }
+#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
+
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
     //------------------------------------------------------------------------
     // setGcPointers: Sets the number of references and the layout of the struct object returned by the VM.


### PR DESCRIPTION
For tail calls the stack params should replace the current function arg
space and not be placed in the outgoing argument area.

Done bunch of code cleanup too.