### PR TITLE
Fix for build break

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -627,7 +627,9 @@ void GcInfoEncoder::Build()
      m_DbgEncoder.Build();
 #endif    
 
+#ifdef _DEBUG
     _ASSERTE(m_IsSlotTableFrozen || m_NumSlots == 0);
+#endif
 
     _ASSERTE((1 << NUM_NORM_CODE_OFFSETS_PER_CHUNK_LOG2) == NUM_NORM_CODE_OFFSETS_PER_CHUNK);
 


### PR DESCRIPTION
When building llilc against coreclr in Linux, m_IsSlotTableFrozen is defined under _DEBUG
but it is used without guard "#ifdef _DEBUG"
This is fix for it.