### PR TITLE
Fix Path tests to work on non-Windows platforms

### DIFF
--- a/tests/src/CoreMangLib/cti/system/io/path/pathcombine.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathcombine.cs
@@ -266,7 +266,7 @@ public class PathCombine
         const string c_TEST_DESC = "NegTest1: path1 contains one  of the invalid characters";
         const string c_TEST_ID = "N001";
 
-        string path1 = "mydir\\my| folder";
+        string path1 = Utilities.IsWindows ? "mydir\\my| folder" : "mydir\\my\u0000 folder";
         string path2 = "yourfolder\\youfile";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -297,7 +297,7 @@ public class PathCombine
         const string c_TEST_ID = "N002";
 
         string path1 = "mydir\\my folder";
-        string path2 = "yourfolder\\>youfile";
+        string path2 = Utilities.IsWindows ? "yourfolder\\>youfile" : "yourfolder\\\u0000youfile";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 

--- a/tests/src/CoreMangLib/cti/system/io/path/pathgetdirectoryname.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathgetdirectoryname.cs
@@ -86,8 +86,8 @@ public class PathGetDirectoryName
         const string c_TEST_DESC = "PosTest2:the source Path is  a root directory";
         const string c_TEST_ID = "P002";
 
-        string sourcePath = @"C:\";
-        string directoryName = Utilities.IsWindows?null:"C:";
+        string sourcePath = Utilities.IsWindows ? @"C:\" : "/";
+        string directoryName = null;
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -212,7 +212,7 @@ public class PathGetDirectoryName
         const string c_TEST_DESC = "NegTest1: the source path  contains  invalid characters";
         const string c_TEST_ID = "N001";
 
-        string sourcePath = "C:\\mydir\\myfolder>\\test.txt"; 
+        string sourcePath = Utilities.IsWindows ? "C:\\mydir\\myfolder>\\test.txt" : "/bin/\u0000bash"; 
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -270,7 +270,7 @@ public class PathGetDirectoryName
         const string c_TEST_DESC = "NegTest3: the source path  contains a wildcard character";
         const string c_TEST_ID = "N003";
 
