### PR TITLE
Fix dac verification errors caused by 48617ae

### DIFF
--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1036,15 +1036,17 @@ public:
     void        AddToCleanupList(HostCodeHeap *pCodeHeap);
     void        DeleteCodeHeap(HeapList *pHeapList);
     void        RemoveCodeHeapFromDomainList(CodeHeap *pHeap, LoaderAllocator *pAllocator);
+#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
 private :
+#ifndef CROSSGEN_COMPILE
     struct DomainCodeHeapList {
         LoaderAllocator *m_pAllocator;
         CDynArray<HeapList *> m_CodeHeapList;
         DomainCodeHeapList();
         ~DomainCodeHeapList();
     };
-#endif // !DACCESS_COMPILE && !CROSSGEN_COMPILE
+#endif
 
 #ifndef DACCESS_COMPILE
 #ifndef CROSSGEN_COMPILE
@@ -1126,7 +1128,7 @@ private :
     //When EH Clauses are resolved we need to atomically update the TypeHandle
     Crst                m_EHClauseCritSec;
 
-#if !defined CROSSGEN_COMPILE && !defined DACCESS_COMPILE
+#if !defined CROSSGEN_COMPILE
     // must hold critical section to access this structure.
     CUnorderedArray<DomainCodeHeapList *, 5> m_DomainCodeHeaps;
     CUnorderedArray<DomainCodeHeapList *, 5> m_DynamicDomainCodeHeaps;


### PR DESCRIPTION
Fields of certain types in VM needs to exactly same as that in dac as dac needs to walkthrough those types. Commit 48617ae changed this condition for type EEJitManager. This is breaking our internal builds. I already have an issue assigned to me to add dac verification check to GitHub build. This should avoid such build breaks in future.