### PR TITLE
Fix a crossgen assert on Linux

### DIFF
--- a/src/utilcode/sstring_com.cpp
+++ b/src/utilcode/sstring_com.cpp
@@ -39,7 +39,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
 
     HRESULT hr = E_FAIL;
 
-#ifndef FEATURE_UTILCODE_NO_DEPENDENCIES
+#if !defined(FEATURE_UTILCODE_NO_DEPENDENCIES) && !(defined(CROSSGEN_COMPILE) && defined(PLATFORM_UNIX))
     if (pResourceDLL == NULL) 
     {
         pResourceDLL = CCompRC::GetDefaultResourceDll();


### PR DESCRIPTION
Running crossgen on Linux fails due to assert (debug build) or segmentation fault (release build). This provides a workaround to allow crossgen to work in rc1.