### PR TITLE
Fix for issue 1995.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1189,7 +1189,8 @@ struct fgArgTabEntry
     fgArgTabEntry()
     {
         otherRegNum                     = REG_NA;
-        isStruct                        = false;  // is this a struct arg
+        isStruct                        = false;            // is this a struct arg
+        classHnd                        = NO_CLASS_HANDLE;  // typeHandle for the struct.
     }
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
@@ -1220,9 +1221,9 @@ struct fgArgTabEntry
     bool           isNonStandard:1; // True if it is an arg that is passed in a reg other than a standard arg reg
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-    regNumber             otherRegNum;              // The (second) register to use when passing this argument.
-    bool                  isStruct;                 // is this a struct arg
-
+    regNumber             otherRegNum;  // The (second) register to use when passing this argument.
+    bool                  isStruct;     // is this a struct arg.
+    CORINFO_CLASS_HANDLE  classHnd;     // type (class) handle for the struct.
     SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
@@ -1287,7 +1288,8 @@ public:
                                         unsigned        alignment,
                                         const bool      isStruct,
                                         const regNumber otherRegNum = REG_NA,
-                                        const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr = nullptr);
+                                        const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR* const structDescPtr = nullptr,
+                                        const CORINFO_CLASS_HANDLE classHandle = NO_CLASS_HANDLE); 
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
     fgArgTabEntryPtr AddStkArg         (unsigned        argNum,
@@ -1295,7 +1297,8 @@ public:
                                         GenTreePtr      parent,
                                         unsigned        numSlots,
                                         unsigned        alignment
-                                        FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct));
+                                        FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const bool isStruct)
+                                        FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(const CORINFO_CLASS_HANDLE classHandle = NO_CLASS_HANDLE)); 
 
     void             RemorphReset      ();
     fgArgTabEntryPtr RemorphRegArg     (unsigned        argNum,

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -2621,19 +2621,40 @@ bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(
         }
         else
         {
-            structPassInRegDescPtr->passedInRegisters = true;
-
             SystemVStructRegisterPassingHelper helper((unsigned int)th.GetSize());
-            bool result = methodTablePtr->ClassifyEightBytes(&helper, 0, 0);
 
-            structPassInRegDescPtr->eightByteCount = helper.eightByteCount;
-            _ASSERTE(structPassInRegDescPtr->eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
-
-            for (unsigned int i = 0; i < CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS; i++)
+            if (!isPassableInRegs)
             {
-                structPassInRegDescPtr->eightByteClassifications[i] = helper.eightByteClassifications[i];
-                structPassInRegDescPtr->eightByteSizes[i] = helper.eightByteSizes[i];
-                structPassInRegDescPtr->eightByteOffsets[i] = helper.eightByteOffsets[i];
+                structPassInRegDescPtr->passedInRegisters = false;
+            }
+            else
+            {
+                bool result = false;
+
+                SystemVStructRegisterPassingHelper helper((unsigned int)th.GetSize());
+
+                if (isNativeStruct)
+                {
+                    result = methodTablePtr->ClassifyEightBytesForNativeStruct(&helper, 0, 0);
+                }
+                else
+                {
+                    result = methodTablePtr->ClassifyEightBytes(&helper, 0, 0);
+                }
+
+                structPassInRegDescPtr->passedInRegisters = result;
+                if (result)
+                {
+                    structPassInRegDescPtr->eightByteCount = helper.eightByteCount;
+                    _ASSERTE(structPassInRegDescPtr->eightByteCount <= CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
+
+                    for (unsigned int i = 0; i < CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS; i++)
+                    {
+                        structPassInRegDescPtr->eightByteClassifications[i] = helper.eightByteClassifications[i];
+                        structPassInRegDescPtr->eightByteSizes[i] = helper.eightByteSizes[i];
+                        structPassInRegDescPtr->eightByteOffsets[i] = helper.eightByteOffsets[i];
+                    }
+                }
             }
         }
     }

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -2635,11 +2635,11 @@ bool CEEInfo::getSystemVAmd64PassStructInRegisterDescriptor(
 
                 if (isNativeStruct)
                 {
-                    result = methodTablePtr->ClassifyEightBytesForNativeStruct(&helper, 0, 0);
+                    result = methodTablePtr->ClassifyEightBytesForNativeStruct(&helper, 0, 0, isNativeStruct);
                 }
                 else
                 {
-                    result = methodTablePtr->ClassifyEightBytes(&helper, 0, 0);
+                    result = methodTablePtr->ClassifyEightBytesForManagedStruct(&helper, 0, 0, isNativeStruct);
                 }
 
                 structPassInRegDescPtr->passedInRegisters = result;

--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -2344,7 +2344,10 @@ SystemVClassificationType MethodTable::ReClassifyField(SystemVClassificationType
 }
 
 // Returns 'true' if the struct is passed in registers, 'false' otherwise.
-bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct)
+bool MethodTable::ClassifyEightBytesForManagedStruct(SystemVStructRegisterPassingHelperPtr helperPtr,
+                                                     unsigned int nestingLevel, 
+                                                     unsigned int startOffsetOfStruct,
+                                                     bool isNativeStruct)
 {
     CONTRACTL
     {
@@ -2355,6 +2358,8 @@ bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helpe
     }
     CONTRACTL_END;
     
+    _ASSERTE(!isNativeStruct);
+
     WORD numIntroducedFields = GetNumIntroducedInstanceFields();
 
     // It appears the VM gives a struct with no fields of size 1.
@@ -2369,7 +2374,7 @@ bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helpe
     // unconditionally disable register struct passing for explicit layout.
     if (GetClass()->HasExplicitFieldOffsetLayout())
     {
-        LOG((LF_JIT, LL_EVERYTHING, "%*s**** ClassifyEightBytes: struct %s has explicit layout; will not be enregistered\n",
+        LOG((LF_JIT, LL_EVERYTHING, "%*s**** ClassifyEightBytesForManagedStruct: struct %s has explicit layout; will not be enregistered\n",
                nestingLevel * 5, "", this->GetDebugClassName()));
         return false;
     }
@@ -2418,7 +2423,7 @@ bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helpe
 
             bool inEmbeddedStructPrev = helperPtr->inEmbeddedStruct;
             helperPtr->inEmbeddedStruct = true;
-            bool structRet = pFieldMT->ClassifyEightBytes(helperPtr, nestingLevel + 1, normalizedFieldOffset);
+            bool structRet = pFieldMT->ClassifyEightBytesForManagedStruct(helperPtr, nestingLevel + 1, normalizedFieldOffset, isNativeStruct);
             helperPtr->inEmbeddedStruct = inEmbeddedStructPrev;
 
             if (!structRet)
@@ -2515,7 +2520,10 @@ bool MethodTable::ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helpe
 }
 
 // Returns 'true' if the struct is passed in registers, 'false' otherwise.
-bool MethodTable::ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct)
+bool MethodTable::ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassingHelperPtr helperPtr,
+                                                    unsigned int nestingLevel, 
+                                                    unsigned int startOffsetOfStruct, 
+                                                    bool isNativeStruct)
 {
     CONTRACTL
     {
@@ -2525,6 +2533,8 @@ bool MethodTable::ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassing
         MODE_ANY;
     }
     CONTRACTL_END;
+
+    _ASSERTE(isNativeStruct);
 
 #ifdef DACCESS_COMPILE
     // No register classification for this case.
@@ -2681,7 +2691,7 @@ bool MethodTable::ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassing
 
             bool inEmbeddedStructPrev = helperPtr->inEmbeddedStruct;
             helperPtr->inEmbeddedStruct = true;
-            bool structRet = pFieldMT->ClassifyEightBytesForNativeStruct(helperPtr, nestingLevel + 1, normalizedFieldOffset);
+            bool structRet = pFieldMT->ClassifyEightBytesForNativeStruct(helperPtr, nestingLevel + 1, normalizedFieldOffset, isNativeStruct);
             helperPtr->inEmbeddedStruct = inEmbeddedStructPrev;
 
             if (!structRet)
@@ -2698,7 +2708,7 @@ bool MethodTable::ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassing
 
             bool inEmbeddedStructPrev = helperPtr->inEmbeddedStruct;
             helperPtr->inEmbeddedStruct = true;
-            bool structRet = pFieldMT->ClassifyEightBytesForNativeStruct(helperPtr, nestingLevel + 1, normalizedFieldOffset);
+            bool structRet = pFieldMT->ClassifyEightBytesForNativeStruct(helperPtr, nestingLevel + 1, normalizedFieldOffset, isNativeStruct);
             helperPtr->inEmbeddedStruct = inEmbeddedStructPrev;
 
             if (!structRet)

--- a/src/vm/methodtable.h
+++ b/src/vm/methodtable.h
@@ -1048,12 +1048,12 @@ public:
     void CheckRunClassInitAsIfConstructingThrowing();
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING_ITF)
-    // Helper function for ClassifyEightBytes
+    // Helper function for ClassifyEightBytesForManagedStruct and ClassifyEightBytesForNativeStruct
     static SystemVClassificationType ReClassifyField(SystemVClassificationType originalClassification, SystemVClassificationType newFieldClassification);
 
     // Builds the internal data structures and classifies struct eightbytes for Amd System V calling convention.
-    bool ClassifyEightBytes(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct);
-    bool ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct);
+    bool ClassifyEightBytesForManagedStruct(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct);
+    bool ClassifyEightBytesForNativeStruct(SystemVStructRegisterPassingHelperPtr helperPtr, unsigned int nestingLevel, unsigned int startOffsetOfStruct, bool isNativeStruct);
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING_ITF)
 
     // Copy m_dwFlags from another method table

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -8475,7 +8475,7 @@ void MethodTableBuilder::SystemVAmd64CheckForPassStructInRegister()
     // Iterate through the fields and make sure they meet requirements to pass in registers
     SystemVStructRegisterPassingHelper helper((unsigned int)totalStructSize);
 