-        string sourcePath = @"C:\<\myfolder\test.txt"; 
+        string sourcePath = Utilities.IsWindows ? @"C:\<\myfolder\test.txt" : "/bin\u0000/bash"; 
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -295,6 +295,7 @@ public class PathGetDirectoryName
 
     public bool NegTest4()
     {
+        if (!Utilities.IsWindows) return true;
         bool retVal = true;
         const string c_TEST_DESC = "NegTest4: the source path is longer than the system-defined maximum length ";
         const string c_TEST_ID = "N004";

--- a/tests/src/CoreMangLib/cti/system/io/path/pathgetextension.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathgetextension.cs
@@ -2,6 +2,7 @@
 using System.Security;
 using System;
 using System.IO;
+using TestLibrary;
 
 /// <summary>
 /// System.IO.Path.GetExtension(string)
@@ -164,7 +165,7 @@ public class PathGetDirectoryName
     {
         bool retVal = true;
 
-        string oldPath = @"C:\mydir\myfolder>\test.txt";
+        string oldPath = Utilities.IsWindows ? @"C:\mydir\myfolder>\test.txt": "/home/user\u0000/test.txt";
         string strExtension = "";
 
         TestLibrary.TestFramework.BeginScenario("NegTest1: the  path contains contains one  of the invalid characters");

--- a/tests/src/CoreMangLib/cti/system/io/path/pathgetfilename.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathgetfilename.cs
@@ -1,7 +1,7 @@
 using System.Security;
 using System;
 using System.IO;
-
+using TestLibrary;
 
 
 /// <summary>
@@ -53,7 +53,7 @@ public class PathGetFileName
         const string c_TEST_DESC = "PosTest1:the source path is a file name.";
         const string c_TEST_ID = "P001";
 
-        string sourcePath = @"C:\mydir\myfolder\test.txt";
+        string sourcePath = Utilities.IsWindows ? @"C:\mydir\myfolder\test.txt" : @"/home/user/test.txt";
         string FileName = "test.txt";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -84,7 +84,7 @@ public class PathGetFileName
         const string c_TEST_DESC = "PosTest2:the source path is not a file name.";
         const string c_TEST_ID = "P002";
 
-        string sourcePath = @"C:\mydir\myfolder\test";
+        string sourcePath = Utilities.IsWindows ? @"C:\mydir\myfolder\test" : @"/home/user/test";
         string FileName = "test";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -115,7 +115,7 @@ public class PathGetFileName
         const string c_TEST_DESC = "PosTest3:the last of character of source path is a directory separator character.";
         const string c_TEST_ID = "P003";
 
-        string sourcePath = @"C:\mydir\myfolder\";
+        string sourcePath = Utilities.IsWindows ? @"C:\mydir\myfolder\" : @"/home/user/myfolder/";
         string FileName = string.Empty;
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -146,8 +146,8 @@ public class PathGetFileName
         const string c_TEST_DESC = "PosTest4:the last of character of source path is a volume separator character.";
         const string c_TEST_ID = "P004";
 
-        string sourcePath = @"C:";
-        string FileName = TestLibrary.Utilities.IsWindows?string.Empty:"C:";
+        string sourcePath = Utilities.IsWindows ? @"C:" : @"/";
+        string FileName = string.Empty;
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -241,7 +241,7 @@ public class PathGetFileName
         const string c_TEST_DESC = "NegTest1: the source path  contains  invalid characters";
         const string c_TEST_ID = "N001";
 
-        string sourcePath = "C:\\mydir\\myfolder>\\test.txt";
+        string sourcePath = Utilities.IsWindows ? "C:\\mydir\\myfolder>\\test.txt" : "/home/user\u0000/test.txt";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -270,7 +270,7 @@ public class PathGetFileName
         const string c_TEST_DESC = "NegTest2: the source path  contains  a wildcard characters";
         const string c_TEST_ID = "N002";
 
-        string sourcePath = "C:\\mydir\\<\\test.txt";
+        string sourcePath = Utilities.IsWindows ? "C:\\mydir\\<\\test.txt" : "/home/user/\u0000/test.txt";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 

--- a/tests/src/CoreMangLib/cti/system/io/path/pathgetfilenamewithoutextension.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathgetfilenamewithoutextension.cs
@@ -1,6 +1,7 @@
 using System.Security;
 using System;
 using System.IO;
+using TestLibrary;
 
 /// <summary>
 /// System.IO.Path.GetFileNameWithoutExtension(string)
@@ -50,7 +51,7 @@ public class PathGetFileNameWithoutExtension
         const string c_TEST_DESC = "PosTest1:the source path is a file name with extension.";
         const string c_TEST_ID = "P001";
 
-        string sourcePath = @"C:\mydir\myfolder\test.txt";
+        string sourcePath = Utilities.IsWindows ? @"C:\mydir\myfolder\test.txt" : @"/home/user/test.txt";
         string FileName = "test";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -81,7 +82,7 @@ public class PathGetFileNameWithoutExtension
         const string c_TEST_DESC = "PosTest2:the source path is not a file name without extension.";
         const string c_TEST_ID = "P002";
 
-        string sourcePath = @"C:\mydir\myfolder\test";
+        string sourcePath = Utilities.IsWindows ? @"C:\mydir\myfolder\test" : @"/home/user/test";
         string FileName = "test";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -112,7 +113,7 @@ public class PathGetFileNameWithoutExtension
         const string c_TEST_DESC = "PosTest3:the last of character of source path is a directory separator character.";
         const string c_TEST_ID = "P003";
 
-        string sourcePath = @"C:\mydir\myfolder\";
+        string sourcePath = Utilities.IsWindows ? @"C:\mydir\myfolder\" : @"/home/user/myfolder/";
         string FileName = string.Empty;
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
@@ -243,7 +244,7 @@ public class PathGetFileNameWithoutExtension
         const string c_TEST_DESC = "NegTest1: the source path  contains  invalid characters";
         const string c_TEST_ID = "N001";
 
-        string sourcePath = "C:\\mydir\\myfolder>\\test.txt";
+        string sourcePath = Utilities.IsWindows ? "C:\\mydir\\myfolder>\\test.txt" : "/home/user\u0000/test.txt";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 

--- a/tests/src/CoreMangLib/cti/system/io/path/pathgetfullpath_extended.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathgetfullpath_extended.cs
@@ -53,7 +53,7 @@ public class PathGetFullPath_Extended
         const string c_TEST_DESC = "NegTest1: the source path  contains  invalid characters";
         const string c_TEST_ID = "N001";
 
-        string sourcePath = "myfolder>\\test.txt";
+        string sourcePath = Utilities.IsWindows ? "myfolder>\\test.txt" : "myfolder\u0000/test.txt";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -82,7 +82,7 @@ public class PathGetFullPath_Extended
         const string c_TEST_DESC = "NegTest2: the source path  contains  a wildcard characters";
         const string c_TEST_ID = "N002";
 
-        string sourcePath = "mydir\\da?\\test.txt";
+        string sourcePath = Utilities.IsWindows ? "mydir\\da?\\test.txt" : "mydir/da\u0000/test.txt";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 
@@ -223,6 +223,7 @@ public class PathGetFullPath_Extended
 
     public bool NegTest7()
     {
+        if (!Utilities.IsWindows) return true;
         bool retVal = true;
 
         const string c_TEST_DESC = "NegTest7: the source path is longer than the system-defined maximum length ";

--- a/tests/src/CoreMangLib/cti/system/io/path/pathgetinvalidpathchars.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathgetinvalidpathchars.cs
@@ -1,6 +1,7 @@
 using System.Security;
 using System;
 using System.IO;
+using TestLibrary;
 
 /// <summary>
 /// System.IO.Path.GetInvalidPathChars()
@@ -8,7 +9,7 @@ using System.IO;
 public class PathGetInvalidPathChars
 {
 
-   private static char[] RealInvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+   private static char[] RealInvalidPathChars = !Utilities.IsWindows ? new char[] { '\0' } : new char[] { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
 
     public static int Main()
     {

--- a/tests/src/CoreMangLib/cti/system/io/path/pathispathrooted.cs
+++ b/tests/src/CoreMangLib/cti/system/io/path/pathispathrooted.cs
@@ -80,7 +80,7 @@ public class PathGetPathRoot
         const string c_TEST_DESC = "PosTest2:the source path is a absolute path.";
         const string c_TEST_ID = "P002";
 
-        string sourcePath = @"\mydir\myfolder\";
+        string sourcePath = Utilities.IsWindows ? @"\mydir\myfolder\" : @"/home/myfolder/";
 
         TestLibrary.TestFramework.BeginScenario(c_TEST_DESC);
 


### PR DESCRIPTION
Not sure if you're running these under CoreCLR yet, but those are the fixes I needed to make while porting them to Mono :)