### PR TITLE
Fix struct padding issues with SysV struct classification.

### DIFF
--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -703,7 +703,6 @@ struct SystemVStructRegisterPassingHelper
         {
             fieldClassifications[i] = SystemVClassificationTypeNoClass;
             fieldSizes[i] = 0;
-            fieldLayoutSizes[i] = 0;
             fieldOffsets[i] = 0;
         }
     }
@@ -723,7 +722,6 @@ struct SystemVStructRegisterPassingHelper
     int                             largestFieldOffset;
     SystemVClassificationType       fieldClassifications[SYSTEMV_MAX_NUM_FIELDS_IN_REGISTER_PASSED_STRUCT];
     unsigned int                    fieldSizes[SYSTEMV_MAX_NUM_FIELDS_IN_REGISTER_PASSED_STRUCT];
-    unsigned int                    fieldLayoutSizes[SYSTEMV_MAX_NUM_FIELDS_IN_REGISTER_PASSED_STRUCT];
     unsigned int                    fieldOffsets[SYSTEMV_MAX_NUM_FIELDS_IN_REGISTER_PASSED_STRUCT];
 };
 


### PR DESCRIPTION
This change revises the handling of padding bytes between struct fields
and bytes that trail the last field in a struct. These changes address
problems with structs that contain > 8 bytes between fields as well as
C# fixed arrays (which are emitted as a struct with a single field of
the fixed array element type and an explicit size derived from the
number of elements and the size of the element type).

The classification given to a particular byte that is not part of a
formal field depends on whether that byte is between fields or
trails the final field in a struct. Bytes in the former category--
padding bytes--are classified as NO_CLASS as per the SysV ABI spec.
Bytes in the latter category--"leftover" bytes after the final
field of a struct--are assigned the classification of the final
field in the struct. This allows C# fixed-size arrays to work
properly, as their representative structs are logically (but
unfortunately not physically) structs with element-count fields of
the element type. Were they explicit, each of these fields would
have the same classification.