### PR TITLE
Use interlocked operation return value to avoid reloading memory.

### DIFF
--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -7566,14 +7566,19 @@ void CExecutionEngine::DetachTlsInfo(void **pTlsData)
 #endif
     }
 
+    ClrTlsInfo *head = g_pDetachedTlsInfo.Load();
+
     while (TRUE)
     {
-        ClrTlsInfo *head = g_pDetachedTlsInfo.Load();
-        pTlsInfo->next =  head;
-        if (FastInterlockCompareExchangePointer(g_pDetachedTlsInfo.GetPointer(), pTlsInfo, head) == head)
+        pTlsInfo->next = head;
+
+        ClrTlsInfo *oldHead = FastInterlockCompareExchangePointer(g_pDetachedTlsInfo.GetPointer(), pTlsInfo, head);
+        if (oldHead == head)
         {
             return;
         }
+
+        head = oldHead;
     }
 }
 

--- a/src/vm/loaderallocator.cpp
+++ b/src/vm/loaderallocator.cpp
@@ -120,10 +120,11 @@ BOOL LoaderAllocator::AddReferenceIfAlive()
     CONTRACTL_END;
     
 #ifndef DACCESS_COMPILE
+    // Local snaphost of ref-count
+    UINT32 cReferencesLocalSnapshot = m_cReferences;
+
     for (;;)
     {
-        // Local snaphost of ref-count
-        UINT32 cReferencesLocalSnapshot = m_cReferences;
         _ASSERTE(cReferencesLocalSnapshot != (UINT32)-1);
         
         if (cReferencesLocalSnapshot == 0)
@@ -140,7 +141,9 @@ BOOL LoaderAllocator::AddReferenceIfAlive()
         {   // The exchange happened
             return TRUE;
         }
+
         // Let's spin till we are the only thread to modify this value
+        cReferencesLocalSnapshot = cOriginalReferences;
     }
 #else //DACCESS_COMPILE
     // DAC won't AddRef

--- a/src/vm/mdaassistants.cpp
+++ b/src/vm/mdaassistants.cpp
@@ -221,17 +221,20 @@ void MdaCallbackOnCollectedDelegate::AddToList(UMEntryThunk* pEntryThunk)
     CONTRACTL_END;
 
     // Get an index to use.
-    ULONG oldIndex = m_iIndex;
-    ULONG newIndex = oldIndex + 1;
-    if (newIndex >= (ULONG)m_size)
-        newIndex = 0;
+    ULONG index = m_iIndex;
     
-    while ((ULONG)FastInterlockCompareExchange((LONG*)&m_iIndex, newIndex, oldIndex) != oldIndex)
+    while (TRUE) 
     {
-        oldIndex = m_iIndex;
-        newIndex = oldIndex + 1;
+        ULONG newIndex = index + 1;
         if (newIndex >= (ULONG)m_size)
             newIndex = 0;
+
+        ULONG oldIndex = (ULONG)FastInterlockCompareExchange((LONG*)&m_iIndex, newIndex, index);
+
+        if (oldIndex == index)
+            break;
+
+        index = oldIndex;
     }
 
     // We successfully incremented the index and can use the oldIndex value as our entry.


### PR DESCRIPTION
Optimize memory bandwidth by reusing interlocked compare exchange return value instead of reloading the value from memory as the cache line touched by the ICX operation was invalidated due to the full barrier. CLR already does this kind of optimization in other areas, this change tries to close the gap.