### PR TITLE
Use InvariantCulture for parsing float arguments in GC stress tests

### DIFF
--- a/tests/src/GC/Stress/Tests/GCSimulator.cs
+++ b/tests/src/GC/Stress/Tests/GCSimulator.cs
@@ -825,7 +825,7 @@ namespace GCSimulator
                     else if (currentArg.StartsWith("datapinned") || currentArg.StartsWith("dp")) // percentage data pinned
                     {
                         currentArgValue = args[++i];
-                        s_percentPinned = float.Parse(currentArgValue);
+                        s_percentPinned = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                         if (s_percentPinned < 0 || s_percentPinned > 1)
                         {
                             Console.WriteLine("Error! datapinned should be a number from 0 to 1");
@@ -848,7 +848,7 @@ namespace GCSimulator
                     else if (currentArg.StartsWith("dataweak") || currentArg.StartsWith("dw"))
                     {
                         currentArgValue = args[++i];
-                        s_percentWeak = float.Parse(currentArgValue);
+                        s_percentWeak = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                         if (s_percentWeak < 0 || s_percentWeak > 1)
                         {
                             Console.WriteLine("Error! dataweak should be a number from 0 to 1");

--- a/tests/src/GC/Stress/Tests/StressAllocator.cs
+++ b/tests/src/GC/Stress/Tests/StressAllocator.cs
@@ -518,7 +518,7 @@ namespace StressAllocator
                     else if (String.Compare(currentArg.ToLower(), "pinned") == 0)
                     {
                         currentArgValue = args[++i];
-                        percentPinned = float.Parse(currentArgValue);
+                        percentPinned = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                     }
                     else if (String.Compare(currentArg.ToLower(), "lohpin") == 0)  //for LOH compacting testing, this is the option to apply the pinning percentage to LOH
                     {
@@ -527,22 +527,22 @@ namespace StressAllocator
                     else if (String.Compare(currentArg.ToLower(), "bucket1") == 0)
                     {
                         currentArgValue = args[++i];
-                        percentBucket1 = float.Parse(currentArgValue);
+                        percentBucket1 = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                     }
                     else if (String.Compare(currentArg.ToLower(), "bucket2") == 0)
                     {
                         currentArgValue = args[++i];
-                        percentBucket2 = float.Parse(currentArgValue);
+                        percentBucket2 = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                     }
                     else if (String.Compare(currentArg.ToLower(), "bucket3") == 0)
                     {
                         currentArgValue = args[++i];
-                        percentBucket3 = float.Parse(currentArgValue);
+                        percentBucket3 = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                     }
                     else if (String.Compare(currentArg.ToLower(), "bucket4") == 0)
                     {
                         currentArgValue = args[++i];
-                        percentBucket4 = float.Parse(currentArgValue);
+                        percentBucket4 = float.Parse(currentArgValue, System.Globalization.CultureInfo.InvariantCulture);
                     }
                     else if (String.Compare(currentArg.ToLower(), "nolocks") == 0)
                     {


### PR DESCRIPTION
Otherwise they'd fail on cultures where '.' isn't used as a decimal separator, like de-DE.