### PR TITLE
Remove thread parameter from a few more places in PAL

### DIFF
--- a/src/pal/src/cruntime/printfcpp.cpp
+++ b/src/pal/src/cruntime/printfcpp.cpp
@@ -104,8 +104,8 @@ static int Internal_Convertfwrite(CPalThread *pthrCurrent, const void *buffer, s
    }
    return ret;
 
-}    
-    
+}
+
 /*******************************************************************************
 Function:
   Internal_ExtractFormatA
@@ -979,7 +979,6 @@ static INT Internal_AddPaddingVfwprintf(CPalThread *pthrCurrent, PAL_FILE *strea
     LengthInStr = PAL_wcslen(In);
     Length = LengthInStr;
 
-
     if (Padding > 0)
     {
         Length += Padding;
@@ -1141,20 +1140,6 @@ int CorUnix::InternalVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const c
 int CorUnix::InternalVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *format, va_list ap)
 {
     return CoreVfwprintf(pthrCurrent, stream, format, ap);
-}
-
-int NativeVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Format, va_list ap)
-{
-    int retVal = 0;
-    retVal = vsnprintf(Buffer, Count, Format, ap);
-    return retVal;
-}
-
-int NativeVfprintf(CPalThread *pthrCurrent, FILE *filePtr, const char *format, va_list ap)
-{
-    int retVal = 0;
-    retVal = vfprintf(filePtr, format, ap);
-    return retVal;
 }
 
 int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *format, va_list aparg)
@@ -1471,7 +1456,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                     va_list apcopy;
 
                     va_copy(apcopy, ap);
-                    TempInt = NativeVsnprintf(pthrCurrent, TempSprintfStr, TEMP_COUNT, TempBuff, apcopy);
+                    TempInt = vsnprintf(TempSprintfStr, TEMP_COUNT, TempBuff, apcopy);
                     va_end(apcopy);
                     PAL_printf_arg_remover(&ap, Width, Precision, Type, Prefix);
 
@@ -1489,7 +1474,7 @@ int CoreVfwprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const wchar_16 *for
                         
                         TempSprintfStr = TempSprintfStrPtr;
                         va_copy(apcopy, ap);
-                        NativeVsnprintf(pthrCurrent, TempSprintfStr, TempInt, TempBuff, apcopy);
+                        vsnprintf(TempSprintfStr, TempInt, TempBuff, apcopy);
                         va_end(apcopy);
                         PAL_printf_arg_remover(&ap, Width, Precision, Type, Prefix);
                     }
@@ -1841,7 +1826,7 @@ int CoreVsnprintf(CPalThread *pthrCurrent, LPSTR Buffer, size_t Count, LPCSTR Fo
                 {
                     va_list apcopy;
                     va_copy(apcopy, ap);
-                    TempInt = NativeVsnprintf(pthrCurrent, BufferPtr, TempCount, TempBuff, apcopy);
+                    TempInt = vsnprintf(BufferPtr, TempCount, TempBuff, apcopy);
                     va_end(apcopy);
                     PAL_printf_arg_remover(&ap, Width, Precision, Type, Prefix);
                 }
@@ -2139,7 +2124,7 @@ int CoreWvsnprintf(CPalThread *pthrCurrent, LPWSTR Buffer, size_t Count, LPCWSTR
                 {
                     va_list apcopy;
                     va_copy(apcopy, ap);
-                    TempInt = NativeVsnprintf(pthrCurrent, (LPSTR) BufferPtr, TempCount, TempBuff, apcopy);
+                    TempInt = vsnprintf((LPSTR) BufferPtr, TempCount, TempBuff, apcopy);
                     va_end(apcopy);
                     PAL_printf_arg_remover(&ap, Width, Precision, Type, Prefix);
                 }
@@ -2520,7 +2505,7 @@ int CoreVfprintf(CPalThread *pthrCurrent, PAL_FILE *stream, const char *format, 
                 {
                     va_list apcopy;
                     va_copy(apcopy, ap);
-                    TempInt = NativeVfprintf(pthrCurrent, stream->bsdFilePtr, TempBuff, apcopy);
+                    TempInt = vfprintf(stream->bsdFilePtr, TempBuff, apcopy);
                     va_end(apcopy);
                     PAL_printf_arg_remover(&ap, Width, Precision, Type, Prefix);
                 }

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -113,7 +113,7 @@ FileCleanupRoutine(
 
     if (pLocalData->pLockController != NULL)
     {
-        pLocalData->pLockController->ReleaseController(pThread);
+        pLocalData->pLockController->ReleaseController();
     }
 
     if (!fShutdown && -1 != pLocalData->unix_fd)
@@ -852,7 +852,7 @@ done:
 
     if (NULL != pLockController)
     {
-        pLockController->ReleaseController(pThread);
+        pLockController->ReleaseController();
     }
 
     if (NULL != pDataLock)
@@ -1228,9 +1228,8 @@ DeleteFileA(
         }
     }
 
-    palError = g_pFileLockManager->GetFileShareModeForFile(pThread,
-							   lpFullUnixFileName,
-							   &dwShareMode);
+    palError = g_pFileLockManager->GetFileShareModeForFile(lpFullUnixFileName, &dwShareMode);
+
     // Use unlink if we succesfully found the file to be opened with
     // a FILE_SHARE_DELETE mode.
     // Note that there is a window here where a race condition can occur:
@@ -2214,7 +2213,7 @@ done:
     
     if (NULL != pTransactionLock)
     {
-        pTransactionLock->ReleaseLock(pThread);
+        pTransactionLock->ReleaseLock();
     }
 
     if (NULL != pLocalDataLock)
@@ -2439,7 +2438,7 @@ done:
 
     if (NULL != pTransactionLock)
     {
-        pTransactionLock->ReleaseLock(pThread);
+        pTransactionLock->ReleaseLock();
     }
 
     if (NULL != pLocalDataLock)
@@ -4843,7 +4842,7 @@ done:
 
     if (NULL != pLockController)
     {
-        pLockController->ReleaseController(pThread);
+        pLockController->ReleaseController();
     }
 
     if (NULL != pDataLock)

--- a/src/pal/src/file/shmfilelockmgr.cpp
+++ b/src/pal/src/file/shmfilelockmgr.cpp
@@ -245,7 +245,7 @@ GetLockControllerForFileExit:
     {
         if (NULL != pController)
         {
-            pController->ReleaseController(pThread);
+            pController->ReleaseController();
         }
 
         if (SHMNULL != shmFileLocks)
@@ -265,7 +265,6 @@ GetLockControllerForFileExit:
 
 PAL_ERROR
 CSharedMemoryFileLockMgr::GetFileShareModeForFile(
-   CPalThread *pThread,
    LPCSTR szFileName,
    DWORD* pdwShareMode)
 {
@@ -273,7 +272,6 @@ CSharedMemoryFileLockMgr::GetFileShareModeForFile(
     *pdwShareMode = SHARE_MODE_NOT_INITALIZED;
     SHMPTR shmFileLocks = SHMNULL;
     SHMFILELOCKS* fileLocks = NULL;
-
 
     SHMLock();
 
@@ -306,7 +304,6 @@ GetLockControllerForFileExit:
     SHMRelease();
 
     return palError;
-  
 }
 
 PAL_ERROR
@@ -427,9 +424,7 @@ CSharedMemoryFileLockController::ReleaseFileLock(
 }
 
 void
-CSharedMemoryFileLockController::ReleaseController(
-    CPalThread *pThread                 // IN, OPTIONAL
-    )
+CSharedMemoryFileLockController::ReleaseController()
 {
     if (SHMNULL != m_shmFileLocks)
     {
@@ -444,9 +439,7 @@ CSharedMemoryFileLockController::ReleaseController(
 }
 
 void
-CSharedMemoryFileTransactionLock::ReleaseLock(
-    CPalThread *pThread
-    )
+CSharedMemoryFileTransactionLock::ReleaseLock()
 {
     FILEUnlockFileRegion(
         m_shmFileLocks,

--- a/src/pal/src/file/shmfilelockmgr.hpp
+++ b/src/pal/src/file/shmfilelockmgr.hpp
@@ -74,10 +74,10 @@ namespace CorUnix
             DWORD dwShareMode,
             IFileLockController **ppLockController  // OUT
             );
+
         virtual
-	PAL_ERROR
-	GetFileShareModeForFile(
-            CPalThread *pThread,
+        PAL_ERROR
+        GetFileShareModeForFile(
             LPCSTR szFileName,
             DWORD* pdwShareMode);
     };
@@ -142,9 +142,7 @@ namespace CorUnix
 
         virtual
         void
-        ReleaseController(
-            CPalThread *pThread                 // IN, OPTIONAL
-            );
+        ReleaseController();
     };
 
     class CSharedMemoryFileTransactionLock : public IFileTransactionLock
@@ -180,9 +178,7 @@ namespace CorUnix
 
         virtual
         void
-        ReleaseLock(
-            CPalThread *pThread                 // IN, OPTIONAL
-            );
+        ReleaseLock();
     };
 }
 

--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -103,7 +103,6 @@ namespace CorUnix
 
         PAL_ERROR
         CopyString(
-            CPalThread *pthr,
             CPalString *psSource
             );
 
@@ -1358,19 +1357,6 @@ namespace CorUnix
     };
 
     extern IFileLockManager *g_pFileLockManager;
-
-    //
-    // Utility function for converting sz object names to wsz
-    //
-
-    PAL_ERROR
-    InternalWszNameFromSzName(
-        CPalThread *pthr,
-        LPCSTR pszName,
-        LPWSTR pwszName,
-        DWORD cch
-        );
-
 }
 
 #endif // _CORUNIX_H

--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -1239,9 +1239,7 @@ namespace CorUnix
 
         virtual
         void
-        ReleaseLock(
-            CPalThread *pThread                 // IN, OPTIONAL
-            ) = 0;
+        ReleaseLock() = 0;
     };
 
     class IFileLockController
@@ -1316,10 +1314,7 @@ namespace CorUnix
 
         virtual
         void
-        ReleaseController(
-            CPalThread *pThread                 // IN, OPTIONAL
-            ) = 0;
-        
+        ReleaseController() = 0;
     };
 
     class IFileLockManager
@@ -1349,9 +1344,8 @@ namespace CorUnix
         // not found)
         // 
         virtual
-	PAL_ERROR
-	GetFileShareModeForFile(
-            CPalThread *pThread,
+        PAL_ERROR
+        GetFileShareModeForFile(
             LPCSTR szFileName,
             DWORD* pdwShareMode) = 0;
     };

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -95,8 +95,8 @@ static PCRITICAL_SECTION init_critsec = NULL;
 
 static int Initialize(int argc, const char *const argv[], DWORD flags);
 static BOOL INIT_IncreaseDescriptorLimit(void);
-static LPWSTR INIT_FormatCommandLine (CPalThread *pThread, int argc, const char * const *argv);
-static LPWSTR INIT_FindEXEPath(CPalThread *pThread, LPCSTR exe_name);
+static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv);
+static LPWSTR INIT_FindEXEPath(LPCSTR exe_name);
 
 #ifdef _DEBUG
 extern void PROCDumpThreadList(void);
@@ -397,7 +397,7 @@ Initialize(
     if (argc > 0 && argv != NULL)
     {
         /* build the command line */
