### PR TITLE
Fix OverflowException in b115557.cs GC test on systems with fewer than four processors/cores

### DIFF
--- a/tests/src/GC/Stress/Tests/b115557.cs
+++ b/tests/src/GC/Stress/Tests/b115557.cs
@@ -28,7 +28,7 @@ internal class MyThread
         for (int i = 0; i < _allocPerThreadMB / 2; i++)
         {
             largeArray[i] = new byte[2 * 1024 * 1024];  // 2 MB
-            largeArray[i][i + 100] = Convert.ToByte(i);
+            largeArray[i][i + 100] = Convert.ToByte(Math.Min(i, byte.MaxValue));
         }
         int sum = 0;
         for (int i = 0; i < _allocPerThreadMB / 2; i++)


### PR DESCRIPTION
`_allocPerThreadMB/2` can be larger than what fits into byte (because it's based on the number of processors/cores), resulting in an OverflowException on those systems.