### PR TITLE
Fixing a typo in developer-guide.md.

### DIFF
--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -15,7 +15,7 @@ The CoreCLR repo can be built from a regular, non-admin command prompt. The buil
 | ARM32 | &#x25EF; | &#x25EF;| &#x25EF; |
 |       | [Instructions](../building/windows-instructions.md) | [Instructions](../building/linux-instructions.md) | [Instructions](../building/osx-instructions.md) |  
 
-The CoreCLR build and test suite is a work in progress, as are the [building and testing instructions](../README.md). The .NET Core team and the community are improving Linux and OS X support on a daily basis are and adding more tests for all platforms. See [CoreCLR Issues](https://github.com/dotnet/coreclr/issues) to find out about specific work items or report issues.
+The CoreCLR build and test suite is a work in progress, as are the [building and testing instructions](../README.md). The .NET Core team and the community are improving Linux and OS X support on a daily basis and are adding more tests for all platforms. See [CoreCLR Issues](https://github.com/dotnet/coreclr/issues) to find out about specific work items or report issues.
 
 Understanding the TFS-Git Mirror
 ================================


### PR DESCRIPTION
The words 'are' and 'and' were mistyped and need to be switched.