### PR TITLE
Enable Clang sanitizers for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,7 +242,6 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     else()
       clr_unknown_arch()
     endif()
-      
   endif(CLR_CMAKE_PLATFORM_LINUX)
 
   if(CLR_CMAKE_PLATFORM_DARWIN)
@@ -253,23 +252,52 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     message("Detected FreeBSD amd64")
   endif(CLR_CMAKE_PLATFORM_FREEBSD)
 
-endif(CLR_CMAKE_PLATFORM_UNIX)
+  # Disable frame pointer optimizations so profilers can get better call stacks
+  add_compile_options(-fno-omit-frame-pointer)
 
-if(CLR_CMAKE_PLATFORM_UNIX)
-    add_subdirectory(src/ToolBox/SOS/lldbplugin)
-    add_subdirectory(src/pal)
-    add_subdirectory(src/corefx)
-    add_subdirectory(src/coreclr/hosts/unixcorerun)
-    add_subdirectory(src/coreclr/hosts/unixcoreconsole)
-endif(CLR_CMAKE_PLATFORM_UNIX)
+  # set the CLANG sanitizer flags for debug build
+  if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+    # obtain settings from running enablesanitizers.sh
+    string(FIND "$ENV{DEBUG_SANITIZERS}" "asan" __ASAN_POS)
+    string(FIND "$ENV{DEBUG_SANITIZERS}" "ubsan" __UBSAN_POS)
+    if ((${__ASAN_POS} GREATER -1) OR (${__UBSAN_POS} GREATER -1))
+      set(CLR_SANITIZE_CXX_FLAGS "${CLR_SANITIZE_CXX_FLAGS} -fsanitize=")
+      set(CLR_SANITIZE_LINK_FLAGS "${CLR_SANITIZE_LINK_FLAGS} -fsanitize=")
+      if (${__ASAN_POS} GREATER -1) 
+        set(CLR_SANITIZE_CXX_FLAGS "${CLR_SANITIZE_CXX_FLAGS}address,")
+        set(CLR_SANITIZE_LINK_FLAGS "${CLR_SANITIZE_LINK_FLAGS}address,")
+        message("Address Sanitizer (asan) enabled")
+      endif ()
+      if (${__UBSAN_POS} GREATER -1)
+        set(CLR_SANITIZE_CXX_FLAGS "${CLR_SANITIZE_CXX_FLAGS}undefined")
+        set(CLR_SANITIZE_LINK_FLAGS "${CLR_SANITIZE_LINK_FLAGS}undefined")
+        message("Undefined Behavior Sanitizer (ubsan) enabled")
+      endif ()
 
+      # -fdata-sections -ffunction-sections: each function has own section instead of one per .o file (needed for --gc-sections)
+      # -fPIC: enable Position Independent Code normally just for shared libraries but required when linking with address sanitizer
+      # -O1: optimization level used instead of -O0 to avoid compile error "invalid operand for inline asm constraint"
+      set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} ${CLR_SANITIZE_CXX_FLAGS} -fdata-sections -ffunction-sections -fPIC -O1")
+
+      set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} ${CLR_SANITIZE_LINK_FLAGS}")
+
+      # -Wl and --gc-sections: drop unused sections\functions (similar to Windows /Gy function-level-linking)
+      set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} ${CLR_SANITIZE_LINK_FLAGS} -Wl,--gc-sections")
+    endif ()
+  endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL DEBUG)
+
+  add_subdirectory(src/ToolBox/SOS/lldbplugin)
+  add_subdirectory(src/pal)
+  add_subdirectory(src/corefx)
+  add_subdirectory(src/coreclr/hosts/unixcorerun)
+  add_subdirectory(src/coreclr/hosts/unixcoreconsole)
+endif(CLR_CMAKE_PLATFORM_UNIX)
 
 if(CLR_CMAKE_PLATFORM_DARWIN)
-    add_subdirectory(src/coreclr/hosts/osxbundlerun)
+  add_subdirectory(src/coreclr/hosts/osxbundlerun)
 endif(CLR_CMAKE_PLATFORM_DARWIN)
 
 # Add this subdir. We install the headers for the jit.
