### PR TITLE
Replace Unicode symbols with escape sequence in test source files

### DIFF
--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetabbreviatedmonthname.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetabbreviatedmonthname.cs
@@ -117,17 +117,17 @@ public class DateTimeFormatInfoGetAbbreviatedMonthName
             string[] expected = new string[] {
                 "",
                 "janv.",
-                "févr.", 
+                "f\u00e9vr.", 
                 "mars",
                 "avr.",
                 "mai",
                 "juin",
                 "juil.",
-                "août",
+                "ao\u00fbt",
                 "sept.",
                 "oct.",
                 "nov.",
-                "déc.",
+                "d\u00e9c.",
                 "",
             };
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetmonthname.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetmonthname.cs
@@ -117,17 +117,17 @@ public class DateTimeFormatInfoGetMonthName
             string[] expected = new string[] {
                 "",
                 "janvier",
-                "février", 
+                "f\u00e9vrier", 
                 "mars",
                 "avril",
                 "mai",
                 "juin",
                 "juillet",
-                "août",
+                "ao\u00fbt",
                 "septembre",
                 "octobre",
                 "novembre",
-                "décembre",
+                "d\u00e9cembre",
                 "",
             };
 

--- a/tests/src/baseservices/regression/v1/threads/functional/thread/tculturedll.cs
+++ b/tests/src/baseservices/regression/v1/threads/functional/thread/tculturedll.cs
@@ -171,7 +171,7 @@ namespace TCulture
 			cultures[121] = new Culture("mn",0x0050,"Mongolian",true);
 			cultures[122] = new Culture("mn-MN",0x0450,"Mongolian - Mongolia",true);
 			cultures[123] = new Culture("no",0x0014,"Norwegian",true);
-			cultures[124] = new Culture("nb-NO",0x0414,"Norwegian (Bokmål) - Norway",true);
+			cultures[124] = new Culture("nb-NO",0x0414,"Norwegian (Bokm\u00e5l) - Norway",true);
 			cultures[125] = new Culture("nn-NO",0x0814,"Norwegian (Nynorsk) - Norway",true);
 			cultures[126] = new Culture("pl",0x0015,"Polish",true);
 			cultures[127] = new Culture("pl-PL",0x0415,"Polish - Poland",true);


### PR DESCRIPTION
Those files don't have a BOM and can be misinterpreted.