### PR TITLE
Fix handling of embedded scopes with multiple exception holders

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6769,11 +6769,9 @@ public:
     // with return value optimization (in CreateHolder).
     void Push();
 
-    // Given the locals stack range find the next holder starting with this one
-    NativeExceptionHolderBase *FindNextHolder(void *frameLowAddress, void *frameHighAddress);
-
-    // Given the locals stack range find the holder
-    static NativeExceptionHolderBase *FindHolder(void *frameLowAddress, void *frameHighAddress);
+    // Given the currentHolder and locals stack range find the next holder starting with this one
+    // To find the first holder, pass nullptr as the currentHolder.
+    static NativeExceptionHolderBase *FindNextHolder(NativeExceptionHolderBase *currentHolder, void *frameLowAddress, void *frameHighAddress);
 };
 
 //

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -321,9 +321,9 @@ NativeExceptionHolderBase::Push()
 }
 
 NativeExceptionHolderBase *
-NativeExceptionHolderBase::FindNextHolder(void *stackLowAddress, void *stackHighAddress)
+NativeExceptionHolderBase::FindNextHolder(NativeExceptionHolderBase *currentHolder, void *stackLowAddress, void *stackHighAddress)
 {
-    NativeExceptionHolderBase *holder = this;
+    NativeExceptionHolderBase *holder = (currentHolder == nullptr) ? t_nativeExceptionHolderHead : currentHolder->m_next;
 
     while (holder != nullptr)
     {
@@ -336,17 +336,6 @@ NativeExceptionHolderBase::FindNextHolder(void *stackLowAddress, void *stackHigh
     }
 
     return nullptr;
-}
-
-NativeExceptionHolderBase *
-NativeExceptionHolderBase::FindHolder(void *stackLowAddress, void *stackHighAddress)
-{
-    NativeExceptionHolderBase *head = t_nativeExceptionHolderHead;
-    if (head == nullptr)
-    {
-        return nullptr;
-    }
-    return head->FindNextHolder(stackLowAddress, stackHighAddress);
 }
 
 #include "seh-unwind.cpp"

--- a/src/vm/clrex.h
+++ b/src/vm/clrex.h
@@ -823,6 +823,10 @@ class EEFileLoadException : public EEException
 #define EX_TRY                                                                                     \
     EX_TRY_CUSTOM(CLRException::HandlerState, (::GetThreadNULLOk()), CLRLastThrownObjectException)
 
+#undef EX_TRY_CPP_ONLY
+#define EX_TRY_CPP_ONLY                                                                             \
+    EX_TRY_CUSTOM_CPP_ONLY(CLRException::HandlerState, (::GetThreadNULLOk()), CLRLastThrownObjectException)
+
 // Faster version with thread, skipping GetThread call
 #define EX_TRY_THREAD(pThread)                                                           \
     EX_TRY_CUSTOM(CLRException::HandlerState, (pThread, CLRException::HandlerState::ThreadIsNotNull), CLRLastThrownObjectException)

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -10105,7 +10105,7 @@ static void ManagedThreadBase_DispatchMiddle(ManagedThreadCallState *pCallState)
     // also invokes SO_INTOLERANT code.
     BEGIN_SO_INTOLERANT_CODE(GetThread());
 
-    EX_TRY
+    EX_TRY_CPP_ONLY
     {
         // During an unwind, we have some cleanup:
         //


### PR DESCRIPTION
During the exception handling pass 1 on Unix, we only find one holder for each
frame. But for the case where there are multiple scopes embedded in each other,
each of them having their own exception holder, this is not correct and we
need to call filters for all holders on such frame, starting from the inner-most
one. This change fixes it.

In addition, it fixes one usage of the EX_CATCH_CPP_ONLY in the src/vm/threads.cpp
where the presence of the exception holder in the EX_TRY is not correct and causes
the exception handler pass 1 to consider the managed exception handled at that place.
The fix is to create a new EX_TRY_CPP_ONLY that doesn't contain the holder and use
it at that place.
In fact, the comment at EX_CATCH_IMPL_CPP_ONLY was suggesting that a separate EX_TRY
clone would be a better solution anyways, since it eliminates one try / catch level
in the EX_CATCH_IMPL_CPP_ONLY.