### PR TITLE
Fix a few bugs in the SysV ABI classifier.

### DIFF
--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -2592,16 +2592,11 @@ bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(
         }
         else if (th.IsTypeDesc())
         {
-            if (th.IsNativeValueType())
-            {
-                methodTablePtr = th.AsNativeValueType();
-                isNativeStruct = true;
-                _ASSERTE(methodTablePtr != nullptr);
-            }
-            else
-            {
-                _ASSERTE(false && "Unhandled TypeHandle for struct!");
-            }
+            _ASSERTE(th.IsNativeValueType());
+
+            methodTablePtr = th.AsNativeValueType();
+            isNativeStruct = true;
+            _ASSERTE(methodTablePtr != nullptr);
         }
 
         bool isPassableInRegs = false;
@@ -2624,7 +2619,8 @@ bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(
             structPassInRegDescPtr->passedInRegisters = true;
 
             SystemVStructRegisterPassingHelper helper((unsigned int)th.GetSize());
-            bool result = methodTablePtr->ClassifyEightBytes(&helper, 0, 0);
+            bool result = isNativeStruct ? methodTablePtr->ClassifyEightBytesForNativeStruct(&helper, 0, 0)
+                                         : methodTablePtr->ClassifyEightBytes(&helper, 0, 0);
 
             structPassInRegDescPtr->eightByteCount = helper.eightByteCount;
             _ASSERTE(structPassInRegDescPtr->eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -1048,9 +1048,6 @@ public:
     void CheckRunClassInitAsIfConstructingThrowing();
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING_ITF)
-    // Helper function for ClassifyEightBytes
-    static SystemVClassificationType ReClassifyField(SystemVClassificationType originalClassification, SystemVClassificationType newFieldClassification);
-
     // Builds the internal data structures and classifies struct eightbytes for Amd System V calling convention.
     bool ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct);
     bool ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct);
@@ -1090,10 +1087,6 @@ public:
     bool ClassRequiresUnmanagedCodeCheck();
 
 private:
-
-#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING_ITF)
-    void AssignClassifiedEightByteTypes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel);
-#endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING_ITF)
 
     DWORD   GetClassIndexFromToken(mdTypeDef typeToken)
     {


### PR DESCRIPTION
- Managed fixed array types were not being handled correctly: only
  the representative field was being classified; the remainder of
  the type was being ignored.
- Native fixed buffer types were being similarly mishandled: each
  of these types was being classified as a single eightbyte
  regardless of the actual size of the fixed array.
- The native classification routine was not being used for native
  structs when such structs were classified via the JIT interface
  or when such structs were nested within managed structs.