### PR TITLE
Allow setting some startup flags outside Windows

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -418,7 +418,8 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
     // Default startup flags
     hr = host->SetStartupFlags((STARTUP_FLAGS)
         (STARTUP_FLAGS::STARTUP_LOADER_OPTIMIZATION_SINGLE_DOMAIN | 
-        STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN)); 
+        STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN |
+        STARTUP_FLAGS::STARTUP_CONCURRENT_GC));
     if (FAILED(hr)) {
         log << W("Failed to set startup flags. ERRORCODE: ") << hr << Logger::endl;
         return false;

--- a/src/coreclr/hosts/corerun/corerun.cpp
+++ b/src/coreclr/hosts/corerun/corerun.cpp
@@ -456,7 +456,8 @@ bool TryRun(const int argc, const wchar_t* argv[], Logger &log, const bool verbo
     // Default startup flags
     hr = host->SetStartupFlags((STARTUP_FLAGS)
         (STARTUP_FLAGS::STARTUP_LOADER_OPTIMIZATION_SINGLE_DOMAIN | 
-        STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN)); 
+        STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN |
+        STARTUP_FLAGS::STARTUP_CONCURRENT_GC));
     if (FAILED(hr)) {
         log << W("Failed to set startup flags. ERRORCODE: ") << Logger::hresult << hr << Logger::endl;
         return false;


### PR DESCRIPTION
Allowing the GC-related flags to be set using properties passed into coreclr_initialize.