-        command_line = INIT_FormatCommandLine(pThread, argc, argv);
+        command_line = INIT_FormatCommandLine(argc, argv);
         if (NULL == command_line)
         {
             ERROR("Error building command line\n");
@@ -405,7 +405,7 @@ Initialize(
         }
 
         /* find out the application's full path */
-        exe_path = INIT_FindEXEPath(pThread, argv[0]);
+        exe_path = INIT_FindEXEPath(argv[0]);
         if (NULL == exe_path)
         {
             ERROR("Unable to find exe path\n");
@@ -998,7 +998,7 @@ Note : not all peculiarities of Windows command-line processing are supported;
      passed to argv as \\a... there may be other similar cases
     -there may be other characters which must be escaped 
 --*/
-static LPWSTR INIT_FormatCommandLine (CPalThread *pThread, int argc, const char * const *argv)
+static LPWSTR INIT_FormatCommandLine (int argc, const char * const *argv)
 {
     LPWSTR retval;
     LPSTR command_line=NULL, command_ptr;
@@ -1032,7 +1032,7 @@ static LPWSTR INIT_FormatCommandLine (CPalThread *pThread, int argc, const char 
     command_ptr=command_line;
     for(i=0; i<argc; i++)
     {
-        /* double-quote at beginning of argument containing at leat one space */
+        /* double-quote at beginning of argument containing at least one space */
         for(j = 0; (argv[i][j] != 0) && (!isspace((unsigned char) argv[i][j])); j++);
 
         if (argv[i][j] != 0)
@@ -1116,7 +1116,7 @@ Notes 2:
     This doesn't handle the case of directories with the desired name
     (and directories are usually executable...)
 --*/
-static LPWSTR INIT_FindEXEPath(CPalThread *pThread, LPCSTR exe_name)
+static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
 {
 #ifndef __APPLE__
     CHAR real_path[PATH_MAX+1];

--- a/src/pal/src/misc/strutil.cpp
+++ b/src/pal/src/misc/strutil.cpp
@@ -35,13 +35,11 @@ Function:
   as necessary
 
 Parameters:
-  pthr -- thread data for calling thread
   psSource -- the string to copy from
 --*/
 
 PAL_ERROR
 CPalString::CopyString(
-    CPalThread *pthr,
     CPalString *psSource
     )
 {
@@ -50,7 +48,7 @@ CPalString::CopyString(
     _ASSERTE(NULL != psSource);
     _ASSERTE(NULL == m_pwsz);
     _ASSERTE(0 == m_dwStringLength);
-    _ASSERTE(0 == m_dwMaxLength);    
+    _ASSERTE(0 == m_dwMaxLength);
 
     if (0 != psSource->GetStringLength())
     {
@@ -63,7 +61,7 @@ CPalString::CopyString(
         if (NULL != pwsz)
         {
             _ASSERTE(NULL != psSource->GetString());
-            
+
             CopyMemory(
                 pwsz,
                 psSource->GetString(),
@@ -102,51 +100,3 @@ CPalString::FreeBuffer(
     
     InternalFree(const_cast<WCHAR*>(m_pwsz));
 }
-
-/*++
-Function:
-  InternalWszNameFromSzName
-
-  Helper function to convert an ANSI string object name parameter to a
-  unicode string
-
-Parameters:
-  pthr -- thread data for calling thread
-  pszName -- the ANSI string name
-  pwszName -- on success, receives the converted unicode string
-  cch -- the size of pwszName, in characters
---*/
-
-PAL_ERROR
-CorUnix::InternalWszNameFromSzName(
-    CPalThread *pthr,
-    LPCSTR pszName,
-    LPWSTR pwszName,
-    DWORD cch
-    )
-{
-    PAL_ERROR palError = NO_ERROR;
-
-    _ASSERTE(NULL != pthr);
-    _ASSERTE(NULL != pszName);
-    _ASSERTE(NULL != pwszName);
-    _ASSERTE(0 < cch);
-    
-    if (MultiByteToWideChar(CP_ACP, 0, pszName, -1, pwszName, cch) == 0)
-    {
-        palError = pthr->GetLastError();
-        if (ERROR_INSUFFICIENT_BUFFER == palError)
-        {
-            ERROR("pszName is larger than cch (%d)!\n", palError);
-            palError = ERROR_FILENAME_EXCED_RANGE;
-        }
-        else
-        {
-            ERROR("MultiByteToWideChar failure! (error=%d)\n", palError);
-            palError = ERROR_INVALID_PARAMETER;
-        }            
-    }
-
-    return palError;
-}
-

--- a/src/pal/src/objmgr/palobjbase.cpp
+++ b/src/pal/src/objmgr/palobjbase.cpp
@@ -97,7 +97,7 @@ CPalObjectBase::Initialize(
 
     if (0 != poa->sObjectName.GetStringLength())
     {
-        palError = m_oa.sObjectName.CopyString(pthr, &poa->sObjectName);
+        palError = m_oa.sObjectName.CopyString(&poa->sObjectName);
     }
 
 IntializeExit:


### PR DESCRIPTION
This continues on the work done in #1930 and #1940 to remove unnecessary thread parameters from functions to cut down on reasons to call `GetCurrentThread` or a variant of it.

This time, the areas addressed are functions in PAL initialization, virtual memory, strings, and file lock management.