### PR TITLE
Fix a couple of issues involving assembly loading

### DIFF
--- a/src/binder/binderinterface.cpp
+++ b/src/binder/binderinterface.cpp
@@ -110,6 +110,7 @@ namespace BinderInterface
                                                         pParentAssembly,
                                                         fNgenExplicitBind,
                                                         fExplicitBindToNativeImage,
+                                                        false, // excludeAppPaths
                                                         ppAssembly));
             }
 

--- a/src/binder/clrprivbindercoreclr.cpp
+++ b/src/binder/clrprivbindercoreclr.cpp
@@ -15,7 +15,8 @@ using namespace BINDER_SPACE;
 //-----------------------------------------------------------------------------
 
 HRESULT CLRPrivBinderCoreCLR::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyName *pAssemblyName,
-                                                       BINDER_SPACE::Assembly **ppCoreCLRFoundAssembly)
+                                                       BINDER_SPACE::Assembly **ppCoreCLRFoundAssembly,
+                                                       bool excludeAppPaths)
 {
     VALIDATE_ARG_RET(pAssemblyName != nullptr && ppCoreCLRFoundAssembly != nullptr);
     HRESULT hr = S_OK;
@@ -31,6 +32,7 @@ HRESULT CLRPrivBinderCoreCLR::BindAssemblyByNameWorker(BINDER_SPACE::AssemblyNam
                                       NULL,
                                       FALSE, //fNgenExplicitBind,
                                       FALSE, //fExplicitBindToNativeImage,
+                                      excludeAppPaths,
                                       ppCoreCLRFoundAssembly);
     if (!FAILED(hr))
     {
@@ -59,7 +61,7 @@ HRESULT CLRPrivBinderCoreCLR::BindAssemblyByName(IAssemblyName     *pIAssemblyNa
         SAFE_NEW(pAssemblyName, AssemblyName);
         IF_FAIL_GO(pAssemblyName->Init(pIAssemblyName));
         
-        hr = BindAssemblyByNameWorker(pAssemblyName, &pCoreCLRFoundAssembly);
+        hr = BindAssemblyByNameWorker(pAssemblyName, &pCoreCLRFoundAssembly, false /* excludeAppPaths */);
         IF_FAIL_GO(hr);
             
         *ppAssembly = pCoreCLRFoundAssembly.Extract();
@@ -167,6 +169,7 @@ HRESULT CLRPrivBinderCoreCLR::Bind(SString           &assemblyDisplayName,
                                           pParentAssembly,
                                           fNgenExplicitBind,
                                           fExplicitBindToNativeImage,
+                                          false, // excludeAppPaths
                                           &pAsm);
         if(SUCCEEDED(hr))
         {

--- a/src/binder/inc/assemblybinder.hpp
+++ b/src/binder/inc/assemblybinder.hpp
@@ -47,6 +47,7 @@ namespace BINDER_SPACE
                                     /* in */  PEAssembly          *pParentAssembly,
                                     /* in */  BOOL                 fNgenExplicitBind,
                                     /* in */  BOOL                 fExplicitBindToNativeImage,
+                                    /* in */  bool                 excludeAppPaths,
                                     /* out */ Assembly           **ppAssembly);
 
         static HRESULT BindToSystem(/* in */ SString    &systemDirectory,
@@ -128,6 +129,7 @@ namespace BINDER_SPACE
         static HRESULT BindByName(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,
                                   /* in */  DWORD               dwBindFlags,
+                                  /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
 
         // See code:BINDER_SPACE::AssemblyBinder::GetAssembly for info on fNgenExplicitBind
@@ -137,14 +139,17 @@ namespace BINDER_SPACE
                                     /* in */  PathString         &assemblyPath,
                                     /* in */  BOOL                fNgenExplicitBind,
                                     /* in */  BOOL                fExplicitBindToNativeImage,
+                                    /* in */  bool                excludeAppPaths,
                                     /* out */ BindResult         *pBindResult);
 
         static HRESULT BindLocked(/* in */  ApplicationContext *pApplicationContext,
                                   /* in */  AssemblyName       *pAssemblyName,
                                   /* in */  DWORD               dwBindFlags,
+                                  /* in */  bool                excludeAppPaths,
                                   /* out */ BindResult         *pBindResult);
         static HRESULT BindLockedOrService(/* in */  ApplicationContext *pApplicationContext,
                                            /* in */  AssemblyName       *pAssemblyName,
+                                           /* in */  bool                excludeAppPaths,
                                            /* out */ BindResult         *pBindResult);
 
         static HRESULT FindInExecutionContext(/* in */  ApplicationContext  *pApplicationContext,
@@ -154,6 +159,7 @@ namespace BINDER_SPACE
         static HRESULT BindByTpaList(/* in */  ApplicationContext  *pApplicationContext,
                                      /* in */  AssemblyName        *pRequestedAssemblyName,
                                      /* in */  BOOL                 fInspectionOnly,
+                                     /* in */  bool                 excludeAppPaths,
                                      /* out */ BindResult          *pBindResult);
         
         static HRESULT Register(/* in */  ApplicationContext *pApplicationContext,

--- a/src/binder/inc/clrprivbindercoreclr.h
+++ b/src/binder/inc/clrprivbindercoreclr.h
@@ -70,7 +70,8 @@ public:
 
     HRESULT BindAssemblyByNameWorker(
             BINDER_SPACE::AssemblyName *pAssemblyName,
-            BINDER_SPACE::Assembly **ppCoreCLRFoundAssembly);
+            BINDER_SPACE::Assembly **ppCoreCLRFoundAssembly,
+            bool excludeAppPaths);
 
     //=========================================================================
     // Internal implementation details

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -1470,8 +1470,9 @@ NotSupported_NoTypeInfo = Cannot resolve {0} to a TypeInfo object.
 NotSupported_PIAInAppxProcess = A Primary Interop Assembly is not supported in AppX.
 #endif
 #if FEATURE_WINDOWSPHONE
-NotSupported_WindowsPhone = {0} is not supported on Windows Phone.
-NotSupported_AssemblyLoadCodeBase = Assembly.Load with a Codebase is not supported on Windows Phone.
+; Not referring to "Windows Phone" in the messages, as FEATURE_WINDOWSPHONE is defined for .NET Core as well.
+NotSupported_WindowsPhone = {0} is not supported.
+NotSupported_AssemblyLoadCodeBase = Assembly.Load with a Codebase is not supported.
 #endif
 
 ; TypeLoadException

--- a/src/vm/assemblyname.cpp
+++ b/src/vm/assemblyname.cpp
@@ -85,7 +85,9 @@ FCIMPL1(Object*, AssemblyNameNative::GetFileInformation, StringObject* filenameU
 
     AssemblySpec spec;
     spec.InitializeSpec(TokenFromRid(mdtAssembly,1),pImage->GetMDImport(),NULL,TRUE);
+#ifndef FEATURE_CORECLR
     spec.SetCodeBase(sUrl);
+#endif
     spec.AssemblyNameInit(&gc.result, pImage);
     
     HELPER_METHOD_FRAME_END();


### PR DESCRIPTION
Fixes #1740
- After an assembly is loaded through a custom load context, when its dependencies are being loaded and the dependencies are in an app folder but not on the TPA list, don't search app paths when using the TPA binder, and instead use the default binder for the dependent assembly to load dependencies through the same custom AssemblyLoadContext.

Fixes #1187
- In the AssemblyName created by AssemblyLoadContext.GetAssemblyName(), don't initialize the CodeBase property since it's not in the exposed surface area for .NET Core. If the AssemblyName is passed to Assembly.Load(), note that regardless of the path sent to GetAssemblyName(), default search orders are still used to load the assembly by name. A custom AssemblyLoadContext would need to be used to control where an assembly is loaded from.

- Fixed a couple of error messages that mentioned phone