### PR TITLE
Fixed FreeBSD sos plugin build.

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/setclrpathcommand.cpp
+++ b/src/ToolBox/SOS/lldbplugin/setclrpathcommand.cpp
@@ -7,6 +7,8 @@
 #include <dlfcn.h>
 #include <string.h>
 #include <string>
+#include <stdlib.h>
+#include <limits.h>
 
 class setclrpathCommand : public lldb::SBCommandPluginInterface
 {

--- a/src/ToolBox/SOS/lldbplugin/setsostidcommand.cpp
+++ b/src/ToolBox/SOS/lldbplugin/setsostidcommand.cpp
@@ -7,6 +7,8 @@
 #include <dlfcn.h>
 #include <string.h>
 #include <string>
+#include <stdlib.h>
+#include <limits.h>
 
 class setsostidCommand : public lldb::SBCommandPluginInterface
 {


### PR DESCRIPTION
Minor problem when building with the lldb environment variables set to lldb3.7.  Added some include files needed to build.