-
 add_subdirectory(src/pal/prebuilt/inc)
 
 # Set to 1 if you want to clear the CMAKE initial compiler flags and set all the flags explicitly
@@ -437,9 +465,6 @@ add_compile_options(-Wno-incompatible-ms-struct)
 add_compile_options(-fms-extensions )
 #-fms-compatibility      Enable full Microsoft Visual C++ compatibility
 #-fms-extensions         Accept some non-standard constructs supported by the Microsoft compiler
-
-# Disable frame pointer optimizations so profilers can get better call stacks
-add_compile_options(-fno-omit-frame-pointer)
 
 endif(CLR_CMAKE_PLATFORM_UNIX)
 

--- a/enablesanitizers.sh
+++ b/enablesanitizers.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+if [ $# -eq 0 ]; then
+    echo "Script for enabling CLang sanitizers for debug builds."
+    echo "*Only tested on Ubuntu x64."
+    echo "*This script must be 'sourced' (via dot+space) so that changes to environment variables are preserved. Run like this:"    
+    if [ "$(dirname $0)" = "." ]; then
+        echo " . enablesanitizers.sh [options]"
+    else
+        echo " cd $(dirname $0);. enablesanitizers.sh [options]; cd -"
+    fi
+    echo "Usage: [asan] [ubsan] [lsan] [all] [off] [clangx.y]"
+    echo "asan: optional argument to enable Address Sanitizer."
+    echo "ubsan: optional argument to enable Undefined Behavior Sanitizer."
+    echo "lsan - optional argument to enable memory Leak Sanitizer."
+    echo "all - optional argument to enable asan, ubsan and lsan."
+    echo "off - optional argument to turn off all sanitizers."
+    echo "clangx.y - optional argument to specify clang version x.y. which is used to resolve stack traces."
+else
+    __ClangMajorVersion=3
+    __ClangMinorVersion=5
+    __EnableASan=0
+    __EnableUBSan=0
+    __EnableLSan=0
+    __TurnOff=0
+    __Options=
+
+    for i in "$@"
+        do
+            lowerI="$(echo $i | awk '{print tolower($0)}')"
+            case $lowerI in
+            asan)
+                __EnableASan=1
+                ;;
+            ubsan)
+                __EnableUBSan=1
+                ;;
+            lsan)
+                __EnableASan=1
+                __EnableLSan=1
+                ;;
+            all)
+                __EnableASan=1
+                __EnableUBSan=1
+                __EnableLSan=1
+                ;;
+            off)
+                __TurnOff=1
+                ;;
+            clang3.5)
+                __ClangMajorVersion=3
+                __ClangMinorVersion=5
+                ;;
+            clang3.6)
+                __ClangMajorVersion=3
+                __ClangMinorVersion=6
+                ;;
+            clang3.7)
+                __ClangMajorVersion=3
+                __ClangMinorVersion=7
+                ;;
+            *)
+                echo "Unknown arg: $i"
+                return 1
+        esac
+    done
+
+    if [ $__TurnOff == 1 ]; then
+        unset DEBUG_SANITIZERS
+        echo "Setting DEBUG_SANITIZERS="
+    else
+        ASAN_OPTIONS="symbolize=1"
+
+        if [ $__EnableASan == 1 ]; then
+            __Options="$__Options asan"
+        fi
+        if [ $__EnableUBSan == 1 ]; then
+            __Options="$__Options ubsan"
+        fi
+        if [ $__EnableLSan == 1 ]; then
+            ASAN_OPTIONS="$ASAN_OPTIONS detect_leaks"
+        fi
+
+        # passed to build.sh
+        DEBUG_SANITIZERS="$__Options"
+        export DEBUG_SANITIZERS
+        echo "Setting DEBUG_SANITIZERS=$DEBUG_SANITIZERS"
+
+        # used by ASan at run-time
+        ASAN_OPTIONS="\"$ASAN_OPTIONS\""
+        export ASAN_OPTIONS
+        echo "Setting ASAN_OPTIONS=$ASAN_OPTIONS"
+
+        # used by ASan at run-time
+        ASAN_SYMBOLIZER_PATH="/usr/bin/llvm-symbolizer-$__ClangMajorVersion.$__ClangMinorVersion"
+        export ASAN_SYMBOLIZER_PATH
+        echo "Setting ASAN_SYMBOLIZER_PATH=$ASAN_SYMBOLIZER_PATH"
+    fi
+
+    unset __ClangMajorVersion
+    unset __ClangMinorVersion
+    unset __EnableASan
+    unset __EnableUBSan
+    unset __EnableLSan
+    unset __TurnOff
+    unset __Options
+fi

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -66,6 +66,8 @@ elseif(PAL_CMAKE_PLATFORM_ARCH_ARM64)
   add_definitions(-D_WIN64=1)
 endif()
 
