### PR TITLE
Improve crossgen error when mscorlib is missing (issue 1889)

### DIFF
--- a/src/utilcode/ccomprc.cpp
+++ b/src/utilcode/ccomprc.cpp
@@ -335,11 +335,15 @@ HRESULT CCompRC::Init(LPCWSTR pResourceFile, BOOL bUseFallback)
         _ASSERTE(!"Unsupported resource file");
     }
 
+#ifndef CROSSGEN_COMPILE
+    // PAL_BindResources requires that libcoreclr.so has been loaded,
+    // and thus can'be be called by crossgen.
     if (!PAL_BindResources(m_pResourceDomain))
     {
         // The function can fail only due to OOM
         return E_OUTOFMEMORY;
     }
+#endif
 
 #endif // FEATURE_PAL
 

--- a/src/utilcode/sstring_com.cpp
+++ b/src/utilcode/sstring_com.cpp
@@ -39,7 +39,7 @@ HRESULT SString::LoadResourceAndReturnHR(CCompRC* pResourceDLL, CCompRC::Resourc
 
     HRESULT hr = E_FAIL;
 
-#if !defined(FEATURE_UTILCODE_NO_DEPENDENCIES) && !(defined(CROSSGEN_COMPILE) && defined(PLATFORM_UNIX))
+#ifndef FEATURE_UTILCODE_NO_DEPENDENCIES
     if (pResourceDLL == NULL) 
     {
         pResourceDLL = CCompRC::GetDefaultResourceDll();

--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -2553,6 +2553,10 @@ void SystemDomain::Init()
 #endif // FEATURE_VERSIONING
 
     m_BaseLibrary.Append(m_SystemDirectory);
+    if (!m_BaseLibrary.EndsWith(DIRECTORY_SEPARATOR_CHAR_W))
+    {
+        m_BaseLibrary.Append(DIRECTORY_SEPARATOR_CHAR_W);
+    }
     m_BaseLibrary.Append(g_pwBaseLibrary);
     m_BaseLibrary.Normalize();
 

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1350,6 +1350,9 @@ ErrExit: ;
         // for minimal impact we won't update hr for regular builds
         hr = GET_EXCEPTION()->GetHR();
         _ASSERTE(FAILED(hr));
+        StackSString exceptionMessage;
+        GET_EXCEPTION()->GetMessage(exceptionMessage);
+        fprintf(stderr, "%S\n", exceptionMessage.GetUnicode());
 #endif // CROSSGEN_COMPILE
     }
     EX_END_CATCH(RethrowTerminalExceptionsWithInitCheck)

--- a/src/vm/clrex.cpp
+++ b/src/vm/clrex.cpp
@@ -2056,6 +2056,7 @@ void DECLSPEC_NORETURN EEFileLoadException::Throw(LPCWSTR path, HRESULT hr, Exce
     if (hr == E_OUTOFMEMORY)
         COMPlusThrowOM();
 
+#ifndef CROSSGEN_COMPILE
     // Remove path - location must be hidden for security purposes
 
     LPCWSTR pStart = wcsrchr(path, '\\');
@@ -2063,6 +2064,9 @@ void DECLSPEC_NORETURN EEFileLoadException::Throw(LPCWSTR path, HRESULT hr, Exce
         pStart++;
     else
         pStart = path;
+#else
+    LPCWSTR pStart = path;
+#endif
     EX_THROW_WITH_INNER(EEFileLoadException, (StackSString(pStart), hr), pInnerException);
 }
 


### PR DESCRIPTION
When mscorlib is missing, crossgen reports a "file not found" error,
without indicating which file is missing. This makes it hard to discover
the actual error. This commit improves error reporting in such cases.