### PR TITLE
Revert change in 4e06e42 that broke ARM cross build

### DIFF
--- a/src/vm/arm/stubs.cpp
+++ b/src/vm/arm/stubs.cpp
@@ -2270,7 +2270,6 @@ void TransitionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     
     LOG((LF_GCROOTS, LL_INFO100000, "STACKWALK    TransitionFrame::UpdateRegDisplay(rip:%p, rsp:%p)\n", pRD->ControlPC, pRD->SP));
 }
-#endif // !CROSSGEN_COMPILE
 
 void TailCallFrame::UpdateRegDisplay(const PREGDISPLAY pRD) 
 { 
@@ -2312,6 +2311,7 @@ void TailCallFrame::InitFromContext(T_CONTEXT * pContext)
 }
 
 #endif // !DACCESS_COMPILE
+#endif // !CROSSGEN_COMPILE
 
 void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD) 
 { 


### PR DESCRIPTION
@steveharter what was the reason for the change in 4e06e42 as this also broke the ARM cross build on Linux, given that a fix liburcu is used. The liburcu issue is mentioned at the end of #1192 .