### PR TITLE
Exit runtest.sh with a failure code if any tests fail

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -247,7 +247,7 @@ function exit_with_error {
     if ((printUsage != 0)); then
         print_usage
     fi
-    exit 1
+    exit $EXIT_CODE_EXCEPTION
 }
 
 # Handle Ctrl-C. We will stop execution and print the results that
@@ -544,6 +544,11 @@ function run_tests_in_directory {
     done
 }
 
+# Exit code constants
+readonly EXIT_CODE_SUCCESS=0       # Script ran normally.
+readonly EXIT_CODE_EXCEPTION=1     # Script exited because something exceptional happened (e.g. bad arguments, Ctrl-C interrupt).
+readonly EXIT_CODE_TEST_FAILURE=2  # Script completed successfully, but one or more tests failed.
+
 # Argument variables
 testRootDir=
 testNativeBinDir=
@@ -561,7 +566,7 @@ do
     case $i in
         -h|--help)
             print_usage
-            exit 0
+            exit $EXIT_CODE_SUCCESS
             ;;
         -v|--verbose)
             verbose=1
@@ -605,7 +610,7 @@ do
         *)
             echo "Unknown switch: $i"
             print_usage
-            exit 0
+            exit $EXIT_CODE_SUCCESS
             ;;
     esac
 done
@@ -617,11 +622,11 @@ fi
 if [ -z "$testRootDir" ]; then
     echo "--testRootDir is required."
     print_usage
-    exit 1
+    exit $EXIT_CODE_EXCEPTION
 fi
 if [ ! -d "$testRootDir" ]; then
     echo "Directory specified by --testRootDir does not exist: $testRootDir"
-    exit 1
+    exit $EXIT_CODE_EXCEPTION
 fi
 
 xunit_output_begin
@@ -651,4 +656,9 @@ finish_remaining_tests
 
 print_results
 xunit_output_end
-exit 0
+
+if ((countFailedTests > 0)); then
+    exit $EXIT_CODE_TEST_FAILURE
+fi
+
+exit $EXIT_CODE_SUCCESS

--- a/tests/src/Loader/regressions/polyrec/Polyrec.csproj
+++ b/tests/src/Loader/regressions/polyrec/Polyrec.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <AssemblyName>polyrec</AssemblyName>
+    <AssemblyName>Polyrec</AssemblyName>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{B50A2D18-32B1-4051-A3E4-B004A6BBBF4D}</ProjectGuid>
     <OutputType>Exe</OutputType>

--- a/tests/src/Regressions/assemblyref/test.csproj
+++ b/tests/src/Regressions/assemblyref/test.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <AssemblyName>Test</AssemblyName>
+    <AssemblyName>test</AssemblyName>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{CDA666E1-9A22-4795-9FBD-3B3FAEB759A4}</ProjectGuid>
     <OutputType>Exe</OutputType>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -75,6 +75,8 @@ JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31746/b31746/b31746.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b37646/b37646/b37646.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b41852/b41852/b41852.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51575/b51575/b51575.sh
+JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b68872/b68872/b68872.sh
 JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b88793/b88793/b88793.sh
 JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b91248/b91248/b91248.sh
 JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748/b409748.sh
+Loader/NativeLibs/FromNativePaths/FromNativePaths.sh

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -11,6 +11,7 @@ JIT/Directed/PREFIX/unaligned/1/arglist/arglist.sh
 JIT/Directed/PREFIX/unaligned/2/arglist/arglist.sh
 JIT/Directed/PREFIX/unaligned/4/arglist/arglist.sh
 JIT/Directed/PREFIX/volatile/1/arglist/arglist.sh
+JIT/Directed/StructABI/StructABI/StructABI.sh
 JIT/Directed/TypedReference/TypedReference/TypedReference.sh
 JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_ref/_il_dbgi_ref.sh
 JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_ref/_il_dbgu_ref.sh


### PR DESCRIPTION
This script was previously exiting with '0' regardless of whether there were any test failures. Changing this allows the status of the CI runs in Jenkins to reflect whether the tests actually passed.

/cc: @mmitche 