### PR TITLE
A few fixes for standalone Jit (RyuJit) for CoreRT integration

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -105,12 +105,14 @@
   <!-- Setup Nuget properties -->
   <ItemGroup>
     <NuSpecSrcs Include="$(SourceDir)\.nuget\Microsoft.DotNet.CoreCLR.nuspec" />
+    <NuSpecSrcs Include="$(SourceDir)\.nuget\toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec" />
     <NuSpecSrcs Condition="'$(Configuration)'=='Release'" Include="$(SourceDir)\.nuget\Microsoft.DotNet.CoreCLR.Development.nuspec" />
     <NuSpecSrcs Condition="'$(Configuration)'=='Debug'" Include="$(SourceDir)\.nuget\Microsoft.DotNet.CoreCLR.Debug.Development.nuspec" />
   </ItemGroup>
   <ItemGroup>
     <!-- Backslash appended, see note in dir.props about the PackagesBinDir property -->
     <NuSpecs Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.nuspec" />
+    <NuSpecs Include="$(PackagesBinDir)\toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec" />
     <NuSpecs Condition="'$(Configuration)'=='Release'" Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.Development.nuspec" />
     <NuSpecs Condition="'$(Configuration)'=='Debug'" Include="$(PackagesBinDir)\Microsoft.DotNet.CoreCLR.Debug.Development.nuspec" />
   </ItemGroup>

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Debug.Development.nuspec
@@ -24,7 +24,6 @@
     <file src="..\corerun.exe" target="lib\aspnetcore50\corerun.exe" />
     <file src="..\mscorlib.dll" target="lib\aspnetcore50\mscorlib.dll" />
     <file src="..\sos.dll" target="lib\aspnetcore50\sos.dll" />
-    <file src="..\protojit.dll" target="lib\aspnetcore50\protojit.dll" />
     <file src="..\PDB\clretwrc.pdb" target="lib\aspnetcore50\clretwrc.pdb" />
     <file src="..\PDB\coreclr.pdb" target="lib\aspnetcore50\coreclr.pdb" />
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
@@ -35,7 +34,6 @@
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
     <file src="..\PDB\sos.pdb" target="lib\aspnetcore50\sos.pdb" />
     <file src="..\PDB\mscorlib.pdb" target="lib\aspnetcore50\mscorlib.pdb" />
-    <file src="..\PDB\protojit.pdb" target="lib\aspnetcore50\protojit.pdb" />
     <file src="..\inc\cor.h" target="inc\cor.h" />
     <file src="..\inc\corerror.h" target="inc\corerror.h" />
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />

--- a/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
+++ b/src/.nuget/Microsoft.DotNet.CoreCLR.Development.nuspec
@@ -24,7 +24,6 @@
     <file src="..\corerun.exe" target="lib\aspnetcore50\corerun.exe" />
     <file src="..\mscorlib.dll" target="lib\aspnetcore50\mscorlib.dll" />
     <file src="..\sos.dll" target="lib\aspnetcore50\sos.dll" />
-    <file src="..\protojit.dll" target="lib\aspnetcore50\protojit.dll" />
     <file src="..\PDB\clretwrc.pdb" target="lib\aspnetcore50\clretwrc.pdb" />
     <file src="..\PDB\coreclr.pdb" target="lib\aspnetcore50\coreclr.pdb" />
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
@@ -35,7 +34,6 @@
     <file src="..\PDB\corerun.pdb" target="lib\aspnetcore50\corerun.pdb" />
     <file src="..\PDB\sos.pdb" target="lib\aspnetcore50\sos.pdb" />
     <file src="..\PDB\mscorlib.pdb" target="lib\aspnetcore50\mscorlib.pdb" />
-    <file src="..\PDB\protojit.pdb" target="lib\aspnetcore50\protojit.pdb" />
     <file src="..\inc\cor.h" target="inc\cor.h" />
     <file src="..\inc\corerror.h" target="inc\corerror.h" />
     <file src="..\inc\corhdr.h" target="inc\corhdr.h" />

--- a/src/.nuget/Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/Microsoft.DotNet.RyuJit.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Microsoft.DotNet.RyuJit</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides standalone managed to native code-generator</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="runtime.json" />
+  </files>
+</package>

