### PR TITLE
Ifdef out useless code in JIT lowering

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -3417,7 +3417,9 @@ void Lowering::DoPhase()
             }
 #endif
             comp->compCurStmt = stmt;
+#if !defined(_TARGET_64BIT_)
             comp->fgWalkTreePost(&stmt->gtStmt.gtStmtExpr, &Lowering::DecompNodeHelper, this, true);
+#endif
             comp->fgWalkTreePost(&stmt->gtStmt.gtStmtExpr, &Lowering::LowerNodeHelper, this, true);
             // We may have removed "stmt" in LowerNode().
             stmt = comp->compCurStmt;


### PR DESCRIPTION
In 64 bit builds Lowering::DecompNodeHelper does nothing so walking the trees is pointless.  Profiling indicates that this accounts for 0.5% of the mscorlib crossgen time.