-    if (GetHalfBakedMethodTable()->ClassifyEightBytes(&helper, 0, 0))
+    if (GetHalfBakedMethodTable()->ClassifyEightBytesForManagedStruct(&helper, 0, 0, false))
     {
         // All the above tests passed. It's registers passed struct!
         GetHalfBakedMethodTable()->SetRegPassedStruct();
@@ -8513,7 +8513,7 @@ void MethodTableBuilder::SystemVAmd64CheckForPassNativeStructInRegister()
    
     // Iterate through the fields and make sure they meet requirements to pass in registers
     SystemVStructRegisterPassingHelper helper((unsigned int)totalStructSize);
-    if (GetHalfBakedMethodTable()->ClassifyEightBytesForNativeStruct(&helper, 0, 0))
+    if (GetHalfBakedMethodTable()->ClassifyEightBytesForNativeStruct(&helper, 0, 0, true))
     {
         GetLayoutInfo()->SetNativeStructPassedInRegisters();
     }


### PR DESCRIPTION
This changes containing a fix for Issue 1995.
When re-morphing an argument that has been already completed (in case of
CSE rewriting for example, as in this case) the classification code was
not run properly and it is triggering an assertion. As the Issue 1995
states the assert failure is benign since the generated code is correct -
the change of registers used during completed argument classification is
not allowed and the code is not changing them.
This changes add the necessary code to properly classify and assign
registers for completed arguments re-morphing, which complies with the expectations of the failing assert.
