### PR TITLE
Remove unneeded EnterCriticalSection / LeaveCriticalSection exports

### DIFF
--- a/src/dlls/mscoree/mscorwks_unixexports.src
+++ b/src/dlls/mscoree/mscorwks_unixexports.src
@@ -31,7 +31,6 @@ CreateMutexW
 CreateSemaphoreW
 DeleteFileW
 DuplicateHandle
-EnterCriticalSection
 FindClose
 FindFirstFileW
 FindNextFileW
@@ -57,7 +56,6 @@ GetStdHandle
 GetSystemInfo
 GetTempFileNameW
 GetTempPathW
-LeaveCriticalSection
 LocalAlloc
 LocalReAlloc
 LocalFree


### PR DESCRIPTION
Clr debugger was using these which turned out to be not needed