### PR TITLE
Fix RyuJIT assert 'emitCurIG != emitPrologIG'

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1498,6 +1498,7 @@ void                emitter::emitBegProlog()
 #endif
 
     emitNoGCIG = true;
+    emitForceNewIG = false;
 
     /* Switch to the pre-allocated prolog IG */
 
@@ -1909,6 +1910,7 @@ void                emitter::emitBegPrologEpilog(insGroup* igPh)
 
     igPh->igFlags &= ~IGF_PLACEHOLDER;
     emitNoGCIG = true;
+    emitForceNewIG = false;
 
     /* Set up the GC info that we stored in the placeholder */
 
@@ -3216,7 +3218,7 @@ void                emitter::emitDispIG(insGroup* ig, insGroup* igPrev, bool ver
             printf("IG%02u ", igPh->igPhData->igPhNext->igNum);
         else
             printf("<END>");
-        printf(", BB=%08XH", dspPtr(igPh->igPhData->igPhBB));
+        printf(", BB=%08XH (BB%02u)", dspPtr(igPh->igPhData->igPhBB), (igPh->igPhData->igPhBB != nullptr) ? igPh->igPhData->igPhBB->bbNum : 0 );
 
         emitDispIGflags(igPh->igFlags);
 


### PR DESCRIPTION
This occurs when the call-to-finally block exists as the last code in the function
(including any funclets). After we generate all "normal" code, we start over and
generate code for all the prologs and epilogs. In this case, we didn't reset the
emitForceNewIG global, which determines if we should force a new IG to be created
the next time code is generated. It is used for specifying no-GC regions. This fix
initializes it (along with emitNOGCIG) at the beginning of generating and prolog
or epilog.