+# turn off capability to remove unused functions (which was enabled in debug build with sanitizers)
+set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -Wl,--no-gc-sections")
 
 add_compile_options(-fno-builtin)
 add_compile_options(-fPIC)

--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2270,6 +2270,7 @@ void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay(rip:%p, rsp:%p)\n", pRD->ControlPC, pRD->SP));
 }
+#endif // !CROSSGEN_COMPILE
 
 void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD) 
 { 
@@ -2311,7 +2312,6 @@ void TailCallFrame::InitFromContext(T_CONTEXT * pContext)
 }
 
 #endif // !DACCESS_COMPILE
-#endif // !CROSSGEN_COMPILE
 
 void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD) 
 { 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -14846,7 +14846,7 @@ void ReflectionModule::ReleaseILData()
 
     Module::ReleaseILData();
 }
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 #endif // !DACCESS_COMPILE
 

--- a/src/vm/ceeload.h
+++ b/src/vm/ceeload.h
@@ -3686,6 +3686,7 @@ private:
     // If true, then only other transient modules can depend on this module.
     bool m_fIsTransient;
 
+#if !defined DACCESS_COMPILE && !defined CROSSGEN_COMPILE
     // Returns true iff metadata capturing is suppressed
     bool IsMetadataCaptureSuppressed();
 
@@ -3705,8 +3706,8 @@ private:
         pModule->ResumeMetadataCapture();
     }
 
-
     ReflectionModule(Assembly *pAssembly, mdFile token, PEFile *pFile);
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
 public:
 
@@ -3715,14 +3716,13 @@ public:
     PTR_SBuffer GetDynamicMetadataBuffer() const;
 #endif
 
+#if !defined DACCESS_COMPILE && !defined CROSSGEN_COMPILE
     static ReflectionModule *Create(Assembly *pAssembly, PEFile *pFile, AllocMemTracker *pamTracker, LPCWSTR szName, BOOL fIsTransient);
-
     void Initialize(AllocMemTracker *pamTracker, LPCWSTR szName);
-
     void Destruct();
-#ifndef DACCESS_COMPILE    
+
     void ReleaseILData();
-#endif
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
     // Overides functions to access sections
     virtual TADDR GetIL(RVA target);
@@ -3786,17 +3786,14 @@ public:
     }
 
 #ifndef DACCESS_COMPILE
+#ifndef CROSSGEN_COMPILE
 
     typedef Wrapper<
         ReflectionModule*, 
         ReflectionModule::SuppressCaptureWrapper, 
         ReflectionModule::ResumeCaptureWrapper> SuppressMetadataCaptureHolder;
+#endif // !CROSSGEN_COMPILE
 
-
-
-    // Eagerly serialize the metadata to a buffer that the debugger can retrieve.
-    void CaptureModuleMetaDataToMemory();
-    
     HRESULT SetISymUnmanagedWriter(ISymUnmanagedWriter *pWriter)
     {
         CONTRACTL
@@ -3825,6 +3822,9 @@ public:
         return S_OK;
     }
 #endif // !DACCESS_COMPILE
