### PR TITLE
Clean up PAL File functions

### DIFF
--- a/src/pal/src/cruntime/filecrt.cpp
+++ b/src/pal/src/cruntime/filecrt.cpp
@@ -153,7 +153,7 @@ PAL_fflush( PAL_FILE *stream )
     PERF_ENTRY(fflush);
     ENTRY( "fflush( %p )\n", stream );
 
-    nRetVal = InternalFflush(stream ? stream->bsdFilePtr : NULL);
+    nRetVal = fflush(stream ? stream->bsdFilePtr : NULL);
 
     LOGEXIT( "fflush returning %d\n", nRetVal );
     PERF_EXIT(fflush);
@@ -162,35 +162,9 @@ PAL_fflush( PAL_FILE *stream )
 
 
 /*++
-Function:
-    InternalFflush
-
-Wrapper for fflush. If stream points to an output stream or an
-update stream, fflush causes any unwritten data for that stream 
-to be written to the file.
-
-InternalFflush is called in DBG_printf_gcc and DBG_printf_c99, 
-in dbgmsg.cpp. We can do this since InternalFflush doesn't use 
-ENTRY/LOGEXIT macros, which would cause a recursion otherwise.
-
-fflush takes an internal lock so the thread calling it
-should not be suspended while inside it.
---*/
-int
-CorUnix::InternalFflush(
-    FILE *stream
-    )
-{
-    int nRet = 0;
-    nRet = fflush(stream);
-    return nRet;
-}
-
-
-/*++
 PAL__getcwd
 
-Wrapper function for InternalGetcwd.
+Wrapper function for getcwd.
 
 Input parameters:
 
@@ -208,44 +182,7 @@ PAL__getcwd(
     size_t nSize
     )
 {
-    return InternalGetcwd(szBuf, nSize);
-}
-
-
-/*++
-InternalGetcwd
-
-Wrapper for getcwd. getcwd returns a pointer to the current directory pathname. 
-getcwd invokes malloc when szBuf is NULL to allocate space to store the path name.
-
-Input parameters:
-
-szBuf = a copy of the absolute pathname of the current working directory
-is copied into szBuf.
-nSize = size, in bytes, of the array referenced by szBuf.
-
-Return value:
-    A pointer to the pathname if successful, otherwise NULL is returned 
-    and errno is set.
---*/
-char *
-CorUnix::InternalGetcwd(
-    char *szBuf,
-    size_t nSize
-    )
-{
-    char *szBufCopy;
-    if (szBuf == NULL)
-    {
-        // malloc is used to allocate space to store the pathname when szBuf is NULL.
-        szBufCopy = (char *)getcwd(szBuf, nSize);
-    }
-    else
-    {
-        szBufCopy = (char *)getcwd(szBuf, nSize);
-    }
-    
-    return szBufCopy;
+    return (char *)getcwd(szBuf, nSize);
 }
 
 
