### PR TITLE
Fix sos clrstack unwinding for special HelperMethodFrame.

### DIFF
--- a/src/ToolBox/SOS/Strike/datatarget.cpp
+++ b/src/ToolBox/SOS/Strike/datatarget.cpp
@@ -196,8 +196,14 @@ DataTarget::Request(
 }
 
 HRESULT STDMETHODCALLTYPE 
-DataTarget::GetPid(
-    /* [out] */ DWORD *pdwProcessId)
+DataTarget::VirtualUnwind(
+    /* [in] */ DWORD threadId,
+    /* [in] */ ULONG32 contextSize,
+    /* [in, out, size_is(contextSize)] */ PBYTE context)
 {
-    return g_ExtSystem->GetCurrentProcessId(pdwProcessId);
+    if (g_ExtClient == NULL)
+    {
+        return E_UNEXPECTED;
+    }
+    return g_ExtClient->VirtualUnwind(threadId, contextSize, context);
 }

--- a/src/ToolBox/SOS/Strike/datatarget.h
+++ b/src/ToolBox/SOS/Strike/datatarget.h
@@ -85,6 +85,8 @@ public:
 
     // ICorDebugDataTarget4
 
-    virtual HRESULT STDMETHODCALLTYPE GetPid(
-        /* [out] */ DWORD *pdwProcessId);
+    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(
+        /* [in] */ DWORD threadId,
+        /* [in] */ ULONG32 contextSize,
+        /* [in, out, size_is(contextSize)] */ PBYTE context);
 };

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -6892,8 +6892,13 @@ HRESULT HandleCLRNotificationEvent()
 
     if (!CheckCLRNotificationEvent(&dle))
     {
+#ifndef FEATURE_PAL
         ExtOut("Expecting first chance CLRN exception\n");
         return E_FAIL;
+#else
+        g_ExtControl->Execute(DEBUG_EXECUTE_NOT_LOGGED, "process continue", 0);
+        return S_OK;
+#endif
     }
 
     // Notification only needs to live for the lifetime of the call below, so it's a non-static

--- a/src/ToolBox/SOS/lldbplugin/debugclient.h
+++ b/src/ToolBox/SOS/lldbplugin/debugclient.h
@@ -13,9 +13,10 @@ private:
     lldb::SBProcess GetCurrentProcess();
     lldb::SBThread GetCurrentThread();
     lldb::SBFrame GetCurrentFrame();
-    ULONG64 GetModuleBase(lldb::SBTarget target, lldb::SBModule module);
-    DWORD_PTR GetExpression(lldb::SBFrame frame, lldb::SBError& error, PCSTR exp);
-    DWORD_PTR GetRegister(lldb::SBFrame frame, const char *name);
+    ULONG64 GetModuleBase(lldb::SBTarget& target, lldb::SBModule& module);
+    DWORD_PTR GetExpression(lldb::SBFrame& frame, lldb::SBError& error, PCSTR exp);
+    void GetContextFromFrame(lldb::SBFrame& frame, DT_CONTEXT *dtcontext);
+    DWORD_PTR GetRegister(lldb::SBFrame& frame, const char *name);
 
 public:
     DebugClient(lldb::SBDebugger &debugger, lldb::SBCommandReturnObject &returnObject);
@@ -192,4 +193,9 @@ public:
 
     DWORD_PTR GetExpression(
         PCSTR exp);
+
+    HRESULT VirtualUnwind(
+        DWORD threadID,
+        ULONG32 contextSize,
+        PBYTE context);
 };

--- a/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/dbgeng.h
@@ -457,6 +457,11 @@ public:
     // Evaluates a lldb expression into a value.
     virtual DWORD_PTR GetExpression(
         /* [in] */ PCSTR exp) = 0;
+
+    virtual HRESULT VirtualUnwind(
+        /* [in] */ DWORD threadID,
+        /* [in] */ ULONG32 contextSize,
+        /* [in, out, size_is(contextSize)] */ PBYTE context) = 0;
 };
 
 typedef class IDebugClient* PDEBUG_CLIENT;

--- a/src/ToolBox/SOS/lldbplugin/sosplugin.h
+++ b/src/ToolBox/SOS/lldbplugin/sosplugin.h
@@ -7,6 +7,7 @@
 #include "mstypes.h"
 #define DEFINE_EXCEPTION_RECORD
 #include <dbgeng.h>