+
+    // Eagerly serialize the metadata to a buffer that the debugger can retrieve.
+    void CaptureModuleMetaDataToMemory();
 };
 
 // Module holders

--- a/src/vm/codeman.cpp
+++ b/src/vm/codeman.cpp
@@ -1823,7 +1823,7 @@ void CodeFragmentHeap::RealBackoutMem(void *pMem
 
     AddBlock(pMem, dwSize);
 }
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 //**************************************************************************
 
@@ -4012,7 +4012,17 @@ void EEJitManager::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 }
 #endif // #ifdef DACCESS_COMPILE
 
-#endif // CROSSGEN_COMPILE
+#else // CROSSGEN_COMPILE
+// stub for compilation
+BOOL EEJitManager::JitCodeToMethodInfo(RangeSection * pRangeSection,
+    PCODE currentPC,
+    MethodDesc ** ppMethodDesc,
+    EECodeInfo * pCodeInfo)
+{
+    _ASSERTE(FALSE);
+    return FALSE;
+}
+#endif // !CROSSGEN_COMPILE
 
 
 #ifndef DACCESS_COMPILE

--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -3311,6 +3311,7 @@ class TailCallFrame : public Frame
 #endif
 
 public:
+#ifndef	CROSSGEN_COMPILE
 #if !defined(_TARGET_X86_)
 
 #ifndef DACCESS_COMPILE
@@ -3360,7 +3361,7 @@ public:
     }
 
     virtual void UpdateRegDisplay(const PREGDISPLAY pRD);
-
+#endif // !CROSSGEN_COMPILE
 #ifdef _TARGET_AMD64_
     void SetGCLayout(TADDR pGCLayout)
     {

--- a/src/vm/loaderallocator.cpp
+++ b/src/vm/loaderallocator.cpp
@@ -52,7 +52,10 @@ LoaderAllocator::LoaderAllocator()
     m_pFatTokenSet = NULL;
 #endif
     
+#ifndef CROSSGEN_COMPILE
     m_pVirtualCallStubManager = NULL;
+#endif
+
     m_fGCPressure = false;
     m_fTerminated = false;
     m_fUnloaded = false;
@@ -298,7 +301,7 @@ BOOL LoaderAllocator::EnsureInstantiation(Module *pDefiningModule, Instantiation
 {
     return FALSE;
 }
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 #ifndef CROSSGEN_COMPILE
 bool LoaderAllocator::Marked()
@@ -881,7 +884,7 @@ void LoaderAllocator::ActivateManagedTracking()
     LOADERALLOCATORREF loaderAllocator = (LOADERALLOCATORREF)ObjectFromHandle(m_hLoaderAllocatorObjectHandle);
     loaderAllocator->SetNativeLoaderAllocator(this);
 }
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 
 // We don't actually allocate a low frequency heap for collectible types
@@ -1217,7 +1220,7 @@ void LoaderAllocator::Terminate()
     LOG((LF_CLASSLOADER, LL_INFO100, "End LoaderAllocator::Terminate for loader allocator %p\n", reinterpret_cast<void *>(static_cast<PTR_LoaderAllocator>(this))));
 }
 
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 
 #else //DACCESS_COMPILE
@@ -1260,8 +1263,10 @@ SIZE_T LoaderAllocator::EstimateSize()
         retval+=m_pStubHeap->GetSize();   
     if(m_pStringLiteralMap)
         retval+=m_pStringLiteralMap->GetSize();
+#ifndef CROSSGEN_COMPILE
     if(m_pVirtualCallStubManager)
         retval+=m_pVirtualCallStubManager->GetSize();
+#endif
 
     return retval;    
 }
@@ -1421,9 +1426,9 @@ void LoaderAllocator::UninitVirtualCallStubManager()
         m_pVirtualCallStubManager = NULL;
     }
 }
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
-#endif // DACCESS_COMPILE
+#endif // !DACCESS_COMPILE
 
 BOOL GlobalLoaderAllocator::CanUnload()
 {
@@ -1661,6 +1666,6 @@ void LoaderAllocator::CleanupFailedTypeInit()
         pLock->Unlink(pItem->m_pListLockEntry);
     }
 }