@@ -378,7 +315,7 @@ CorUnix::InternalOpen(
 /*++
 PAL_unlink
 
-Wrapper function for InternalUnlink.
+Wrapper function for unlink.
 
 Input parameters:
 
@@ -391,36 +328,14 @@ int
 __cdecl
 PAL_unlink(const char *szPath)
 {
-    return InternalUnlink(szPath);
-}
-
-/*++
-InternalUnlink
-
-Wrapper for unlink.
-
-Input parameters:
-
-szPath = a symbolic link or a hard link to a file
-
-Return value:
-    Returns 0 on success and -1 on failure
---*/
-int
-CorUnix::InternalUnlink(
-    const char *szPath
-    )
-{
-    int nRet = -1;
-    nRet = unlink(szPath);
-    return nRet;
+    return unlink(szPath);
 }
 
 
 /*++
 InternalDeleteFile
 
-Wrapper that does the same thing as InternalUnlink, except that
+Wrapper that does the same thing as unlink, except that
 it uses the SYS_Delete system call present on Apple instead of unlink.
 
 Input parameters:
@@ -448,7 +363,7 @@ CorUnix::InternalDeleteFile(
 /*++
 PAL_rename
 
-Wrapper function for InternalRename.
+Wrapper function for rename.
 
 Input parameters:
 
@@ -465,32 +380,9 @@ PAL_rename(
     const char *szNewName
     )
 {
-    return InternalRename(szOldName, szNewName);
+    return rename(szOldName, szNewName);
 }
 
-/*++
-InternalRename
-
-Wrapper for rename.
-
-Input parameters:
-
-szOldName = pointer to the pathname of the file to be renamed
-szNewName = pointer to the new pathname of the file
-
-Return value:
-    Returns 0 on success and -1 on failure
---*/
-int
-CorUnix::InternalRename(
-    const char *szOldName, 
-    const char *szNewName
-    )
-{
-    int nRet = -1;
-    nRet = rename(szOldName, szNewName);
-    return nRet;
-}
 
 /*++
 PAL_fgets
@@ -696,7 +588,7 @@ CorUnix::InternalFwrite(
 /*++
 PAL_fseek
 
-Wrapper function for InternalFseek.
+Wrapper function for fseek.
 
 Input parameters:
 
@@ -720,37 +612,9 @@ PAL_fseek(
     PERF_ENTRY(fseek);
     ENTRY( "fseek( %p, %ld, %d )\n", pf, lOffset, nWhence );
 
-    nRet = InternalFseek(pf ? pf->bsdFilePtr : NULL, lOffset, nWhence);
+    nRet = fseek(pf ? pf->bsdFilePtr : NULL, lOffset, nWhence);
 
     LOGEXIT("fseek returning %d\n", nRet);
     PERF_EXIT(fseek);
-    return nRet;
-}
-
-/*++
-InternalFseek
-
-Wrapper for fseek.
-
-Input parameters:
-
-f = a given file stream
-lOffset = distance from position to set file-position indicator
-nWhence = method used to determine the file_position indicator location relative to lOffset
-
-Return value:
-    0 on success, -1 on failure.
---*/
-int
-CorUnix::InternalFseek(
-    FILE *f,
-    long lOffset,
-    int nWhence
-    )
-{
-    int nRet = -1;
-    _ASSERTE(f != NULL);
-    
-    nRet = fseek(f, lOffset, nWhence);
     return nRet;
 }

--- a/src/pal/src/cruntime/printfcpp.cpp
+++ b/src/pal/src/cruntime/printfcpp.cpp
@@ -84,7 +84,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
             InternalFree(newBuff);
             return -1;
         }
