### PR TITLE
Fix for issue 1995.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1189,7 +1189,7 @@ struct fgArgTabEntry
     fgArgTabEntry()
     {
         otherRegNum                     = REG_NA;
-        isStruct                        = false;  // is this a struct arg
+        isStruct                        = false;            // is this a struct arg
     }
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
@@ -1220,9 +1220,8 @@ struct fgArgTabEntry
     bool           isNonStandard:1; // True if it is an arg that is passed in a reg other than a standard arg reg
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-    regNumber             otherRegNum;              // The (second) register to use when passing this argument.
-    bool                  isStruct;                 // is this a struct arg
-
+    regNumber             otherRegNum;  // The (second) register to use when passing this argument.
+    bool                  isStruct;     // is this a struct arg.
     SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -932,7 +932,7 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                     argNode = argNode->gtEffectiveVal();
                 }
 
-                // If the struct arg is wraped in CPYBLK the type of the param will beTYP_VOID.
+                // If the struct arg is wraped in CPYBLK the type of the param will be TYP_VOID.
                 // Use the curArgTabEntry's isStruct to get whether the param is a struct.
                 if (argNode->TypeGet() == TYP_STRUCT 
                     FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY(|| curArgTabEntry->isStruct))


### PR DESCRIPTION
This changes contain a fix for Issue 1995.
When remorphing an argument that has been already completed (in case of
CSE rewriting for example, as in this case) the classification code was
not run properly and it is triggering an assertion. As the Issue 1995
states the assert failure is benign since the generated code is correct -
the change of registers used during completed argument classification is
not allowed and the code is not changing them.
This changes add the necessary code to properly classify and assign
registers for completed arguments remorphing, which complies with the expectation of the failing assert.