-#endif // CROSSGEN_COMPILE
+#endif // !CROSSGEN_COMPILE
 
-#endif //!DACCES_COMPILE
+#endif // !DACCESS_COMPILE

--- a/src/vm/loaderallocator.hpp
+++ b/src/vm/loaderallocator.hpp
@@ -144,7 +144,9 @@ protected:
     FatTokenSet *m_pFatTokenSet;
 #endif
 
+#ifndef CROSSGEN_COMPILE
     VirtualCallStubManager *m_pVirtualCallStubManager;
+#endif
 
 private:
     typedef SHash<PtrSetSHashTraits<LoaderAllocator * > > LoaderAllocatorSet;
@@ -432,11 +434,13 @@ public:
 
     void InitVirtualCallStubManager(BaseDomain *pDomain, BOOL fCollectible = FALSE);
     void UninitVirtualCallStubManager();
+#ifndef CROSSGEN_COMPILE
     inline VirtualCallStubManager *GetVirtualCallStubManager()
     {
         LIMITED_METHOD_CONTRACT;
         return m_pVirtualCallStubManager;
     }
+#endif
 };  // class LoaderAllocator
 
 typedef VPTR(LoaderAllocator) PTR_LoaderAllocator;

--- a/src/vm/stubmgr.h
+++ b/src/vm/stubmgr.h
@@ -193,6 +193,7 @@ typedef VPTR(class StubManager) PTR_StubManager;
 
 class StubManager
 {
+#ifndef CROSSGEN_COMPILE
     friend class StubManagerIterator;
 
     VPTR_BASE_VTABLE_CLASS(StubManager)
@@ -326,6 +327,7 @@ private:
     PTR_StubManager m_pNextManager;
 
     static CrstStatic s_StubManagerListCrst;
+#endif // !CROSSGEN_COMPILE
 };
 
 // -------------------------------------------------------
@@ -374,6 +376,8 @@ class LockedRangeList : public RangeList
 
     SimpleRWLock m_RangeListRWLock;
 };
+
+#ifndef CROSSGEN_COMPILE
 
 //-----------------------------------------------------------
 // Stub manager for the prestub.  Although there is just one, it has
@@ -991,4 +995,5 @@ public:
 
 };
 
-#endif
+#endif // !CROSSGEN_COMPILE
+#endif // !__stubmgr_h__

--- a/src/vm/virtualcallstub.h
+++ b/src/vm/virtualcallstub.h
@@ -16,6 +16,8 @@
 #ifndef _VIRTUAL_CALL_STUB_H 
 #define _VIRTUAL_CALL_STUB_H
 
+#ifndef CROSSGEN_COMPILE
+
 #define CHAIN_LOOKUP
 
 #if defined(_TARGET_X86_)
@@ -1619,5 +1621,6 @@ private:
     static FastTable* dead;             //linked list head of to be deleted (abandoned) buckets
 };
 
-#endif // !_VIRTUAL_CALL_STUB_H
+#endif // !CROSSGEN_COMPILE
 
+#endif // !_VIRTUAL_CALL_STUB_H


### PR DESCRIPTION
This enables the Clang sanitizers to the coreclr (https://github.com/dotnet/corefx/issues/4434) which instruments the binaries to detect issues with native code such as referencing invalid memory, or performing 'undefined' behavior like shifting a 32-bit int >= 32 or <0 bits.

When enabling the sanitizers various cryptic (and hard-to-fix) linker errors occur because various classes have functions with missing implementations. The majority of the code changes add #ifdefs to .h files to align to the #ifdefs in the corresponding .cpp files especially around the defines CROSSGEN_COMPILE and DACCESS_COMPILE. I did what I could to enable function-level linking in Clang in order to remove dead code, but the various linker errors still existed when the sanitizers are enabled.

The sanitizers are definitely finding various issues so it’s a good thing. The next step after this is in is to fix a few of the issues to reduce the error output noise, and then log issues for the remaining. Eventually this would be hooked up to the build system in some way.
