### PR TITLE
Added --no-keep-memory dynamic linker flag for linux embedded

### DIFF
--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -21,7 +21,7 @@ else()
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
 
 	# Follow option is necessary to avoid ld process gets killed on low-memory embedded systems such as BananaPi
-	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --no-keep-memory")
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker --no-keep-memory")
 
         # The following linked options can be inserted into the linker libraries list to 
         # ensure proper resolving of circular references between a subset of the libraries.

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -20,6 +20,9 @@ else()
         # of the utilcode will be used instead of the standard library delete operator.
         set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
 
+	# Follow option is necessary to avoid ld process gets killed on low-memory embedded systems such as BananaPi
+	set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --no-keep-memory")
+
         # The following linked options can be inserted into the linker libraries list to 
         # ensure proper resolving of circular references between a subset of the libraries.
         set(START_LIBRARY_GROUP -Wl,--start-group)


### PR DESCRIPTION
I tried to compile coreclr from bananapi (1MB ram) with 1.5GB swap but that not helped to avoid ld process gets killed during the build of the libcoreclr.so.
Adding the --no-keep-memory option allow the build not hangs on there.