### PR TITLE
Restrict allocation of executable memory by DebuggerHeap

### DIFF
--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -1103,6 +1103,7 @@ protected:
 #ifdef USE_INTEROPSAFE_HEAP
     HANDLE m_hHeap;
 #endif
+    BOOL m_fExecutable;
 };
 
 class DebuggerJitInfo;


### PR DESCRIPTION
DebuggerHeap is a common class that is used for both executable and
non-executable memory allocations by debugging infrustructure.
On Windows, OS supports concept of executable heap and CLR doesn't need
to do anything extra for each executable allocation. On Linux/OSX
this is not true. That's why this changes preserves fExecutable flag for each heap
and makes sure that we mark memory as executable only when it is necessary.

This change should address performance degradation described in #711.
It doesn't fix managed debugging on CentoOS, but allows to run CoreCLR processes there without constant SELinux warnings.