-        ret = InternalFwrite(pthrCurrent, newBuff, 1, count, stream, &iError);
+        ret = InternalFwrite(newBuff, 1, count, stream, &iError);
         if (iError != 0)
         {
             ERROR("InternalFwrite did not write the whole buffer. Error is %d\n", iError);
@@ -95,7 +95,7 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
    }
    else
    {
-        ret = InternalFwrite(pthrCurrent, buffer, size, count, stream, &iError);
+        ret = InternalFwrite(buffer, size, count, stream, &iError);
         if (iError != 0)
         {
             ERROR("InternalFwrite did not write the whole buffer. Error is %d\n", iError);
@@ -941,7 +941,7 @@ INT Internal_AddPaddingVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, LPSTR
     clearerr (stream->bsdFilePtr);
 #endif
     
-    Written = InternalFwrite(pthrCurrent, OutOriginal, 1, Length, stream->bsdFilePtr, &stream->PALferrorCode);
+    Written = InternalFwrite(OutOriginal, 1, Length, stream->bsdFilePtr, &stream->PALferrorCode);
     if (stream->PALferrorCode == PAL_FILE_ERROR)
     {
         ERROR("fwrite() failed with errno == %d\n", errno);
@@ -2542,7 +2542,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
             clearerr (stream->bsdFilePtr);
 #endif
 
-            InternalFwrite(pthrCurrent, Fmt++, 1, 1, stream->bsdFilePtr, &stream->PALferrorCode); /* copy regular chars into buffer */
+            InternalFwrite(Fmt++, 1, 1, stream->bsdFilePtr, &stream->PALferrorCode); /* copy regular chars into buffer */
             if (stream->PALferrorCode == PAL_FILE_ERROR)
             {
                 ERROR("fwrite() failed with errno == %d\n", errno);

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -682,7 +682,7 @@ ReadProcessMemory(
 #else   // HAVE_VM_READ
 #if HAVE_PROCFS_CTL
     snprintf(memPath, sizeof(memPath), "/proc/%u/%s", processId, PROCFS_MEM_NAME);
-    fd = InternalOpen(pThread, memPath, O_RDONLY);
+    fd = InternalOpen(memPath, O_RDONLY);
     if (fd == -1)
     {
         ERROR("Failed to open %s\n", memPath);
@@ -957,7 +957,7 @@ WriteProcessMemory(
 #else   // HAVE_VM_READ
 #if HAVE_PROCFS_CTL
     snprintf(memPath, sizeof(memPath), "/proc/%u/%s", processId, PROCFS_MEM_NAME);
-    fd = InternalOpen(pThread, memPath, O_WRONLY);
+    fd = InternalOpen(memPath, O_WRONLY);
     if (fd == -1)
     {
         ERROR("Failed to open %s\n", memPath);
@@ -1280,7 +1280,7 @@ DBGAttachProcess(
         nanosleep(&waitTime, NULL);
         
         sprintf_s(ctlPath, sizeof(ctlPath), "/proc/%d/ctl", processId);
-        fd = InternalOpen(pThread, ctlPath, O_WRONLY);
+        fd = InternalOpen(ctlPath, O_WRONLY);
         if (fd == -1)
         {
             ERROR("Failed to open %s: errno is %d (%s)\n", ctlPath,

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -284,9 +284,9 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD c
         char pszCwdBuffer[MAXPATHLEN+1]; // MAXPATHLEN is for getcwd()
         DWORD cchCwdBuffer = sizeof(pszCwdBuffer)/sizeof(pszCwdBuffer[0]);
 
-        if (InternalGetcwd(pszCwdBuffer, cchCwdBuffer) == NULL)
+        if (getcwd(pszCwdBuffer, cchCwdBuffer) == NULL)
         {
-            WARN("InternalGetcwd(NULL) failed with error %d\n", errno);
+            WARN("getcwd(NULL) failed with error %d\n", errno);
             palError = DIRGetLastErrorFromErrno();
             goto LExit;
         }
@@ -842,7 +842,7 @@ done:
         }
         if (bFileCreated)
         {
-            if (-1 == InternalUnlink(lpUnixPath))
+            if (-1 == unlink(lpUnixPath))
             {
                 WARN("can't delete file; unlink() failed with errno %d (%s)\n",
                      errno, strerror(errno));
@@ -1243,10 +1243,10 @@ DeleteFileA(
     //   Instead, we call unlink which will succeed.
 
     if (palError == NO_ERROR &&
-	dwShareMode != SHARE_MODE_NOT_INITALIZED &&
-	(dwShareMode & FILE_SHARE_DELETE) != 0)
+    dwShareMode != SHARE_MODE_NOT_INITALIZED &&
+    (dwShareMode & FILE_SHARE_DELETE) != 0)
     {
-      result = InternalUnlink( lpFullUnixFileName );
+      result = unlink( lpFullUnixFileName );
     }
     else
     {
@@ -1497,7 +1497,7 @@ MoveFileExA(
         }
     }
 
-    result = InternalRename( source, dest );
+    result = rename( source, dest );
     if ((result < 0) && (dwFlags & MOVEFILE_REPLACE_EXISTING) &&
         ((errno == ENOTDIR) || (errno == EEXIST)))
     {
@@ -1505,7 +1505,7 @@ MoveFileExA(
         
         if ( bRet ) 
         {
-            result = InternalRename( source, dest );
+            result = rename( source, dest );
         }
         else
         { 

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -246,12 +246,12 @@ InternalCanonicalizeRealPath
     realpath() requires the buffer to be atleast PATH_MAX).
 --*/
 PAL_ERROR
-CorUnix::InternalCanonicalizeRealPath(CPalThread *pThread, LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD cch)
+CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD cch)
 {
     PAL_ERROR palError = NO_ERROR;
     LPSTR lpRealPath = NULL;
 
-#if !REALPATH_SUPPORTS_NONEXISTENT_FILES    
+#if !REALPATH_SUPPORTS_NONEXISTENT_FILES
     LPSTR lpExistingPath = NULL;
     LPSTR pchSeparator = NULL;
     LPSTR lpFilename = NULL;
@@ -284,7 +284,7 @@ CorUnix::InternalCanonicalizeRealPath(CPalThread *pThread, LPCSTR lpUnixPath, LP
         char pszCwdBuffer[MAXPATHLEN+1]; // MAXPATHLEN is for getcwd()
         DWORD cchCwdBuffer = sizeof(pszCwdBuffer)/sizeof(pszCwdBuffer[0]);
 
-        if (InternalGetcwd(pThread, pszCwdBuffer, cchCwdBuffer) == NULL)
+        if (InternalGetcwd(pszCwdBuffer, cchCwdBuffer) == NULL)
         {
             WARN("InternalGetcwd(NULL) failed with error %d\n", errno);
             palError = DIRGetLastErrorFromErrno();
@@ -484,8 +484,8 @@ CorUnix::InternalCreateFile(
 
     const char* szNonfilePrefix = "\\\\.\\";
     LPSTR lpFullUnixPath = NULL;
-    DWORD cchFullUnixPath = PATH_MAX+1;// InternalCanonicalizeRealPath requires this to be atleast PATH_MAX
-    
+    DWORD cchFullUnixPath = PATH_MAX+1; // InternalCanonicalizeRealPath requires this to be atleast PATH_MAX
+
     /* for dwShareMode only three flags are accepted */
     if ( dwShareMode & ~(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE) )
     {
@@ -539,7 +539,7 @@ CorUnix::InternalCreateFile(
 
     // Compute the absolute pathname to the file.  This pathname is used
     // to determine if two file names represent the same file.
-    palError = InternalCanonicalizeRealPath(pThread, lpUnixPath, lpFullUnixPath, cchFullUnixPath);
+    palError = InternalCanonicalizeRealPath(lpUnixPath, lpFullUnixPath, cchFullUnixPath);
     if (palError != NO_ERROR)
     {
         goto done;
@@ -692,7 +692,7 @@ CorUnix::InternalCreateFile(
         TRACE("I/O will be buffered\n");
     }
 
-    filed = InternalOpen(pThread, lpUnixPath, open_flags, create_flags);
+    filed = InternalOpen(lpUnixPath, open_flags, create_flags);
     TRACE("Allocated file descriptor [%d]\n", filed);
 
     if ( filed < 0 )
@@ -842,7 +842,7 @@ done:
         }
         if (bFileCreated)
         {
-            if (-1 == InternalUnlink(pThread, lpUnixPath))
+            if (-1 == InternalUnlink(lpUnixPath))
             {
                 WARN("can't delete file; unlink() failed with errno %d (%s)\n",
                      errno, strerror(errno));
@@ -1216,7 +1216,7 @@ DeleteFileA(
     
     // Compute the absolute pathname to the file.  This pathname is used
     // to determine if two file names represent the same file.
-    palError = InternalCanonicalizeRealPath(pThread, lpUnixFileName, lpFullUnixFileName, cchFullUnixFileName);
+    palError = InternalCanonicalizeRealPath(lpUnixFileName, lpFullUnixFileName, cchFullUnixFileName);
     if (palError != NO_ERROR)
     {
         InternalFree(lpFullUnixFileName);
@@ -1246,11 +1246,11 @@ DeleteFileA(
 	dwShareMode != SHARE_MODE_NOT_INITALIZED &&
 	(dwShareMode & FILE_SHARE_DELETE) != 0)
     {
-      result = InternalUnlink( pThread, lpFullUnixFileName );
+      result = InternalUnlink( lpFullUnixFileName );
     }
     else
     {
-      result = InternalDeleteFile( pThread, lpFullUnixFileName );
+      result = InternalDeleteFile( lpFullUnixFileName );
     }
 
     if ( result < 0 )
@@ -1497,7 +1497,7 @@ MoveFileExA(
         }
     }
 
-    result = InternalRename( pThread, source, dest );
+    result = InternalRename( source, dest );
     if ((result < 0) && (dwFlags & MOVEFILE_REPLACE_EXISTING) &&
         ((errno == ENOTDIR) || (errno == EEXIST)))
     {
@@ -1505,7 +1505,7 @@ MoveFileExA(
         
         if ( bRet ) 
         {
-            result = InternalRename( pThread, source, dest );
+            result = InternalRename( source, dest );
         }
         else
         { 

--- a/src/pal/src/include/pal/file.h
+++ b/src/pal/src/include/pal/file.h
@@ -189,8 +189,7 @@ void FILEGetProperNotFoundError( LPSTR lpPath, LPDWORD lpErrorCode );
 /*++
 PAL__getcwd
 
-Calls InternalGetcwd to call getcwd with a thread that is marked
-as suspension unsafe.
+Calls getcwd
 
 Input parameters:
 
@@ -206,8 +205,7 @@ char * __cdecl PAL__getcwd(char *szBuf, size_t nSize);
 /*++
 PAL_fflush
 
-Calls InternalFflush to call fflush with a thread that is marked
-as suspension unsafe.
+Calls fflush
 
 Input parameters:
 
@@ -235,8 +233,7 @@ int __cdecl PAL_mkstemp(char *szNameTemplate);
 /*++
 PAL_unlink
 
-Calls InternalUnlink to call unlink with a thread that is marked
-as suspension unsafe. 
+Calls unlink. 
 
 Input parameters:
 
@@ -250,8 +247,7 @@ int __cdecl PAL_unlink(const char *szPath);
 /*++
 PAL_rename
 
-Calls InternalRename to call rename with a thread that is marked
-as suspension unsafe. 
+Calls rename
 
 Input parameters:
 
@@ -316,7 +312,7 @@ int __cdecl PAL__open(const char *szPath, int nFlags, ...);
 /*++
 PAL_fseek
 
-Wrapper function for InternalFseek
+Wrapper function for fseek
 
 Input parameters:
 

--- a/src/pal/src/include/pal/file.h
+++ b/src/pal/src/include/pal/file.h
@@ -221,8 +221,7 @@ int _cdecl PAL_fflush( PAL_FILE *stream );
 /*++
 PAL_mkstemp
     
-Calls InternalMkstemp to call mkstemp with a thread that is marked
-as suspension unsafe. 
+Calls InternalMkstemp to call mkstemp
 
 Input parameters:
 

--- a/src/pal/src/include/pal/file.hpp
+++ b/src/pal/src/include/pal/file.hpp
@@ -42,11 +42,11 @@ namespace CorUnix
 
         int  unix_fd;
         DWORD dwDesiredAccess; /* Unix assumes files are always opened for reading.
-                                  In Windows we can open a file for writing only */                             
+                                  In Windows we can open a file for writing only */
         int  open_flags;       /* stores Unix file creation flags */
         BOOL open_flags_deviceaccessonly;
         char unix_filename[MAXPATHLEN];
-        BOOL inheritable;        
+        BOOL inheritable;
     };
 
     PAL_ERROR
@@ -180,82 +180,73 @@ namespace CorUnix
       --*/
     PAL_ERROR
     InternalCanonicalizeRealPath(
-        CPalThread *pThread,
         LPCSTR lpUnixPath,
         LPSTR lpBuffer,
         DWORD cch
-        );  
+        );
 
     /*++
-    InternalGetcwd     
-    Wraps getcwd so the thread calling it can't be suspended holding an internal lock.
+    InternalGetcwd
+    Wraps getcwd
     --*/
     char *
     InternalGetcwd(
-        CPalThread *pthrCurrent,
         char *szBuf,
         size_t nSize
         );
 
     /*++
-    InternalFflush    
-    Wraps fflush so the thread calling it can't be suspended holding an internal lock.
+    InternalFflush
+    Wraps fflush
     --*/
     int
     InternalFflush(
-        CPalThread *pthrCurrent,
         FILE * stream
         );
 
     /*++
-    InternalMkstemp     
-    Wraps mkstemp so the thread calling it can't be suspended holding an internal lock.
+    InternalMkstemp
+    Wraps mkstemp
     --*/
     int 
     InternalMkstemp(
-        CPalThread *pthrCurrent,
         char *szNameTemplate
         );
 
     /*++
     InternalUnlink
-    Wraps unlink so the thread calling it can't be suspended holding an internal lock.
+    Wraps unlink
     --*/
     int
     InternalUnlink(
-        CPalThread *pthrCurrent,
         const char *szPath
         );
 
-
     /*++
     InternalDeleteFile
-    Wraps SYS_delete so the thread calling it can't be suspended holding an internal lock.
+    Wraps SYS_delete
     --*/
     int 
     InternalDeleteFile(
-        CPalThread *pthrCurrent,
         const char *szPath
         );
 
     /*++
     InternalRename
-    Wraps rename so the thread calling it can't be suspended holding an internal lock.
+    Wraps rename
     --*/
     int 
     InternalRename(
-        CPalThread *pthrCurrent, 
         const char *szOldName, 
         const char *szNewName
         );
 
     /*++
     InternalFgets
-    Wraps fgets so the thread calling it can't be suspended holding an internal lock.
+    Wraps fgets
     --*/
     char *
     InternalFgets(
-        CPalThread *pthrCurrent,
         char *sz,
         int nSize,
         FILE *f,
@@ -264,25 +255,23 @@ namespace CorUnix
 
     /*++
     InternalFwrite
-    Wraps fwrite so the thread calling it can't be suspended holding an internal lock.
+    Wraps fwrite
     --*/
     size_t
     InternalFwrite(
-        CPalThread *pthrCurrent,
-        const void *pvBuffer, 
-        size_t nSize, 
-        size_t nCount,     
+        const void *pvBuffer,
+        size_t nSize,
+        size_t nCount,
         FILE *f,
         INT *pnErrorCode
         );
 
     /*++
     InternalOpen
-    Wraps open so the thread calling it can't be suspended holding an internal lock.
+    Wraps open
     --*/
     int
     InternalOpen(
-        CPalThread *pthrCurrent,
         const char *szFilename,
         int nFlags,
         ...
@@ -290,11 +279,10 @@ namespace CorUnix
 
     /*++
     InternalFseek
-    Wraps fseek so the thread calling it can't be suspended holding an internal lock.
+    Wraps fseek
     --*/
     int
     InternalFseek(
-        CPalThread *pthrCurrent,
         FILE *f,
         long lOffset,
         int nWhence

--- a/src/pal/src/include/pal/file.hpp
+++ b/src/pal/src/include/pal/file.hpp
@@ -186,25 +186,6 @@ namespace CorUnix
         );
 
     /*++
-    InternalGetcwd
-    Wraps getcwd
-    --*/
-    char *
-    InternalGetcwd(
-        char *szBuf,
-        size_t nSize
-        );
-
-    /*++
-    InternalFflush
-    Wraps fflush
-    --*/
-    int
-    InternalFflush(
-        FILE * stream
-        );
-
-    /*++
     InternalMkstemp
     Wraps mkstemp
     --*/
@@ -214,31 +195,12 @@ namespace CorUnix
         );
 
     /*++
-    InternalUnlink
-    Wraps unlink
-    --*/
-    int
-    InternalUnlink(
-        const char *szPath
-        );
-
-    /*++
     InternalDeleteFile
     Wraps SYS_delete
     --*/
     int 
     InternalDeleteFile(
         const char *szPath
-        );
-
-    /*++
-    InternalRename
-    Wraps rename
-    --*/
-    int 
-    InternalRename(
-        const char *szOldName, 
-        const char *szNewName
         );
 
     /*++
@@ -275,17 +237,6 @@ namespace CorUnix
         const char *szFilename,
         int nFlags,
         ...
-        );
-
-    /*++
-    InternalFseek
-    Wraps fseek
-    --*/
-    int
-    InternalFseek(
-        FILE *f,
-        long lOffset,
-        int nWhence
         );
 }
 

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -179,7 +179,7 @@ FileMappingCleanupRoutine(
 
         if (pImmutableData->bPALCreatedTempFile)
         {
-            InternalUnlink(pThread, pImmutableData->szFileName);
+            InternalUnlink(pImmutableData->szFileName);
         }
     }
 
@@ -240,7 +240,6 @@ FileMappingInitializationRoutine(
         reinterpret_cast<CFileMappingProcessLocalData *>(pvProcessLocalData);
 
     pProcessLocalData->UnixFd = InternalOpen(
-        pThread,
         pImmutableData->szFileName,
         MAPProtectionToFileOpenFlags(pImmutableData->flProtect)
         );
@@ -506,7 +505,7 @@ CorUnix::InternalCreateFileMapping(
 
 #if HAVE_MMAP_DEV_ZERO
 
-        UnixFd = InternalOpen(pThread, pImmutableData->szFileName, O_RDWR);
+        UnixFd = InternalOpen(pImmutableData->szFileName, O_RDWR);
         if ( -1 == UnixFd )
         {
             ERROR( "Unable to open the file.\n");
@@ -767,7 +766,7 @@ ExitInternalCreateFileMapping:
 
         if (bPALCreatedTempFile)
         {
-            InternalUnlink(pThread, pImmutableData->szFileName);
+            InternalUnlink(pImmutableData->szFileName);
         }
 
         if (-1 != UnixFd)
@@ -784,9 +783,9 @@ ExitInternalCreateFileMapping:
     if (NULL != pFileObject)
     {
         pFileObject->ReleaseReference(pThread);
-    }  
+    }
 
-    return palError;    
+    return palError;
 }
 
 /*++

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -179,7 +179,7 @@ FileMappingCleanupRoutine(
 
         if (pImmutableData->bPALCreatedTempFile)
         {
-            InternalUnlink(pImmutableData->szFileName);
+            unlink(pImmutableData->szFileName);
         }
     }
 
@@ -766,7 +766,7 @@ ExitInternalCreateFileMapping:
 
         if (bPALCreatedTempFile)
         {
-            InternalUnlink(pImmutableData->szFileName);
+            unlink(pImmutableData->szFileName);
         }
 
         if (-1 != UnixFd)

--- a/src/pal/src/misc/dbgmsg.cpp
+++ b/src/pal/src/misc/dbgmsg.cpp
@@ -550,7 +550,7 @@ int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
     /* Can call InternalFflush since InternalFflush does not have ENTRY/LOGEXIT 
     macros. If that changes, then this will need to be switched back to calling the 
     cruntime fflush with some other protection from suspension. */    
-    if (InternalFflush(pthrCurrent, output_file) != 0)
+    if (InternalFflush(output_file) != 0)
     {
         fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n", 
                 errno, strerror(errno));
@@ -661,7 +661,7 @@ int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
         ENTRY/LOGEXIT macros. If that changes, then this will need
         to be switched back to calling the cruntime fflush with some 
         other protection from suspension. */
-        if (InternalFflush(pthrCurrent, output_file) != 0)
+        if (InternalFflush(output_file) != 0)
         {
             fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n", 
                    errno, strerror(errno));

--- a/src/pal/src/misc/dbgmsg.cpp
+++ b/src/pal/src/misc/dbgmsg.cpp
@@ -547,17 +547,14 @@ int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
     InternalLeaveCriticalSection(pthrCurrent, &fprintf_crit_section);
 
     /* flush the output to file */
-    /* Can call InternalFflush since InternalFflush does not have ENTRY/LOGEXIT 
-    macros. If that changes, then this will need to be switched back to calling the 
-    cruntime fflush with some other protection from suspension. */    
-    if (InternalFflush(output_file) != 0)
+    if ( fflush(output_file) != 0 )
     {
         fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n", 
                 errno, strerror(errno));
     }
 
     // Some systems support displaying a GUI dialog. We attempt this only for asserts.
-    if (level == DLI_ASSERT)
+    if ( level == DLI_ASSERT )
         PAL_DisplayDialog("PAL ASSERT", buffer);
 
     if ( old_errno != errno )
@@ -657,11 +654,7 @@ int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
     if(call_count>5)
     {
         call_count=0;
-        /* Can call InternalFflush since InternalFflush does not have
-        ENTRY/LOGEXIT macros. If that changes, then this will need
-        to be switched back to calling the cruntime fflush with some 
-        other protection from suspension. */
-        if (InternalFflush(output_file) != 0)
+        if ( fflush(output_file) != 0 )
         {
             fprintf(stderr, "ERROR : fflush() failed errno:%d (%s)\n", 
                    errno, strerror(errno));

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -2899,7 +2899,7 @@ namespace CorUnix
 
         _ASSERT_MSG(fRet, "Failed to retrieve process pipe's name!\n");
 
-        iProcessPipe = InternalOpen(pthrCurrent, strPipeFilename, O_WRONLY);
+        iProcessPipe = InternalOpen(strPipeFilename, O_WRONLY);
         if (-1 == iProcessPipe)
         {
             ERROR("Unable to open a process pipe to wake up a remote thread "
@@ -3778,7 +3778,7 @@ namespace CorUnix
             {
                 /* Some how no one deleted the pipe, perhaps it was left behind
                 from a crash?? Delete the pipe and try again. */
-                if ( -1 == InternalUnlink( pthrCurrent, szPipeFilename ) )
+                if ( -1 == InternalUnlink( szPipeFilename ) )
                 {
                     ERROR( "Unable to delete the process pipe that was left behind.\n" );
                     fRet = false;
@@ -3802,7 +3802,7 @@ namespace CorUnix
             }
         }
 
-        iPipeRd = InternalOpen(pthrCurrent, szPipeFilename, O_RDONLY | O_NONBLOCK);
+        iPipeRd = InternalOpen(szPipeFilename, O_RDONLY | O_NONBLOCK);
         if (iPipeRd == -1)
         {
             ERROR("Unable to open the process pipe for read\n");
@@ -3810,7 +3810,7 @@ namespace CorUnix
             goto CPP_exit;
         }
 
-        iPipeWr = InternalOpen(pthrCurrent, szPipeFilename, O_WRONLY | O_NONBLOCK);
+        iPipeWr = InternalOpen(szPipeFilename, O_WRONLY | O_NONBLOCK);
         if (iPipeWr == -1)
         {
             ERROR("Unable to open the process pipe for write\n");
@@ -3858,7 +3858,7 @@ namespace CorUnix
             // Failed
             if (0 != szPipeFilename[0])
             {
-                InternalUnlink(pthrCurrent, szPipeFilename);
+                InternalUnlink(szPipeFilename);
             }
             if (-1 != iPipeRd)
             {
@@ -3907,7 +3907,7 @@ namespace CorUnix
 
         if(GetProcessPipeName(szPipeFilename, MAX_PATH, gPID))
         {
-            if (InternalUnlink(pthrCurrent, szPipeFilename) == -1)
+            if (InternalUnlink(szPipeFilename) == -1)
             {
                 ERROR("Unable to unlink the pipe file name errno=%d (%s)\n", 
                       errno, strerror(errno));

--- a/src/pal/src/synchmgr/synchmanager.cpp
+++ b/src/pal/src/synchmgr/synchmanager.cpp
@@ -3778,7 +3778,7 @@ namespace CorUnix
             {
                 /* Some how no one deleted the pipe, perhaps it was left behind
                 from a crash?? Delete the pipe and try again. */
-                if ( -1 == InternalUnlink( szPipeFilename ) )
+                if ( -1 == unlink( szPipeFilename ) )
                 {
                     ERROR( "Unable to delete the process pipe that was left behind.\n" );
                     fRet = false;
@@ -3858,7 +3858,7 @@ namespace CorUnix
             // Failed
             if (0 != szPipeFilename[0])
             {
-                InternalUnlink(szPipeFilename);
+                unlink(szPipeFilename);
             }
             if (-1 != iPipeRd)
             {
@@ -3901,13 +3901,13 @@ namespace CorUnix
     PAL_ERROR CPalSynchronizationManager::ShutdownProcessPipe(
         CPalThread *pthrCurrent)
     {
-        PAL_ERROR palErr = NO_ERROR;        
+        PAL_ERROR palErr = NO_ERROR;
 #ifndef CORECLR
         char szPipeFilename[MAX_PATH];
 
         if(GetProcessPipeName(szPipeFilename, MAX_PATH, gPID))
         {
-            if (InternalUnlink(szPipeFilename) == -1)
+            if (unlink(szPipeFilename) == -1)
             {
                 ERROR("Unable to unlink the pipe file name errno=%d (%s)\n", 
                       errno, strerror(errno));


### PR DESCRIPTION
This change removes the unused thread parameter from file-related functions in PAL, which (as in #1930) should improve performance because we will need to call `GetCurrentThread` in fewer places. 

I also removed `InternalFflush`, `InternalGetCwd`, `InternalUnlink`, and `InternalFseek` since they no longer do anything other than call the functions they wrap.