+#include <dbgtargetcontext.h>
 #include "debugclient.h"
 
 typedef HRESULT (*CommandFunc)(PDEBUG_CLIENT client, const char *args);

--- a/src/debug/daccess/dacfn.cpp
+++ b/src/debug/daccess/dacfn.cpp
@@ -219,7 +219,7 @@ DacWriteAll(TADDR addr, PVOID buffer, ULONG32 size, bool throwEx)
 }
 
 HRESULT 
-DacVirtualUnwind(DWORD threadId, CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers)
+DacVirtualUnwind(DWORD threadId, PCONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers)
 {
     if (!g_dacImpl)
     {
@@ -230,7 +230,7 @@ DacVirtualUnwind(DWORD threadId, CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS
     // The DAC code doesn't use these context pointers but zero them out to be safe.
     if (contextPointers != NULL)
     {
-        memset(contextPointers, 0, sizeof(KNONVOLATILE_CONTEXT_POINTERS));
+        memset(contextPointers, 0, sizeof(T_KNONVOLATILE_CONTEXT_POINTERS));
     }
 
     ReleaseHolder<ICorDebugDataTarget4> dt;

--- a/src/debug/daccess/dacfn.cpp
+++ b/src/debug/daccess/dacfn.cpp
@@ -219,7 +219,7 @@ DacWriteAll(TADDR addr, PVOID buffer, ULONG32 size, bool throwEx)
 }
 
 HRESULT 
-DacGetPid(DWORD *pid)
+DacVirtualUnwind(DWORD threadId, CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers)
 {
     if (!g_dacImpl)
     {
@@ -227,11 +227,17 @@ DacGetPid(DWORD *pid)
         UNREACHABLE();
     }
 
+    // The DAC code doesn't use these context pointers but zero them out to be safe.
+    if (contextPointers != NULL)
+    {
+        memset(contextPointers, 0, sizeof(KNONVOLATILE_CONTEXT_POINTERS));
+    }
+
     ReleaseHolder<ICorDebugDataTarget4> dt;
     HRESULT hr = g_dacImpl->m_pTarget->QueryInterface(IID_ICorDebugDataTarget4, (void **)&dt);
     if (SUCCEEDED(hr))
     {
-        hr = dt->GetPid(pid);
+        hr = dt->VirtualUnwind(threadId, sizeof(CONTEXT), (BYTE*)context);
     }
 
     return hr;

--- a/src/debug/daccess/dacfn.cpp
+++ b/src/debug/daccess/dacfn.cpp
@@ -218,6 +218,7 @@ DacWriteAll(TADDR addr, PVOID buffer, ULONG32 size, bool throwEx)
     return S_OK;
 }
 
+#if defined(WIN64EXCEPTIONS) && defined(FEATURE_PAL)
 HRESULT 
 DacVirtualUnwind(DWORD threadId, PCONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers)
 {
@@ -242,6 +243,7 @@ DacVirtualUnwind(DWORD threadId, PCONTEXT context, PT_KNONVOLATILE_CONTEXT_POINT
 
     return hr;
 }
+#endif // defined(WIN64EXCEPTIONS) && defined(FEATURE_PAL)
 
 // DacAllocVirtual - Allocate memory from the target process
 // Note: this is only available to clients supporting the legacy

--- a/src/debug/di/shimdatatarget.cpp
+++ b/src/debug/di/shimdatatarget.cpp
@@ -68,22 +68,30 @@ ULONG STDMETHODCALLTYPE ShimDataTarget::Release()
     return ref;
 }
 
-
 //---------------------------------------------------------------------------------------
 //
 // Get the OS Process ID that this DataTarget is for.
 //
 // Return Value: 
 //     The OS PID of the process this data target is representing.
-HRESULT STDMETHODCALLTYPE ShimDataTarget::GetPid(DWORD *pdwProcessId)
+DWORD ShimDataTarget::GetPid()
 {
-    if (pdwProcessId == NULL)  
-    {
-        return E_INVALIDARG;
-    }
+    return m_processId;
+}
 
-    *pdwProcessId = m_processId;
-    return S_OK;
+//---------------------------------------------------------------------------------------
+//
+// Unwind the stack to the next frame.
+//
+// Return Value: 
+//     context and contextPointers filled in with the next frame
+//
+HRESULT STDMETHODCALLTYPE ShimDataTarget::VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context)
+{
+#ifndef FEATURE_PAL
+    _ASSERTE(!"ShimDataTarget::VirtualUnwind NOT IMPLEMENTED");
+#endif 
+    return E_NOTIMPL;
 }
 
 //---------------------------------------------------------------------------------------

--- a/src/debug/di/shimdatatarget.h
+++ b/src/debug/di/shimdatatarget.h
@@ -36,6 +36,9 @@ public:
     // is unavailable because it's running
     void SetError(HRESULT hr);
 
+    // Get the OS Process ID that this DataTarget is for.
+    DWORD GetPid();
+
     //
     // IUnknown.
     //
@@ -86,8 +89,8 @@ public:
     // ICorDebugDataTarget4
     //    
 
-    // Get the OS Process ID that this DataTarget is for.
-    virtual HRESULT STDMETHODCALLTYPE GetPid(DWORD *pdwProcessId); 
+    // Unwind to the next stack frame
+    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context);
 
 protected:
     // Pid of the target process.

