### PR TITLE
Selective VirtualProtect in debugger heap for Realloc

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -16802,14 +16802,17 @@ void *DebuggerHeap::Realloc(void *pMem, DWORD newSize, DWORD oldSize)
 
 
 #ifdef FEATURE_PAL
-    // We don't have executable heap in PAL, but we still need to allocate 
-    // executable memory, that's why have change protection level for 
-    // each allocation. 
-    // UNIXTODO: We need to look how JIT solves this problem.
-    DWORD unusedFlags;
-    if (!VirtualProtect(ret, newSize, PAGE_EXECUTE_READWRITE, &unusedFlags))
-    {
-        _ASSERTE(!"VirtualProtect failed to make this memory executable");
+    if (m_fExecutable)
+    {    
+        // We don't have executable heap in PAL, but we still need to allocate 
+        // executable memory, that's why have change protection level for 
+        // each allocation. 
+        // UNIXTODO: We need to look how JIT solves this problem.
+        DWORD unusedFlags;
+        if (!VirtualProtect(ret, newSize, PAGE_EXECUTE_READWRITE, &unusedFlags))
+        {
+            _ASSERTE(!"VirtualProtect failed to make this memory executable");
+        }
     }
 #endif // FEATURE_PAL    
 


### PR DESCRIPTION
This is just an additional fix for PR #1963 which, unexpectedly for me, got merged before I was done testing.