### PR TITLE
Use uuid_generate_random instead of uuid_generate in CoCreateGuid

### DIFF
--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -353,10 +353,10 @@ PALAPI
 CoCreateGuid(OUT GUID * pguid)
 {
 #if HAVE_LIBUUID_H
-    uuid_generate(*(uuid_t*)pguid);
+    uuid_generate_random(*(uuid_t*)pguid);
 
-    // Change the byte order of the Data1, 2 and 3, since the uuid_generate generates them
-    // with big endian while GUIDS need to have them in little endian.
+    // Change the byte order of the Data1, 2 and 3, since the uuid_generate_random
+    // generates them with big endian while GUIDS need to have them in little endian.
     pguid->Data1 = SWAP32(pguid->Data1);
     pguid->Data2 = SWAP16(pguid->Data2);
     pguid->Data3 = SWAP16(pguid->Data3);


### PR DESCRIPTION
The PAL implementation of CoCreateGuid is currently using uuid_generate. This will be based on high-quality randomness if available, otherwise it falls back to an algorithm that incorporates the local ethernet MAC address along with the current time and a pseudo-random generator. To avoid potential
privacy issues, this commit switches to using uuid_generate_random, which instead falls back purely to a pseudo-random generator.

Fixes https://github.com/dotnet/corefx/issues/4458
cc: @janvorli, @blowdart, @morganbr, @GrabYourPitchforks 