--- a/src/.nuget/runtime.json
+++ b/src/.nuget/runtime.json
@@ -1,0 +1,14 @@
+{
+  "runtimes": {
+    "win7-x64": {
+      "Microsoft.DotNet.RyuJit": {
+        "toolchain.win7-x64.Microsoft.DotNet.RyuJit": "1.0.0-prerelease"
+      }
+    },
+    "ubuntu.14.04-x64": {
+      "Microsoft.DotNet.RyuJit": {
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit": "1.0.0-prerelease"
+      }
+    }
+  }
+}

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides standalone managed to native code-generator</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="../libryujit.so" target="runtimes/ubuntu.14.04-x64/native/libryujit.so" />
+  </files>
+</package>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>toolchain.win7-x64.Microsoft.DotNet.RyuJit</id>
+    <version>1.0.0-prerelease</version>
+    <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
+    <authors>Microsoft</authors>
+    <owners>Microsoft</owners>
+    <licenseUrl>http://go.microsoft.com/fwlink/?LinkId=329770</licenseUrl>
+    <projectUrl>https://github.com/dotnet/coreclr</projectUrl>
+    <iconUrl>http://go.microsoft.com/fwlink/?LinkID=288859</iconUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>Provides standalone managed to native code-generator</description>
+    <releaseNotes>Initial release</releaseNotes>
+    <copyright>Copyright &#169; Microsoft Corporation</copyright>
+  </metadata>
+  <files>
+    <file src="..\ryujit.dll" target="runtimes\win7-x64\native\ryujit.dll" />
+    <file src="..\PDB\ryujit.pdb" target="runtimes\win7-x64\native\ryujit.pdb" />
+  </files>
+</package>

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8476,6 +8476,10 @@ public:
     // a field sequence as a member; otherwise, it may be the addition of an a byref and a constant, where the const
     // has a field sequence -- in this case "fieldSeq" is appended to that of the constant; otherwise, we
     // record the the field sequence using the ZeroOffsetFieldMap described above.
+    //
+    // One exception above is that "op1" is a node of type "TYP_REF" where "op1" is a GT_LCL_VAR.
+    // This happens when System.Object vtable pointer is a regular field at offset 0 in System.Private.CoreLib in CoreRT.
+    // Such case is handled same as the default case.
     void fgAddFieldSeqForZeroOffset(GenTreePtr op1, FieldSeqNode* fieldSeq);
 
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15608,7 +15608,12 @@ bool Compiler::fgFitsInOrNotLoc(GenTreePtr tree, unsigned width)
 
 void Compiler::fgAddFieldSeqForZeroOffset(GenTreePtr op1, FieldSeqNode* fieldSeq)
 {
+#ifdef FEATURE_REF_ZERO_OFFSET_ALLOWED
+    assert(op1->TypeGet() == TYP_BYREF || op1->TypeGet() == TYP_I_IMPL || op1->TypeGet() == TYP_REF);
+#else
     assert(op1->TypeGet() == TYP_BYREF || op1->TypeGet() == TYP_I_IMPL);
+#endif
+
     switch (op1->OperGet())
     {
     case GT_ADDR:

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -1,27 +1,28 @@
-project(protojit)
+project(ryujit)
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
 add_definitions(-DFEATURE_READYTORUN_COMPILER)
+add_definitions(-DFEATURE_REF_ZERO_OFFSET_ALLOWED)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
-add_library(protojit
+add_library(ryujit
    SHARED
    ${SHARED_LIB_SOURCES}
 )
 
-set(PROTOJIT_LINK_LIBRARIES
+set(RYUJIT_LINK_LIBRARIES
    utilcodestaticnohost
    gcinfo
 )
 
 if(CLR_CMAKE_PLATFORM_UNIX)
-    list(APPEND PROTOJIT_LINK_LIBRARIES
+    list(APPEND RYUJIT_LINK_LIBRARIES
        mscorrc_debug
        coreclrpal
        palrt
     )
 else()
-    list(APPEND PROTOJIT_LINK_LIBRARIES
+    list(APPEND RYUJIT_LINK_LIBRARIES
        msvcrt.lib
        kernel32.lib
        advapi32.lib
@@ -37,12 +38,12 @@ else()
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-target_link_libraries(protojit
-   ${PROTOJIT_LINK_LIBRARIES}
+target_link_libraries(ryujit
+   ${RYUJIT_LINK_LIBRARIES}
 )
 
 # add the install targets
-install (TARGETS protojit DESTINATION .)
+install (TARGETS ryujit DESTINATION .)
 if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/protojit.pdb DESTINATION PDB)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ryujit.pdb DESTINATION PDB)
 endif(WIN32)


### PR DESCRIPTION
1. Fix for assertion in fgAddFieldSeqForZeroOffset
The fix relaxed the assertion under FEATURE_REF_ZERO_OFFSET_ALLOWED.
The feature is enabled when the standalone Jit is built.

2. Rename ProtoJit to RyuJit

3. Package spec files for Windows/Linux and redirection.
Note automating packaging and publishing are not implemented yet.