--- a/src/debug/di/shimprocess.cpp
+++ b/src/debug/di/shimprocess.cpp
@@ -133,9 +133,7 @@ void ShimProcess::SetProcess(ICorDebugProcess * pProcess)
     if (pProcess != NULL)
     {
         // Verify that DataTarget + new process have the same pid?
-        DWORD pid = 0;
-        _ASSERTE(SUCCEEDED(m_pLiveDataTarget->GetPid(&pid)));
-        _ASSERTE(m_pProcess->GetPid() == pid);
+        _ASSERTE(m_pProcess->GetPid() == m_pLiveDataTarget->GetPid());
     }
 }
 
@@ -740,11 +738,8 @@ HRESULT ShimProcess::HandleWin32DebugEvent(const DEBUG_EVENT * pEvent)
             // This assert could be our only warning of various catastrophic failures in the left-side.
             if (!dwFirstChance && (pRecord->ExceptionCode == STATUS_BREAKPOINT) && !m_fIsInteropDebugging)
             {            
-                DWORD pid = 0;
-                if (m_pLiveDataTarget != NULL) 
-                {
-                    m_pLiveDataTarget->GetPid(&pid);
-                }
+                DWORD pid = (m_pLiveDataTarget == NULL) ? 0 : m_pLiveDataTarget->GetPid();
+
                 CONSISTENCY_CHECK_MSGF(false, 
                     ("Unhandled breakpoint exception in debuggee (pid=%d (0x%x)) on thread %d(0x%x)\n"
                     "This may mean there was an assert in the debuggee on that thread.\n"
@@ -1748,11 +1743,8 @@ void ShimProcess::PreDispatchEvent(bool fRealCreateProcessEvent /*= false*/)
 CORDB_ADDRESS ShimProcess::GetCLRInstanceBaseAddress()
 {
     CORDB_ADDRESS baseAddress = CORDB_ADDRESS(NULL);
-    DWORD dwPid = 0;
-    if (FAILED(m_pLiveDataTarget->GetPid(&dwPid)))
-    {
-        return baseAddress;
-    }
+    DWORD dwPid = m_pLiveDataTarget->GetPid();
+
 #if defined(FEATURE_CORESYSTEM)
     // Debugger attaching to CoreCLR via CoreCLRCreateCordbObject should have already specified CLR module address.
     // Code that help to find it now lives in dbgshim.

--- a/src/inc/cordebug.idl
+++ b/src/inc/cordebug.idl
@@ -823,9 +823,11 @@ interface ICorDebugDataTarget3 : IUnknown
 interface ICorDebugDataTarget4 : IUnknown
 {
     /*
-    * gives back a process id
-    */
-    HRESULT GetPid([out] DWORD *pdwProcessId);
+     * Unwinds one native stack frame in the target process/thread
+     */
+    HRESULT VirtualUnwind([in] DWORD threadId,
+                          [in] ULONG32 contextSize,
+                          [in, out, size_is(contextSize)] BYTE *context);
 };
 
 /*

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -663,7 +663,6 @@ HRESULT DacFreeVirtual(TADDR mem, ULONG32 size, ULONG32 typeFlags,
 PVOID   DacInstantiateTypeByAddress(TADDR addr, ULONG32 size, bool throwEx);
 PVOID   DacInstantiateTypeByAddressNoReport(TADDR addr, ULONG32 size, bool throwEx);
 PVOID   DacInstantiateClassByVTable(TADDR addr, ULONG32 minSize, bool throwEx);
-HRESULT DacVirtualUnwind(ULONG32 threadId, PCONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers);
 
 // Copy a null-terminated ascii or unicode string from the target to the host.
 // Note that most of the work here is to find the null terminator.  If you know the exact length,
@@ -780,6 +779,11 @@ struct _UNWIND_INFO * DacGetUnwindInfo(TADDR taUnwindInfo);
 // virtually unwind a CONTEXT out-of-process
 struct _KNONVOLATILE_CONTEXT_POINTERS;
 BOOL DacUnwindStackFrame(T_CONTEXT * pContext, T_KNONVOLATILE_CONTEXT_POINTERS* pContextPointers);
+
+#if defined(FEATURE_PAL)
+// call back through data target to unwind out-of-process
+HRESULT DacVirtualUnwind(ULONG32 threadId, PCONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers);
+#endif // FEATURE_PAL
 #endif // _WIN64
 
 #ifdef FEATURE_MINIMETADATA_IN_TRIAGEDUMPS

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -663,7 +663,7 @@ HRESULT DacFreeVirtual(TADDR mem, ULONG32 size, ULONG32 typeFlags,
 PVOID   DacInstantiateTypeByAddress(TADDR addr, ULONG32 size, bool throwEx);
 PVOID   DacInstantiateTypeByAddressNoReport(TADDR addr, ULONG32 size, bool throwEx);
 PVOID   DacInstantiateClassByVTable(TADDR addr, ULONG32 minSize, bool throwEx);
-HRESULT DacGetPid(DWORD *pid);
+HRESULT DacVirtualUnwind(ULONG32 threadId, CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers);
 
 // Copy a null-terminated ascii or unicode string from the target to the host.
 // Note that most of the work here is to find the null terminator.  If you know the exact length,

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -663,7 +663,7 @@ HRESULT DacFreeVirtual(TADDR mem, ULONG32 size, ULONG32 typeFlags,
 PVOID   DacInstantiateTypeByAddress(TADDR addr, ULONG32 size, bool throwEx);
 PVOID   DacInstantiateTypeByAddressNoReport(TADDR addr, ULONG32 size, bool throwEx);
 PVOID   DacInstantiateClassByVTable(TADDR addr, ULONG32 minSize, bool throwEx);
-HRESULT DacVirtualUnwind(ULONG32 threadId, CONTEXT *context, KNONVOLATILE_CONTEXT_POINTERS *contextPointers);
+HRESULT DacVirtualUnwind(ULONG32 threadId, PCONTEXT context, PT_KNONVOLATILE_CONTEXT_POINTERS contextPointers);
 
 // Copy a null-terminated ascii or unicode string from the target to the host.
 // Note that most of the work here is to find the null terminator.  If you know the exact length,

--- a/src/pal/prebuilt/idl/cordebug_i.c
+++ b/src/pal/prebuilt/idl/cordebug_i.c
@@ -1,8 +1,3 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
-//
-
 
 
 /* this ALWAYS GENERATED file contains the IIDs and CLSIDs */
@@ -10,7 +5,17 @@
 /* link this file in with the server and any clients */
 
 
- /* File created by MIDL compiler version 8.00.0603 */
+ /* File created by MIDL compiler version 8.00.0613 */
+/* at Mon Jan 18 19:14:07 2038
+ */
+/* Compiler settings for C:/ssd/coreclr/src/inc/cordebug.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.00.0613 
+    protocol : dce , ms_ext, c_ext, robust
+    error checks: allocation ref bounds_check enum stub_data 
+    VC __declspec() decoration level: 
+         __declspec(uuid()), __declspec(selectany), __declspec(novtable)
+         DECLSPEC_UUID(), MIDL_INTERFACE()
+*/
 /* @@MIDL_FILE_HEADING(  ) */
 
 #pragma warning( disable: 4049 )  /* more than 64k source lines */

--- a/src/pal/prebuilt/inc/cordebug.h
+++ b/src/pal/prebuilt/inc/cordebug.h
@@ -1,12 +1,19 @@
-//
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
-//
+
 
 /* this ALWAYS GENERATED file contains the definitions for the interfaces */
 
 
- /* File created by MIDL compiler version 8.00.0603 */
+ /* File created by MIDL compiler version 8.00.0613 */
+/* at Mon Jan 18 19:14:07 2038
+ */
+/* Compiler settings for C:/ssd/coreclr/src/inc/cordebug.idl:
+    Oicf, W1, Zp8, env=Win32 (32b run), target_arch=X86 8.00.0613 
+    protocol : dce , ms_ext, c_ext, robust
+    error checks: allocation ref bounds_check enum stub_data 
+    VC __declspec() decoration level: 
+         __declspec(uuid()), __declspec(selectany), __declspec(novtable)
+         DECLSPEC_UUID(), MIDL_INTERFACE()
+*/
 /* @@MIDL_FILE_HEADING(  ) */
 
 #pragma warning( disable: 4049 )  /* more than 64k source lines */
@@ -22,7 +29,7 @@
 
 #ifndef __RPCNDR_H_VERSION__
 #error this stub requires an updated version of <rpcndr.h>
-#endif // __RPCNDR_H_VERSION__
+#endif /* __RPCNDR_H_VERSION__ */
 
 #ifndef COM_NO_WINDOWS_H
 #include "windows.h"
@@ -2853,8 +2860,10 @@ EXTERN_C const IID IID_ICorDebugDataTarget4;
     ICorDebugDataTarget4 : public IUnknown
     {
     public:
-        virtual HRESULT STDMETHODCALLTYPE GetPid( 
-            /* [out] */ DWORD *pdwProcessId) = 0;
+        virtual HRESULT STDMETHODCALLTYPE VirtualUnwind( 
+            /* [in] */ DWORD threadId,
+            /* [in] */ ULONG32 contextSize,
+            /* [size_is][out][in] */ BYTE *context) = 0;
         
     };
     
@@ -2877,9 +2886,11 @@ EXTERN_C const IID IID_ICorDebugDataTarget4;
         ULONG ( STDMETHODCALLTYPE *Release )( 
             ICorDebugDataTarget4 * This);
         
-        HRESULT ( STDMETHODCALLTYPE *GetPid )( 
+        HRESULT ( STDMETHODCALLTYPE *VirtualUnwind )( 
             ICorDebugDataTarget4 * This,
-            /* [out] */ DWORD *pdwProcessId);
+            /* [in] */ DWORD threadId,
+            /* [in] */ ULONG32 contextSize,
+            /* [size_is][out][in] */ BYTE *context);
         
         END_INTERFACE
     } ICorDebugDataTarget4Vtbl;
@@ -2904,8 +2915,8 @@ EXTERN_C const IID IID_ICorDebugDataTarget4;
     ( (This)->lpVtbl -> Release(This) ) 
 
 
-#define ICorDebugDataTarget4_GetPid(This,pdwProcessId)	\
-    ( (This)->lpVtbl -> GetPid(This,pdwProcessId) ) 
+#define ICorDebugDataTarget4_VirtualUnwind(This,threadId,contextSize,context)	\
+    ( (This)->lpVtbl -> VirtualUnwind(This,threadId,contextSize,context) ) 
 
 #endif /* COBJMACROS */
 

--- a/src/vm/amd64/gmscpu.h
+++ b/src/vm/amd64/gmscpu.h
@@ -102,6 +102,7 @@ struct LazyMachState : public MachState
     void setLazyStateFromUnwind(MachState* copy);
     static void unwindLazyState(LazyMachState* baseState,
                                 MachState* lazyState,
+                                DWORD threadId,
                                 int funCallDepth = 1,
                                 HostCallPreference hostCallPreference = AllowHostCalls);
 

--- a/src/vm/arm/gmscpu.h
+++ b/src/vm/arm/gmscpu.h
@@ -82,6 +82,7 @@ struct LazyMachState : public MachState {
     void setLazyStateFromUnwind(MachState* copy);
     static void unwindLazyState(LazyMachState* baseState,
                                 MachState* lazyState,
+                                DWORD threadId,
                                 int funCallDepth = 1,
                                 HostCallPreference hostCallPreference = AllowHostCalls);
 

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -494,6 +494,7 @@ void StompWriteBarrierEphemeral(void)
 #ifndef CROSSGEN_COMPILE
 void LazyMachState::unwindLazyState(LazyMachState* baseState,
                                     MachState* unwoundstate,
+                                    DWORD threadId,
                                     int funCallDepth,
                                     HostCallPreference hostCallPreference)
 {

--- a/src/vm/arm64/gmscpu.h
+++ b/src/vm/arm64/gmscpu.h
@@ -42,6 +42,7 @@ struct LazyMachState : public MachState{
     void setLazyStateFromUnwind(MachState* copy);
     static void unwindLazyState(LazyMachState* baseState,
                                 MachState* lazyState,
+                                DWORD threadId,
                                 int funCallDepth = 1,
                                 HostCallPreference hostCallPreference = AllowHostCalls);
 };

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -271,6 +271,7 @@ static BYTE gLoadFromLabelIF[sizeof(LoadFromLabelInstructionFormat)];
 #ifndef CROSSGEN_COMPILE
 void LazyMachState::unwindLazyState(LazyMachState* baseState,
                                     MachState* unwoundstate,
+                                    DWORD threadId,
                                     int funCallDepth,
                                     HostCallPreference hostCallPreference)
 {

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1823,6 +1823,7 @@ BOOL HelperMethodFrame::InsureInit(bool initialInit,
     // Work with a copy so that we only write the values once.
     // this avoids race conditions.
     LazyMachState* lazy = &m_MachState;
+    DWORD threadId = m_pThread->GetOSThreadId();
     MachState unwound;
     
     if (!initialInit &&
@@ -1832,6 +1833,7 @@ BOOL HelperMethodFrame::InsureInit(bool initialInit,
         LazyMachState::unwindLazyState(
             lazy, 
             &unwound, 
+            threadId,
             0,
             hostCallPreference);
 
@@ -1859,12 +1861,12 @@ BOOL HelperMethodFrame::InsureInit(bool initialInit,
              (m_Attribs & Frame::FRAME_ATTR_CAPTURE_DEPTH_2) != 0)
     {
         // explictly told depth
-        LazyMachState::unwindLazyState(lazy, &unwound, 2);
+        LazyMachState::unwindLazyState(lazy, &unwound, threadId, 2);
     }
     else
     {
         // True FCall 
-        LazyMachState::unwindLazyState(lazy, &unwound, 1);
+        LazyMachState::unwindLazyState(lazy, &unwound, threadId, 1);
     }
 
     _ASSERTE(unwound.isValid());

--- a/src/vm/i386/gmscpu.h
+++ b/src/vm/i386/gmscpu.h
@@ -99,6 +99,7 @@ struct LazyMachState : public MachState {
     void setLazyStateFromUnwind(MachState* copy);
     static void unwindLazyState(LazyMachState* baseState,
                                 MachState* lazyState,
+                                DWORD threadId,
                                 int funCallDepth = 1,
                                 HostCallPreference hostCallPreference = AllowHostCalls);
 

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -339,6 +339,7 @@ static bool shouldEnterCall(PTR_BYTE ip) {
 //
 void LazyMachState::unwindLazyState(LazyMachState* baseState,
                                     MachState* lazyState,
+                                    DWORD threadId,
                                     int funCallDepth /* = 1 */,
                                     HostCallPreference hostCallPreference /* = (HostCallPreference)(-1) */)
 {


### PR DESCRIPTION
Add and implement new ICorDebugDataTarget4 unwind interface using lldb stack unwinder ABIs. The implementation
does a linear search of the native frames for the stack pointer provided. It doesn't happen often so the
performance is fine.

Stub out the DBI's ICorDebugDataTarget4 (in ShimDataTarget::VirtualUnwind) for now. Since PAL_VirtualUnwindOutOfProc
is disabled it makes sense to just return E_NOTIMPL.