### PR TITLE
Remove an unsafe memory write in HeapFree

### DIFF
--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -309,8 +309,6 @@ HeapFree(
         goto done;
     }
 
-    *((DWORD *) lpMem) = 0;
-
     bRetVal = TRUE;
 #ifdef __APPLE__
     // This is patterned off of InternalFree in malloc.cpp.


### PR DESCRIPTION
The PAL implementation of HeapFree assumes that the memory region always
have at least 4 bytes. Depending on the heap implementation, this is not
necessarily true, and can potentially cause memory corruption.