### PR TITLE
Remove redefinition of new and delete in alloc.h

### DIFF
--- a/src/jit/alloc.h
+++ b/src/jit/alloc.h
@@ -31,32 +31,6 @@ inline void DbgDelete(void * ptr)
     (void)ClrFreeInProcessHeap(0, ptr);
 }
 
-// technically we can use these, we just have to insure that
-//  1) we can clean up.  2) we check out of memory conditions
-// Outlawing them is easier, if you need some memory for debug-only
-// stuff, define a special new operator with a dummy arg
-
-#define __OPERATOR_NEW_INLINE 1         // indicate that I have defined these 
-#ifdef _MSC_VER
-static inline void * __cdecl operator new(size_t n)
-{
-    assert(!"use JIT memory allocators");
-    return(0);
-}
-static inline void * __cdecl operator new[](size_t n)
-{
-    assert(!"use JIT memory allocators ");
-    return(0);
-};
-static inline void __cdecl operator delete(void * p)
-{
-    assert(!"use JIT memory allocators ");
-};
-static inline void __cdecl operator delete[](void * p)
-{
-    assert(!"use JIT memory allocators ");
-}
-#endif // _MSC_VER
 #endif // DEBUG
 
 /*****************************************************************************/


### PR DESCRIPTION
VS 2015 RC 1 causes a breaking build with redefining new and delete as
static functions. Removing the static will cause link errors with other
redefined new and delete operators. These functions are redefined to just
assertonly in debug.