### PR TITLE
Fix exception when writing null/empty arrays to EventSource

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs
@@ -1055,16 +1055,27 @@ namespace System.Diagnostics.Tracing
         {
             if (m_eventSourceEnabled)
             {
-                if (arg1 == null) arg1 = Array.Empty<byte>();
-                int blobSize = arg1.Length;
-                fixed (byte* blob = &arg1[0])
+                EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
+                if (arg1 == null || arg1.Length == 0)
                 {
-                    EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
+                    int blobSize = 0;
                     descrs[0].DataPointer = (IntPtr)(&blobSize);
                     descrs[0].Size = 4;
-                    descrs[1].DataPointer = (IntPtr)blob;
-                    descrs[1].Size = blobSize;
+                    descrs[1].DataPointer = (IntPtr)(&blobSize); // valid address instead of empty content
+                    descrs[1].Size = 0;
                     WriteEventCore(eventId, 2, descrs);
+                }
+                else
+                {
+                    int blobSize = arg1.Length;
+                    fixed (byte* blob = &arg1[0])
+                    {
+                        descrs[0].DataPointer = (IntPtr)(&blobSize);
+                        descrs[0].Size = 4;
+                        descrs[1].DataPointer = (IntPtr)blob;
+                        descrs[1].Size = blobSize;
+                        WriteEventCore(eventId, 2, descrs);
+                    }
                 }
             }
         }
@@ -1075,18 +1086,29 @@ namespace System.Diagnostics.Tracing
         {
             if (m_eventSourceEnabled)
             {
-                if (arg2 == null) arg2 = Array.Empty<byte>();
-                int blobSize = arg2.Length;
-                fixed (byte* blob = &arg2[0])
+                EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
+                descrs[0].DataPointer = (IntPtr)(&arg1);
+                descrs[0].Size = 8;
+                if (arg2 == null || arg2.Length == 0)
                 {
-                    EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
-                    descrs[0].DataPointer = (IntPtr)(&arg1);
-                    descrs[0].Size = 8;
+                    int blobSize = 0;
                     descrs[1].DataPointer = (IntPtr)(&blobSize);
                     descrs[1].Size = 4;
-                    descrs[2].DataPointer = (IntPtr)blob;
-                    descrs[2].Size = blobSize;
+                    descrs[2].DataPointer = (IntPtr)(&blobSize); // valid address instead of empty contents
+                    descrs[2].Size = 0;
                     WriteEventCore(eventId, 3, descrs);
+                }
+                else
+                {
+                    int blobSize = arg2.Length;
+                    fixed (byte* blob = &arg2[0])
+                    {
+                        descrs[1].DataPointer = (IntPtr)(&blobSize);
+                        descrs[1].Size = 4;
+                        descrs[2].DataPointer = (IntPtr)blob;
+                        descrs[2].Size = blobSize;
+                        WriteEventCore(eventId, 3, descrs);
+                    }
                 }
             }
         }


### PR DESCRIPTION
EventSource has two WriteEvent overloads that take a byte[].  If the byte[] provided is null, it uses an empty array.  It then tries to get the address of the 0th element of the array, resulting in an IndexOutOfRangeException.  We could instead just use ```byte* blob = arg1``` instead of ```byte* blob = &arg1[0]```, but doing so with an empty array has undefined behavior in C#.  Instead, we just special-case null and empty arrays.

cc: @vancem, @brianrob 