### PR TITLE
Fix hardcoded Utilities.IsWindows property

### DIFF
--- a/tests/src/Common/CoreCLRTestLibrary/Utilities.cs
+++ b/tests/src/Common/CoreCLRTestLibrary/Utilities.cs
@@ -76,7 +76,7 @@ namespace TestLibrary
             [SecuritySafeCritical]
             get
             {
-                return true;
+                return Path.DirectorySeparatorChar == '\\';
             }
         }
 


### PR DESCRIPTION
This could probably use the new RuntimeInformation API in the future,
but since this would require touching project.json and bringing in a new
dependency I decided to go with the simple fix for now :)