### PR TITLE
More PAL thread cleanup (last one)

### DIFF
--- a/src/pal/src/cruntime/misc.cpp
+++ b/src/pal/src/cruntime/misc.cpp
@@ -47,27 +47,6 @@ CRITICAL_SECTION gcsEnvironment;
 
 using namespace CorUnix;
 
-namespace CorUnix
-{
-    int InternalRand(CPalThread *pthrCurrent);
-
-    /*++
-    Function:
-    InternalRand
-
-    Wrapper for rand.
-    --*/
-    int
-    InternalRand(
-        CPalThread *pthrCurrent
-        )
-    {
-        int nRet;
-        nRet = rand();
-        return nRet;
-    }
-}
-
 /*++
 Function:
   _gcvt_s
@@ -271,7 +250,7 @@ PAL_rand(void)
     PERF_ENTRY(rand);
     ENTRY("rand(void)\n");
 
-    ret = (InternalRand(InternalGetCurrentThread()) % (PAL_RAND_MAX + 1));
+    ret = (rand() % (PAL_RAND_MAX + 1));
 
     LOGEXIT("rand() returning %d\n", ret);
     PERF_EXIT(rand);

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -43,7 +43,6 @@ SET_DEFAULT_DEBUG_CHANNEL(FILE);
 namespace CorUnix
 {
     int InternalGlob(
-        CPalThread *pthrCurrent,
         const char *szPattern,
         int nFlags,
 #if ERROR_FUNC_FOR_GLOB_HAS_FIXED_PARAMS    
@@ -59,7 +58,6 @@ namespace CorUnix
 
     Input parameters:
 
-    pthrCurrent = reference to executing thread
     szPattern = pointer to a pathname pattern to be expanded
     nFlags = arguments to modify the behavior of glob
     pnErrFunc = pointer to a routine that handles errors during the glob call
@@ -76,7 +74,6 @@ namespace CorUnix
     --*/
     int
     InternalGlob(
-        CPalThread *pthrCurrent,
         const char *szPattern,
         int nFlags,
 #if ERROR_FUNC_FOR_GLOB_HAS_FIXED_PARAMS
@@ -102,7 +99,6 @@ static BOOL FILEDosGlobA(
 static int FILEGlobQsortCompare(const void *in_str1, const void *in_str2);
 
 static int FILEGlobFromSplitPath( 
-        CPalThread *pthrCurrent,
         const char *dir,
         const char *fname,
         const char *ext,
@@ -767,8 +763,7 @@ in broken-down form like _splitpath produces.
 ie. calling splitpath on a pattern then calling this function should
 produce the same result as just calling glob() on the pattern.
 --*/
-static int FILEGlobFromSplitPath( CPalThread *pthrCurrent,
-                                  const char *dir,
+static int FILEGlobFromSplitPath( const char *dir,
                                   const char *fname,
                                   const char *ext,
                                   int flags, 
@@ -811,7 +806,7 @@ static int FILEGlobFromSplitPath( CPalThread *pthrCurrent,
 #ifdef GLOB_QUOTE
     flags |= GLOB_QUOTE;
 #endif  // GLOB_QUOTE
-    Ret = InternalGlob(pthrCurrent, EscapedPattern, flags, NULL, pgGlob);
+    Ret = InternalGlob(EscapedPattern, flags, NULL, pgGlob);
 
 #ifdef GLOB_NOMATCH
     if (Ret == GLOB_NOMATCH)
@@ -950,7 +945,7 @@ static BOOL FILEDosGlobA( CPalThread *pthrCurrent,
     if ( !(A && B) ) 
     {
         /* the original pattern */
-        globResult = FILEGlobFromSplitPath(pthrCurrent, Dir, Filename, Ext, 0, pgGlob);
+        globResult = FILEGlobFromSplitPath(Dir, Filename, Ext, 0, pgGlob);
         if ( globResult != 0 )
         {
             goto done;
@@ -959,7 +954,7 @@ static BOOL FILEDosGlobA( CPalThread *pthrCurrent,
         if (C)
         {
             /* the original pattern but '.' prepended to filename */
-            globResult = FILEGlobFromSplitPath(pthrCurrent, Dir, Filename - 1, Ext,
+            globResult = FILEGlobFromSplitPath(Dir, Filename - 1, Ext,
                                                GLOB_APPEND, pgGlob);
             if ( globResult != 0 )
             {
@@ -973,7 +968,7 @@ static BOOL FILEDosGlobA( CPalThread *pthrCurrent,
         /* if (A && B), this is the first glob() call. The first call
            to glob must use flags = 0, while proceeding calls should
            set the GLOB_APPEND flag. */
-        globResult = FILEGlobFromSplitPath(pthrCurrent, Dir, Filename, "",
+        globResult = FILEGlobFromSplitPath(Dir, Filename, "",
                                            (A && B)?0:GLOB_APPEND, pgGlob);
         if ( globResult != 0 )
         {
@@ -983,7 +978,7 @@ static BOOL FILEDosGlobA( CPalThread *pthrCurrent,
         if (C)
         {
             /* omit the extension and prepend '.' to filename */
-            globResult = FILEGlobFromSplitPath(pthrCurrent, Dir, Filename - 1, "",
+            globResult = FILEGlobFromSplitPath(Dir, Filename - 1, "",
                                                GLOB_APPEND, pgGlob);
             if ( globResult != 0 )
             {

--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -107,9 +107,7 @@ namespace CorUnix
             );
 
         void
-        FreeBuffer(
-            CPalThread *pthr
-            );            
+        FreeBuffer();
 
         const WCHAR *
         GetString()

--- a/src/pal/src/include/pal/procobj.hpp
+++ b/src/pal/src/include/pal/procobj.hpp
@@ -114,7 +114,6 @@ namespace CorUnix
 
     PAL_ERROR
     InitializeProcessCommandLine(
-        CPalThread *pThread,
         LPWSTR lpwstrCmdLine,
         LPWSTR lpwstrFullPath
         );

--- a/src/pal/src/include/pal/synchobjects.hpp
+++ b/src/pal/src/include/pal/synchobjects.hpp
@@ -168,7 +168,7 @@ namespace CorUnix
         }
 
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
-        PAL_ERROR RunDeferredThreadConditionSignalings(CPalThread * pthrCurrent);
+        PAL_ERROR RunDeferredThreadConditionSignalings();
 #endif // SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
     
         // NOTE: the following methods provide non-synchronized access to 
@@ -205,8 +205,7 @@ namespace CorUnix
     class CPalSynchMgrController
     {
     public:
-        static IPalSynchronizationManager * CreatePalSynchronizationManager(
-            CPalThread * pthrCurrent);
+        static IPalSynchronizationManager * CreatePalSynchronizationManager();
 
         static PAL_ERROR StartWorker(CPalThread * pthrCurrent);
 

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -378,7 +378,7 @@ Initialize(
         // Initialize the synchronization manager
         //
         g_pSynchronizationManager =
-            CPalSynchMgrController::CreatePalSynchronizationManager(pThread);
+            CPalSynchMgrController::CreatePalSynchronizationManager();
 
         if (NULL == g_pSynchronizationManager)
         {
@@ -419,7 +419,6 @@ Initialize(
         }
 
         palError = InitializeProcessCommandLine(
-            pThread,
             command_line,
             exe_path);
         

--- a/src/pal/src/map/map.cpp
+++ b/src/pal/src/map/map.cpp
@@ -80,7 +80,6 @@ static PMAPPED_VIEW_LIST FindSharedMappingReplacement(CPalThread *pThread, dev_t
 
 static PAL_ERROR
 MAPRecordMapping(
-    CPalThread *pThread,
     IPalObject *pMappingObject,
     void *pPEBaseAddress,
     void *addr,
@@ -90,7 +89,6 @@ MAPRecordMapping(
 
 static PAL_ERROR
 MAPmmapAndRecord(
-    CPalThread *pThread,
     IPalObject *pMappingObject,
     void *pPEBaseAddress,
     void *addr,
@@ -2185,7 +2183,6 @@ static LONG NativeMapHolderRelease(CPalThread *pThread, NativeMapHolder * thisNM
 // This call assumes the mapping_critsec has already been taken.
 static PAL_ERROR
 MAPRecordMapping(
-    CPalThread *pThread,
     IPalObject *pMappingObject,
     void *pPEBaseAddress,
     void *addr,
@@ -2225,7 +2222,6 @@ MAPRecordMapping(
 // This call assumes the mapping_critsec has already been taken.
 static PAL_ERROR
 MAPmmapAndRecord(
-    CPalThread *pThread,
     IPalObject *pMappingObject,
     void *pPEBaseAddress,
     void *addr,
@@ -2250,7 +2246,7 @@ MAPmmapAndRecord(
     }
     else
     {
-        palError = MAPRecordMapping(pThread, pMappingObject, pPEBaseAddress, pvBaseAddress, len, prot);
+        palError = MAPRecordMapping(pMappingObject, pPEBaseAddress, pvBaseAddress, len, prot);
         if (NO_ERROR != palError)
         {
             if (-1 == munmap(pvBaseAddress, len))
@@ -2475,7 +2471,7 @@ void * MAPMapPEFile(HANDLE hFile)
     headerSize = VIRTUAL_PAGE_SIZE; // if there are lots of sections, this could be wrong
 
     //first, map the PE header to the first page in the image.  Get pointers to the section headers
-    palError = MAPmmapAndRecord(pThread, pFileObject, loadedBase,
+    palError = MAPmmapAndRecord(pFileObject, loadedBase,
                     loadedBase, headerSize, PROT_READ, MAP_FILE|MAP_PRIVATE|MAP_FIXED, fd, 0,
                     (void**)&loadedHeader);
     if (NO_ERROR != palError)
@@ -2543,7 +2539,7 @@ void * MAPMapPEFile(HANDLE hFile)
         if ((char*)prevSectionBase + prevSectionSizeInMemory < sectionBase)
         {
             char* gapBase = (char*)prevSectionBase + prevSectionSizeInMemory;
-            palError = MAPRecordMapping(pThread, pFileObject,
+            palError = MAPRecordMapping(pFileObject,
                             loadedBase,
                             (void*)gapBase,
                             (char*)sectionBase - gapBase,
@@ -2565,7 +2561,7 @@ void * MAPMapPEFile(HANDLE hFile)
         if (currentHeader.Characteristics & IMAGE_SCN_MEM_WRITE)
             prot |= PROT_WRITE;
 
-        palError = MAPmmapAndRecord(pThread, pFileObject, loadedBase,
+        palError = MAPmmapAndRecord(pFileObject, loadedBase,
                         sectionBase,
                         currentHeader.SizeOfRawData,
                         prot,
@@ -2600,7 +2596,7 @@ void * MAPMapPEFile(HANDLE hFile)
     if ((char*)prevSectionBase + prevSectionSizeInMemory < imageEnd)
     {
         char* gapBase = (char*)prevSectionBase + prevSectionSizeInMemory;
-        palError = MAPRecordMapping(pThread, pFileObject,
+        palError = MAPRecordMapping(pFileObject,
                         loadedBase,
                         (void*)gapBase,
                         imageEnd - gapBase,

--- a/src/pal/src/misc/strutil.cpp
+++ b/src/pal/src/misc/strutil.cpp
@@ -87,16 +87,11 @@ Function:
 
   Frees the contained string buffer
 
-Parameters:
-  pthr -- thread data for calling thread
 --*/
 
 void
-CPalString::FreeBuffer(
-    CPalThread *pthr
-    )
+CPalString::FreeBuffer()
 {
     _ASSERTE(NULL != m_pwsz);
-    
     InternalFree(const_cast<WCHAR*>(m_pwsz));
 }

--- a/src/pal/src/objmgr/palobjbase.cpp
+++ b/src/pal/src/objmgr/palobjbase.cpp
@@ -340,11 +340,6 @@ CPalObjectBase::~CPalObjectBase()
 {
     ENTRY("CPalObjectBase::~CPalObjectBase(this = %p)\n", this);
 
-    // There is no need to call InternalGetCurrentThread here because
-    // ReleaseReference already stores the thread object that
-    // deletes this object in m_pthrCleanup to make sure the
-    // thread object is alive throughout the object cleanup process.
-
     if (NULL != m_pvImmutableData)
     {
         InternalFree(m_pvImmutableData);
@@ -357,7 +352,7 @@ CPalObjectBase::~CPalObjectBase()
 
     if (NULL != m_oa.sObjectName.GetString())
     {
-        m_oa.sObjectName.FreeBuffer(m_pthrCleanup);
+        m_oa.sObjectName.FreeBuffer();
     }
 
     LOGEXIT("CPalObjectBase::~CPalObjectBase\n");

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -587,7 +587,7 @@ namespace CorUnix
         COwnedObjectsListNodeCache      m_cacheOwnedObjectsListNodes;
 
         // static methods
-        static PAL_ERROR Initialize(CPalThread * pthrCurrent);
+        static PAL_ERROR Initialize();
         static DWORD PALAPI WorkerThread(LPVOID pArg);
 
     protected:
@@ -601,8 +601,7 @@ namespace CorUnix
             CSynchControllerBase::ControllerType ctCtrlrType);
 
     private:
-        static IPalSynchronizationManager * CreatePalSynchronizationManager(
-            CPalThread * pthrCurrent);
+        static IPalSynchronizationManager * CreatePalSynchronizationManager();
         static PAL_ERROR StartWorker(CPalThread * pthrCurrent);
         static PAL_ERROR PrepareForShutdown(void);
 
@@ -637,7 +636,7 @@ namespace CorUnix
                 InternalLeaveCriticalSection(pthrCurrent, &s_csSynchProcessLock);
                 
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
-                pthrCurrent->synchronizationInfo.RunDeferredThreadConditionSignalings(pthrCurrent);
+                pthrCurrent->synchronizationInfo.RunDeferredThreadConditionSignalings();
 #endif // SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
             }
         }
@@ -652,14 +651,14 @@ namespace CorUnix
                 InternalLeaveCriticalSection(pthrCurrent, &s_csSynchProcessLock);
 
 #if SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
-                pthrCurrent->synchronizationInfo.RunDeferredThreadConditionSignalings(pthrCurrent);
+                pthrCurrent->synchronizationInfo.RunDeferredThreadConditionSignalings();
 #endif // SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING && !SYNCHMGR_PIPE_BASED_THREAD_BLOCKING
             }            
             return lRet;
         }
         static LONG GetLocalSynchLockCount(CPalThread * pthrCurrent) 
         {
-            _ASSERTE(0 <= pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);            
+            _ASSERTE(0 <= pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount);
             return pthrCurrent->synchronizationInfo.m_lLocalSynchLockCount;
         }
 
@@ -962,7 +961,6 @@ namespace CorUnix
             DWORD * pdwData);
 
         PAL_ERROR WakeUpLocalWorkerThread(
-            CPalThread * pthrCurrent,
             SynchWorkerCmd swcWorkerCmd);
 
         void DiscardAllPendingAPCs(
@@ -974,9 +972,9 @@ namespace CorUnix
             BYTE * pRecvBuf,
             LONG lBytes);
 
-        bool CreateProcessPipe(CPalThread * pthrCurrent);
+        bool CreateProcessPipe();
 
-        PAL_ERROR ShutdownProcessPipe(CPalThread * pthrCurrent);
+        PAL_ERROR ShutdownProcessPipe();
 
     public:
         //

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2313,7 +2313,6 @@ Abstract
     Initializes (or re-initializes) the saved command line and exe path.
 
 Parameter
-    pThread - the initial thread
     lpwstrCmdLine
     lpwstrFullPath
  
@@ -2326,7 +2325,6 @@ Notes
 
 PAL_ERROR
 CorUnix::InitializeProcessCommandLine(
-    CPalThread *pThread,
     LPWSTR lpwstrCmdLine,
     LPWSTR lpwstrFullPath
 )

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -214,7 +214,7 @@ Abstract:
 Return:
     The fresh thread structure, NULL otherwise
 --*/
-CPalThread* AllocTHREAD(CPalThread *pthr)
+CPalThread* AllocTHREAD()
 {
     CPalThread* pThread = NULL;
 
@@ -574,7 +574,7 @@ CorUnix::InternalCreateThread(
     // Create the CPalThread for the thread
     //
 
-    pNewThread = AllocTHREAD(pThread);
+    pNewThread = AllocTHREAD();
     if (NULL == pNewThread)
     {
         palError = ERROR_OUTOFMEMORY;
@@ -1613,8 +1613,7 @@ CorUnix::CreateThreadData(
     CPalThread *pThread = NULL;
     
     /* Create the thread object */
-    /* Passing NULL to AllocTHREAD since there is no thread reference to pass in. */
-    pThread = AllocTHREAD(NULL);
+    pThread = AllocTHREAD();
 
     if (NULL == pThread)
     {
@@ -1830,7 +1829,7 @@ CorUnix::InternalCreateDummyThread(
     CObjectAttributes oa(NULL, lpThreadAttributes);
     bool fThreadDataStoredInObject = FALSE;
 
-    pDummyThread = AllocTHREAD(pThread);
+    pDummyThread = AllocTHREAD();
     if (NULL == pDummyThread)
     {
         palError = ERROR_OUTOFMEMORY;


### PR DESCRIPTION
This is the final set of changes I'll be making with regard to removing unused CPalThread* parameters in functions and removing `Internal___` wrapper functions that are no longer needed.

As always, there are more things that can be cleaned up. For example, there are functions that only use their thread parameter to call `SetLastError`, and there are still functions that take (non-thread) parameters they don't use. This series of changes doesn't try to address those things; it is meant to just clean up loose ends after removing thread suspend/resume.

If there are no objections, I will consider #1795 complete with this change.

@sergiy-k 