### PR TITLE
Adjust platform IDs for Unix NIs

### DIFF
--- a/src/inc/pedecoder.h
+++ b/src/inc/pedecoder.h
@@ -84,13 +84,6 @@ inline CHECK CheckOverflow(RVA value1, COUNT_T value2)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_I386
 #elif defined(_TARGET_AMD64_)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_AMD64
-#if defined(__LINUX__)
-#define IMAGE_FILE_MACHINE_NATIVE_NI   0x9664
-#elif defined(__APPLE__)
-#define IMAGE_FILE_MACHINE_NATIVE_NI   0xa664
-#elif defined(__FreeBSD__)
-#define IMAGE_FILE_MACHINE_NATIVE_NI   0xb664
-#endif
 #elif defined(_TARGET_ARM_)
 #define IMAGE_FILE_MACHINE_NATIVE   IMAGE_FILE_MACHINE_ARMNT
 #elif defined(_TARGET_ARM64_)
@@ -100,9 +93,17 @@ inline CHECK CheckOverflow(RVA value1, COUNT_T value2)
 #endif
 
 // Machine code for native images
-#ifndef IMAGE_FILE_MACHINE_NATIVE_NI
-#define IMAGE_FILE_MACHINE_NATIVE_NI IMAGE_FILE_MACHINE_NATIVE
+#if defined(__LINUX__)
+#define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0x7B79
+#elif defined(__APPLE__)
+#define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0x4644
+#elif defined(__FreeBSD__)
+#define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0xADC4
+#else
+#define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0
 #endif
+
+#define IMAGE_FILE_MACHINE_NATIVE_NI (IMAGE_FILE_MACHINE_NATIVE ^ IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE)
 
 // --------------------------------------------------------------------------------
 // Types


### PR DESCRIPTION
Previous change for native image platform IDs only works on x64 architecture.
Adjusted the code to work on all architectures.