### PR TITLE
Refactor gc types

### DIFF
--- a/src/ToolBox/SOS/Strike/gchist.cpp
+++ b/src/ToolBox/SOS/Strike/gchist.cpp
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <stddef.h>
 

--- a/src/ToolBox/SOS/Strike/strike.h
+++ b/src/ToolBox/SOS/Strike/strike.h
@@ -70,6 +70,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 
 

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -8333,7 +8333,7 @@ CLRDATA_ADDRESS DacStackReferenceWalker::ReadPointer(TADDR addr)
 }
    
 
-void DacStackReferenceWalker::GCEnumCallbackSOS(LPVOID hCallback, OBJECTREF *pObject, DWORD flags, DacSlotLocation loc)
+void DacStackReferenceWalker::GCEnumCallbackSOS(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc)
 {
     GCCONTEXT *gcctx = (GCCONTEXT *)hCallback;
     DacScanContext *dsc = (DacScanContext*)gcctx->sc;
@@ -8392,7 +8392,7 @@ void DacStackReferenceWalker::GCEnumCallbackSOS(LPVOID hCallback, OBJECTREF *pOb
 }
 
 
-void DacStackReferenceWalker::GCReportCallbackSOS(PTR_PTR_Object ppObj, ScanContext *sc, DWORD flags)
+void DacStackReferenceWalker::GCReportCallbackSOS(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags)
 {
     DacScanContext *dsc = (DacScanContext*)sc;
     CLRDATA_ADDRESS obj = dsc->pWalker->ReadPointer(ppObj.GetAddr());

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -8160,7 +8160,7 @@ void DacHandleWalker::GetRefCountedHandleInfo(
         *pIsStrong = FALSE;
 }
 
-void CALLBACK DacHandleWalker::EnumCallbackSOS(PTR_UNCHECKED_OBJECTREF handle, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2)
+void CALLBACK DacHandleWalker::EnumCallbackSOS(PTR_UNCHECKED_OBJECTREF handle, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2)
 {
     SUPPORTS_DAC;
     

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -7547,7 +7547,7 @@ void CALLBACK DacHandleWalker::EnumCallbackDac(PTR_UNCHECKED_OBJECTREF handle, L
 }
 
 
-void DacStackReferenceWalker::GCEnumCallbackDac(LPVOID hCallback, OBJECTREF *pObject, DWORD flags, DacSlotLocation loc)
+void DacStackReferenceWalker::GCEnumCallbackDac(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc)
 {
     GCCONTEXT *gcctx = (GCCONTEXT *)hCallback;
     DacScanContext *dsc = (DacScanContext*)gcctx->sc;
@@ -7587,7 +7587,7 @@ void DacStackReferenceWalker::GCEnumCallbackDac(LPVOID hCallback, OBJECTREF *pOb
 }
 
 
-void DacStackReferenceWalker::GCReportCallbackDac(PTR_PTR_Object ppObj, ScanContext *sc, DWORD flags)
+void DacStackReferenceWalker::GCReportCallbackDac(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags)
 {
     DacScanContext *dsc = (DacScanContext*)sc;
     

--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -7459,7 +7459,7 @@ HRESULT DacHandleWalker::Next(ULONG celt, DacGcReference roots[], ULONG *pceltFe
 }
 
 
-void CALLBACK DacHandleWalker::EnumCallbackDac(PTR_UNCHECKED_OBJECTREF handle, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2)
+void CALLBACK DacHandleWalker::EnumCallbackDac(PTR_UNCHECKED_OBJECTREF handle, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2)
 {
     SUPPORTS_DAC;
     

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -2152,8 +2152,8 @@ private:
     static UINT32 BuildTypemask(UINT types[], UINT typeCount);
 
 private:
-    static void CALLBACK EnumCallbackSOS(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pExtraInfo, LPARAM userParam, LPARAM type);
-    static void CALLBACK EnumCallbackDac(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pExtraInfo, LPARAM userParam, LPARAM type);
+    static void CALLBACK EnumCallbackSOS(PTR_UNCHECKED_OBJECTREF pref, uintptr_t *pExtraInfo, uintptr_t userParam, uintptr_t type);
+    static void CALLBACK EnumCallbackDac(PTR_UNCHECKED_OBJECTREF pref, uintptr_t *pExtraInfo, uintptr_t userParam, uintptr_t type);
     
     bool FetchMoreHandles(HANDLESCANPROC proc);
     static inline bool IsAlwaysStrongReference(unsigned int type)

--- a/src/debug/daccess/dacimpl.h
+++ b/src/debug/daccess/dacimpl.h
@@ -1918,10 +1918,10 @@ public:
                                    
 private:
     static StackWalkAction Callback(CrawlFrame *pCF, VOID *pData);
-    static void GCEnumCallbackSOS(LPVOID hCallback, OBJECTREF *pObject, DWORD flags, DacSlotLocation loc);
-    static void GCReportCallbackSOS(PTR_PTR_Object ppObj, ScanContext *sc, DWORD flags);
-    static void GCEnumCallbackDac(LPVOID hCallback, OBJECTREF *pObject, DWORD flags, DacSlotLocation loc);
-    static void GCReportCallbackDac(PTR_PTR_Object ppObj, ScanContext *sc, DWORD flags);
+    static void GCEnumCallbackSOS(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc);
+    static void GCReportCallbackSOS(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags);
+    static void GCEnumCallbackDac(LPVOID hCallback, OBJECTREF *pObject, uint32_t flags, DacSlotLocation loc);
+    static void GCReportCallbackDac(PTR_PTR_Object ppObj, ScanContext *sc, uint32_t flags);
 
     CLRDATA_ADDRESS ReadPointer(TADDR addr);
 

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -25,45 +25,22 @@
 //
 
 typedef uint32_t BOOL;
-typedef uint16_t WORD;
-typedef uint16_t USHORT;
 typedef uint32_t DWORD;
 typedef uintptr_t DWORD_PTR;
-typedef uint8_t BYTE;
-typedef int8_t SBYTE;
-typedef BYTE* PBYTE;
 typedef void* LPVOID;
-typedef int8_t INT8;
 typedef uint32_t UINT;
-typedef uint32_t UINT32;
-typedef uint16_t UINT16;
-typedef uint8_t UINT8;
-typedef int16_t INT16;
-typedef int32_t INT32;
 typedef int32_t LONG;
-typedef int64_t LONGLONG;
 typedef uint32_t ULONG;
-typedef uint32_t ULONG32;
-typedef intptr_t INT_PTR;
-typedef uintptr_t UINT_PTR;
 typedef uintptr_t ULONG_PTR;
-typedef uint64_t UINT64;
-typedef uint64_t ULONG64;
-typedef uint64_t ULONGLONG;
-typedef uint64_t DWORDLONG;
-typedef int64_t INT64;
 typedef void VOID;
 typedef void* PVOID;
 typedef uintptr_t LPARAM;
-typedef void* LPCGUID;
 typedef void * LPSECURITY_ATTRIBUTES;
 typedef void const * LPCVOID;
 typedef uint32_t * PULONG;
-typedef char * PSTR;
 typedef wchar_t * PWSTR, *LPWSTR;
 typedef const wchar_t *LPCWSTR, *PCWSTR;
 typedef size_t SIZE_T;
-typedef ptrdiff_t ssize_t;
 typedef ptrdiff_t SSIZE_T;
 
 typedef void * HANDLE;
@@ -71,18 +48,18 @@ typedef void * HANDLE;
 typedef union _LARGE_INTEGER {
     struct {
 #if BIGENDIAN
-        LONG HighPart;
-        DWORD LowPart;
+        int32_t HighPart;
+        uint32_t LowPart;
 #else
-        DWORD LowPart;
-        LONG HighPart;
+        uint32_t LowPart;
+        int32_t HighPart;
 #endif
     } u;
-    LONGLONG QuadPart;
+    int64_t QuadPart;
 } LARGE_INTEGER, *PLARGE_INTEGER;
 
 #define SIZE_T_MAX ((size_t)-1)
-#define SSIZE_T_MAX ((ssize_t)(SIZE_T_MAX / 2))
+#define SSIZE_T_MAX ((SSIZE_T)(SIZE_T_MAX / 2))
 
 // -----------------------------------------------------------------------------------------------------------
 // HRESULT subset.
@@ -146,7 +123,7 @@ inline HRESULT HRESULT_FROM_WIN32(unsigned long x)
 #pragma pack(push, 8)
 
 typedef struct _RTL_CRITICAL_SECTION {
-    PVOID DebugInfo;
+    void* DebugInfo;
 
     //
     //  The following three fields control entering and exiting the critical
@@ -171,24 +148,24 @@ typedef struct _RTL_CRITICAL_SECTION {
 #endif
 
 typedef struct _MEMORYSTATUSEX {
-  DWORD     dwLength;
-  DWORD     dwMemoryLoad;
-  DWORDLONG ullTotalPhys;
-  DWORDLONG ullAvailPhys;
-  DWORDLONG ullTotalPageFile;
-  DWORDLONG ullAvailPageFile;
-  DWORDLONG ullTotalVirtual;
-  DWORDLONG ullAvailVirtual;
-  DWORDLONG ullAvailExtendedVirtual;
+  uint32_t dwLength;
+  uint32_t dwMemoryLoad;
+  uint64_t ullTotalPhys;
+  uint64_t ullAvailPhys;
+  uint64_t ullTotalPageFile;
+  uint64_t ullAvailPageFile;
+  uint64_t ullTotalVirtual;
+  uint64_t ullAvailVirtual;
+  uint64_t ullAvailExtendedVirtual;
 } MEMORYSTATUSEX, *LPMEMORYSTATUSEX;
 
 #define WINBASEAPI extern "C"
 #define WINAPI __stdcall
 
-typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(PVOID lpThreadParameter);
+typedef DWORD (WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
 
 WINBASEAPI
-void 
+void
 WINAPI
 DebugBreak();
 
@@ -425,7 +402,7 @@ typedef uintptr_t TADDR;
     type var[size]
 
 typedef DPTR(size_t)    PTR_size_t;
-typedef DPTR(BYTE)      PTR_BYTE;
+typedef DPTR(uint8_t)   PTR_uint8_t;
 
 struct _DacGlobals;
 
@@ -634,7 +611,7 @@ class Thread;
 Thread * GetThread();
 
 struct ScanContext;
-typedef void promote_func(PTR_PTR_Object, ScanContext*, unsigned);
+typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
 
 typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2);
 

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -29,15 +29,15 @@ typedef uint32_t DWORD;
 typedef uintptr_t DWORD_PTR;
 typedef void* LPVOID;
 typedef uint32_t UINT;
-typedef int32_t LONG;
-typedef uint32_t ULONG;
+//typedef int32_t LONG;
+//typedef uint32_t ULONG;
 typedef uintptr_t ULONG_PTR;
 typedef void VOID;
 typedef void* PVOID;
 typedef uintptr_t LPARAM;
 typedef void * LPSECURITY_ATTRIBUTES;
 typedef void const * LPCVOID;
-typedef uint32_t * PULONG;
+//typedef uint32_t * PULONG;
 typedef wchar_t * PWSTR, *LPWSTR;
 typedef const wchar_t *LPCWSTR, *PCWSTR;
 typedef size_t SIZE_T;
@@ -130,8 +130,8 @@ typedef struct _RTL_CRITICAL_SECTION {
     //  section for the resource
     //
 
-    LONG LockCount;
-    LONG RecursionCount;
+    int32_t LockCount;
+    int32_t RecursionCount;
     HANDLE OwningThread;        // from the thread's ClientId->UniqueThread
     HANDLE LockSemaphore;
     ULONG_PTR SpinCount;        // force size on 64-bit systems when packed
@@ -191,7 +191,7 @@ GetWriteWatch(
   SIZE_T dwRegionSize,
   PVOID *lpAddresses,
   ULONG_PTR * lpdwCount,
-  ULONG * lpdwGranularity
+  uint32_t * lpdwGranularity
 );
 
 WINBASEAPI
@@ -260,8 +260,8 @@ DWORD
 WINAPI
 SetFilePointer(
            HANDLE hFile,
-           LONG lDistanceToMove,
-           LONG * lpDistanceToMoveHigh,
+           int32_t lDistanceToMove,
+           int32_t * lpDistanceToMoveHigh,
            DWORD dwMoveMethod);
 
 WINBASEAPI
@@ -430,7 +430,7 @@ struct _DacGlobals;
 
 int32_t FastInterlockIncrement(int32_t volatile *lpAddend);
 int32_t FastInterlockDecrement(int32_t volatile *lpAddend);
-int32_t FastInterlockExchange(int32_t volatile *Target, LONG Value);
+int32_t FastInterlockExchange(int32_t volatile *Target, int32_t Value);
 int32_t FastInterlockCompareExchange(int32_t volatile *Destination, int32_t Exchange, int32_t Comperand);
 int32_t FastInterlockExchangeAdd(int32_t volatile *Addend, int32_t Value);
 

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -28,6 +28,7 @@ typedef uint32_t BOOL;
 typedef uint32_t DWORD;
 typedef void* LPVOID;
 typedef uint32_t UINT;
+typedef uintptr_t ULONG_PTR;
 typedef void VOID;
 typedef void* PVOID;
 typedef void * LPSECURITY_ATTRIBUTES;
@@ -183,8 +184,8 @@ GetWriteWatch(
   PVOID lpBaseAddress,
   SIZE_T dwRegionSize,
   PVOID *lpAddresses,
-  uintptr_t * lpdwCount,
-  uint32_t * lpdwGranularity
+  ULONG_PTR * lpdwCount,
+  DWORD * lpdwGranularity
 );
 
 WINBASEAPI

--- a/src/gc/env/gcenv.base.h
+++ b/src/gc/env/gcenv.base.h
@@ -26,22 +26,15 @@
 
 typedef uint32_t BOOL;
 typedef uint32_t DWORD;
-typedef uintptr_t DWORD_PTR;
 typedef void* LPVOID;
 typedef uint32_t UINT;
-//typedef int32_t LONG;
-//typedef uint32_t ULONG;
-typedef uintptr_t ULONG_PTR;
 typedef void VOID;
 typedef void* PVOID;
-typedef uintptr_t LPARAM;
 typedef void * LPSECURITY_ATTRIBUTES;
 typedef void const * LPCVOID;
-//typedef uint32_t * PULONG;
 typedef wchar_t * PWSTR, *LPWSTR;
 typedef const wchar_t *LPCWSTR, *PCWSTR;
 typedef size_t SIZE_T;
-typedef ptrdiff_t SSIZE_T;
 
 typedef void * HANDLE;
 
@@ -59,7 +52,7 @@ typedef union _LARGE_INTEGER {
 } LARGE_INTEGER, *PLARGE_INTEGER;
 
 #define SIZE_T_MAX ((size_t)-1)
-#define SSIZE_T_MAX ((SSIZE_T)(SIZE_T_MAX / 2))
+#define SSIZE_T_MAX ((ptrdiff_t)(SIZE_T_MAX / 2))
 
 // -----------------------------------------------------------------------------------------------------------
 // HRESULT subset.
@@ -134,7 +127,7 @@ typedef struct _RTL_CRITICAL_SECTION {
     int32_t RecursionCount;
     HANDLE OwningThread;        // from the thread's ClientId->UniqueThread
     HANDLE LockSemaphore;
-    ULONG_PTR SpinCount;        // force size on 64-bit systems when packed
+    uintptr_t SpinCount;        // force size on 64-bit systems when packed
 } CRITICAL_SECTION, RTL_CRITICAL_SECTION, *PRTL_CRITICAL_SECTION;
 
 #pragma pack(pop)
@@ -190,7 +183,7 @@ GetWriteWatch(
   PVOID lpBaseAddress,
   SIZE_T dwRegionSize,
   PVOID *lpAddresses,
-  ULONG_PTR * lpdwCount,
+  uintptr_t * lpdwCount,
   uint32_t * lpdwGranularity
 );
 
@@ -613,7 +606,7 @@ Thread * GetThread();
 struct ScanContext;
 typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
 
-typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2);
+typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2);
 
 class GCToEEInterface
 {
@@ -659,7 +652,7 @@ public:
     static bool RefCountedHandleCallbacks(Object * pObject);
 
     // Sync block cache management
-    static void SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, LPARAM lp1, LPARAM lp2) { }
+    static void SyncBlockCacheWeakPtrScan(HANDLESCANPROC scanProc, uintptr_t lp1, uintptr_t lp2) { }
     static void SyncBlockCacheDemote(int max_gen) { }
     static void SyncBlockCachePromotionsGranted(int max_gen) { }
 

--- a/src/gc/env/gcenv.object.h
+++ b/src/gc/env/gcenv.object.h
@@ -130,19 +130,19 @@ public:
         m_pMethTab = pMT;
     }
 };
-#define MIN_OBJECT_SIZE     (2*sizeof(BYTE*) + sizeof(ObjHeader))
+#define MIN_OBJECT_SIZE     (2*sizeof(uint8_t*) + sizeof(ObjHeader))
 
 class ArrayBase : public Object
 {
-    DWORD m_dwLength;
+    uint32_t m_dwLength;
 
 public:
-    DWORD GetNumComponents()
+    uint32_t GetNumComponents()
     {
         return m_dwLength;
     }
 
-    static SIZE_T GetOffsetOfNumComponents()
+    static size_t GetOffsetOfNumComponents()
     {
         return offsetof(ArrayBase, m_dwLength);
     }

--- a/src/gc/env/gcenv.sync.h
+++ b/src/gc/env/gcenv.sync.h
@@ -10,14 +10,14 @@
 class EEThreadId
 {
 public:
-    EEThreadId(UINT32 uiId) : m_uiId(uiId) {}
+    EEThreadId(uint32_t uiId) : m_uiId(uiId) {}
     bool IsSameThread()
     {
         return m_uiId == GetCurrentThreadId();
     }
 
 private:
-    UINT32 m_uiId;
+    uint32_t m_uiId;
 };
 
 #define CRST_REENTRANCY         0
@@ -35,7 +35,7 @@ class CrstStatic
 {
     CRITICAL_SECTION m_cs;
 #ifdef _DEBUG
-    UINT32 m_holderThreadId;
+    uint32_t m_holderThreadId;
 #endif
 
 public:

--- a/src/gc/env/gcenv.unix.cpp
+++ b/src/gc/env/gcenv.unix.cpp
@@ -100,7 +100,7 @@ void GetProcessMemoryLoad(LPMEMORYSTATUSEX pMSEX)
     // Unix, so we use a constant value representing 128TB, which is 
     // the approximate size of total user virtual address space on
     // the currently supported Unix systems.
-    static const UINT64 _128TB = (1ull << 47);
+    static const uint64_t _128TB = (1ull << 47);
     pMSEX->ullTotalVirtual = _128TB;
     pMSEX->ullAvailVirtual = _128TB;
 
@@ -465,7 +465,7 @@ QueryPerformanceCounter(LARGE_INTEGER *lpPerformanceCount)
         return FALSE;
     }
     lpPerformanceCount->QuadPart =
-        (LONGLONG) tv.tv_sec * (LONGLONG) tccSecondsToMicroSeconds + (LONGLONG) tv.tv_usec;
+        (int64_t) tv.tv_sec * (int64_t) tccSecondsToMicroSeconds + (int64_t) tv.tv_usec;
     return TRUE;
 }
 
@@ -474,7 +474,7 @@ BOOL
 WINAPI
 QueryPerformanceFrequency(LARGE_INTEGER *lpFrequency)
 {
-    lpFrequency->QuadPart = (LONGLONG) tccSecondsToMicroSeconds;
+    lpFrequency->QuadPart = (int64_t) tccSecondsToMicroSeconds;
     return TRUE;
 }
 

--- a/src/gc/env/gcenv.unix.cpp
+++ b/src/gc/env/gcenv.unix.cpp
@@ -389,7 +389,7 @@ GetWriteWatch(
     SIZE_T dwRegionSize,
     PVOID *lpAddresses,
     ULONG_PTR * lpdwCount,
-    ULONG * lpdwGranularity
+    uint32_t * lpdwGranularity
     )
 {
     // TODO: Implement for background GC
@@ -519,8 +519,8 @@ DWORD
 WINAPI
 SetFilePointer(
     HANDLE hFile,
-    LONG lDistanceToMove,
-    LONG * lpDistanceToMoveHigh,
+    int32_t lDistanceToMove,
+    int32_t * lpDistanceToMoveHigh,
     DWORD dwMoveMethod)
 {
     // TODO: Reimplement callers using CRT

--- a/src/gc/env/gcenv.unix.cpp
+++ b/src/gc/env/gcenv.unix.cpp
@@ -388,7 +388,7 @@ GetWriteWatch(
     PVOID lpBaseAddress,
     SIZE_T dwRegionSize,
     PVOID *lpAddresses,
-    ULONG_PTR * lpdwCount,
+    uintptr_t * lpdwCount,
     uint32_t * lpdwGranularity
     )
 {

--- a/src/gc/env/gcenv.windows.cpp
+++ b/src/gc/env/gcenv.windows.cpp
@@ -26,7 +26,7 @@ int32_t FastInterlockDecrement(int32_t volatile *lpAddend)
 
 int32_t FastInterlockExchange(int32_t volatile *Target, int32_t Value)
 {
-    return InterlockedExchange((LONG *)Target, Value);
+    return InterlockedExchange((int32_t *)Target, Value);
 }
 
 int32_t FastInterlockCompareExchange(int32_t volatile *Destination, int32_t Exchange, int32_t Comperand)

--- a/src/gc/env/gcenv.windows.cpp
+++ b/src/gc/env/gcenv.windows.cpp
@@ -16,12 +16,12 @@
 
 int32_t FastInterlockIncrement(int32_t volatile *lpAddend)
 {
-    return InterlockedIncrement((LONG *)lpAddend);
+    return InterlockedIncrement((int32_t *)lpAddend);
 }
 
 int32_t FastInterlockDecrement(int32_t volatile *lpAddend)
 {
-    return InterlockedDecrement((LONG *)lpAddend);
+    return InterlockedDecrement((int32_t *)lpAddend);
 }
 
 int32_t FastInterlockExchange(int32_t volatile *Target, int32_t Value)
@@ -31,12 +31,12 @@ int32_t FastInterlockExchange(int32_t volatile *Target, int32_t Value)
 
 int32_t FastInterlockCompareExchange(int32_t volatile *Destination, int32_t Exchange, int32_t Comperand)
 {
-    return InterlockedCompareExchange((LONG *)Destination, Exchange, Comperand);
+    return InterlockedCompareExchange((int32_t *)Destination, Exchange, Comperand);
 }
 
 int32_t FastInterlockExchangeAdd(int32_t volatile *Addend, int32_t Value)
 {
-    return InterlockedExchangeAdd((LONG *)Addend, Value);
+    return InterlockedExchangeAdd((int32_t *)Addend, Value);
 }
 
 void * _FastInterlockExchangePointer(void * volatile *Target, void * Value)
@@ -51,12 +51,12 @@ void * _FastInterlockCompareExchangePointer(void * volatile *Destination, void *
 
 void FastInterlockOr(uint32_t volatile *p, uint32_t msk)
 {
-    InterlockedOr((LONG *)p, msk);
+    InterlockedOr((int32_t *)p, msk);
 }
 
 void FastInterlockAnd(uint32_t volatile *p, uint32_t msk)
 {
-    InterlockedAnd((LONG *)p, msk);
+    InterlockedAnd((int32_t *)p, msk);
 }
 
 

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -1716,7 +1716,7 @@ static void enter_spin_lock (GCSpinLock* spin_lock)
 {
 retry:
 
-    if (FastInterlockExchange (&spin_lock->lock, 0) >= 0)
+    if (FastInterlockExchange ((LONG*)&spin_lock->lock, 0) >= 0)
     {
         unsigned int i = 0;
         while (spin_lock->lock >= 0)
@@ -1767,7 +1767,7 @@ retry:
 
 inline BOOL try_enter_spin_lock(GCSpinLock* spin_lock)
 {
-    return (FastInterlockExchange (&spin_lock->lock, 0) < 0);
+    return (FastInterlockExchange ((LONG*)&spin_lock->lock, 0) < 0);
 }
 
 inline
@@ -9161,7 +9161,7 @@ void gc_heap::update_card_table_bundle()
             dprintf (3,("Probing card table pages [%Ix, %Ix[", (size_t)base_address, (size_t)base_address+region_size));
             uint32_t status = GetWriteWatch (0, base_address, region_size,
                                          (void**)g_addresses,
-                                         &bcount, (DWORD*)&granularity);
+                                         (ULONG_PTR*)&bcount, (DWORD*)&granularity);
             assert (status == 0);
             assert (granularity == OS_PAGE_SIZE);
             dprintf (3,("Found %d pages written", bcount));
@@ -18424,7 +18424,7 @@ void gc_heap::fix_card_table ()
 #endif //TIME_WRITE_WATCH
             uint32_t status = GetWriteWatch (mode, base_address, region_size,
                                           (void**)g_addresses,
-                                          &bcount, (DWORD*)&granularity);
+                                          (ULONG_PTR*)&bcount, (DWORD*)&granularity);
             assert (status == 0);
 
 #ifdef TIME_WRITE_WATCH
@@ -26157,7 +26157,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
 
                     uint32_t status = GetWriteWatch (mode, base_address, region_size,
                                                 (void**)background_written_addresses,
-                                                &bcount, (DWORD*)&granularity);
+                                                (ULONG_PTR*)&bcount, (DWORD*)&granularity);
 
     //#ifdef _DEBUG
                     if (status != 0)

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -46,7 +46,7 @@ inline BOOL ShouldTrackMovementForProfilerOrEtw()
 #define MAYBE_UNUSED_VAR(v)
 #endif // FEATURE_REDHAWK
 
-#define MAX_PTR ((BYTE*)(~(SSIZE_T)0))
+#define MAX_PTR ((uint8_t*)(~(SSIZE_T)0))
 
 #ifdef SERVER_GC
 #define partial_size_th 100
@@ -162,12 +162,12 @@ void GCStatistics::AddGCStats(const gc_mechanisms& settings, size_t timeInMSec)
 #ifdef BACKGROUND_GC
     if (settings.concurrent)
     {
-        bgc.Accumulate((DWORD)timeInMSec*1000);
+        bgc.Accumulate((uint32_t)timeInMSec*1000);
         cntBGC++;
     }
     else if (settings.background_p)
     {
-        fgc.Accumulate((DWORD)timeInMSec*1000);
+        fgc.Accumulate((uint32_t)timeInMSec*1000);
         cntFGC++;
         if (settings.compaction)
             cntCompactFGC++;
@@ -177,7 +177,7 @@ void GCStatistics::AddGCStats(const gc_mechanisms& settings, size_t timeInMSec)
     else
 #endif // BACKGROUND_GC
     {
-        ngc.Accumulate((DWORD)timeInMSec*1000);
+        ngc.Accumulate((uint32_t)timeInMSec*1000);
         cntNGC++;
         if (settings.compaction)
             cntCompactNGC++;
@@ -210,8 +210,8 @@ void GCStatistics::Initialize()
             "The first field of GCStatistics follows the pointer sized vtable");
 
     int podOffs = offsetof(GCStatistics, cntDisplay);       // offset of the first POD field
-    memset((BYTE*)(&g_GCStatistics)+podOffs, 0, sizeof(g_GCStatistics)-podOffs);
-    memset((BYTE*)(&g_LastGCStatistics)+podOffs, 0, sizeof(g_LastGCStatistics)-podOffs);
+    memset((uint8_t*)(&g_GCStatistics)+podOffs, 0, sizeof(g_GCStatistics)-podOffs);
+    memset((uint8_t*)(&g_LastGCStatistics)+podOffs, 0, sizeof(g_LastGCStatistics)-podOffs);
 }
 
 void GCStatistics::DisplayAndUpdate()
@@ -285,13 +285,13 @@ void GCStatistics::DisplayAndUpdate()
 #endif // GC_STATS
 
 #ifdef BACKGROUND_GC
-DWORD bgc_alloc_spin_count = 140;
-DWORD bgc_alloc_spin_count_loh = 16;
-DWORD bgc_alloc_spin = 2;
+uint32_t bgc_alloc_spin_count = 140;
+uint32_t bgc_alloc_spin_count_loh = 16;
+uint32_t bgc_alloc_spin = 2;
 
 
 inline
-void c_write (DWORD& place, DWORD value)
+void c_write (uint32_t& place, uint32_t value)
 {
     FastInterlockExchange (&(LONG&)place, value);
     //place = value;
@@ -299,7 +299,7 @@ void c_write (DWORD& place, DWORD value)
 
 // TODO - can't make it work with the syntax for Volatile<T>
 inline
-void c_write_volatile (BOOL* place, DWORD value)
+void c_write_volatile (BOOL* place, uint32_t value)
 {
     FastInterlockExchange ((LONG*)place, value);
     //place = value;
@@ -326,7 +326,7 @@ void gc_heap::add_to_history_per_heap()
     current_hist->gc_index = settings.gc_index;
     current_hist->current_bgc_state = current_bgc_state;
     size_t elapsed = dd_gc_elapsed_time (dynamic_data_of (0));
-    current_hist->gc_time_ms = (DWORD)elapsed;
+    current_hist->gc_time_ms = (uint32_t)elapsed;
     current_hist->gc_efficiency = (elapsed ? (total_promoted_bytes / elapsed) : total_promoted_bytes);
     current_hist->eph_low = generation_allocation_start (generation_of (max_generation-1));
     current_hist->gen0_start = generation_allocation_start (generation_of (0));
@@ -377,12 +377,12 @@ static MUTEX_COOKIE   gc_log_lock = 0;
 
 // we keep this much in a buffer and only flush when the buffer is full
 #define gc_log_buffer_size (1024*1024)
-BYTE* gc_log_buffer = 0;
+uint8_t* gc_log_buffer = 0;
 size_t gc_log_buffer_offset = 0;
 
 void log_va_msg(const char *fmt, va_list args)
 {
-    DWORD status = ClrWaitForMutex(gc_log_lock, INFINITE, FALSE);
+    uint32_t status = ClrWaitForMutex(gc_log_lock, INFINITE, FALSE);
     assert (WAIT_OBJECT_0 == status);
 
     const int BUFFERSIZE = 512;
@@ -418,8 +418,8 @@ void log_va_msg(const char *fmt, va_list args)
             SetFilePointer (gc_log, 0, NULL, FILE_BEGIN);
             gc_buffer_index = 0;
         }
-        DWORD written_to_log = 0;
-        WriteFile (gc_log, gc_log_buffer, (DWORD)gc_log_buffer_size, &written_to_log, NULL);
+        uint32_t written_to_log = 0;
+        WriteFile (gc_log, gc_log_buffer, (uint32_t)gc_log_buffer_size, &written_to_log, NULL);
         FlushFileBuffers (gc_log);
         memset (gc_log_buffer, '*', gc_log_buffer_size);
         gc_log_buffer_offset = 0;
@@ -450,7 +450,7 @@ HANDLE gc_config_log = INVALID_HANDLE_VALUE;
 
 // we keep this much in a buffer and only flush when the buffer is full
 #define gc_config_log_buffer_size (1*1024) // TEMP
-BYTE* gc_config_log_buffer = 0;
+uint8_t* gc_config_log_buffer = 0;
 size_t gc_config_log_buffer_offset = 0;
 
 // For config since we log so little we keep the whole history. Also it's only
@@ -470,8 +470,8 @@ void log_va_msg_config(const char *fmt, va_list args)
 
     if ((gc_config_log_buffer_offset + msg_len) > gc_config_log_buffer_size)
     {
-        DWORD written_to_log = 0;
-        WriteFile (gc_config_log, gc_config_log_buffer, (DWORD)gc_config_log_buffer_offset, &written_to_log, NULL);
+        uint32_t written_to_log = 0;
+        WriteFile (gc_config_log, gc_config_log_buffer, (uint32_t)gc_config_log_buffer_offset, &written_to_log, NULL);
         FlushFileBuffers (gc_config_log);
         gc_config_log_buffer_offset = 0;
     }
@@ -501,10 +501,10 @@ static const unsigned int   log_interval = 5000;
 static unsigned int         log_start_tick;
 static unsigned int         gc_lock_contended;
 // Cycles accumulated in SuspendEE during log_interval.
-static ULONGLONG            suspend_ee_during_log;
+static uint64_t             suspend_ee_during_log;
 // Cycles accumulated in RestartEE during log_interval.
-static ULONGLONG            restart_ee_during_log;
-static ULONGLONG            gc_during_log;
+static uint64_t             restart_ee_during_log;
+static uint64_t             gc_during_log;
 
 #endif //SYNCHRONIZATION_STATS
 
@@ -660,7 +660,7 @@ class t_join
     // remember join id and last thread to arrive so restart can use these
     int thd;
     // we want to print statistics every 10 seconds - this is to remember the start of the 10 sec interval
-    DWORD start_tick;
+    uint32_t start_tick;
     // counters for joins, in 1000's of clock cycles
     unsigned int elapsed_total[gc_join_max], seq_loss_total[gc_join_max], par_loss_total[gc_join_max], in_join_total[gc_join_max];
 #endif //JOIN_STATS
@@ -757,7 +757,7 @@ respin:
 
                     //Thread* current_thread = GetThread();
                     //BOOL cooperative_mode = gc_heap::enable_preemptive (current_thread);
-                    DWORD dwJoinWait = join_struct.joined_event[color].Wait(INFINITE, FALSE);
+                    uint32_t dwJoinWait = join_struct.joined_event[color].Wait(INFINITE, FALSE);
                     //gc_heap::disable_preemptive (current_thread, cooperative_mode);
 
                     if (dwJoinWait != WAIT_OBJECT_0)
@@ -854,7 +854,7 @@ respin:
                     if (!join_struct.wait_done)
                     {
                         dprintf (JOIN_LOG, ("Join() hard wait on reset event %d", first_thread_arrived));
-                        DWORD dwJoinWait = join_struct.joined_event[first_thread_arrived].Wait(INFINITE, FALSE);
+                        uint32_t dwJoinWait = join_struct.joined_event[first_thread_arrived].Wait(INFINITE, FALSE);
                         if (dwJoinWait != WAIT_OBJECT_0)
                         {
                             STRESS_LOG1 (LF_GC, LL_FATALERROR, "joined event wait failed with code: %Ix", dwJoinWait);
@@ -1007,21 +1007,21 @@ t_join bgc_t_join;
 class exclusive_sync
 {
     // TODO - verify that this is the right syntax for Volatile.
-    VOLATILE(BYTE*) rwp_object;
+    VOLATILE(uint8_t*) rwp_object;
     VOLATILE(LONG) needs_checking;
     
     int spin_count;
 
-    BYTE cache_separator[HS_CACHE_LINE_SIZE - sizeof (int) - sizeof (LONG)];
+    uint8_t cache_separator[HS_CACHE_LINE_SIZE - sizeof (int) - sizeof (LONG)];
 
     // TODO - perhaps each object should be on its own cache line...
-    VOLATILE(BYTE*) alloc_objects[max_pending_allocs];
+    VOLATILE(uint8_t*) alloc_objects[max_pending_allocs];
 
     int find_free_index ()
     {
         for (int i = 0; i < max_pending_allocs; i++)
         {
-            if (alloc_objects [i] == (BYTE*)0)
+            if (alloc_objects [i] == (uint8_t*)0)
             {
                 return i;
             }
@@ -1038,7 +1038,7 @@ public:
         needs_checking = 0;
         for (int i = 0; i < max_pending_allocs; i++)
         {
-            alloc_objects [i] = (BYTE*)0;
+            alloc_objects [i] = (uint8_t*)0;
         }
     }
 
@@ -1046,14 +1046,14 @@ public:
     {
         for (int i = 0; i < max_pending_allocs; i++)
         {
-            if (alloc_objects [i] != (BYTE*)0)
+            if (alloc_objects [i] != (uint8_t*)0)
             {
                 DebugBreak();
             }
         }
     }
 
-    void bgc_mark_set (BYTE* obj)
+    void bgc_mark_set (uint8_t* obj)
     {
         dprintf (3, ("cm: probing %Ix", obj));
 retry:
@@ -1086,7 +1086,7 @@ retry:
         }
     }
 
-    int loh_alloc_set (BYTE* obj)
+    int loh_alloc_set (uint8_t* obj)
     {
         if (!gc_heap::cm_in_progress)
         {
@@ -1139,18 +1139,18 @@ retry:
 
     void bgc_mark_done ()
     {
-        dprintf (3, ("cm: release lock on %Ix", (BYTE *)rwp_object));
+        dprintf (3, ("cm: release lock on %Ix", (uint8_t *)rwp_object));
         rwp_object = 0;
     }
 
     void loh_alloc_done_with_index (int index)
     {
-        dprintf (3, ("loh alloc: release lock on %Ix based on %d", (BYTE *)alloc_objects[index], index));
+        dprintf (3, ("loh alloc: release lock on %Ix based on %d", (uint8_t *)alloc_objects[index], index));
         assert ((index >= 0) && (index < max_pending_allocs)); 
-        alloc_objects[index] = (BYTE*)0;
+        alloc_objects[index] = (uint8_t*)0;
     }
 
-    void loh_alloc_done (BYTE* obj)
+    void loh_alloc_done (uint8_t* obj)
     {
 #ifdef BACKGROUND_GC
         if (!gc_heap::cm_in_progress)
@@ -1162,8 +1162,8 @@ retry:
         {
             if (alloc_objects [i] == obj)
             {
-                dprintf (3, ("loh alloc: release lock on %Ix at %d", (BYTE *)alloc_objects[i], i));
-                alloc_objects[i] = (BYTE*)0;
+                dprintf (3, ("loh alloc: release lock on %Ix at %d", (uint8_t *)alloc_objects[i], i));
+                alloc_objects[i] = (uint8_t*)0;
                 return;
             }
         }
@@ -1186,7 +1186,7 @@ class recursive_gc_sync
     static VOLATILE(LONG) foreground_request_count;//initial state 0
     static VOLATILE(BOOL) gc_background_running; //initial state FALSE
     static VOLATILE(LONG) foreground_count; // initial state 0;
-    static VOLATILE(DWORD) foreground_gate; // initial state FALSE;
+    static VOLATILE(uint32_t) foreground_gate; // initial state FALSE;
     static CLREvent foreground_complete;//Auto Reset
     static CLREvent foreground_allowed;//Auto Reset
 public:
@@ -1203,7 +1203,7 @@ public:
 VOLATILE(LONG) recursive_gc_sync::foreground_request_count = 0;//initial state 0
 VOLATILE(LONG) recursive_gc_sync::foreground_count = 0; // initial state 0;
 VOLATILE(BOOL) recursive_gc_sync::gc_background_running = FALSE; //initial state FALSE
-VOLATILE(DWORD) recursive_gc_sync::foreground_gate = 0;
+VOLATILE(uint32_t) recursive_gc_sync::foreground_gate = 0;
 CLREvent recursive_gc_sync::foreground_complete;//Auto Reset
 CLREvent recursive_gc_sync::foreground_allowed;//Manual Reset
 
@@ -1431,13 +1431,13 @@ hlet* hlet::bindings = 0;
 
 #endif //TRACE_GC
 
-void reset_memory (BYTE* o, size_t sizeo);
+void reset_memory (uint8_t* o, size_t sizeo);
 
 #ifdef WRITE_WATCH
 
 #define MEM_WRITE_WATCH 0x200000
 
-static DWORD mem_reserve = MEM_RESERVE;
+static uint32_t mem_reserve = MEM_RESERVE;
 
 #ifndef FEATURE_REDHAWK
 BOOL write_watch_capability = FALSE;
@@ -1813,7 +1813,7 @@ typedef void **  PTR_PTR;
 // size has to be Dword aligned
 
 inline
-void memclr ( BYTE* mem, size_t size)
+void memclr ( uint8_t* mem, size_t size)
 {
     dprintf (3, ("MEMCLR: %Ix, %d", mem, size));
     assert ((size & (sizeof(PTR_PTR)-1)) == 0);
@@ -1830,7 +1830,7 @@ void memclr ( BYTE* mem, size_t size)
     memset (mem, 0, size);
 }
 
-void memcopy (BYTE* dmem, BYTE* smem, size_t size)
+void memcopy (uint8_t* dmem, uint8_t* smem, size_t size)
 {
     const size_t sz4ptr = sizeof(PTR_PTR)*4;
     const size_t sz2ptr = sizeof(PTR_PTR)*2;
@@ -1897,7 +1897,7 @@ ptrdiff_t round_down (ptrdiff_t add, int pitch)
 #endif
 
 inline
-BOOL same_large_alignment_p (BYTE* p1, BYTE* p2)
+BOOL same_large_alignment_p (uint8_t* p1, uint8_t* p2)
 {
 #ifdef RESPECT_LARGE_ALIGNMENT
     return ((((size_t)p1 ^ (size_t)p2) & 7) == 0);
@@ -1917,12 +1917,12 @@ size_t switch_alignment_size (BOOL already_padded_p)
 
 
 #ifdef FEATURE_STRUCTALIGN
-void set_node_aligninfo (BYTE *node, int requiredAlignment, ptrdiff_t pad);
-void clear_node_aligninfo (BYTE *node);
+void set_node_aligninfo (uint8_t *node, int requiredAlignment, ptrdiff_t pad);
+void clear_node_aligninfo (uint8_t *node);
 #else // FEATURE_STRUCTALIGN
 #define node_realigned(node)    (((plug_and_reloc*)(node))[-1].reloc & 1)
-void set_node_realigned (BYTE* node);
-void clear_node_realigned(BYTE* node);
+void set_node_realigned (uint8_t* node);
+void clear_node_realigned(uint8_t* node);
 #endif // FEATURE_STRUCTALIGN
 
 inline
@@ -1970,7 +1970,7 @@ ptrdiff_t AdjustmentForMinPadSize(ptrdiff_t pad, int requiredAlignment)
 }
 
 inline
-BYTE* StructAlign (BYTE* origPtr, int requiredAlignment, ptrdiff_t alignmentOffset=OBJECT_ALIGNMENT_OFFSET)
+uint8_t* StructAlign (uint8_t* origPtr, int requiredAlignment, ptrdiff_t alignmentOffset=OBJECT_ALIGNMENT_OFFSET)
 {
     // required alignment must be a power of two
     _ASSERTE(((size_t)origPtr & ALIGNCONST) == 0);
@@ -1983,19 +1983,19 @@ BYTE* StructAlign (BYTE* origPtr, int requiredAlignment, ptrdiff_t alignmentOffs
     // we're done is the pointer to the payload of the object (which means
     // the actual resulting object pointer is typically not aligned).
 
-    BYTE* result = (BYTE*)Align ((size_t)origPtr + alignmentOffset, requiredAlignment-1) - alignmentOffset;
+    uint8_t* result = (uint8_t*)Align ((size_t)origPtr + alignmentOffset, requiredAlignment-1) - alignmentOffset;
     ptrdiff_t alignpad = result - origPtr;
 
     return result + AdjustmentForMinPadSize (alignpad, requiredAlignment);
 }
 
 inline
-ptrdiff_t ComputeStructAlignPad (BYTE* plug, int requiredAlignment, size_t alignmentOffset=OBJECT_ALIGNMENT_OFFSET)
+ptrdiff_t ComputeStructAlignPad (uint8_t* plug, int requiredAlignment, size_t alignmentOffset=OBJECT_ALIGNMENT_OFFSET)
 {
     return StructAlign (plug, requiredAlignment, alignmentOffset) - plug;
 }
 
-BOOL IsStructAligned (BYTE *ptr, int requiredAlignment)
+BOOL IsStructAligned (uint8_t *ptr, int requiredAlignment)
 {
     return StructAlign (ptr, requiredAlignment) == ptr;
 }
@@ -2023,9 +2023,9 @@ ptrdiff_t ComputeMaxStructAlignPadLarge (int requiredAlignment)
     return requiredAlignment + Align (min_obj_size) * 2 - DATA_ALIGNMENT;
 }
 
-BYTE* gc_heap::pad_for_alignment (BYTE* newAlloc, int requiredAlignment, size_t size, alloc_context* acontext)
+uint8_t* gc_heap::pad_for_alignment (uint8_t* newAlloc, int requiredAlignment, size_t size, alloc_context* acontext)
 {
-    BYTE* alignedPtr = StructAlign (newAlloc, requiredAlignment);
+    uint8_t* alignedPtr = StructAlign (newAlloc, requiredAlignment);
     if (alignedPtr != newAlloc) {
         make_unused_array (newAlloc, alignedPtr - newAlloc);
     }
@@ -2033,9 +2033,9 @@ BYTE* gc_heap::pad_for_alignment (BYTE* newAlloc, int requiredAlignment, size_t 
     return alignedPtr;
 }
 
-BYTE* gc_heap::pad_for_alignment_large (BYTE* newAlloc, int requiredAlignment, size_t size)
+uint8_t* gc_heap::pad_for_alignment_large (uint8_t* newAlloc, int requiredAlignment, size_t size)
 {
-    BYTE* alignedPtr = StructAlign (newAlloc, requiredAlignment);
+    uint8_t* alignedPtr = StructAlign (newAlloc, requiredAlignment);
     if (alignedPtr != newAlloc) {
         make_unused_array (newAlloc, alignedPtr - newAlloc);
     }
@@ -2123,9 +2123,9 @@ size_t align_on_page (size_t add)
 }
 
 inline
-BYTE* align_on_page (BYTE* add)
+uint8_t* align_on_page (uint8_t* add)
 {
-    return (BYTE*)align_on_page ((size_t) add);
+    return (uint8_t*)align_on_page ((size_t) add);
 }
 
 inline
@@ -2135,9 +2135,9 @@ size_t align_lower_page (size_t add)
 }
 
 inline
-BYTE* align_lower_page (BYTE* add)
+uint8_t* align_lower_page (uint8_t* add)
 {
-    return (BYTE*)align_lower_page ((size_t)add);
+    return (uint8_t*)align_lower_page ((size_t)add);
 }
 
 inline
@@ -2177,9 +2177,9 @@ int log2(unsigned int n)
     return pos;
 }
 
-//extract the low bits [0,low[ of a DWORD
+//extract the low bits [0,low[ of a uint32_t
 #define lowbits(wrd, bits) ((wrd) & ((1 << (bits))-1))
-//extract the high bits [high, 32] of a DWORD
+//extract the high bits [high, 32] of a uint32_t
 #define highbits(wrd, bits) ((wrd) & ~((1 << (bits))-1))
 
 
@@ -2199,14 +2199,14 @@ HRESULT AllocateCFinalize(CFinalize **pCFinalize);
 #endif //!DACCESS_COMPILE
 #endif // FEATURE_PREMORTEM_FINALIZATION
 
-BYTE* tree_search (BYTE* tree, BYTE* old_address);
+uint8_t* tree_search (uint8_t* tree, uint8_t* old_address);
 
 
 #ifdef USE_INTROSORT
 #define _sort introsort::sort
 #else //USE_INTROSORT
 #define _sort qsort1
-void qsort1(BYTE** low, BYTE** high, unsigned int depth);
+void qsort1(uint8_t** low, uint8_t** high, unsigned int depth);
 #endif //USE_INTROSORT
 
 void* virtual_alloc (size_t size);
@@ -2215,15 +2215,15 @@ void virtual_free (void* add, size_t size);
 /* per heap static initialization */
 #ifdef MARK_ARRAY
 #ifndef MULTIPLE_HEAPS
-SPTR_IMPL_NS(DWORD, WKS, gc_heap, mark_array);
+SPTR_IMPL_NS(uint32_t, WKS, gc_heap, mark_array);
 #endif //!MULTIPLE_HEAPS
 #endif //MARK_ARRAY
 
 #ifdef MARK_LIST
-BYTE**      gc_heap::g_mark_list;
+uint8_t**   gc_heap::g_mark_list;
 
 #ifdef PARALLEL_MARK_LIST_SORT
-BYTE**      gc_heap::g_mark_list_copy;
+uint8_t**   gc_heap::g_mark_list_copy;
 #endif //PARALLEL_MARK_LIST_SORT
 
 size_t      gc_heap::mark_list_size;
@@ -2306,9 +2306,9 @@ size_t      gc_heap::youngest_gen_desired_th;
 
 size_t      gc_heap::mem_one_percent;
 
-ULONGLONG   gc_heap::total_physical_mem;
+uint64_t    gc_heap::total_physical_mem;
 
-ULONGLONG   gc_heap::available_physical_mem;
+uint64_t    gc_heap::available_physical_mem;
 #endif //_WIN64
 
 #ifdef BACKGROUND_GC
@@ -2324,7 +2324,7 @@ BOOL        gc_heap::gc_can_use_concurrent = FALSE;
 
 BOOL        gc_heap::temp_disable_concurrent_p = FALSE;
 
-DWORD       gc_heap::cm_in_progress = FALSE;
+uint32_t    gc_heap::cm_in_progress = FALSE;
 
 BOOL        gc_heap::dont_restart_ee_p = FALSE;
 
@@ -2358,17 +2358,17 @@ size_t      gc_heap::fgn_last_alloc = 0;
 
 int         gc_heap::generation_skip_ratio = 100;
 
-UINT64      gc_heap::loh_alloc_since_cg = 0;
+uint64_t    gc_heap::loh_alloc_since_cg = 0;
 
 BOOL        gc_heap::elevation_requested = FALSE;
 
 BOOL        gc_heap::last_gc_before_oom = FALSE;
 
 #ifdef BACKGROUND_GC
-SPTR_IMPL_NS_INIT(BYTE, WKS, gc_heap, background_saved_lowest_address, 0);
-SPTR_IMPL_NS_INIT(BYTE, WKS, gc_heap, background_saved_highest_address, 0);
-SPTR_IMPL_NS_INIT(BYTE, WKS, gc_heap, next_sweep_obj, 0);
-BYTE*       gc_heap::current_sweep_pos = 0;
+SPTR_IMPL_NS_INIT(uint8_t, WKS, gc_heap, background_saved_lowest_address, 0);
+SPTR_IMPL_NS_INIT(uint8_t, WKS, gc_heap, background_saved_highest_address, 0);
+SPTR_IMPL_NS_INIT(uint8_t, WKS, gc_heap, next_sweep_obj, 0);
+uint8_t*    gc_heap::current_sweep_pos = 0;
 exclusive_sync* gc_heap::bgc_alloc_lock;
 #endif //BACKGROUND_GC
 
@@ -2380,34 +2380,34 @@ BOOL        gc_heap::ro_segments_in_range;
 
 size_t      gc_heap::gen0_big_free_spaces = 0;
 
-BYTE*       gc_heap::lowest_address;
+uint8_t*    gc_heap::lowest_address;
 
-BYTE*       gc_heap::highest_address;
+uint8_t*    gc_heap::highest_address;
 
 BOOL        gc_heap::ephemeral_promotion;
 
-BYTE*       gc_heap::saved_ephemeral_plan_start[NUMBERGENERATIONS-1];
+uint8_t*    gc_heap::saved_ephemeral_plan_start[NUMBERGENERATIONS-1];
 size_t      gc_heap::saved_ephemeral_plan_start_size[NUMBERGENERATIONS-1];
 
 short*      gc_heap::brick_table;
 
-DWORD*      gc_heap::card_table;
+uint32_t*   gc_heap::card_table;
 
 #ifdef CARD_BUNDLE
-DWORD*      gc_heap::card_bundle_table;
+uint32_t*   gc_heap::card_bundle_table;
 #endif //CARD_BUNDLE
 
-BYTE*       gc_heap::gc_low;
+uint8_t*    gc_heap::gc_low;
 
-BYTE*       gc_heap::gc_high;
+uint8_t*    gc_heap::gc_high;
 
-BYTE*       gc_heap::demotion_low;
+uint8_t*    gc_heap::demotion_low;
 
-BYTE*       gc_heap::demotion_high;
+uint8_t*    gc_heap::demotion_high;
 
 BOOL        gc_heap::demote_gen1_p = TRUE;
 
-BYTE*       gc_heap::last_gen1_pin_end;
+uint8_t*    gc_heap::last_gen1_pin_end;
 
 gen_to_condemn_tuning gc_heap::gen_to_condemn_reasons;
 
@@ -2437,7 +2437,7 @@ mark*       gc_heap::mark_stack_array = 0;
 
 BOOL        gc_heap::verify_pinned_queue_p = FALSE;
 
-BYTE*       gc_heap::oldest_pinned_plug = 0;
+uint8_t*    gc_heap::oldest_pinned_plug = 0;
 
 #ifdef FEATURE_LOH_COMPACTION
 size_t      gc_heap::loh_pinned_queue_tos = 0;
@@ -2453,9 +2453,9 @@ BOOL        gc_heap::loh_compacted_p = FALSE;
 
 #ifdef BACKGROUND_GC
 
-DWORD       gc_heap::bgc_thread_id = 0;
+uint32_t    gc_heap::bgc_thread_id = 0;
 
-BYTE*       gc_heap::background_written_addresses [array_size+2];
+uint8_t*    gc_heap::background_written_addresses [array_size+2];
 
 heap_segment* gc_heap::freeable_small_heap_segment = 0;
 
@@ -2464,7 +2464,7 @@ size_t      gc_heap::bgc_overflow_count = 0;
 size_t      gc_heap::bgc_begin_loh_size = 0;
 size_t      gc_heap::end_loh_size = 0;
 
-DWORD       gc_heap::bgc_alloc_spin_loh = 0;
+uint32_t    gc_heap::bgc_alloc_spin_loh = 0;
 
 size_t      gc_heap::bgc_loh_size_increased = 0;
 
@@ -2474,24 +2474,24 @@ size_t      gc_heap::background_soh_alloc_count = 0;
 
 size_t      gc_heap::background_loh_alloc_count = 0;
 
-BYTE**      gc_heap::background_mark_stack_tos = 0;
+uint8_t**   gc_heap::background_mark_stack_tos = 0;
 
-BYTE**      gc_heap::background_mark_stack_array = 0;
+uint8_t**   gc_heap::background_mark_stack_array = 0;
 
 size_t      gc_heap::background_mark_stack_array_length = 0;
 
-BYTE*       gc_heap::background_min_overflow_address =0;
+uint8_t*    gc_heap::background_min_overflow_address =0;
 
-BYTE*       gc_heap::background_max_overflow_address =0;
+uint8_t*    gc_heap::background_max_overflow_address =0;
 
 BOOL        gc_heap::processed_soh_overflow_p = FALSE;
 
-BYTE*       gc_heap::background_min_soh_overflow_address =0;
+uint8_t*    gc_heap::background_min_soh_overflow_address =0;
 
-BYTE*       gc_heap::background_max_soh_overflow_address =0;
+uint8_t*    gc_heap::background_max_soh_overflow_address =0;
 
 SPTR_IMPL_NS_INIT(heap_segment, WKS, gc_heap, saved_sweep_ephemeral_seg, 0);
-SPTR_IMPL_NS_INIT(BYTE, WKS, gc_heap, saved_sweep_ephemeral_start, 0);
+SPTR_IMPL_NS_INIT(uint8_t, WKS, gc_heap, saved_sweep_ephemeral_start, 0);
 
 heap_segment* gc_heap::saved_overflow_ephemeral_seg = 0;
 
@@ -2499,7 +2499,7 @@ Thread*     gc_heap::bgc_thread = 0;
 
 BOOL        gc_heap::expanded_in_fgc = FALSE;
 
-BYTE**      gc_heap::c_mark_list = 0;
+uint8_t**   gc_heap::c_mark_list = 0;
 
 size_t      gc_heap::c_mark_list_length = 0;
 
@@ -2518,22 +2518,22 @@ CLREvent gc_heap::gc_lh_block_event;
 #endif //BACKGROUND_GC
 
 #ifdef MARK_LIST
-BYTE**      gc_heap::mark_list;
-BYTE**      gc_heap::mark_list_index;
-BYTE**      gc_heap::mark_list_end;
+uint8_t**   gc_heap::mark_list;
+uint8_t**   gc_heap::mark_list_index;
+uint8_t**   gc_heap::mark_list_end;
 #endif //MARK_LIST
 
 #ifdef SNOOP_STATS
 snoop_stats_data gc_heap::snoop_stat;
 #endif //SNOOP_STATS
 
-BYTE*       gc_heap::min_overflow_address = MAX_PTR;
+uint8_t*    gc_heap::min_overflow_address = MAX_PTR;
 
-BYTE*       gc_heap::max_overflow_address = 0;
+uint8_t*    gc_heap::max_overflow_address = 0;
 
-BYTE*       gc_heap::shigh = 0;
+uint8_t*    gc_heap::shigh = 0;
 
-BYTE*       gc_heap::slow = MAX_PTR;
+uint8_t*    gc_heap::slow = MAX_PTR;
 
 size_t      gc_heap::ordered_free_space_indices[MAX_NUM_BUCKETS];
 
@@ -2547,7 +2547,7 @@ BOOL        gc_heap::ordered_plug_indices_init = FALSE;
 
 BOOL        gc_heap::use_bestfit = FALSE;
 
-BYTE*       gc_heap::bestfit_first_pin = 0;
+uint8_t*    gc_heap::bestfit_first_pin = 0;
 
 BOOL        gc_heap::commit_end_of_seg = FALSE;
 
@@ -2569,11 +2569,11 @@ size_t      gc_heap::total_ephemeral_size = 0;
 
 size_t      gc_heap::internal_root_array_length = initial_internal_roots;
 
-SPTR_IMPL_NS_INIT(PTR_BYTE, WKS, gc_heap, internal_root_array, 0);
+SPTR_IMPL_NS_INIT(PTR_uint8_t, WKS, gc_heap, internal_root_array, 0);
 SVAL_IMPL_NS_INIT(size_t, WKS, gc_heap, internal_root_array_index, 0);
 SVAL_IMPL_NS_INIT(BOOL, WKS, gc_heap, heap_analyze_success, TRUE);
 
-BYTE*       gc_heap::current_obj = 0;
+uint8_t*    gc_heap::current_obj = 0;
 size_t      gc_heap::current_obj_size = 0;
 
 #endif //HEAP_ANALYZE
@@ -2611,9 +2611,9 @@ CLREvent gc_heap::full_gc_approach_event;
 
 CLREvent gc_heap::full_gc_end_event;
 
-DWORD gc_heap::fgn_maxgen_percent = 0;
+uint32_t gc_heap::fgn_maxgen_percent = 0;
 
-DWORD gc_heap::fgn_loh_percent = 0;
+uint32_t gc_heap::fgn_loh_percent = 0;
 
 #ifdef BACKGROUND_GC
 BOOL gc_heap::fgn_last_gc_was_concurrent = FALSE;
@@ -2656,7 +2656,7 @@ dynamic_data gc_heap::dynamic_data_table [NUMBERGENERATIONS+1];
 gc_history_per_heap gc_heap::gc_data_per_heap;
 size_t gc_heap::maxgen_pinned_compact_before_advance = 0;
 
-SPTR_IMPL_NS_INIT(BYTE, WKS, gc_heap, alloc_allocated, 0);
+SPTR_IMPL_NS_INIT(uint8_t, WKS, gc_heap, alloc_allocated, 0);
 
 size_t gc_heap::allocation_quantum = CLR_SIZE;
 
@@ -2665,7 +2665,7 @@ GCSpinLock gc_heap::more_space_lock;
 #ifdef SYNCHRONIZATION_STATS
 unsigned int gc_heap::good_suspension = 0;
 unsigned int gc_heap::bad_suspension = 0;
-ULONGLONG     gc_heap::total_msl_acquire = 0;
+uint64_t     gc_heap::total_msl_acquire = 0;
 unsigned int gc_heap::num_msl_acquired = 0;
 unsigned int gc_heap::num_high_msl_acquire = 0;
 unsigned int gc_heap::num_low_msl_acquire = 0;
@@ -2737,9 +2737,9 @@ void gc_generation_data::print (int heap_num, int gen_num)
 #endif //SIMPLE_DPRINTF && DT_LOG
 }
 
-void gc_history_per_heap::set_mechanism (gc_mechanism_per_heap mechanism_per_heap, DWORD value)
+void gc_history_per_heap::set_mechanism (gc_mechanism_per_heap mechanism_per_heap, uint32_t value)
 {
-    DWORD* mechanism = &mechanisms[mechanism_per_heap];
+    uint32_t* mechanism = &mechanisms[mechanism_per_heap];
     *mechanism = 0;
     *mechanism |= mechanism_mask;
     *mechanism |= (1 << value);
@@ -2818,19 +2818,19 @@ void gc_heap::fire_per_heap_hist_event (gc_history_per_heap* current_gc_data_per
 {
     maxgen_size_increase* maxgen_size_info = &(current_gc_data_per_heap->maxgen_size_info);
     FireEtwGCPerHeapHistory_V3(GetClrInstanceId(),
-                               (BYTE*)(maxgen_size_info->free_list_allocated),
-                               (BYTE*)(maxgen_size_info->free_list_rejected),
-                               (BYTE*)(maxgen_size_info->end_seg_allocated),
-                               (BYTE*)(maxgen_size_info->condemned_allocated),
-                               (BYTE*)(maxgen_size_info->pinned_allocated),
-                               (BYTE*)(maxgen_size_info->pinned_allocated_advance),
+                               (uint8_t*)(maxgen_size_info->free_list_allocated),
+                               (uint8_t*)(maxgen_size_info->free_list_rejected),
+                               (uint8_t*)(maxgen_size_info->end_seg_allocated),
+                               (uint8_t*)(maxgen_size_info->condemned_allocated),
+                               (uint8_t*)(maxgen_size_info->pinned_allocated),
+                               (uint8_t*)(maxgen_size_info->pinned_allocated_advance),
                                maxgen_size_info->running_free_list_efficiency,
                                current_gc_data_per_heap->gen_to_condemn_reasons.get_reasons0(),
                                current_gc_data_per_heap->gen_to_condemn_reasons.get_reasons1(),
                                current_gc_data_per_heap->mechanisms[gc_heap_compact],
                                current_gc_data_per_heap->mechanisms[gc_heap_expand],
                                current_gc_data_per_heap->heap_index,
-                               (BYTE*)(current_gc_data_per_heap->extra_gen0_committed),
+                               (uint8_t*)(current_gc_data_per_heap->extra_gen0_committed),
                                (max_generation + 2),
                                sizeof (gc_generation_data),
                                &(current_gc_data_per_heap->gen_data[0]));
@@ -2957,7 +2957,7 @@ gc_heap::dt_high_frag_p (gc_tuning_point tp,
 }
 
 inline BOOL 
-gc_heap::dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number, ULONGLONG total_mem)
+gc_heap::dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number, uint64_t total_mem)
 {
     BOOL ret = FALSE;
 
@@ -2984,7 +2984,7 @@ gc_heap::dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number, ULONGL
                             dd_fragmentation (dd),
                             (size_t)((float)total_mem * 0.03)));
 #endif //SIMPLE_DPRINTF
-                DWORD num_heaps = 1;
+                uint32_t num_heaps = 1;
 
 #ifdef MULTIPLE_HEAPS
                 num_heaps = gc_heap::n_heaps;
@@ -3012,7 +3012,7 @@ gc_heap::dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number, ULONGL
 // on 64-bit though we should consider gen1 or even gen0 fragmentatioin as
 // well 
 inline BOOL 
-gc_heap::dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, ULONGLONG available_mem)
+gc_heap::dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, uint64_t available_mem)
 {
     BOOL ret = FALSE;
 
@@ -3046,12 +3046,12 @@ gc_heap::dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, ULONGLONG 
                     (int)(est_frag_ratio*100),
                     est_frag));
 
-                DWORD num_heaps = 1;
+                uint32_t num_heaps = 1;
 
 #ifdef MULTIPLE_HEAPS
                 num_heaps = gc_heap::n_heaps;
 #endif //MULTIPLE_HEAPS
-                ULONGLONG min_frag_th = min_high_fragmentation_threshold(available_mem, num_heaps);
+                uint64_t min_frag_th = min_high_fragmentation_threshold(available_mem, num_heaps);
                 //dprintf (GTC_LOG, ("h%d, min frag is %I64d", heap_number, min_frag_th));
                 ret = (est_frag >= min_frag_th);
             }
@@ -3093,7 +3093,7 @@ gc_heap::dt_low_card_table_efficiency_p (gc_tuning_point tp)
 }
 
 inline BOOL
-in_range_for_segment(BYTE* add, heap_segment* seg)
+in_range_for_segment(uint8_t* add, heap_segment* seg)
 {
     return ((add >= heap_segment_mem (seg)) && (add < heap_segment_reserved (seg)));
 }
@@ -3105,7 +3105,7 @@ in_range_for_segment(BYTE* add, heap_segment* seg)
 // what buckets() returns.
 struct bk
 {
-    BYTE* add;
+    uint8_t* add;
 };
 
 class sorted_table
@@ -3115,13 +3115,13 @@ private:
     ptrdiff_t count;
     bk* slots;
     bk* buckets() { return (slots + 1); }
-    BYTE*& last_slot (bk* arr) { return arr[0].add; }
+    uint8_t*& last_slot (bk* arr) { return arr[0].add; }
     bk* old_slots;
 public:
     static  sorted_table* make_sorted_table ();
-    BOOL    insert (BYTE* add, size_t val);;
-    size_t  lookup (BYTE*& add);
-    void    remove (BYTE* add);
+    BOOL    insert (uint8_t* add, size_t val);;
+    size_t  lookup (uint8_t*& add);
+    void    remove (uint8_t* add);
     void    clear ();
     void    delete_sorted_table();
     void    delete_old_slots();
@@ -3158,10 +3158,10 @@ sorted_table::delete_sorted_table()
 void
 sorted_table::delete_old_slots()
 {
-    BYTE* sl = (BYTE*)old_slots;
+    uint8_t* sl = (uint8_t*)old_slots;
     while (sl)
     {
-        BYTE* dsl = sl;
+        uint8_t* dsl = sl;
         sl = last_slot ((bk*)sl);
         delete dsl;
     }
@@ -3170,13 +3170,13 @@ sorted_table::delete_old_slots()
 void
 sorted_table::enqueue_old_slot(bk* sl)
 {
-    last_slot (sl) = (BYTE*)old_slots;
+    last_slot (sl) = (uint8_t*)old_slots;
     old_slots = sl;
 }
 
 inline
 size_t
-sorted_table::lookup (BYTE*& add)
+sorted_table::lookup (uint8_t*& add)
 {
     ptrdiff_t high = (count-1);
     ptrdiff_t low = 0;
@@ -3233,7 +3233,7 @@ sorted_table::insure_space_for_insert()
 }
 
 BOOL
-sorted_table::insert (BYTE* add, size_t val)
+sorted_table::insert (uint8_t* add, size_t val)
 {
     //val is ignored for non concurrent gc
     val = val;
@@ -3287,7 +3287,7 @@ sorted_table::insert (BYTE* add, size_t val)
 }
 
 void
-sorted_table::remove (BYTE* add)
+sorted_table::remove (uint8_t* add)
 {
     ptrdiff_t high = (count-1);
     ptrdiff_t low = 0;
@@ -3337,18 +3337,18 @@ sorted_table::clear()
 #ifdef SEG_MAPPING_TABLE
 #ifdef GROWABLE_SEG_MAPPING_TABLE
 inline
-BYTE* align_on_segment (BYTE* add)
+uint8_t* align_on_segment (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add + (gc_heap::min_segment_size - 1)) & ~(gc_heap::min_segment_size - 1));
+    return (uint8_t*)((size_t)(add + (gc_heap::min_segment_size - 1)) & ~(gc_heap::min_segment_size - 1));
 }
 
 inline
-BYTE* align_lower_segment (BYTE* add)
+uint8_t* align_lower_segment (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add) & ~(gc_heap::min_segment_size - 1));
+    return (uint8_t*)((size_t)(add) & ~(gc_heap::min_segment_size - 1));
 }
 
-size_t size_seg_mapping_table_of (BYTE* from, BYTE* end)
+size_t size_seg_mapping_table_of (uint8_t* from, uint8_t* end)
 {
     from = align_lower_segment (from);
     end = align_on_segment (end);
@@ -3357,7 +3357,7 @@ size_t size_seg_mapping_table_of (BYTE* from, BYTE* end)
 }
 
 inline
-size_t seg_mapping_word_of (BYTE* add)
+size_t seg_mapping_word_of (uint8_t* add)
 {
     return (size_t)add / gc_heap::min_segment_size;
 }
@@ -3365,9 +3365,9 @@ size_t seg_mapping_word_of (BYTE* add)
 BOOL seg_mapping_table_init()
 {
 #ifdef _WIN64
-    ULONGLONG total_address_space = (ULONGLONG)8*1024*1024*1024*1024;
+    uint64_t total_address_space = (uint64_t)8*1024*1024*1024*1024;
 #else
-    ULONGLONG total_address_space = (ULONGLONG)4*1024*1024*1024;
+    uint64_t total_address_space = (uint64_t)4*1024*1024*1024;
 #endif //_WIN64
 
     size_t num_entries = (size_t)(total_address_space / gc_heap::min_segment_size);
@@ -3426,9 +3426,9 @@ void seg_mapping_table_remove_ro_segment (heap_segment* seg)
 #endif //0
 }
 
-heap_segment* ro_segment_lookup (BYTE* o)
+heap_segment* ro_segment_lookup (uint8_t* o)
 {
-    BYTE* ro_seg = 0;
+    uint8_t* ro_seg = 0;
     gc_heap::seg_table->lookup (ro_seg);
 
     if (ro_seg && in_range_for_segment (o, (heap_segment*)ro_seg))
@@ -3456,10 +3456,10 @@ void gc_heap::seg_mapping_table_add_segment (heap_segment* seg, gc_heap* hp)
 #ifdef MULTIPLE_HEAPS
 #ifdef SIMPLE_DPRINTF
     dprintf (1, ("begin %d: h0: %Ix(%d), h1: %Ix(%d); end %d: h0: %Ix(%d), h1: %Ix(%d)",
-        begin_index, (BYTE*)(begin_entry->h0), (begin_entry->h0 ? begin_entry->h0->heap_number : -1),
-        (BYTE*)(begin_entry->h1), (begin_entry->h1 ? begin_entry->h1->heap_number : -1),
-        end_index, (BYTE*)(end_entry->h0), (end_entry->h0 ? end_entry->h0->heap_number : -1),
-        (BYTE*)(end_entry->h1), (end_entry->h1 ? end_entry->h1->heap_number : -1)));
+        begin_index, (uint8_t*)(begin_entry->h0), (begin_entry->h0 ? begin_entry->h0->heap_number : -1),
+        (uint8_t*)(begin_entry->h1), (begin_entry->h1 ? begin_entry->h1->heap_number : -1),
+        end_index, (uint8_t*)(end_entry->h0), (end_entry->h0 ? end_entry->h0->heap_number : -1),
+        (uint8_t*)(end_entry->h1), (end_entry->h1 ? end_entry->h1->heap_number : -1)));
 #endif //SIMPLE_DPRINTF
     assert (end_entry->boundary == 0);
     assert (end_entry->h0 == 0);
@@ -3468,7 +3468,7 @@ void gc_heap::seg_mapping_table_add_segment (heap_segment* seg, gc_heap* hp)
     begin_entry->h1 = hp;
 #endif //MULTIPLE_HEAPS
 
-    end_entry->boundary = (BYTE*)seg_end;
+    end_entry->boundary = (uint8_t*)seg_end;
 
     dprintf (1, ("set entry %d seg1 and %d seg0 to %Ix", begin_index, end_index, seg));
     assert ((begin_entry->seg1 == 0) || ((size_t)(begin_entry->seg1) == ro_in_entry));
@@ -3491,10 +3491,10 @@ void gc_heap::seg_mapping_table_add_segment (heap_segment* seg, gc_heap* hp)
         end_index, (seg_mapping_table[end_index].boundary + 1)));
 #if defined(MULTIPLE_HEAPS) && defined(SIMPLE_DPRINTF)
     dprintf (1, ("begin %d: h0: %Ix(%d), h1: %Ix(%d); end: %d h0: %Ix(%d), h1: %Ix(%d)",
-        begin_index, (BYTE*)(begin_entry->h0), (begin_entry->h0 ? begin_entry->h0->heap_number : -1),
-        (BYTE*)(begin_entry->h1), (begin_entry->h1 ? begin_entry->h1->heap_number : -1),
-        end_index, (BYTE*)(end_entry->h0), (end_entry->h0 ? end_entry->h0->heap_number : -1),
-        (BYTE*)(end_entry->h1), (end_entry->h1 ? end_entry->h1->heap_number : -1)));
+        begin_index, (uint8_t*)(begin_entry->h0), (begin_entry->h0 ? begin_entry->h0->heap_number : -1),
+        (uint8_t*)(begin_entry->h1), (begin_entry->h1 ? begin_entry->h1->heap_number : -1),
+        end_index, (uint8_t*)(end_entry->h0), (end_entry->h0 ? end_entry->h0->heap_number : -1),
+        (uint8_t*)(end_entry->h1), (end_entry->h1 ? end_entry->h1->heap_number : -1)));
 #endif //MULTIPLE_HEAPS && SIMPLE_DPRINTF
 }
 
@@ -3508,7 +3508,7 @@ void gc_heap::seg_mapping_table_remove_segment (heap_segment* seg)
     dprintf (1, ("removing seg %Ix(%d)-%Ix(%d)", 
         seg, begin_index, heap_segment_reserved (seg), end_index));
 
-    assert (end_entry->boundary == (BYTE*)seg_end);
+    assert (end_entry->boundary == (uint8_t*)seg_end);
     end_entry->boundary = 0;
 
 #ifdef MULTIPLE_HEAPS
@@ -3540,14 +3540,14 @@ void gc_heap::seg_mapping_table_remove_segment (heap_segment* seg)
         end_index, (seg_mapping_table[end_index].boundary + 1)));
 #ifdef MULTIPLE_HEAPS
     dprintf (1, ("begin %d: h0: %Ix, h1: %Ix; end: %d h0: %Ix, h1: %Ix",
-        begin_index, (BYTE*)(begin_entry->h0), (BYTE*)(begin_entry->h1), 
-        end_index, (BYTE*)(end_entry->h0), (BYTE*)(end_entry->h1)));
+        begin_index, (uint8_t*)(begin_entry->h0), (uint8_t*)(begin_entry->h1),
+        end_index, (uint8_t*)(end_entry->h0), (uint8_t*)(end_entry->h1)));
 #endif //MULTIPLE_HEAPS
 }
 
 #ifdef MULTIPLE_HEAPS
 inline
-gc_heap* seg_mapping_table_heap_of_worker (BYTE* o)
+gc_heap* seg_mapping_table_heap_of_worker (uint8_t* o)
 {
     size_t index = (size_t)o / gc_heap::min_segment_size;
     seg_mapping* entry = &seg_mapping_table[index];
@@ -3556,8 +3556,8 @@ gc_heap* seg_mapping_table_heap_of_worker (BYTE* o)
 
     dprintf (2, ("checking obj %Ix, index is %Id, entry: boundry: %Ix, h0: %Ix, seg0: %Ix, h1: %Ix, seg1: %Ix",
         o, index, (entry->boundary + 1), 
-        (BYTE*)(entry->h0), (BYTE*)(entry->seg0), 
-        (BYTE*)(entry->h1), (BYTE*)(entry->seg1)));
+        (uint8_t*)(entry->h0), (uint8_t*)(entry->seg0),
+        (uint8_t*)(entry->h1), (uint8_t*)(entry->seg1)));
 
 #ifdef _DEBUG
     heap_segment* seg = ((o > entry->boundary) ? entry->seg1 : entry->seg0);
@@ -3570,12 +3570,12 @@ gc_heap* seg_mapping_table_heap_of_worker (BYTE* o)
     {
         if (in_range_for_segment (o, seg))
         {
-            dprintf (2, ("obj %Ix belongs to segment %Ix(-%Ix)", o, seg, (BYTE*)heap_segment_allocated (seg)));
+            dprintf (2, ("obj %Ix belongs to segment %Ix(-%Ix)", o, seg, (uint8_t*)heap_segment_allocated (seg)));
         }
         else
         {
             dprintf (2, ("found seg %Ix(-%Ix) for obj %Ix, but it's not on the seg", 
-                seg, (BYTE*)heap_segment_allocated (seg), o));
+                seg, (uint8_t*)heap_segment_allocated (seg), o));
         }
     }
     else
@@ -3587,7 +3587,7 @@ gc_heap* seg_mapping_table_heap_of_worker (BYTE* o)
     return hp;
 }
 
-gc_heap* seg_mapping_table_heap_of (BYTE* o)
+gc_heap* seg_mapping_table_heap_of (uint8_t* o)
 {
 #ifdef GROWABLE_SEG_MAPPING_TABLE
     if ((o < g_lowest_address) || (o >= g_highest_address))
@@ -3597,7 +3597,7 @@ gc_heap* seg_mapping_table_heap_of (BYTE* o)
     return seg_mapping_table_heap_of_worker (o);
 }
 
-gc_heap* seg_mapping_table_heap_of_gc (BYTE* o)
+gc_heap* seg_mapping_table_heap_of_gc (uint8_t* o)
 {
 #if defined(FEATURE_BASICFREEZE) && defined(GROWABLE_SEG_MAPPING_TABLE)
     if ((o < g_lowest_address) || (o >= g_highest_address))
@@ -3609,7 +3609,7 @@ gc_heap* seg_mapping_table_heap_of_gc (BYTE* o)
 #endif //MULTIPLE_HEAPS
 
 // Only returns a valid seg if we can actually find o on the seg.
-heap_segment* seg_mapping_table_segment_of (BYTE* o)
+heap_segment* seg_mapping_table_segment_of (uint8_t* o)
 {
 #if defined(FEATURE_BASICFREEZE) && defined(GROWABLE_SEG_MAPPING_TABLE)
     if ((o < g_lowest_address) || (o >= g_highest_address))
@@ -3625,7 +3625,7 @@ heap_segment* seg_mapping_table_segment_of (BYTE* o)
 
     dprintf (2, ("checking obj %Ix, index is %Id, entry: boundry: %Ix, seg0: %Ix, seg1: %Ix",
         o, index, (entry->boundary + 1), 
-        (BYTE*)(entry->seg0), (BYTE*)(entry->seg1)));
+        (uint8_t*)(entry->seg0), (uint8_t*)(entry->seg1)));
 
     heap_segment* seg = ((o > entry->boundary) ? entry->seg1 : entry->seg0);
 #ifdef FEATURE_BASICFREEZE
@@ -3639,12 +3639,12 @@ heap_segment* seg_mapping_table_segment_of (BYTE* o)
         //assert (in_range_for_segment (o, seg));
         if (in_range_for_segment (o, seg))
         {
-            dprintf (2, ("obj %Ix belongs to segment %Ix(-%Ix)", o, (BYTE*)heap_segment_mem(seg), (BYTE*)heap_segment_reserved(seg)));
+            dprintf (2, ("obj %Ix belongs to segment %Ix(-%Ix)", o, (uint8_t*)heap_segment_mem(seg), (uint8_t*)heap_segment_reserved(seg)));
         }
         else
         {
             dprintf (2, ("found seg %Ix(-%Ix) for obj %Ix, but it's not on the seg, setting it to 0", 
-                (BYTE*)heap_segment_mem(seg), (BYTE*)heap_segment_reserved(seg), o));
+                (uint8_t*)heap_segment_mem(seg), (uint8_t*)heap_segment_reserved(seg), o));
             seg = 0;
         }
     }
@@ -3666,14 +3666,14 @@ heap_segment* seg_mapping_table_segment_of (BYTE* o)
 }
 #endif //SEG_MAPPING_TABLE
 
-size_t gcard_of ( BYTE*);
+size_t gcard_of ( uint8_t*);
 void gset_card (size_t card);
 
-#define memref(i) *(BYTE**)(i)
+#define memref(i) *(uint8_t**)(i)
 
 //GC Flags
 #define GC_MARKED       (size_t)0x1
-#define slot(i, j) ((BYTE**)(i))[j+1]
+#define slot(i, j) ((uint8_t**)(i))[j+1]
 
 #define free_object_base_size (plug_skew + sizeof(ArrayBase))
 
@@ -3684,7 +3684,7 @@ public:
 #ifdef FEATURE_REDHAWK
     // The GC expects the following methods that are provided by the Object class in the CLR but not provided
     // by Redhawk's version of Object.
-    DWORD GetNumComponents()
+    uint32_t GetNumComponents()
     {
         return ((ArrayBase *)this)->GetNumComponents();
     }
@@ -3703,7 +3703,7 @@ public:
         _ASSERTE(GetMethodTable()->GetBaseSize() >= 8);
 
 #ifdef FEATURE_STRUCTALIGN
-        _ASSERTE(IsStructAligned((BYTE *)this, GetMethodTable()->GetBaseAlignment()));
+        _ASSERTE(IsStructAligned((uint8_t *)this, GetMethodTable()->GetBaseAlignment()));
 #endif // FEATURE_STRUCTALIGN
 
 #ifdef VERIFY_HEAP
@@ -3712,7 +3712,7 @@ public:
 #endif
     }
 
-    void ValidatePromote(ScanContext *sc, DWORD flags)
+    void ValidatePromote(ScanContext *sc, uint32_t flags)
     {
         Validate();
     }
@@ -3779,14 +3779,14 @@ public:
 
         RawSetMethodTable( g_pFreeObjectMethodTable );
 
-        SIZE_T* numComponentsPtr = (SIZE_T*) &((BYTE*) this)[ArrayBase::GetOffsetOfNumComponents()];
+        size_t* numComponentsPtr = (size_t*) &((uint8_t*) this)[ArrayBase::GetOffsetOfNumComponents()];
         *numComponentsPtr = size - free_object_base_size;
 #ifdef VERIFY_HEAP
         //This introduces a bug in the free list management. 
         //((void**) this)[-1] = 0;    // clear the sync block,
         assert (*numComponentsPtr >= 0);
         if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
-            memset (((BYTE*)this)+sizeof(ArrayBase), 0xcc, *numComponentsPtr);
+            memset (((uint8_t*)this)+sizeof(ArrayBase), 0xcc, *numComponentsPtr);
 #endif //VERIFY_HEAP
     }
 
@@ -3838,39 +3838,39 @@ public:
 
 #define header(i) ((CObjectHeader*)(i))
 
-#define free_list_slot(x) ((BYTE**)(x))[2]
-#define free_list_undo(x) ((BYTE**)(x))[-1]
-#define UNDO_EMPTY ((BYTE*)1)
+#define free_list_slot(x) ((uint8_t**)(x))[2]
+#define free_list_undo(x) ((uint8_t**)(x))[-1]
+#define UNDO_EMPTY ((uint8_t*)1)
 
 #ifdef SHORT_PLUGS
 inline 
-void set_plug_padded (BYTE* node)
+void set_plug_padded (uint8_t* node)
 {
     header(node)->SetMarked();
 }
 inline
-void clear_plug_padded (BYTE* node)
+void clear_plug_padded (uint8_t* node)
 {
     header(node)->ClearMarked();
 }
 inline
-BOOL is_plug_padded (BYTE* node)
+BOOL is_plug_padded (uint8_t* node)
 {
     return header(node)->IsMarked();
 }
 #else //SHORT_PLUGS
-inline void set_plug_padded (BYTE* node){}
-inline void clear_plug_padded (BYTE* node){}
+inline void set_plug_padded (uint8_t* node){}
+inline void clear_plug_padded (uint8_t* node){}
 inline
-BOOL is_plug_padded (BYTE* node){return FALSE;}
+BOOL is_plug_padded (uint8_t* node){return FALSE;}
 #endif //SHORT_PLUGS
 
 
-inline size_t unused_array_size(BYTE * p)
+inline size_t unused_array_size(uint8_t * p)
 {
     assert(((CObjectHeader*)p)->IsFree());
 
-    SIZE_T* numComponentsPtr = (SIZE_T*)(p + ArrayBase::GetOffsetOfNumComponents());
+    size_t* numComponentsPtr = (size_t*)(p + ArrayBase::GetOffsetOfNumComponents());
     return free_object_base_size + *numComponentsPtr;
 }
 
@@ -3967,7 +3967,7 @@ heap_segment* heap_segment_next_in_range (heap_segment* seg)
 
 typedef struct
 {
-    BYTE* memory_base;
+    uint8_t* memory_base;
 } imemory_data;
 
 typedef struct
@@ -4036,7 +4036,7 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
 
     size_t requestedMemory = memory_details.block_count * (normal_size + large_size);
 
-    BYTE* allatonce_block = (BYTE*)virtual_alloc (requestedMemory);
+    uint8_t* allatonce_block = (uint8_t*)virtual_alloc (requestedMemory);
     if (allatonce_block)
     {
         g_lowest_address =  allatonce_block;
@@ -4054,12 +4054,12 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
     else
     {
         // try to allocate 2 blocks
-        BYTE* b1 = 0;
-        BYTE* b2 = 0;
-        b1 = (BYTE*)virtual_alloc (memory_details.block_count * normal_size);
+        uint8_t* b1 = 0;
+        uint8_t* b2 = 0;
+        b1 = (uint8_t*)virtual_alloc (memory_details.block_count * normal_size);
         if (b1)
         {
-            b2 = (BYTE*)virtual_alloc (memory_details.block_count * large_size);
+            b2 = (uint8_t*)virtual_alloc (memory_details.block_count * large_size);
             if (b2)
             {
                 memory_details.allocation_pattern = initial_memory_details::TWO_STAGE;
@@ -4092,7 +4092,7 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
                                      memory_details.block_size_normal :
                                      memory_details.block_size_large);
                 current_block->memory_base =
-                    (BYTE*)virtual_alloc (block_size);
+                    (uint8_t*)virtual_alloc (block_size);
                 if (current_block->memory_base == 0)
                 {
                     // Free the blocks that we've allocated so far
@@ -4112,7 +4112,7 @@ BOOL reserve_initial_memory (size_t normal_size, size_t large_size, size_t num_h
                 {
                     if (current_block->memory_base < g_lowest_address)
                         g_lowest_address =  current_block->memory_base;
-                    if (((BYTE *) current_block->memory_base + block_size) > g_highest_address)
+                    if (((uint8_t *) current_block->memory_base + block_size) > g_highest_address)
                         g_highest_address = (current_block->memory_base + block_size);
                 }
                 reserve_success = TRUE;
@@ -4194,7 +4194,7 @@ void* next_initial_memory (size_t size)
 heap_segment* get_initial_segment (size_t size, int h_number)
 {
     void* mem = next_initial_memory (size);
-    heap_segment* res = gc_heap::make_heap_segment ((BYTE*)mem, size , h_number);
+    heap_segment* res = gc_heap::make_heap_segment ((uint8_t*)mem, size , h_number);
 
     return res;
 }
@@ -4223,13 +4223,13 @@ void* virtual_alloc (size_t size)
     // when we do alloc_ptr+size.
     if (prgmem)
     {
-        BYTE* end_mem = (BYTE*)prgmem + requested_size;
+        uint8_t* end_mem = (uint8_t*)prgmem + requested_size;
 
         if ((end_mem == 0) || ((size_t)(MAX_PTR - end_mem) <= END_SPACE_AFTER_GC))
         {
             VirtualFree (prgmem, 0, MEM_RELEASE);
             dprintf (2, ("Virtual Alloc size %Id returned memory right against 4GB [%Ix, %Ix[ - discarding",
-                        requested_size, (size_t)prgmem, (size_t)((BYTE*)prgmem+requested_size)));
+                        requested_size, (size_t)prgmem, (size_t)((uint8_t*)prgmem+requested_size)));
             prgmem = 0;
             aligned_mem = 0;
         }
@@ -4241,7 +4241,7 @@ void* virtual_alloc (size_t size)
     }
 
     dprintf (2, ("Virtual Alloc size %Id: [%Ix, %Ix[",
-                 requested_size, (size_t)prgmem, (size_t)((BYTE*)prgmem+requested_size)));
+                 requested_size, (size_t)prgmem, (size_t)((uint8_t*)prgmem+requested_size)));
 
     return aligned_mem;
 }
@@ -4251,7 +4251,7 @@ void virtual_free (void* add, size_t size)
     VirtualFree (add, 0, MEM_RELEASE);
     gc_heap::reserved_memory -= size;
     dprintf (2, ("Virtual Free size %Id: [%Ix, %Ix[",
-                 size, (size_t)add, (size_t)((BYTE*)add+size)));
+                 size, (size_t)add, (size_t)((uint8_t*)add+size)));
 }
 
 // We have a few places that call this but the seg size doesn't change so call it
@@ -4475,7 +4475,7 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
         heap_segment* last = 0;
         while (result)
         {
-            size_t hs = (size_t)(heap_segment_reserved (result) - (BYTE*)result);
+            size_t hs = (size_t)(heap_segment_reserved (result) - (uint8_t*)result);
             if ((hs >= size) && ((hs / 2) < size))
             {
                 dprintf (2, ("Hoarded segment %Ix found", (size_t) result));
@@ -4542,28 +4542,28 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
             return 0;
         }
 
-        result = gc_heap::make_heap_segment ((BYTE*)mem, size, heap_number);
+        result = gc_heap::make_heap_segment ((uint8_t*)mem, size, heap_number);
 
         if (result)
         {
-            BYTE* start;
-            BYTE* end;
+            uint8_t* start;
+            uint8_t* end;
             if (mem < g_lowest_address)
             {
-                start =  (BYTE*)mem;
+                start =  (uint8_t*)mem;
             }
             else
             {
-                start = (BYTE*)g_lowest_address;
+                start = (uint8_t*)g_lowest_address;
             }
 
-            if (((BYTE*)mem + size) > g_highest_address)
+            if (((uint8_t*)mem + size) > g_highest_address)
             {
-                end = (BYTE*)mem + size;
+                end = (uint8_t*)mem + size;
             }
             else
             {
-                end = (BYTE*)g_highest_address;
+                end = (uint8_t*)g_highest_address;
             }
 
             if (gc_heap::grow_brick_card_tables (start, end, size, result, __this, loh_p) != 0)
@@ -4583,7 +4583,7 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
 #ifdef SEG_MAPPING_TABLE
             seg_mapping_table_add_segment (result, __this);
 #else //SEG_MAPPING_TABLE
-            gc_heap::seg_table->insert ((BYTE*)result, delta);
+            gc_heap::seg_table->insert ((uint8_t*)result, delta);
 #endif //SEG_MAPPING_TABLE
         }
     }
@@ -4591,14 +4591,14 @@ gc_heap::get_segment (size_t size, BOOL loh_p)
 #ifdef BACKGROUND_GC
     if (result)
     {
-        ::record_changed_seg ((BYTE*)result, heap_segment_reserved (result), 
+        ::record_changed_seg ((uint8_t*)result, heap_segment_reserved (result), 
                             settings.gc_index, current_bgc_state,
                             seg_added);
         bgc_verify_mark_array_cleared (result);
     }
 #endif //BACKGROUND_GC
 
-    dprintf (GC_TABLE_LOG, ("h%d: new seg: %Ix-%Ix (%Id)", heap_number, result, ((BYTE*)result + size), size));
+    dprintf (GC_TABLE_LOG, ("h%d: new seg: %Ix-%Ix (%Id)", heap_number, result, ((uint8_t*)result + size), size));
     return result;
 }
 
@@ -4606,7 +4606,7 @@ void release_segment (heap_segment* sg)
 {
     ptrdiff_t delta = 0;
     FireEtwGCFreeSegment_V1((size_t)heap_segment_mem(sg), GetClrInstanceId());
-    virtual_free (sg, (BYTE*)heap_segment_reserved (sg)-(BYTE*)sg);
+    virtual_free (sg, (uint8_t*)heap_segment_reserved (sg)-(uint8_t*)sg);
 }
 
 heap_segment* gc_heap::get_segment_for_loh (size_t size
@@ -4710,12 +4710,12 @@ gc_heap::get_large_segment (size_t size, BOOL* did_full_compact_gc)
 
 BOOL gc_heap::unprotect_segment (heap_segment* seg)
 {
-    BYTE* start = align_lower_page (heap_segment_mem (seg));
+    uint8_t* start = align_lower_page (heap_segment_mem (seg));
     ptrdiff_t region_size = heap_segment_allocated (seg) - start;
 
     if (region_size != 0 )
     {
-        DWORD old_protection;
+        uint32_t old_protection;
         dprintf (3, ("unprotecting segment %Ix:", (size_t)seg));
 
         BOOL status = VirtualProtect (start, region_size,
@@ -4749,7 +4749,7 @@ BOOL gc_heap::unprotect_segment (heap_segment* seg)
 #endif //_MSC_VER
 #elif defined(_TARGET_AMD64_) 
 #ifdef _MSC_VER
-extern "C" UINT64 __rdtsc();
+extern "C" uint64_t __rdtsc();
 #pragma intrinsic(__rdtsc)
     static SSIZE_T get_cycle_count()
     {
@@ -4789,26 +4789,26 @@ extern "C" UINT64 __rdtsc();
 
 // The purpose of this whole class is to guess the right heap to use for a given thread.
 typedef
-DWORD (WINAPI *GetCurrentProcessorNumber_t)(VOID);
+uint32_t (WINAPI *GetCurrentProcessorNumber_t)(void);
 
 class heap_select
 {
     heap_select() {}
-    static BYTE* sniff_buffer;
+    static uint8_t* sniff_buffer;
     static unsigned n_sniff_buffers;
     static unsigned cur_sniff_index;
 
-    static BYTE proc_no_to_heap_no[MAX_SUPPORTED_CPUS];
-    static BYTE heap_no_to_proc_no[MAX_SUPPORTED_CPUS];
-    static BYTE heap_no_to_numa_node[MAX_SUPPORTED_CPUS];
-    static BYTE heap_no_to_cpu_group[MAX_SUPPORTED_CPUS];
-    static BYTE heap_no_to_group_proc[MAX_SUPPORTED_CPUS];
-    static BYTE numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
+    static uint8_t proc_no_to_heap_no[MAX_SUPPORTED_CPUS];
+    static uint8_t heap_no_to_proc_no[MAX_SUPPORTED_CPUS];
+    static uint8_t heap_no_to_numa_node[MAX_SUPPORTED_CPUS];
+    static uint8_t heap_no_to_cpu_group[MAX_SUPPORTED_CPUS];
+    static uint8_t heap_no_to_group_proc[MAX_SUPPORTED_CPUS];
+    static uint8_t numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
 
-    static int access_time(BYTE *sniff_buffer, int heap_number, unsigned sniff_index, unsigned n_sniff_buffers)
+    static int access_time(uint8_t *sniff_buffer, int heap_number, unsigned sniff_index, unsigned n_sniff_buffers)
     {
         SSIZE_T start_cycles = get_cycle_count();
-        BYTE sniff = sniff_buffer[(1 + heap_number*n_sniff_buffers + sniff_index)*HS_CACHE_LINE_SIZE];
+        uint8_t sniff = sniff_buffer[(1 + heap_number*n_sniff_buffers + sniff_index)*HS_CACHE_LINE_SIZE];
         assert (sniff == 0);
         SSIZE_T elapsed_cycles = get_cycle_count() - start_cycles;
         // add sniff here just to defeat the optimizer
@@ -4856,10 +4856,10 @@ public:
             }
             sniff_buf_size = safe_sniff_buf_size.Value();
 #endif //FEATURE_REDHAWK
-            sniff_buffer = new (nothrow) BYTE[sniff_buf_size];
+            sniff_buffer = new (nothrow) uint8_t[sniff_buf_size];
             if (sniff_buffer == 0)
                 return FALSE;
-            memset(sniff_buffer, 0, sniff_buf_size*sizeof(BYTE));
+            memset(sniff_buffer, 0, sniff_buf_size*sizeof(uint8_t));
         }
 
         //can not enable gc numa aware, force all heaps to be in
@@ -4874,11 +4874,11 @@ public:
     {
         if (GCGetCurrentProcessorNumber != 0)
         {
-            DWORD proc_no = GCGetCurrentProcessorNumber() % gc_heap::n_heaps;
-            // We can safely cast heap_number to a BYTE 'cause GetCurrentProcessCpuCount
+            uint32_t proc_no = GCGetCurrentProcessorNumber() % gc_heap::n_heaps;
+            // We can safely cast heap_number to a uint8_t 'cause GetCurrentProcessCpuCount
             // only returns up to MAX_SUPPORTED_CPUS procs right now. We only ever create at most
             // MAX_SUPPORTED_CPUS GC threads.
-            proc_no_to_heap_no[proc_no] = (BYTE)heap_number;
+            proc_no_to_heap_no[proc_no] = (uint8_t)heap_number;
         }
     }
 
@@ -4903,7 +4903,7 @@ public:
         int best_access_time = 1000*1000*1000;
         int second_best_access_time = best_access_time;
 
-        BYTE *l_sniff_buffer = sniff_buffer;
+        uint8_t *l_sniff_buffer = sniff_buffer;
         unsigned l_n_sniff_buffers = n_sniff_buffers;
         for (int heap_number = 0; heap_number < gc_heap::n_heaps; heap_number++)
         {
@@ -4942,42 +4942,42 @@ public:
             return FALSE;
     }
 
-    static BYTE find_proc_no_from_heap_no(int heap_number)
+    static uint8_t find_proc_no_from_heap_no(int heap_number)
     {
         return heap_no_to_proc_no[heap_number];
     }
 
-    static void set_proc_no_for_heap(int heap_number, BYTE proc_no)
+    static void set_proc_no_for_heap(int heap_number, uint8_t proc_no)
     {
         heap_no_to_proc_no[heap_number] = proc_no;
     }
 
-    static BYTE find_numa_node_from_heap_no(int heap_number)
+    static uint8_t find_numa_node_from_heap_no(int heap_number)
     {
         return heap_no_to_numa_node[heap_number];
     }
 
-    static void set_numa_node_for_heap(int heap_number, BYTE numa_node)
+    static void set_numa_node_for_heap(int heap_number, uint8_t numa_node)
     {
         heap_no_to_numa_node[heap_number] = numa_node;
     }
 
-    static BYTE find_cpu_group_from_heap_no(int heap_number)
+    static uint8_t find_cpu_group_from_heap_no(int heap_number)
     {
         return heap_no_to_cpu_group[heap_number];
     }
 
-    static void set_cpu_group_for_heap(int heap_number, BYTE group_number)
+    static void set_cpu_group_for_heap(int heap_number, uint8_t group_number)
     {
         heap_no_to_cpu_group[heap_number] = group_number;
     }
 
-    static BYTE find_group_proc_from_heap_no(int heap_number)
+    static uint8_t find_group_proc_from_heap_no(int heap_number)
     {
         return heap_no_to_group_proc[heap_number];
     }
 
-    static void set_group_proc_for_heap(int heap_number, BYTE group_proc)
+    static void set_group_proc_for_heap(int heap_number, uint8_t group_proc)
     {
         heap_no_to_group_proc[heap_number] = group_proc;
     }
@@ -4992,29 +4992,29 @@ public:
         for (int i=1; i < nheaps; i++)
         {
             if (heap_no_to_numa_node[i] != heap_no_to_numa_node[i-1])
-                numa_node_to_heap_map[node_index++] = (BYTE)i;
+                numa_node_to_heap_map[node_index++] = (uint8_t)i;
         }
-        numa_node_to_heap_map[node_index] = (BYTE)nheaps; //mark the end with nheaps
+        numa_node_to_heap_map[node_index] = (uint8_t)nheaps; //mark the end with nheaps
     }
 
     static void get_heap_range_for_heap(int hn, int* start, int* end)
     {   // 1-tier/no numa case: heap_no_to_numa_node[] all zeros, 
         // and treated as in one node. thus: start=0, end=n_heaps
-        BYTE numa_node = heap_no_to_numa_node[hn];
+        uint8_t numa_node = heap_no_to_numa_node[hn];
         *start = (int)numa_node_to_heap_map[numa_node];
         *end   = (int)(numa_node_to_heap_map[numa_node+1]);
     }
 };
-BYTE* heap_select::sniff_buffer;
+uint8_t* heap_select::sniff_buffer;
 unsigned heap_select::n_sniff_buffers;
 unsigned heap_select::cur_sniff_index;
 GetCurrentProcessorNumber_t heap_select::GCGetCurrentProcessorNumber;
-BYTE heap_select::proc_no_to_heap_no[MAX_SUPPORTED_CPUS];
-BYTE heap_select::heap_no_to_proc_no[MAX_SUPPORTED_CPUS];
-BYTE heap_select::heap_no_to_numa_node[MAX_SUPPORTED_CPUS];
-BYTE heap_select::heap_no_to_cpu_group[MAX_SUPPORTED_CPUS];
-BYTE heap_select::heap_no_to_group_proc[MAX_SUPPORTED_CPUS];
-BYTE heap_select::numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
+uint8_t heap_select::proc_no_to_heap_no[MAX_SUPPORTED_CPUS];
+uint8_t heap_select::heap_no_to_proc_no[MAX_SUPPORTED_CPUS];
+uint8_t heap_select::heap_no_to_numa_node[MAX_SUPPORTED_CPUS];
+uint8_t heap_select::heap_no_to_cpu_group[MAX_SUPPORTED_CPUS];
+uint8_t heap_select::heap_no_to_group_proc[MAX_SUPPORTED_CPUS];
+uint8_t heap_select::numa_node_to_heap_map[MAX_SUPPORTED_CPUS+4];
 
 BOOL gc_heap::create_thread_support (unsigned number_of_heaps)
 {
@@ -5062,9 +5062,9 @@ void set_thread_group_affinity_for_heap(HANDLE gc_thread, int heap_number)
 {
 #if !defined(FEATURE_REDHAWK) && !defined(FEATURE_CORECLR)
     GROUP_AFFINITY ga;
-    WORD gn, gpn;
+    uint16_t gn, gpn;
 
-    CPUGroupInfo::GetGroupForProcessor((WORD)heap_number, &gn, &gpn);
+    CPUGroupInfo::GetGroupForProcessor((uint16_t)heap_number, &gn, &gpn);
     ga.Group  = gn;
     ga.Reserved[0] = 0; // reserve must be filled with zero
     ga.Reserved[1] = 0; // otherwise call may fail
@@ -5078,22 +5078,22 @@ void set_thread_group_affinity_for_heap(HANDLE gc_thread, int heap_number)
             dprintf(3, ("using processor group %d, mask %x%Ix for heap %d\n", gn, mask, heap_number));
             ga.Mask = mask;
             CPUGroupInfo::SetThreadGroupAffinity(gc_thread, &ga, NULL);
-            heap_select::set_cpu_group_for_heap(heap_number, (BYTE)gn);
-            heap_select::set_group_proc_for_heap(heap_number, (BYTE)gpn);
+            heap_select::set_cpu_group_for_heap(heap_number, (uint8_t)gn);
+            heap_select::set_group_proc_for_heap(heap_number, (uint8_t)gpn);
             if (NumaNodeInfo::CanEnableGCNumaAware())
             {  
                 PROCESSOR_NUMBER proc_no;
                 proc_no.Group    = gn;
-                proc_no.Number   = (BYTE)gpn;
+                proc_no.Number   = (uint8_t)gpn;
                 proc_no.Reserved = 0;
 
-                WORD node_no = 0;
+                uint16_t node_no = 0;
                 if (NumaNodeInfo::GetNumaProcessorNodeEx(&proc_no, &node_no))
-                    heap_select::set_numa_node_for_heap(heap_number, (BYTE)node_no);
+                    heap_select::set_numa_node_for_heap(heap_number, (uint8_t)node_no);
             }
             else
             {   // no numa setting, each cpu group is treated as a node
-                heap_select::set_numa_node_for_heap(heap_number, (BYTE)gn);
+                heap_select::set_numa_node_for_heap(heap_number, (uint8_t)gn);
             }
             return;
         }
@@ -5111,7 +5111,7 @@ void set_thread_affinity_mask_for_heap(HANDLE gc_thread, int heap_number)
     {
         pmask &= smask;
         int bit_number = 0; 
-        BYTE proc_number = 0;
+        uint8_t proc_number = 0;
         for (DWORD_PTR mask = 1; mask != 0; mask <<= 1)
         {
             if ((mask & pmask) != 0)
@@ -5124,21 +5124,21 @@ void set_thread_affinity_mask_for_heap(HANDLE gc_thread, int heap_number)
                     if (NumaNodeInfo::CanEnableGCNumaAware())
                     { // have the processor number, find the numa node
 #if !defined(FEATURE_CORESYSTEM)
-                        BYTE node_no = 0;
+                        uint8_t node_no = 0;
                         if (NumaNodeInfo::GetNumaProcessorNode(proc_number, &node_no))
                             heap_select::set_numa_node_for_heap(heap_number, node_no);
 #else
-                        WORD gn, gpn;
-                        WORD node_no = 0;
-                        CPUGroupInfo::GetGroupForProcessor((WORD)heap_number, &gn, &gpn);
+                        uint16_t gn, gpn;
+                        uint16_t node_no = 0;
+                        CPUGroupInfo::GetGroupForProcessor((uint16_t)heap_number, &gn, &gpn);
                         
                         PROCESSOR_NUMBER proc_no;
                         proc_no.Group = gn;
-                        proc_no.Number = (BYTE)gpn;
+                        proc_no.Number = (uint8_t)gpn;
                         proc_no.Reserved = 0;
                         if (NumaNodeInfo::GetNumaProcessorNodeEx(&proc_no, &node_no))
                         {
-                            heap_select::set_numa_node_for_heap(heap_number, (BYTE)node_no);
+                            heap_select::set_numa_node_for_heap(heap_number, (uint8_t)node_no);
                         }
 #endif
                     }
@@ -5154,7 +5154,7 @@ void set_thread_affinity_mask_for_heap(HANDLE gc_thread, int heap_number)
 
 HANDLE gc_heap::create_gc_thread ()
 {
-    DWORD thread_id;
+    uint32_t thread_id;
     dprintf (3, ("Creating gc thread\n"));
 
 #ifdef FEATURE_REDHAWK
@@ -5184,7 +5184,7 @@ HANDLE gc_heap::create_gc_thread ()
 #ifdef _MSC_VER
 #pragma warning(disable:4715) //IA64 xcompiler recognizes that without the 'break;' the while(1) will never end and therefore not return a value for that code path
 #endif //_MSC_VER
-DWORD gc_heap::gc_thread_function ()
+uint32_t gc_heap::gc_thread_function ()
 {
     assert (gc_done_event.IsValid());
     assert (gc_start_event.IsValid());
@@ -5280,8 +5280,8 @@ DWORD gc_heap::gc_thread_function ()
 
 #endif //MULTIPLE_HEAPS
 
-void* virtual_alloc_commit_for_heap(void* addr, size_t size, DWORD type, 
-                                    DWORD prot, int h_number)
+void* virtual_alloc_commit_for_heap(void* addr, size_t size, uint32_t type, 
+                                    uint32_t prot, int h_number)
 {
 #if defined(MULTIPLE_HEAPS) && !defined(FEATURE_REDHAWK) && !defined(FEATURE_PAL)
     // Currently there is no way for us to specific the numa node to allocate on via hosting interfaces to
@@ -5290,7 +5290,7 @@ void* virtual_alloc_commit_for_heap(void* addr, size_t size, DWORD type,
     {
         if (NumaNodeInfo::CanEnableGCNumaAware())
         {
-            DWORD numa_node = heap_select::find_numa_node_from_heap_no(h_number);
+            uint32_t numa_node = heap_select::find_numa_node_from_heap_no(h_number);
             void * ret = NumaNodeInfo::VirtualAllocExNuma(GetCurrentProcess(), addr, size, 
                                                         type, prot, numa_node);
             if (ret != NULL)
@@ -5305,9 +5305,9 @@ void* virtual_alloc_commit_for_heap(void* addr, size_t size, DWORD type,
 
 #ifndef SEG_MAPPING_TABLE
 inline
-heap_segment* gc_heap::segment_of (BYTE* add, ptrdiff_t& delta, BOOL verify_p)
+heap_segment* gc_heap::segment_of (uint8_t* add, ptrdiff_t& delta, BOOL verify_p)
 {
-    BYTE* sadd = add;
+    uint8_t* sadd = add;
     heap_segment* hs = 0;
     heap_segment* hs1 = 0;
     if (!((add >= g_lowest_address) && (add < g_highest_address)))
@@ -5336,7 +5336,7 @@ heap_segment* gc_heap::segment_of (BYTE* add, ptrdiff_t& delta, BOOL verify_p)
 class mark
 {
 public:
-    BYTE* first;
+    uint8_t* first;
     size_t len;
 
     // If we want to save space we can have a pool of plug_and_gap's instead of 
@@ -5356,14 +5356,14 @@ public:
     // We need to calculate this after we are done with plan phase and before compact
     // phase because compact phase will change the bricks so relocate_address will no 
     // longer work.
-    BYTE* saved_pre_plug_info_reloc_start;
+    uint8_t* saved_pre_plug_info_reloc_start;
 
     // We need to save this because we will have no way to calculate it, unlike the 
     // pre plug info start which is right before this plug.
-    BYTE* saved_post_plug_info_start;
+    uint8_t* saved_post_plug_info_start;
 
 #ifdef SHORT_PLUGS
-    BYTE* allocation_context_start_region;
+    uint8_t* allocation_context_start_region;
 #endif //SHORT_PLUGS
 
     // How the bits in these bytes are organized:
@@ -5381,13 +5381,13 @@ public:
 
     size_t get_max_short_bits()
     {
-        return (sizeof (gap_reloc_pair) / sizeof (BYTE*));
+        return (sizeof (gap_reloc_pair) / sizeof (uint8_t*));
     }
 
     // pre bits
     size_t get_pre_short_start_bit ()
     {
-        return (sizeof (saved_pre_p) * 8 - 1 - (sizeof (gap_reloc_pair) / sizeof (BYTE*)));
+        return (sizeof (saved_pre_p) * 8 - 1 - (sizeof (gap_reloc_pair) / sizeof (uint8_t*)));
     }
 
     BOOL pre_short_p()
@@ -5425,7 +5425,7 @@ public:
     // post bits
     size_t get_post_short_start_bit ()
     {
-        return (sizeof (saved_post_p) * 8 - 1 - (sizeof (gap_reloc_pair) / sizeof (BYTE*)));
+        return (sizeof (saved_post_p) * 8 - 1 - (sizeof (gap_reloc_pair) / sizeof (uint8_t*)));
     }
 
     BOOL post_short_p()
@@ -5460,15 +5460,15 @@ public:
     }
 #endif //COLLECTIBLE_CLASS
 
-    BYTE* get_plug_address() { return first; }
+    uint8_t* get_plug_address() { return first; }
 
     BOOL has_pre_plug_info() { return saved_pre_p; }
     BOOL has_post_plug_info() { return saved_post_p; }
 
     gap_reloc_pair* get_pre_plug_reloc_info() { return &saved_pre_plug_reloc; }
     gap_reloc_pair* get_post_plug_reloc_info() { return &saved_post_plug_reloc; }
-    void set_pre_plug_info_reloc_start (BYTE* reloc) { saved_pre_plug_info_reloc_start = reloc; }
-    BYTE* get_post_plug_info_start() { return saved_post_plug_info_start; }
+    void set_pre_plug_info_reloc_start (uint8_t* reloc) { saved_pre_plug_info_reloc_start = reloc; }
+    uint8_t* get_post_plug_info_start() { return saved_post_plug_info_start; }
 
     // We need to temporarily recover the shortened plugs for compact phase so we can
     // copy over the whole plug and their related info (mark bits/cards). But we will
@@ -5704,7 +5704,7 @@ void gc_heap::fix_allocation_context (alloc_context* acontext, BOOL for_gc_p,
     if (((size_t)(alloc_allocated - acontext->alloc_limit) > Align (min_obj_size, align_const)) ||
         !for_gc_p)
     {
-        BYTE*  point = acontext->alloc_ptr;
+        uint8_t*  point = acontext->alloc_ptr;
         if (point != 0)
         {
             size_t  size = (acontext->alloc_limit - acontext->alloc_ptr);
@@ -5745,7 +5745,7 @@ void gc_heap::fix_allocation_context (alloc_context* acontext, BOOL for_gc_p,
 //it nulls out the words set by fix_allocation_context for heap_verification
 void repair_allocation (alloc_context* acontext)
 {
-    BYTE*  point = acontext->alloc_ptr;
+    uint8_t*  point = acontext->alloc_ptr;
 
     if (point != 0)
     {
@@ -5758,7 +5758,7 @@ void repair_allocation (alloc_context* acontext)
 
 void void_allocation (alloc_context* acontext)
 {
-    BYTE*  point = acontext->alloc_ptr;
+    uint8_t*  point = acontext->alloc_ptr;
 
     if (point != 0)
     {
@@ -5793,7 +5793,7 @@ void gc_heap::fix_older_allocation_area (generation* older_gen)
     if (generation_allocation_limit (older_gen) !=
         heap_segment_plan_allocated (older_gen_seg))
     {
-        BYTE*  point = generation_allocation_pointer (older_gen);
+        uint8_t*  point = generation_allocation_pointer (older_gen);
 
         size_t  size = (generation_allocation_limit (older_gen) -
                                generation_allocation_pointer (older_gen));
@@ -5816,7 +5816,7 @@ void gc_heap::fix_older_allocation_area (generation* older_gen)
 
 void gc_heap::set_allocation_heap_segment (generation* gen)
 {
-    BYTE* p = generation_allocation_start (gen);
+    uint8_t* p = generation_allocation_start (gen);
     assert (p);
     heap_segment* seg = generation_allocation_segment (gen);
     if (in_range_for_segment (p, seg))
@@ -5840,7 +5840,7 @@ void gc_heap::set_allocation_heap_segment (generation* gen)
     generation_allocation_segment (gen) = seg;
 }
 
-void gc_heap::reset_allocation_pointers (generation* gen, BYTE* start)
+void gc_heap::reset_allocation_pointers (generation* gen, uint8_t* start)
 {
     assert (start);
     assert (Align ((size_t)start) == (size_t)start);
@@ -5901,7 +5901,7 @@ bool gc_heap::new_allocation_allowed (int gen_number)
         if ((allocation_running_amount - dd_new_allocation (dd0)) >
             dd_min_gc_size (dd0))
         {
-            DWORD ctime = GetTickCount();
+            uint32_t ctime = GetTickCount();
             if ((ctime - allocation_running_time) > 1000)
             {
                 dprintf (2, (">1s since last gen0 gc"));
@@ -5959,7 +5959,7 @@ BOOL grow_mark_stack (mark*& m, size_t& len, size_t init_len)
 }
 
 inline
-BYTE* pinned_plug (mark* m)
+uint8_t* pinned_plug (mark* m)
 {
    return m->first;
 }
@@ -5971,7 +5971,7 @@ size_t& pinned_len (mark* m)
 }
 
 inline
-void set_new_pin_info (mark* m, BYTE* pin_free_space_start)
+void set_new_pin_info (mark* m, uint8_t* pin_free_space_start)
 {
     m->len = pinned_plug (m) - pin_free_space_start;
 #ifdef SHORT_PLUGS
@@ -5981,15 +5981,15 @@ void set_new_pin_info (mark* m, BYTE* pin_free_space_start)
 
 #ifdef SHORT_PLUGS
 inline
-BYTE*& pin_allocation_context_start_region (mark* m)
+uint8_t*& pin_allocation_context_start_region (mark* m)
 {
     return m->allocation_context_start_region;
 }
 
-BYTE* get_plug_start_in_saved (BYTE* old_loc, mark* pinned_plug_entry)
+uint8_t* get_plug_start_in_saved (uint8_t* old_loc, mark* pinned_plug_entry)
 {
-    BYTE* saved_pre_plug_info = (BYTE*)(pinned_plug_entry->get_pre_plug_reloc_info());
-    BYTE* plug_start_in_saved = saved_pre_plug_info + (old_loc - (pinned_plug (pinned_plug_entry) - sizeof (plug_and_gap)));
+    uint8_t* saved_pre_plug_info = (uint8_t*)(pinned_plug_entry->get_pre_plug_reloc_info());
+    uint8_t* plug_start_in_saved = saved_pre_plug_info + (old_loc - (pinned_plug (pinned_plug_entry) - sizeof (plug_and_gap)));
     //dprintf (1, ("detected a very short plug: %Ix before PP %Ix, pad %Ix", 
     //    old_loc, pinned_plug (pinned_plug_entry), plug_start_in_saved));
     dprintf (1, ("EP: %Ix(%Ix), %Ix", old_loc, pinned_plug (pinned_plug_entry), plug_start_in_saved));
@@ -5997,7 +5997,7 @@ BYTE* get_plug_start_in_saved (BYTE* old_loc, mark* pinned_plug_entry)
 }
 
 inline
-void set_padding_in_expand (BYTE* old_loc, 
+void set_padding_in_expand (uint8_t* old_loc,
                             BOOL set_padding_on_saved_p,
                             mark* pinned_plug_entry)
 {
@@ -6012,7 +6012,7 @@ void set_padding_in_expand (BYTE* old_loc,
 }
 
 inline
-void clear_padding_in_expand (BYTE* old_loc, 
+void clear_padding_in_expand (uint8_t* old_loc,
                               BOOL set_padding_on_saved_p,
                               mark* pinned_plug_entry)
 {
@@ -6039,7 +6039,7 @@ void gc_heap::reset_pinned_queue_bos()
 }
 
 // last_pinned_plug is only for asserting purpose.
-void gc_heap::merge_with_last_pinned_plug (BYTE* last_pinned_plug, size_t plug_size)
+void gc_heap::merge_with_last_pinned_plug (uint8_t* last_pinned_plug, size_t plug_size)
 {
     if (last_pinned_plug)
     {
@@ -6057,14 +6057,14 @@ void gc_heap::merge_with_last_pinned_plug (BYTE* last_pinned_plug, size_t plug_s
     }
 }
 
-void gc_heap::set_allocator_next_pin (BYTE* alloc_pointer, BYTE*& alloc_limit)
+void gc_heap::set_allocator_next_pin (uint8_t* alloc_pointer, uint8_t*& alloc_limit)
 {
     dprintf (3, ("sanp: ptr: %Ix, limit: %Ix", alloc_pointer, alloc_limit));
     dprintf (3, ("oldest %Id: %Ix", mark_stack_bos, pinned_plug (oldest_pin())));
     if (!(pinned_plug_que_empty_p()))
     {
         mark*  oldest_entry = oldest_pin();
-        BYTE* plug = pinned_plug (oldest_entry);
+        uint8_t* plug = pinned_plug (oldest_entry);
         if ((plug >= alloc_pointer) && (plug < alloc_limit))
         {
             alloc_limit = pinned_plug (oldest_entry);
@@ -6080,7 +6080,7 @@ void gc_heap::set_allocator_next_pin (generation* gen)
     if (!(pinned_plug_que_empty_p()))
     {
         mark*  oldest_entry = oldest_pin();
-        BYTE* plug = pinned_plug (oldest_entry);
+        uint8_t* plug = pinned_plug (oldest_entry);
         if ((plug >= generation_allocation_pointer (gen)) &&
             (plug <  generation_allocation_limit (gen)))
         {
@@ -6097,7 +6097,7 @@ void gc_heap::set_allocator_next_pin (generation* gen)
 }
 
 // After we set the info, we increase tos.
-void gc_heap::set_pinned_info (BYTE* last_pinned_plug, size_t plug_len, BYTE* alloc_pointer, BYTE*& alloc_limit)
+void gc_heap::set_pinned_info (uint8_t* last_pinned_plug, size_t plug_len, uint8_t* alloc_pointer, uint8_t*& alloc_limit)
 {
     mark& m = mark_stack_array[mark_stack_tos];
     assert (m.first == last_pinned_plug);
@@ -6108,7 +6108,7 @@ void gc_heap::set_pinned_info (BYTE* last_pinned_plug, size_t plug_len, BYTE* al
 }
 
 // After we set the info, we increase tos.
-void gc_heap::set_pinned_info (BYTE* last_pinned_plug, size_t plug_len, generation* gen)
+void gc_heap::set_pinned_info (uint8_t* last_pinned_plug, size_t plug_len, generation* gen)
 {
     mark& m = mark_stack_array[mark_stack_tos];
     assert (m.first == last_pinned_plug);
@@ -6159,7 +6159,7 @@ mark* gc_heap::before_oldest_pin()
 }
 
 inline
-BOOL gc_heap::ephemeral_pointer_p (BYTE* o)
+BOOL gc_heap::ephemeral_pointer_p (uint8_t* o)
 {
     return ((o >= ephemeral_low) && (o < ephemeral_high));
 }
@@ -6194,14 +6194,14 @@ size_t& gc_heap::bpromoted_bytes(int thread)
 #endif //MULTIPLE_HEAPS
 }
 
-void gc_heap::make_background_mark_stack (BYTE** arr)
+void gc_heap::make_background_mark_stack (uint8_t** arr)
 {
     background_mark_stack_array = arr;
     background_mark_stack_array_length = MARK_STACK_INITIAL_LENGTH;
     background_mark_stack_tos = arr;
 }
 
-void gc_heap::make_c_mark_list (BYTE** arr)
+void gc_heap::make_c_mark_list (uint8_t** arr)
 {
     c_mark_list = arr;
     c_mark_list_index = 0;
@@ -6216,19 +6216,19 @@ void gc_heap::make_c_mark_list (BYTE** arr)
 #endif //_TARGET_AMD64_
 
 inline
-size_t gc_heap::brick_of (BYTE* add)
+size_t gc_heap::brick_of (uint8_t* add)
 {
     return (size_t)(add - lowest_address) / brick_size;
 }
 
 inline
-BYTE* gc_heap::brick_address (size_t brick)
+uint8_t* gc_heap::brick_address (size_t brick)
 {
     return lowest_address + (brick_size * brick);
 }
 
 
-void gc_heap::clear_brick_table (BYTE* from, BYTE* end)
+void gc_heap::clear_brick_table (uint8_t* from, uint8_t* end)
 {
     for (size_t i = brick_of (from);i < brick_of (end); i++)
         brick_table[i] = 0;
@@ -6272,18 +6272,18 @@ int gc_heap::brick_entry (size_t index)
 
 
 inline
-BYTE* align_on_brick (BYTE* add)
+uint8_t* align_on_brick (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add + brick_size - 1) & ~(brick_size - 1));
+    return (uint8_t*)((size_t)(add + brick_size - 1) & ~(brick_size - 1));
 }
 
 inline
-BYTE* align_lower_brick (BYTE* add)
+uint8_t* align_lower_brick (uint8_t* add)
 {
-    return (BYTE*)(((size_t)add) & ~(brick_size - 1));
+    return (uint8_t*)(((size_t)add) & ~(brick_size - 1));
 }
 
-size_t size_brick_of (BYTE* from, BYTE* end)
+size_t size_brick_of (uint8_t* from, uint8_t* end)
 {
     assert (((size_t)from & (brick_size-1)) == 0);
     assert (((size_t)end  & (brick_size-1)) == 0);
@@ -6292,13 +6292,13 @@ size_t size_brick_of (BYTE* from, BYTE* end)
 }
 
 inline
-BYTE* gc_heap::card_address (size_t card)
+uint8_t* gc_heap::card_address (size_t card)
 {
-    return  (BYTE*) (card_size * card);
+    return  (uint8_t*) (card_size * card);
 }
 
 inline
-size_t gc_heap::card_of ( BYTE* object)
+size_t gc_heap::card_of ( uint8_t* object)
 {
     return (size_t)(object) / card_size;
 }
@@ -6310,20 +6310,20 @@ size_t gc_heap::card_to_brick (size_t card)
 }
 
 inline
-BYTE* align_on_card (BYTE* add)
+uint8_t* align_on_card (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add + card_size - 1) & ~(card_size - 1 ));
+    return (uint8_t*)((size_t)(add + card_size - 1) & ~(card_size - 1 ));
 }
 inline
-BYTE* align_on_card_word (BYTE* add)
+uint8_t* align_on_card_word (uint8_t* add)
 {
-    return (BYTE*) ((size_t)(add + (card_size*card_word_width)-1) & ~(card_size*card_word_width - 1));
+    return (uint8_t*) ((size_t)(add + (card_size*card_word_width)-1) & ~(card_size*card_word_width - 1));
 }
 
 inline
-BYTE* align_lower_card (BYTE* add)
+uint8_t* align_lower_card (uint8_t* add)
 {
-    return (BYTE*)((size_t)add & ~(card_size-1));
+    return (uint8_t*)((size_t)add & ~(card_size-1));
 }
 
 inline
@@ -6356,24 +6356,24 @@ BOOL  gc_heap::card_set_p (size_t card)
 
 // Returns the number of DWORDs in the card table that cover the
 // range of addresses [from, end[.
-size_t count_card_of (BYTE* from, BYTE* end)
+size_t count_card_of (uint8_t* from, uint8_t* end)
 {
     return card_word (gcard_of (end - 1)) - card_word (gcard_of (from)) + 1;
 }
 
 // Returns the number of bytes to allocate for a card table
 // that covers the range of addresses [from, end[.
-size_t size_card_of (BYTE* from, BYTE* end)
+size_t size_card_of (uint8_t* from, uint8_t* end)
 {
-    return count_card_of (from, end) * sizeof(DWORD);
+    return count_card_of (from, end) * sizeof(uint32_t);
 }
 
 #ifdef CARD_BUNDLE
 
 //The card bundle keeps track of groups of card words
 #define card_bundle_word_width ((size_t)32)
-//how do we express the fact that 32 bits (card_word_width) is one DWORD?
-#define card_bundle_size ((size_t)(OS_PAGE_SIZE/(sizeof (DWORD)*card_bundle_word_width)))
+//how do we express the fact that 32 bits (card_word_width) is one uint32_t?
+#define card_bundle_size ((size_t)(OS_PAGE_SIZE/(sizeof (uint32_t)*card_bundle_word_width)))
 
 inline
 size_t card_bundle_word (size_t cardb)
@@ -6382,9 +6382,9 @@ size_t card_bundle_word (size_t cardb)
 }
 
 inline
-DWORD card_bundle_bit (size_t cardb)
+uint32_t card_bundle_bit (size_t cardb)
 {
-    return (DWORD)(cardb % card_bundle_word_width);
+    return (uint32_t)(cardb % card_bundle_word_width);
 }
 
 size_t align_cardw_on_bundle (size_t cardw)
@@ -6440,23 +6440,23 @@ BOOL gc_heap::card_bundle_set_p (size_t cardb)
     return ( card_bundle_table [ card_bundle_word (cardb) ] & (1 << card_bundle_bit (cardb)));
 }
 
-size_t size_card_bundle_of (BYTE* from, BYTE* end)
+size_t size_card_bundle_of (uint8_t* from, uint8_t* end)
 {
     //align from to lower
-    from = (BYTE*)((size_t)from & ~(card_size*card_word_width*card_bundle_size*card_bundle_word_width - 1));
+    from = (uint8_t*)((size_t)from & ~(card_size*card_word_width*card_bundle_size*card_bundle_word_width - 1));
     //align to to upper
-    end = (BYTE*)((size_t)(end + (card_size*card_word_width*card_bundle_size*card_bundle_word_width - 1)) &
+    end = (uint8_t*)((size_t)(end + (card_size*card_word_width*card_bundle_size*card_bundle_word_width - 1)) &
                   ~(card_size*card_word_width*card_bundle_size*card_bundle_word_width - 1));
 
     assert (((size_t)from & ((card_size*card_word_width*card_bundle_size*card_bundle_word_width)-1)) == 0);
     assert (((size_t)end  & ((card_size*card_word_width*card_bundle_size*card_bundle_word_width)-1)) == 0);
 
-    return ((end - from) / (card_size*card_word_width*card_bundle_size*card_bundle_word_width)) * sizeof (DWORD);
+    return ((end - from) / (card_size*card_word_width*card_bundle_size*card_bundle_word_width)) * sizeof (uint32_t);
 }
 
-DWORD* translate_card_bundle_table (DWORD* cb)
+uint32_t* translate_card_bundle_table (uint32_t* cb)
 {
-    return (DWORD*)((BYTE*)cb - ((((size_t)g_lowest_address) / (card_size*card_word_width*card_bundle_size*card_bundle_word_width)) * sizeof (DWORD)));
+    return (uint32_t*)((uint8_t*)cb - ((((size_t)g_lowest_address) / (card_size*card_word_width*card_bundle_size*card_bundle_word_width)) * sizeof (uint32_t)));
 }
 
 void gc_heap::enable_card_bundles ()
@@ -6483,58 +6483,58 @@ class card_table_info
 {
 public:
     unsigned    recount;
-    BYTE*       lowest_address;
-    BYTE*       highest_address;
+    uint8_t*       lowest_address;
+    uint8_t*       highest_address;
     short*      brick_table;
 
 #ifdef CARD_BUNDLE
-    DWORD*      card_bundle_table;
+    uint32_t*      card_bundle_table;
 #endif //CARD_BUNDLE
 
     // mark_array is always at the end of the data structure because we
     // want to be able to make one commit call for everything before it.
 #ifdef MARK_ARRAY
-    DWORD*      mark_array;
+    uint32_t*      mark_array;
 #endif //MARK_ARRAY
 
-    DWORD*      next_card_table;
+    uint32_t*      next_card_table;
 };
 
 //These are accessors on untranslated cardtable
 inline
-unsigned& card_table_refcount (DWORD* c_table)
+unsigned& card_table_refcount (uint32_t* c_table)
 {
     return *(unsigned*)((char*)c_table - sizeof (card_table_info));
 }
 
 inline
-BYTE*& card_table_lowest_address (DWORD* c_table)
+uint8_t*& card_table_lowest_address (uint32_t* c_table)
 {
-    return ((card_table_info*)((BYTE*)c_table - sizeof (card_table_info)))->lowest_address;
+    return ((card_table_info*)((uint8_t*)c_table - sizeof (card_table_info)))->lowest_address;
 }
 
-DWORD* translate_card_table (DWORD* ct)
+uint32_t* translate_card_table (uint32_t* ct)
 {
-    return (DWORD*)((BYTE*)ct - card_word (gcard_of (card_table_lowest_address (ct))) * sizeof(DWORD));
-}
-
-inline
-BYTE*& card_table_highest_address (DWORD* c_table)
-{
-    return ((card_table_info*)((BYTE*)c_table - sizeof (card_table_info)))->highest_address;
+    return (uint32_t*)((uint8_t*)ct - card_word (gcard_of (card_table_lowest_address (ct))) * sizeof(uint32_t));
 }
 
 inline
-short*& card_table_brick_table (DWORD* c_table)
+uint8_t*& card_table_highest_address (uint32_t* c_table)
 {
-    return ((card_table_info*)((BYTE*)c_table - sizeof (card_table_info)))->brick_table;
+    return ((card_table_info*)((uint8_t*)c_table - sizeof (card_table_info)))->highest_address;
+}
+
+inline
+short*& card_table_brick_table (uint32_t* c_table)
+{
+    return ((card_table_info*)((uint8_t*)c_table - sizeof (card_table_info)))->brick_table;
 }
 
 #ifdef CARD_BUNDLE
 inline
-DWORD*& card_table_card_bundle_table (DWORD* c_table)
+uint32_t*& card_table_card_bundle_table (uint32_t* c_table)
 {
-    return ((card_table_info*)((BYTE*)c_table - sizeof (card_table_info)))->card_bundle_table;
+    return ((card_table_info*)((uint8_t*)c_table - sizeof (card_table_info)))->card_bundle_table;
 }
 #endif //CARD_BUNDLE
 
@@ -6542,9 +6542,9 @@ DWORD*& card_table_card_bundle_table (DWORD* c_table)
 /* Support for mark_array */
 
 inline
-DWORD*& card_table_mark_array (DWORD* c_table)
+uint32_t*& card_table_mark_array (uint32_t* c_table)
 {
-    return ((card_table_info*)((BYTE*)c_table - sizeof (card_table_info)))->mark_array;
+    return ((card_table_info*)((uint8_t*)c_table - sizeof (card_table_info)))->mark_array;
 }
 
 #if defined (_TARGET_AMD64_)
@@ -6556,37 +6556,37 @@ DWORD*& card_table_mark_array (DWORD* c_table)
 #define mark_word_size (mark_word_width * mark_bit_pitch)
 
 inline
-BYTE* align_on_mark_bit (BYTE* add)
+uint8_t* align_on_mark_bit (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add + (mark_bit_pitch - 1)) & ~(mark_bit_pitch - 1));
+    return (uint8_t*)((size_t)(add + (mark_bit_pitch - 1)) & ~(mark_bit_pitch - 1));
 }
 
 inline
-BYTE* align_lower_mark_bit (BYTE* add)
+uint8_t* align_lower_mark_bit (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add) & ~(mark_bit_pitch - 1));
+    return (uint8_t*)((size_t)(add) & ~(mark_bit_pitch - 1));
 }
 
 inline
-BOOL is_aligned_on_mark_word (BYTE* add)
+BOOL is_aligned_on_mark_word (uint8_t* add)
 {
     return ((size_t)add == ((size_t)(add) & ~(mark_word_size - 1)));
 }
 
 inline
-BYTE* align_on_mark_word (BYTE* add)
+uint8_t* align_on_mark_word (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add + mark_word_size - 1) & ~(mark_word_size - 1));
+    return (uint8_t*)((size_t)(add + mark_word_size - 1) & ~(mark_word_size - 1));
 }
 
 inline
-BYTE* align_lower_mark_word (BYTE* add)
+uint8_t* align_lower_mark_word (uint8_t* add)
 {
-    return (BYTE*)((size_t)(add) & ~(mark_word_size - 1));
+    return (uint8_t*)((size_t)(add) & ~(mark_word_size - 1));
 }
 
 inline
-size_t mark_bit_of (BYTE* add)
+size_t mark_bit_of (uint8_t* add)
 {
     return ((size_t)add / mark_bit_pitch);
 }
@@ -6604,44 +6604,44 @@ size_t mark_bit_word (size_t mark_bit)
 }
 
 inline
-size_t mark_word_of (BYTE* add)
+size_t mark_word_of (uint8_t* add)
 {
     return ((size_t)add) / mark_word_size;
 }
 
-BYTE* mark_word_address (size_t wd)
+uint8_t* mark_word_address (size_t wd)
 {
-    return (BYTE*)(wd*mark_word_size);
+    return (uint8_t*)(wd*mark_word_size);
 }
 
-BYTE* mark_bit_address (size_t mark_bit)
+uint8_t* mark_bit_address (size_t mark_bit)
 {
-    return (BYTE*)(mark_bit*mark_bit_pitch);
+    return (uint8_t*)(mark_bit*mark_bit_pitch);
 }
 
 inline
-size_t mark_bit_bit_of (BYTE* add)
+size_t mark_bit_bit_of (uint8_t* add)
 {
     return  (((size_t)add / mark_bit_pitch) % mark_word_width);
 }
 
 inline
-unsigned int gc_heap::mark_array_marked(BYTE* add)
+unsigned int gc_heap::mark_array_marked(uint8_t* add)
 {
     return mark_array [mark_word_of (add)] & (1 << mark_bit_bit_of (add));
 }
 
 inline
-BOOL gc_heap::is_mark_bit_set (BYTE* add)
+BOOL gc_heap::is_mark_bit_set (uint8_t* add)
 {
     return (mark_array [mark_word_of (add)] & (1 << mark_bit_bit_of (add)));
 }
 
 inline
-void gc_heap::mark_array_set_marked (BYTE* add)
+void gc_heap::mark_array_set_marked (uint8_t* add)
 {
     size_t index = mark_word_of (add);
-    DWORD val = (1 << mark_bit_bit_of (add));
+    uint32_t val = (1 << mark_bit_bit_of (add));
 #ifdef MULTIPLE_HEAPS
     InterlockedOr ((LONG*)&(mark_array [index]), val);
 #else
@@ -6650,28 +6650,28 @@ void gc_heap::mark_array_set_marked (BYTE* add)
 }
 
 inline
-void gc_heap::mark_array_clear_marked (BYTE* add)
+void gc_heap::mark_array_clear_marked (uint8_t* add)
 {
     mark_array [mark_word_of (add)] &= ~(1 << mark_bit_bit_of (add));
 }
 
-size_t size_mark_array_of (BYTE* from, BYTE* end)
+size_t size_mark_array_of (uint8_t* from, uint8_t* end)
 {
     assert (((size_t)from & ((mark_word_size)-1)) == 0);
     assert (((size_t)end  & ((mark_word_size)-1)) == 0);
-    return sizeof (DWORD)*(((end - from) / mark_word_size));
+    return sizeof (uint32_t)*(((end - from) / mark_word_size));
 }
 
 //In order to eliminate the lowest_address in the mark array
 //computations (mark_word_of, etc) mark_array is offset
 // according to the lowest_address.
-DWORD* translate_mark_array (DWORD* ma)
+uint32_t* translate_mark_array (uint32_t* ma)
 {
-    return (DWORD*)((BYTE*)ma - size_mark_array_of (0, g_lowest_address));
+    return (uint32_t*)((uint8_t*)ma - size_mark_array_of (0, g_lowest_address));
 }
 
 // from and end must be page aligned addresses. 
-void gc_heap::clear_mark_array (BYTE* from, BYTE* end, BOOL check_only/*=TRUE*/)
+void gc_heap::clear_mark_array (uint8_t* from, uint8_t* end, BOOL check_only/*=TRUE*/)
 {
     if(!gc_can_use_concurrent)
         return;
@@ -6680,11 +6680,11 @@ void gc_heap::clear_mark_array (BYTE* from, BYTE* end, BOOL check_only/*=TRUE*/)
     assert (end == align_on_mark_word (end));
 
 #ifdef BACKGROUND_GC
-    BYTE* current_lowest_address = background_saved_lowest_address;
-    BYTE* current_highest_address = background_saved_highest_address;
+    uint8_t* current_lowest_address = background_saved_lowest_address;
+    uint8_t* current_highest_address = background_saved_highest_address;
 #else
-    BYTE* current_lowest_address = lowest_address;
-    BYTE* current_highest_address = highest_address;
+    uint8_t* current_lowest_address = lowest_address;
+    uint8_t* current_highest_address = highest_address;
 #endif //BACKGROUND_GC
 
     //there is a possibility of the addresses to be
@@ -6704,14 +6704,14 @@ void gc_heap::clear_mark_array (BYTE* from, BYTE* end, BOOL check_only/*=TRUE*/)
                      (check_only ? "check_only" : "clear")));
         if (!check_only)
         {
-            BYTE* op = from;
+            uint8_t* op = from;
             while (op < mark_word_address (beg_word))
             {
                 mark_array_clear_marked (op);
                 op += mark_bit_pitch;
             }
 
-            memset (&mark_array[beg_word], 0, (end_word - beg_word)*sizeof (DWORD));
+            memset (&mark_array[beg_word], 0, (end_word - beg_word)*sizeof (uint32_t));
         }
 #ifdef _DEBUG
         else
@@ -6726,7 +6726,7 @@ void gc_heap::clear_mark_array (BYTE* from, BYTE* end, BOOL check_only/*=TRUE*/)
                 assert (!(mark_array [markw]));
                 markw++;
             }
-            BYTE* p = mark_word_address (markw_end);
+            uint8_t* p = mark_word_address (markw_end);
             while (p < end)
             {
                 assert (!(mark_array_marked (p)));
@@ -6740,21 +6740,21 @@ void gc_heap::clear_mark_array (BYTE* from, BYTE* end, BOOL check_only/*=TRUE*/)
 
 //These work on untranslated card tables
 inline
-DWORD*& card_table_next (DWORD* c_table)
+uint32_t*& card_table_next (uint32_t* c_table)
 {
-    return ((card_table_info*)((BYTE*)c_table - sizeof (card_table_info)))->next_card_table;
+    return ((card_table_info*)((uint8_t*)c_table - sizeof (card_table_info)))->next_card_table;
 }
 
-void own_card_table (DWORD* c_table)
+void own_card_table (uint32_t* c_table)
 {
     card_table_refcount (c_table) += 1;
 }
 
-void destroy_card_table (DWORD* c_table);
+void destroy_card_table (uint32_t* c_table);
 
-void delete_next_card_table (DWORD* c_table)
+void delete_next_card_table (uint32_t* c_table)
 {
-    DWORD* n_table = card_table_next (c_table);
+    uint32_t* n_table = card_table_next (c_table);
     if (n_table)
     {
         if (card_table_next (n_table))
@@ -6769,7 +6769,7 @@ void delete_next_card_table (DWORD* c_table)
     }
 }
 
-void release_card_table (DWORD* c_table)
+void release_card_table (uint32_t* c_table)
 {
     assert (card_table_refcount (c_table) >0);
     card_table_refcount (c_table) -= 1;
@@ -6782,7 +6782,7 @@ void release_card_table (DWORD* c_table)
             // sever the link from the parent
             if (&g_card_table[card_word (gcard_of(g_lowest_address))] == c_table)
                 g_card_table = 0;
-            DWORD* p_table = &g_card_table[card_word (gcard_of(g_lowest_address))];
+            uint32_t* p_table = &g_card_table[card_word (gcard_of(g_lowest_address))];
             if (p_table)
             {
                 while (p_table && (card_table_next (p_table) != c_table))
@@ -6793,19 +6793,19 @@ void release_card_table (DWORD* c_table)
     }
 }
 
-void destroy_card_table (DWORD* c_table)
+void destroy_card_table (uint32_t* c_table)
 {
-//  delete (DWORD*)&card_table_refcount(c_table);
+//  delete (uint32_t*)&card_table_refcount(c_table);
     VirtualFree (&card_table_refcount(c_table), 0, MEM_RELEASE);
     dprintf (2, ("Table Virtual Free : %Ix", (size_t)&card_table_refcount(c_table)));
 }
 
-DWORD* gc_heap::make_card_table (BYTE* start, BYTE* end)
+uint32_t* gc_heap::make_card_table (uint8_t* start, uint8_t* end)
 {
     assert (g_lowest_address == start);
     assert (g_highest_address == end);
 
-    DWORD mem_flags = MEM_RESERVE;
+    uint32_t mem_flags = MEM_RESERVE;
 
     size_t bs = size_brick_of (start, end);
     size_t cs = size_card_of (start, end);
@@ -6835,49 +6835,49 @@ DWORD* gc_heap::make_card_table (BYTE* start, BYTE* end)
 
     // it is impossible for alloc_size to overflow due bounds on each of 
     // its components.
-    size_t alloc_size = sizeof (BYTE)*(bs + cs + cb + ms + st + sizeof (card_table_info));
+    size_t alloc_size = sizeof (uint8_t)*(bs + cs + cb + ms + st + sizeof (card_table_info));
     size_t alloc_size_aligned = Align (alloc_size, g_SystemInfo.dwAllocationGranularity-1);
 
-    DWORD* ct = (DWORD*)VirtualAlloc (0, alloc_size_aligned,
+    uint32_t* ct = (uint32_t*)VirtualAlloc (0, alloc_size_aligned,
                                       mem_flags, PAGE_READWRITE);
 
     if (!ct)
         return 0;
 
     dprintf (2, ("init - table alloc for %Id bytes: [%Ix, %Ix[",
-                 alloc_size, (size_t)ct, (size_t)((BYTE*)ct+alloc_size)));
+                 alloc_size, (size_t)ct, (size_t)((uint8_t*)ct+alloc_size)));
 
     // mark array will be committed separately (per segment).
     size_t commit_size = alloc_size - ms;
         
-    if (!VirtualAlloc ((BYTE*)ct, commit_size, MEM_COMMIT, PAGE_READWRITE))
+    if (!VirtualAlloc ((uint8_t*)ct, commit_size, MEM_COMMIT, PAGE_READWRITE))
     {
         dprintf (2, ("Table commit failed: %d", GetLastError()));
-        VirtualFree ((BYTE*)ct, 0, MEM_RELEASE);
+        VirtualFree ((uint8_t*)ct, 0, MEM_RELEASE);
         return 0;
     }
 
     // initialize the ref count
-    ct = (DWORD*)((BYTE*)ct+sizeof (card_table_info));
+    ct = (uint32_t*)((uint8_t*)ct+sizeof (card_table_info));
     card_table_refcount (ct) = 0;
     card_table_lowest_address (ct) = start;
     card_table_highest_address (ct) = end;
-    card_table_brick_table (ct) = (short*)((BYTE*)ct + cs);
+    card_table_brick_table (ct) = (short*)((uint8_t*)ct + cs);
     card_table_next (ct) = 0;
 
 #ifdef CARD_BUNDLE
-    card_table_card_bundle_table (ct) = (DWORD*)((BYTE*)card_table_brick_table (ct) + bs);
+    card_table_card_bundle_table (ct) = (uint32_t*)((uint8_t*)card_table_brick_table (ct) + bs);
 #endif //CARD_BUNDLE
 
 #ifdef GROWABLE_SEG_MAPPING_TABLE
-    seg_mapping_table = (seg_mapping*)((BYTE*)card_table_brick_table (ct) + bs + cb);
-    seg_mapping_table = (seg_mapping*)((BYTE*)seg_mapping_table - 
+    seg_mapping_table = (seg_mapping*)((uint8_t*)card_table_brick_table (ct) + bs + cb);
+    seg_mapping_table = (seg_mapping*)((uint8_t*)seg_mapping_table - 
                                         size_seg_mapping_table_of (0, (align_lower_segment (g_lowest_address))));
 #endif //GROWABLE_SEG_MAPPING_TABLE
 
 #ifdef MARK_ARRAY
     if (gc_can_use_concurrent)
-        card_table_mark_array (ct) = (DWORD*)((BYTE*)card_table_brick_table (ct) + bs + cb + st);
+        card_table_mark_array (ct) = (uint32_t*)((uint8_t*)card_table_brick_table (ct) + bs + cb + st);
     else
         card_table_mark_array (ct) = NULL;
 #endif //MARK_ARRAY
@@ -6904,21 +6904,21 @@ void gc_heap::set_fgm_result (failure_get_memory f, size_t s, BOOL loh_p)
 // and fail to decommit it would make the failure case very complicated to 
 // handle. This way we can waste some decommit if we call this multiple 
 // times before the next FGC but it's easier to handle the failure case.
-int gc_heap::grow_brick_card_tables (BYTE* start, 
-                                     BYTE* end, 
+int gc_heap::grow_brick_card_tables (uint8_t* start,
+                                     uint8_t* end,
                                      size_t size,
                                      heap_segment* new_seg, 
                                      gc_heap* hp, 
                                      BOOL loh_p)
 {
-    BYTE* la = g_lowest_address;
-    BYTE* ha = g_highest_address;
-    BYTE* saved_g_lowest_address = min (start, g_lowest_address);
-    BYTE* saved_g_highest_address = max (end, g_highest_address);
+    uint8_t* la = g_lowest_address;
+    uint8_t* ha = g_highest_address;
+    uint8_t* saved_g_lowest_address = min (start, g_lowest_address);
+    uint8_t* saved_g_highest_address = max (end, g_highest_address);
 #ifdef BACKGROUND_GC
     // This value is only for logging purpose - it's not necessarily exactly what we 
     // would commit for mark array but close enough for diagnostics purpose.
-    size_t logging_ma_commit_size = size_mark_array_of (0, (BYTE*)size);
+    size_t logging_ma_commit_size = size_mark_array_of (0, (uint8_t*)size);
 #endif //BACKGROUND_GC
 
     // See if the address is already covered
@@ -6929,7 +6929,7 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
             //is twice the previous one.
             MEMORYSTATUSEX st;
             GetProcessMemoryLoad (&st);
-            BYTE* top = (BYTE*)0 + Align ((size_t)(st.ullTotalVirtual));
+            uint8_t* top = (uint8_t*)0 + Align ((size_t)(st.ullTotalVirtual));
             // On non-Windows systems, we get only an approximate ullTotalVirtual
             // value that can possibly be slightly lower than the saved_g_highest_address.
             // In such case, we set the top to the saved_g_highest_address so that the
@@ -6940,8 +6940,8 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
             }
             size_t ps = ha-la;
 #ifdef _WIN64
-            if (ps > (ULONGLONG)200*1024*1024*1024)
-                ps += (ULONGLONG)100*1024*1024*1024;
+            if (ps > (uint64_t)200*1024*1024*1024)
+                ps += (uint64_t)100*1024*1024*1024;
             else
 #endif //_WIN64
                 ps *= 2;
@@ -6949,7 +6949,7 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
             if (saved_g_lowest_address < g_lowest_address)
             {
                 if (ps > (size_t)g_lowest_address)
-                    saved_g_lowest_address = (BYTE*)OS_PAGE_SIZE;
+                    saved_g_lowest_address = (uint8_t*)OS_PAGE_SIZE;
                 else
                 {
                     assert (((size_t)g_lowest_address - ps) >= OS_PAGE_SIZE);
@@ -6968,9 +6968,9 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
                                 (size_t)saved_g_lowest_address,
                                 (size_t)saved_g_highest_address));
 
-        DWORD mem_flags = MEM_RESERVE;
-        DWORD* saved_g_card_table = g_card_table;
-        DWORD* ct = 0;
+        uint32_t mem_flags = MEM_RESERVE;
+        uint32_t* saved_g_card_table = g_card_table;
+        uint32_t* ct = 0;
         short* bt = 0;
 
         size_t cs = size_card_of (saved_g_lowest_address, saved_g_highest_address);
@@ -7002,12 +7002,12 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
 
         // it is impossible for alloc_size to overflow due bounds on each of 
         // its components.
-        size_t alloc_size = sizeof (BYTE)*(bs + cs + cb + ms +st + sizeof (card_table_info));
+        size_t alloc_size = sizeof (uint8_t)*(bs + cs + cb + ms +st + sizeof (card_table_info));
         size_t alloc_size_aligned = Align (alloc_size, g_SystemInfo.dwAllocationGranularity-1);
         dprintf (GC_TABLE_LOG, ("brick table: %Id; card table: %Id; mark array: %Id, card bundle: %Id, seg table: %Id",
                                   bs, cs, ms, cb, st));
 
-        BYTE* mem = (BYTE*)VirtualAlloc (0, alloc_size_aligned, mem_flags, PAGE_READWRITE);
+        uint8_t* mem = (uint8_t*)VirtualAlloc (0, alloc_size_aligned, mem_flags, PAGE_READWRITE);
 
         if (!mem)
         {
@@ -7016,7 +7016,7 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
         }
 
         dprintf (GC_TABLE_LOG, ("Table alloc for %Id bytes: [%Ix, %Ix[",
-                                 alloc_size, (size_t)mem, (size_t)((BYTE*)mem+alloc_size)));
+                                 alloc_size, (size_t)mem, (size_t)((uint8_t*)mem+alloc_size)));
 
         {   
             // mark array will be committed separately (per segment).
@@ -7030,7 +7030,7 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
             }
         }
 
-        ct = (DWORD*)(mem + sizeof (card_table_info));
+        ct = (uint32_t*)(mem + sizeof (card_table_info));
         card_table_refcount (ct) = 0;
         card_table_lowest_address (ct) = saved_g_lowest_address;
         card_table_highest_address (ct) = saved_g_highest_address;
@@ -7038,28 +7038,28 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
 
         //clear the card table
 /*
-        memclr ((BYTE*)ct,
-                (((saved_g_highest_address - saved_g_lowest_address)*sizeof (DWORD) /
+        memclr ((uint8_t*)ct,
+                (((saved_g_highest_address - saved_g_lowest_address)*sizeof (uint32_t) /
                   (card_size * card_word_width))
-                 + sizeof (DWORD)));
+                 + sizeof (uint32_t)));
 */
 
-        bt = (short*)((BYTE*)ct + cs);
+        bt = (short*)((uint8_t*)ct + cs);
 
         // No initialization needed, will be done in copy_brick_card
 
         card_table_brick_table (ct) = bt;
 
 #ifdef CARD_BUNDLE
-        card_table_card_bundle_table (ct) = (DWORD*)((BYTE*)card_table_brick_table (ct) + bs);
+        card_table_card_bundle_table (ct) = (uint32_t*)((uint8_t*)card_table_brick_table (ct) + bs);
         //set all bundle to look at all of the cards
         memset(card_table_card_bundle_table (ct), 0xFF, cb);
 #endif //CARD_BUNDLE
 
 #ifdef GROWABLE_SEG_MAPPING_TABLE
         {
-            seg_mapping* new_seg_mapping_table = (seg_mapping*)((BYTE*)card_table_brick_table (ct) + bs + cb);
-            new_seg_mapping_table = (seg_mapping*)((BYTE*)new_seg_mapping_table - 
+            seg_mapping* new_seg_mapping_table = (seg_mapping*)((uint8_t*)card_table_brick_table (ct) + bs + cb);
+            new_seg_mapping_table = (seg_mapping*)((uint8_t*)new_seg_mapping_table -
                                               size_seg_mapping_table_of (0, (align_lower_segment (saved_g_lowest_address))));
             memcpy(&new_seg_mapping_table[seg_mapping_word_of(g_lowest_address)],
                 &seg_mapping_table[seg_mapping_word_of(g_lowest_address)],
@@ -7071,7 +7071,7 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
 
 #ifdef MARK_ARRAY
         if(gc_can_use_concurrent)
-            card_table_mark_array (ct) = (DWORD*)((BYTE*)card_table_brick_table (ct) + bs + cb + st);
+            card_table_mark_array (ct) = (uint32_t*)((uint8_t*)card_table_brick_table (ct) + bs + cb + st);
         else
             card_table_mark_array (ct) = NULL;
 #endif //MARK_ARRAY
@@ -7088,7 +7088,7 @@ int gc_heap::grow_brick_card_tables (BYTE* start,
                                     saved_g_lowest_address, saved_g_highest_address,
                                     card_table_mark_array (ct),
                                     translate_mark_array (card_table_mark_array (ct))));
-            DWORD* new_mark_array = (DWORD*)((BYTE*)card_table_mark_array (ct) - size_mark_array_of (0, saved_g_lowest_address));
+            uint32_t* new_mark_array = (uint32_t*)((uint8_t*)card_table_mark_array (ct) - size_mark_array_of (0, saved_g_lowest_address));
             if (!commit_new_mark_array_global (new_mark_array))
             {
                 dprintf (GC_TABLE_LOG, ("failed to commit portions in the mark array for existing segments"));
@@ -7138,7 +7138,7 @@ fail:
                 g_card_table = saved_g_card_table; 
             }
 
-            //delete (DWORD*)((BYTE*)ct - sizeof(card_table_info));
+            //delete (uint32_t*)((uint8_t*)ct - sizeof(card_table_info));
             if (!VirtualFree (mem, 0, MEM_RELEASE))
             {
                 dprintf (GC_TABLE_LOG, ("VirtualFree failed: %d", GetLastError()));
@@ -7168,10 +7168,10 @@ fail:
 }
 
 //copy all of the arrays managed by the card table for a page aligned range
-void gc_heap::copy_brick_card_range (BYTE* la, DWORD* old_card_table,
+void gc_heap::copy_brick_card_range (uint8_t* la, uint32_t* old_card_table,
                                      short* old_brick_table,
                                      heap_segment* seg,
-                                     BYTE* start, BYTE* end)
+                                     uint8_t* start, uint8_t* end)
 {
     ptrdiff_t brick_offset = brick_of (start) - brick_of (la);
 
@@ -7192,12 +7192,12 @@ void gc_heap::copy_brick_card_range (BYTE* la, DWORD* old_card_table,
         // This is a large heap, just clear the brick table
     }
 
-    DWORD* old_ct = &old_card_table[card_word (card_of (la))];
+    uint32_t* old_ct = &old_card_table[card_word (card_of (la))];
 #ifdef MARK_ARRAY
 #ifdef BACKGROUND_GC
     if (recursive_gc_sync::background_running_p())
     {
-        DWORD* old_mark_array = card_table_mark_array (old_ct);
+        uint32_t* old_mark_array = card_table_mark_array (old_ct);
 
         // We don't need to go through all the card tables here because 
         // we only need to copy from the GC version of the mark array - when we
@@ -7210,8 +7210,8 @@ void gc_heap::copy_brick_card_range (BYTE* la, DWORD* old_card_table,
             {
                 //copy the mark bits
                 // segments are always on page boundaries
-                BYTE* m_start = max (background_saved_lowest_address, start);
-                BYTE* m_end = min (background_saved_highest_address, end);
+                uint8_t* m_start = max (background_saved_lowest_address, start);
+                uint8_t* m_end = min (background_saved_highest_address, end);
                 memcpy (&mark_array[mark_word_of (m_start)],
                         &old_mark_array[mark_word_of (m_start) - mark_word_of (la)],
                         size_mark_array_of (m_start, m_end));
@@ -7230,7 +7230,7 @@ void gc_heap::copy_brick_card_range (BYTE* la, DWORD* old_card_table,
 #endif //MARK_ARRAY
 
     // n way merge with all of the card table ever used in between
-    DWORD* ct = card_table_next (&card_table[card_word (card_of(lowest_address))]);
+    uint32_t* ct = card_table_next (&card_table[card_word (card_of(lowest_address))]);
 
     assert (ct);
     while (card_table_next (old_ct) != ct)
@@ -7240,8 +7240,8 @@ void gc_heap::copy_brick_card_range (BYTE* la, DWORD* old_card_table,
             (card_table_lowest_address (ct) <= start))
         {
             // or the card_tables
-            DWORD* dest = &card_table [card_word (card_of (start))];
-            DWORD* src = &((translate_card_table (ct)) [card_word (card_of (start))]);
+            uint32_t* dest = &card_table [card_word (card_of (start))];
+            uint32_t* src = &((translate_card_table (ct)) [card_word (card_of (start))]);
             ptrdiff_t count = count_card_of (start, end);
             for (int x = 0; x < count; x++)
             {
@@ -7283,17 +7283,17 @@ void gc_heap::init_brick_card_range (heap_segment* seg)
 
 void gc_heap::copy_brick_card_table()
 {
-    BYTE* la = lowest_address;
-    BYTE* ha = highest_address;
+    uint8_t* la = lowest_address;
+    uint8_t* ha = highest_address;
     MAYBE_UNUSED_VAR(ha);
-    DWORD* old_card_table = card_table;
+    uint32_t* old_card_table = card_table;
     short* old_brick_table = brick_table;
 
     assert (la == card_table_lowest_address (&old_card_table[card_word (card_of (la))]));
     assert (ha == card_table_highest_address (&old_card_table[card_word (card_of (la))]));
 
     /* todo: Need a global lock for this */
-    DWORD* ct = &g_card_table[card_word (gcard_of (g_lowest_address))];
+    uint32_t* ct = &g_card_table[card_word (gcard_of (g_lowest_address))];
     own_card_table (ct);
     card_table = translate_card_table (ct);
     /* End of global lock */
@@ -7321,7 +7321,7 @@ void gc_heap::copy_brick_card_table()
     size_t st = 0;
 #endif //GROWABLE_SEG_MAPPING_TABLE
     assert (!gc_can_use_concurrent || 
-            (((BYTE*)card_table_card_bundle_table (ct) + size_card_bundle_of (g_lowest_address, g_highest_address) + st) == (BYTE*)card_table_mark_array (ct)));
+            (((uint8_t*)card_table_card_bundle_table (ct) + size_card_bundle_of (g_lowest_address, g_highest_address) + st) == (uint8_t*)card_table_mark_array (ct)));
 #endif //MARK_ARRAY && _DEBUG
     card_bundle_table = translate_card_bundle_table (card_table_card_bundle_table (ct));
     assert (&card_bundle_table [card_bundle_word (cardw_card_bundle (card_word (card_of (g_lowest_address))))] ==
@@ -7336,10 +7336,10 @@ void gc_heap::copy_brick_card_table()
     //check if we need to turn on card_bundles.
 #ifdef MULTIPLE_HEAPS
     // use INT64 arithmetic here because of possible overflow on 32p
-    UINT64 th = (UINT64)MH_TH_CARD_BUNDLE*gc_heap::n_heaps;
+    uint64_t th = (uint64_t)MH_TH_CARD_BUNDLE*gc_heap::n_heaps;
 #else
     // use INT64 arithmetic here because of possible overflow on 32p
-    UINT64 th = (UINT64)SH_TH_CARD_BUNDLE;
+    uint64_t th = (uint64_t)SH_TH_CARD_BUNDLE;
 #endif //MULTIPLE_HEAPS
     if (reserved_memory >= th)
     {
@@ -7365,7 +7365,7 @@ void gc_heap::copy_brick_card_table()
         else
         {
 
-            BYTE* end = align_on_page (heap_segment_allocated (seg));
+            uint8_t* end = align_on_page (heap_segment_allocated (seg));
             copy_brick_card_range (la, old_card_table,
                                    old_brick_table,
                                    seg,
@@ -7389,7 +7389,7 @@ void gc_heap::copy_brick_card_table()
         }
         else
         {
-            BYTE* end = align_on_page (heap_segment_allocated (seg));
+            uint8_t* end = align_on_page (heap_segment_allocated (seg));
             copy_brick_card_range (la, old_card_table,
                                    0,
                                    seg,
@@ -7421,7 +7421,7 @@ BOOL gc_heap::insert_ro_segment (heap_segment* seg)
     generation_start_segment (gen2) = seg;
 
     ptrdiff_t sdelta = 0;
-    seg_table->insert ((BYTE*)seg, sdelta);
+    seg_table->insert ((uint8_t*)seg, sdelta);
 
 #ifdef SEG_MAPPING_TABLE
     seg_mapping_table_add_ro_segment (seg);
@@ -7457,7 +7457,7 @@ void gc_heap::remove_ro_segment (heap_segment* seg)
 
     enter_spin_lock (&gc_heap::gc_lock);
 
-    seg_table->remove ((BYTE*)seg);
+    seg_table->remove ((uint8_t*)seg);
 
 #ifdef SEG_MAPPING_TABLE
     seg_mapping_table_remove_ro_segment (seg);
@@ -7498,17 +7498,17 @@ BOOL gc_heap::set_ro_segment_in_range (heap_segment* seg)
 
 #ifdef MARK_LIST
 
-BYTE** make_mark_list (size_t size)
+uint8_t** make_mark_list (size_t size)
 {
-    BYTE** mark_list = new (nothrow) BYTE* [size];
+    uint8_t** mark_list = new (nothrow) uint8_t* [size];
     return mark_list;
 }
 
-#define swap(a,b){BYTE* t; t = a; a = b; b = t;}
+#define swap(a,b){uint8_t* t; t = a; a = b; b = t;}
 
-void verify_qsort_array (BYTE* *low, BYTE* *high)
+void verify_qsort_array (uint8_t* *low, uint8_t* *high)
 {
-    BYTE **i = 0;
+    uint8_t **i = 0;
 
     for (i = low+1; i <= high; i++)
     {
@@ -7520,15 +7520,15 @@ void verify_qsort_array (BYTE* *low, BYTE* *high)
 }
 
 #ifndef USE_INTROSORT
-void qsort1( BYTE* *low, BYTE* *high, unsigned int depth)
+void qsort1( uint8_t* *low, uint8_t* *high, unsigned int depth)
 {
     if (((low + 16) >= high) || (depth > 100))
     {
         //insertion sort
-        BYTE **i, **j;
+        uint8_t **i, **j;
         for (i = low+1; i <= high; i++)
         {
-            BYTE* val = *i;
+            uint8_t* val = *i;
             for (j=i;j >low && val<*(j-1);j--)
             {
                 *j=*(j-1);
@@ -7538,7 +7538,7 @@ void qsort1( BYTE* *low, BYTE* *high, unsigned int depth)
     }
     else
     {
-        BYTE *pivot, **left, **right;
+        uint8_t *pivot, **left, **right;
 
         //sort low middle and high
         if (*(low+((high-low)/2)) < *low)
@@ -7567,15 +7567,15 @@ void qsort1( BYTE* *low, BYTE* *high, unsigned int depth)
     }
 }
 #endif //USE_INTROSORT
-void rqsort1( BYTE* *low, BYTE* *high)
+void rqsort1( uint8_t* *low, uint8_t* *high)
 {
     if ((low + 16) >= high)
     {
         //insertion sort
-        BYTE **i, **j;
+        uint8_t **i, **j;
         for (i = low+1; i <= high; i++)
         {
-            BYTE* val = *i;
+            uint8_t* val = *i;
             for (j=i;j >low && val>*(j-1);j--)
             {
                 *j=*(j-1);
@@ -7585,7 +7585,7 @@ void rqsort1( BYTE* *low, BYTE* *high)
     }
     else
     {
-        BYTE *pivot, **left, **right;
+        uint8_t *pivot, **left, **right;
 
         //sort low middle and high
         if (*(low+((high-low)/2)) > *low)
@@ -7623,15 +7623,15 @@ private:
     static const int max_depth = 100;
 
 
-inline static void swap_elements(BYTE** i,BYTE** j) 
+inline static void swap_elements(uint8_t** i,uint8_t** j)
     {
-        BYTE* t=*i; 
+        uint8_t* t=*i;
         *i=*j; 
         *j=t;
     }
 
 public:
-    static void sort (BYTE** begin, BYTE** end, int ignored)
+    static void sort (uint8_t** begin, uint8_t** end, int ignored)
     {
         ignored = 0;
         introsort_loop (begin, end, max_depth);
@@ -7640,7 +7640,7 @@ public:
 
 private: 
 
-    static void introsort_loop (BYTE** lo, BYTE** hi, int depth_limit)
+    static void introsort_loop (uint8_t** lo, uint8_t** hi, int depth_limit)
     {
         while (hi-lo >= size_threshold)
         {
@@ -7649,16 +7649,16 @@ private:
                 heapsort (lo, hi);
                 return;
             }
-            BYTE** p=median_partition (lo, hi);
+            uint8_t** p=median_partition (lo, hi);
             depth_limit=depth_limit-1;
             introsort_loop (p, hi, depth_limit);
             hi=p-1;
         }        
     }
 
-    static BYTE** median_partition (BYTE** low, BYTE** high)
+    static uint8_t** median_partition (uint8_t** low, uint8_t** high)
     {
-        BYTE *pivot, **left, **right;
+        uint8_t *pivot, **left, **right;
 
         //sort low middle and high
         if (*(low+((high-low)/2)) < *low)
@@ -7686,12 +7686,12 @@ private:
     }
 
 
-    static void insertionsort (BYTE** lo, BYTE** hi)
+    static void insertionsort (uint8_t** lo, uint8_t** hi)
     {
-        for (BYTE** i=lo+1; i <= hi; i++)
+        for (uint8_t** i=lo+1; i <= hi; i++)
         {
-            BYTE** j = i;
-            BYTE* t = *i;
+            uint8_t** j = i;
+            uint8_t* t = *i;
             while((j > lo) && (t <*(j-1)))
             {
                 *j = *(j-1);
@@ -7701,7 +7701,7 @@ private:
         }
     }
 
-    static void heapsort (BYTE** lo, BYTE** hi)
+    static void heapsort (uint8_t** lo, uint8_t** hi)
     { 
         size_t n = hi - lo + 1;
         for (size_t i=n / 2; i >= 1; i--)
@@ -7715,9 +7715,9 @@ private:
         }
     }
 
-    static void downheap (size_t i, size_t n, BYTE** lo)
+    static void downheap (size_t i, size_t n, uint8_t** lo)
     {
-        BYTE* d = *(lo + i - 1);
+        uint8_t* d = *(lo + i - 1);
         size_t child;
         while (i <= n / 2)
         {
@@ -7780,7 +7780,7 @@ void gc_heap::sort_mark_list()
         mark_list_piece_end[heap_num] = NULL;
     }
 
-    BYTE** x = mark_list;
+    uint8_t** x = mark_list;
 
 // predicate means: x is still within the mark list, and within the bounds of this heap
 #define predicate(x) (((x) < mark_list_index) && (*(x) < heap->ephemeral_high))
@@ -7825,7 +7825,7 @@ void gc_heap::sort_mark_list()
             do
             {
                 inc *= 2;
-                BYTE** temp_x = x;
+                uint8_t** temp_x = x;
                 x += inc;
                 if (temp_x > x)
                 {
@@ -7859,7 +7859,7 @@ void gc_heap::sort_mark_list()
 //    printf("second phase of sort_mark_list for heap %d took %u cycles\n", this->heap_number, GetCycleCount32() - start);
 }
 
-void gc_heap::append_to_mark_list(BYTE **start, BYTE **end)
+void gc_heap::append_to_mark_list(uint8_t **start, uint8_t **end)
 {
     size_t slots_needed = end - start;
     size_t slots_available = mark_list_end + 1 - mark_list_index;
@@ -7871,8 +7871,8 @@ void gc_heap::append_to_mark_list(BYTE **start, BYTE **end)
 
 void gc_heap::merge_mark_lists()
 {
-    BYTE** source[MAX_SUPPORTED_CPUS];
-    BYTE** source_end[MAX_SUPPORTED_CPUS];
+    uint8_t** source[MAX_SUPPORTED_CPUS];
+    uint8_t** source_end[MAX_SUPPORTED_CPUS];
     int source_heap[MAX_SUPPORTED_CPUS];
     int source_count = 0;
 
@@ -7907,7 +7907,7 @@ void gc_heap::merge_mark_lists()
         dprintf(3, (" source from heap %d = %Ix .. %Ix (%Id entries)",
             (size_t)(source_heap[j]), (size_t)(source[j][0]), (size_t)(source_end[j][-1]), (size_t)(source_end[j] - source[j])));
        // the sources should all be sorted
-        for (BYTE **x = source[j]; x < source_end[j] - 1; x++)
+        for (uint8_t **x = source[j]; x < source_end[j] - 1; x++)
         {
             if (x[0] > x[1])
             {
@@ -7941,8 +7941,8 @@ void gc_heap::merge_mark_lists()
         {
             // find the lowest and second lowest value in the sources we're merging from
             int lowest_source = 0;
-            BYTE *lowest = *source[0];
-            BYTE *second_lowest = *source[1];
+            uint8_t *lowest = *source[0];
+            uint8_t *second_lowest = *source[1];
             for (int i = 1; i < source_count; i++)
             {
                 if (lowest > *source[i])
@@ -7960,7 +7960,7 @@ void gc_heap::merge_mark_lists()
             // find the point in the lowest source where it either runs out or is not <= second_lowest anymore
 
             // let's first try to get lucky and see if the whole source is <= second_lowest -- this is actually quite common
-            BYTE **x;
+            uint8_t **x;
             if (source_end[lowest_source][-1] <= second_lowest)
                 x = source_end[lowest_source];
             else
@@ -7999,7 +7999,7 @@ void gc_heap::merge_mark_lists()
 
 #if defined(_DEBUG) || defined(TRACE_GC)
     // the final mark list must be sorted
-    for (BYTE **x = mark_list; x < mark_list_index - 1; x++)
+    for (uint8_t **x = mark_list; x < mark_list_index - 1; x++)
     {
         if (x[0] > x[1])
         {
@@ -8029,14 +8029,14 @@ void gc_heap::combine_mark_lists()
         dprintf (3, ("Using mark list"));
         //compact the gaps out of the mark list
         int gn = 0;
-        BYTE** current_gap = g_heaps [gn]->mark_list_index;
-        BYTE** current_gap_end = g_heaps[gn]->mark_list_end + 1;
-        BYTE** dst_last = current_gap-1;
+        uint8_t** current_gap = g_heaps [gn]->mark_list_index;
+        uint8_t** current_gap_end = g_heaps[gn]->mark_list_end + 1;
+        uint8_t** dst_last = current_gap-1;
 
         int srcn = n_heaps-1;
         gc_heap* srch = g_heaps [srcn];
-        BYTE** src = srch->mark_list_index - 1;
-        BYTE** src_beg = srch->mark_list;
+        uint8_t** src = srch->mark_list_index - 1;
+        uint8_t** src_beg = srch->mark_list;
 
         while (current_gap <= src)
         {
@@ -8068,7 +8068,7 @@ void gc_heap::combine_mark_lists()
         }
         dprintf (3, ("src: %Ix dst_last: %Ix", (size_t)src, (size_t)dst_last));
 
-        BYTE** end_of_list = max (src, dst_last);
+        uint8_t** end_of_list = max (src, dst_last);
 
         //sort the resulting compacted list
         assert (end_of_list < &g_mark_list [n_heaps*mark_list_size]);
@@ -8084,7 +8084,7 @@ void gc_heap::combine_mark_lists()
     }
     else
     {
-        BYTE** end_of_list = g_mark_list;
+        uint8_t** end_of_list = g_mark_list;
         //adjust the mark_list to the begining of the resulting mark list.
         //put the index beyond the end to turn off mark list processing
         for (int i = 0; i < n_heaps; i++)
@@ -8235,7 +8235,7 @@ class seg_free_spaces
 
     void dump_free_space (seg_free_space* item)
     {
-        BYTE* addr = 0;
+        uint8_t* addr = 0;
         size_t len = 0;
 
         if (item->is_plug)
@@ -8310,7 +8310,7 @@ public:
             MAX_NUM_BUCKETS * sizeof (free_space_bucket) +
             MAX_NUM_FREE_SPACES * sizeof (seg_free_space);
 
-        free_space_buckets = (free_space_bucket*) new (nothrow) BYTE[total_prealloc_size];
+        free_space_buckets = (free_space_bucket*) new (nothrow) uint8_t[total_prealloc_size];
 
         return (!!free_space_buckets);
     }
@@ -8462,7 +8462,7 @@ public:
 
 #endif //_DEBUG
 
-    BYTE* fit (BYTE* old_loc, 
+    uint8_t* fit (uint8_t* old_loc,
 #ifdef SHORT_PLUGS
                BOOL set_padding_on_saved_p,
                mark* pinned_plug_entry,
@@ -8497,7 +8497,7 @@ public:
 
         int plug_power2 = index_of_set_bit (round_up_power2 (plug_size_to_fit + Align(min_obj_size)));
         SSIZE_T i;
-        BYTE* new_address = 0;
+        uint8_t* new_address = 0;
 
         if (plug_power2 < base_power2)
         {
@@ -8541,7 +8541,7 @@ retry:
             if (bucket_free_space[i].is_plug)
             {
                 mark* m = (mark*)(bucket_free_space[i].start);
-                BYTE* plug_free_space_start = pinned_plug (m) - pinned_len (m);
+                uint8_t* plug_free_space_start = pinned_plug (m) - pinned_len (m);
                 
 #ifdef SHORT_PLUGS
                 if ((pad_in_front & USE_PADDING_FRONT) &&
@@ -8717,15 +8717,15 @@ inline size_t my_get_size (Object* ob)
 inline
 void gc_heap::seg_clear_mark_array_bits_soh (heap_segment* seg)
 {
-    BYTE* range_beg = 0;
-    BYTE* range_end = 0;
+    uint8_t* range_beg = 0;
+    uint8_t* range_end = 0;
     if (bgc_mark_array_range (seg, FALSE, &range_beg, &range_end))
     {
         clear_mark_array (range_beg, align_on_mark_word (range_end), FALSE);
     }
 }
 
-void gc_heap::clear_batch_mark_array_bits (BYTE* start, BYTE* end)
+void gc_heap::clear_batch_mark_array_bits (uint8_t* start, uint8_t* end)
 {
     if ((start < background_saved_highest_address) &&
         (end > background_saved_lowest_address))
@@ -8774,7 +8774,7 @@ void gc_heap::clear_batch_mark_array_bits (BYTE* start, BYTE* end)
     }
 }
 
-void gc_heap::bgc_clear_batch_mark_array_bits (BYTE* start, BYTE* end)
+void gc_heap::bgc_clear_batch_mark_array_bits (uint8_t* start, uint8_t* end)
 {
     if ((start < background_saved_highest_address) &&
         (end > background_saved_lowest_address))
@@ -8786,17 +8786,17 @@ void gc_heap::bgc_clear_batch_mark_array_bits (BYTE* start, BYTE* end)
     }
 }
 
-void gc_heap::clear_mark_array_by_objects (BYTE* from, BYTE* end, BOOL loh_p)
+void gc_heap::clear_mark_array_by_objects (uint8_t* from, uint8_t* end, BOOL loh_p)
 {
     dprintf (3, ("clearing mark array bits by objects for addr [%Ix,[%Ix", 
                   from, end));
     int align_const = get_alignment_constant (!loh_p);
 
-    BYTE* o = from;
+    uint8_t* o = from;
 
     while (o < end)
     {
-        BYTE*  next_o = o + Align (size (o), align_const);
+        uint8_t*  next_o = o + Align (size (o), align_const);
 
         if (background_object_marked (o, TRUE))
         {
@@ -8809,7 +8809,7 @@ void gc_heap::clear_mark_array_by_objects (BYTE* from, BYTE* end, BOOL loh_p)
 #endif //MARK_ARRAY && BACKGROUND_GC
 
 inline
-BOOL gc_heap::is_mark_set (BYTE* o)
+BOOL gc_heap::is_mark_set (uint8_t* o)
 {
     return marked (o);
 }
@@ -8821,7 +8821,7 @@ BOOL gc_heap::is_mark_set (BYTE* o)
 // return the generation number of an object.
 // It is assumed that the object is valid.
 //Note that this will return max_generation for a LOH object
-int gc_heap::object_gennum (BYTE* o)
+int gc_heap::object_gennum (uint8_t* o)
 {
     if (in_range_for_segment (o, ephemeral_heap_segment) &&
         (o >= generation_allocation_start (generation_of (max_generation-1))))
@@ -8840,13 +8840,13 @@ int gc_heap::object_gennum (BYTE* o)
     }
 }
 
-int gc_heap::object_gennum_plan (BYTE* o)
+int gc_heap::object_gennum_plan (uint8_t* o)
 {
     if (in_range_for_segment (o, ephemeral_heap_segment))
     {
         for (int i = 0; i <= max_generation-1; i++)
         {
-            BYTE* plan_start = generation_plan_allocation_start (generation_of (i));
+            uint8_t* plan_start = generation_plan_allocation_start (generation_of (i));
             if (plan_start && (o >= plan_start))
             {
                 return i;
@@ -8860,7 +8860,7 @@ int gc_heap::object_gennum_plan (BYTE* o)
 #pragma optimize("", on)        // Go back to command line default optimizations
 #endif //_MSC_VER && _TARGET_X86_
 
-heap_segment* gc_heap::make_heap_segment (BYTE* new_pages, size_t size, int h_number)
+heap_segment* gc_heap::make_heap_segment (uint8_t* new_pages, size_t size, int h_number)
 {
     void * res;
     size_t initial_commit = SEGMENT_INITIAL_COMMIT;
@@ -8875,7 +8875,7 @@ heap_segment* gc_heap::make_heap_segment (BYTE* new_pages, size_t size, int h_nu
     //overlay the heap_segment
     heap_segment* new_segment = (heap_segment*)new_pages;
 
-    BYTE* start = 0;
+    uint8_t* start = 0;
 #ifdef BACKGROUND_GC
     //leave the first page to contain only segment info
     //because otherwise we could need to revisit the first page frequently in 
@@ -8918,8 +8918,8 @@ void gc_heap::delete_heap_segment (heap_segment* seg, BOOL consider_hoarding)
 
     if (consider_hoarding)
     {
-        assert ((heap_segment_mem (seg) - (BYTE*)seg) <= 2*OS_PAGE_SIZE);
-        size_t ss = (size_t) (heap_segment_reserved (seg) - (BYTE*)seg);
+        assert ((heap_segment_mem (seg) - (uint8_t*)seg) <= 2*OS_PAGE_SIZE);
+        size_t ss = (size_t) (heap_segment_reserved (seg) - (uint8_t*)seg);
         //Don't keep the big ones.
         if (ss <= INITIAL_ALLOC)
         {
@@ -8950,7 +8950,7 @@ void gc_heap::delete_heap_segment (heap_segment* seg, BOOL consider_hoarding)
                      (size_t)(heap_segment_reserved (seg))));
 
 #ifdef BACKGROUND_GC
-        ::record_changed_seg ((BYTE*)seg, heap_segment_reserved (seg), 
+        ::record_changed_seg ((uint8_t*)seg, heap_segment_reserved (seg), 
                             settings.gc_index, current_bgc_state,
                             seg_deleted);
         decommit_mark_array_by_seg (seg);
@@ -8959,7 +8959,7 @@ void gc_heap::delete_heap_segment (heap_segment* seg, BOOL consider_hoarding)
 #ifdef SEG_MAPPING_TABLE
         seg_mapping_table_remove_segment (seg);
 #else //SEG_MAPPING_TABLE
-        seg_table->remove ((BYTE*)seg);
+        seg_table->remove ((uint8_t*)seg);
 #endif //SEG_MAPPING_TABLE
 
         release_segment (seg);
@@ -8981,7 +8981,7 @@ void gc_heap::reset_heap_segment_pages (heap_segment* seg)
 void gc_heap::decommit_heap_segment_pages (heap_segment* seg,
                                            size_t extra_space)
 {
-    BYTE*  page_start = align_on_page (heap_segment_allocated(seg));
+    uint8_t*  page_start = align_on_page (heap_segment_allocated(seg));
     size_t size = heap_segment_committed (seg) - page_start;
     extra_space = align_on_page (extra_space);
     if (size >= max ((extra_space + 2*OS_PAGE_SIZE), 100*OS_PAGE_SIZE))
@@ -9005,7 +9005,7 @@ void gc_heap::decommit_heap_segment_pages (heap_segment* seg,
 //decommit all pages except one or 2
 void gc_heap::decommit_heap_segment (heap_segment* seg)
 {
-    BYTE*  page_start = align_on_page (heap_segment_mem (seg));
+    uint8_t*  page_start = align_on_page (heap_segment_mem (seg));
 
     dprintf (3, ("Decommitting heap segment %Ix", (size_t)seg));
 
@@ -9094,7 +9094,7 @@ void gc_heap::rearrange_heap_segments(BOOL compacting)
         }
         else
         {
-            BYTE* end_segment = (compacting ? 
+            uint8_t* end_segment = (compacting ?
                                  heap_segment_plan_allocated (seg) : 
                                  heap_segment_allocated (seg));
             // check if the segment was reached by allocation
@@ -9136,7 +9136,7 @@ void gc_heap::rearrange_heap_segments(BOOL compacting)
 
 #ifdef WRITE_WATCH
 
-BYTE* g_addresses [array_size+2]; // to get around the bug in GetWriteWatch
+uint8_t* g_addresses [array_size+2]; // to get around the bug in GetWriteWatch
 
 #ifdef TIME_WRITE_WATCH
 static unsigned int tot_cycles = 0;
@@ -9148,27 +9148,27 @@ void gc_heap::update_card_table_bundle()
 {
     if (card_bundles_enabled())
     {
-        BYTE* base_address = (BYTE*)(&card_table[card_word (card_of (lowest_address))]);
-        BYTE* saved_base_address = base_address;
+        uint8_t* base_address = (uint8_t*)(&card_table[card_word (card_of (lowest_address))]);
+        uint8_t* saved_base_address = base_address;
         ULONG_PTR bcount = array_size;
         ULONG granularity = 0;
-        BYTE* high_address = (BYTE*)(&card_table[card_word (card_of (highest_address))]);
+        uint8_t* high_address = (uint8_t*)(&card_table[card_word (card_of (highest_address))]);
         size_t saved_region_size = align_on_page (high_address) - saved_base_address;
 
         do
         {
             size_t region_size = align_on_page (high_address) - base_address;
             dprintf (3,("Probing card table pages [%Ix, %Ix[", (size_t)base_address, (size_t)base_address+region_size));
-            UINT status = GetWriteWatch (0, base_address, region_size,
-                                         (PVOID*)g_addresses,
+            uint32_t status = GetWriteWatch (0, base_address, region_size,
+                                         (void**)g_addresses,
                                          &bcount, &granularity);
             assert (status == 0);
             assert (granularity == OS_PAGE_SIZE);
             dprintf (3,("Found %d pages written", bcount));
             for (unsigned  i = 0; i < bcount; i++)
             {
-                size_t bcardw = (DWORD*)(max(g_addresses[i],base_address)) - &card_table[0];
-                size_t ecardw = (DWORD*)(min(g_addresses[i]+granularity, high_address)) - &card_table[0];
+                size_t bcardw = (uint32_t*)(max(g_addresses[i],base_address)) - &card_table[0];
+                size_t ecardw = (uint32_t*)(min(g_addresses[i]+granularity, high_address)) - &card_table[0];
                 assert (bcardw >= card_word (card_of (g_lowest_address)));
 
                 card_bundles_set (cardw_card_bundle (bcardw),
@@ -9210,8 +9210,8 @@ void gc_heap::update_card_table_bundle()
             if (card_bundle_set_p (cardb)==0)
             {
                 //verify that the cards are indeed empty
-                DWORD* card_word = &card_table[max(card_bundle_cardw (cardb), lowest_card)];
-                DWORD* card_word_end = &card_table[min(card_bundle_cardw (cardb+1), highest_card)];
+                uint32_t* card_word = &card_table[max(card_bundle_cardw (cardb), lowest_card)];
+                uint32_t* card_word_end = &card_table[min(card_bundle_cardw (cardb+1), highest_card)];
                 while (card_word < card_word_end)
                 {
                     if ((*card_word) != 0)
@@ -9244,7 +9244,7 @@ void gc_heap::switch_one_quantum()
     disable_preemptive (current_thread, TRUE);
 }
 
-void gc_heap::reset_ww_by_chunk (BYTE* start_address, size_t total_reset_size)
+void gc_heap::reset_ww_by_chunk (uint8_t* start_address, size_t total_reset_size)
 {
     size_t reset_size = 0;
     size_t remaining_reset_size = 0;
@@ -9298,14 +9298,14 @@ void gc_heap::reset_write_watch (BOOL concurrent_p)
 
     while (seg)
     {
-        BYTE* base_address = align_lower_page (heap_segment_mem (seg));
+        uint8_t* base_address = align_lower_page (heap_segment_mem (seg));
 
         if (concurrent_p)
         {
             base_address = max (base_address, background_saved_lowest_address);
         }
 
-        BYTE* high_address = 0;
+        uint8_t* high_address = 0;
         if (concurrent_p)
         {
             high_address = ((seg == ephemeral_heap_segment) ? alloc_allocated : heap_segment_allocated (seg));
@@ -9350,8 +9350,8 @@ void gc_heap::reset_write_watch (BOOL concurrent_p)
 
     while (seg)
     {
-        BYTE* base_address = align_lower_page (heap_segment_mem (seg));
-        BYTE* high_address =  heap_segment_allocated (seg);
+        uint8_t* base_address = align_lower_page (heap_segment_mem (seg));
+        uint8_t* high_address =  heap_segment_allocated (seg);
 
         if (concurrent_p)
         {
@@ -9386,7 +9386,7 @@ void gc_heap::reset_write_watch (BOOL concurrent_p)
     }
 
 #ifdef DEBUG_WRITE_WATCH
-    debug_write_watch = (BYTE**)~0;
+    debug_write_watch = (uint8_t**)~0;
 #endif //DEBUG_WRITE_WATCH
 }
 
@@ -9429,7 +9429,7 @@ void gc_heap::fire_alloc_wait_event_end (alloc_wait_reason awr)
     fire_alloc_wait_event (awr, FALSE);
 }
 #endif //BACKGROUND_GC
-void gc_heap::make_generation (generation& gen, heap_segment* seg, BYTE* start, BYTE* pointer)
+void gc_heap::make_generation (generation& gen, heap_segment* seg, uint8_t* start, uint8_t* pointer)
 {
     gen.allocation_start = start;
     gen.allocation_context.alloc_ptr = pointer;
@@ -9539,7 +9539,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
         }
 
         gc_log_lock = ClrCreateMutex(NULL, FALSE, NULL);
-        gc_log_buffer = new (nothrow) BYTE [gc_log_buffer_size];
+        gc_log_buffer = new (nothrow) uint8_t [gc_log_buffer_size];
         if (!gc_log_buffer)
         {
             CloseHandle(gc_log);
@@ -9561,7 +9561,7 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
         if (gc_config_log == INVALID_HANDLE_VALUE)
             return E_FAIL;
 
-        gc_config_log_buffer = new (nothrow) BYTE [gc_config_log_buffer_size];
+        gc_config_log_buffer = new (nothrow) uint8_t [gc_config_log_buffer_size];
         if (!gc_config_log_buffer)
         {
             CloseHandle(gc_config_log);
@@ -9637,10 +9637,10 @@ HRESULT gc_heap::initialize_gc (size_t segment_size,
     //check if we need to turn on card_bundles.
 #ifdef MULTIPLE_HEAPS
     // use INT64 arithmetic here because of possible overflow on 32p
-    UINT64 th = (UINT64)MH_TH_CARD_BUNDLE*number_of_heaps;
+    uint64_t th = (uint64_t)MH_TH_CARD_BUNDLE*number_of_heaps;
 #else
     // use INT64 arithmetic here because of possible overflow on 32p
-    UINT64 th = (UINT64)SH_TH_CARD_BUNDLE;
+    uint64_t th = (uint64_t)SH_TH_CARD_BUNDLE;
 #endif //MULTIPLE_HEAPS
 
     if ((can_use_write_watch() && reserved_memory >= th))
@@ -9866,7 +9866,7 @@ gc_heap* gc_heap::make_gc_heap (
 
 #ifdef MARK_LIST
 #ifdef PARALLEL_MARK_LIST_SORT
-    res->mark_list_piece_start = new (nothrow) BYTE**[n_heaps];
+    res->mark_list_piece_start = new (nothrow) uint8_t**[n_heaps];
     if (!res->mark_list_piece_start)
         return 0;
 
@@ -9874,7 +9874,7 @@ gc_heap* gc_heap::make_gc_heap (
 #pragma warning(push)
 #pragma warning(disable:22011) // Suppress PREFast warning about integer underflow/overflow
 #endif // _PREFAST_
-    res->mark_list_piece_end = new (nothrow) BYTE**[n_heaps + 32]; // +32 is padding to reduce false sharing
+    res->mark_list_piece_end = new (nothrow) uint8_t**[n_heaps + 32]; // +32 is padding to reduce false sharing
 #ifdef _PREFAST_ 
 #pragma warning(pop)
 #endif // _PREFAST_
@@ -9905,13 +9905,13 @@ gc_heap* gc_heap::make_gc_heap (
 #endif //MULTIPLE_HEAPS
 }
 
-DWORD 
-gc_heap::wait_for_gc_done(INT32 timeOut)
+uint32_t
+gc_heap::wait_for_gc_done(int32_t timeOut)
 {
     Thread* current_thread = GetThread();
     BOOL cooperative_mode = enable_preemptive (current_thread);
 
-    DWORD dwWaitResult = NOERROR;
+    uint32_t dwWaitResult = NOERROR;
 
     gc_heap* wait_heap = NULL;
     while (gc_heap::gc_started)
@@ -9961,7 +9961,7 @@ gc_heap::reset_gc_done()
 void 
 gc_heap::enter_gc_done_event_lock()
 {
-    DWORD dwSwitchCount = 0;
+    uint32_t dwSwitchCount = 0;
 retry:
 
     if (FastInterlockExchange (&gc_done_event_lock, 0) >= 0)
@@ -10045,7 +10045,7 @@ gc_heap::init_gc_heap (int  h_number)
 #endif //SPINLOCK_HISTORY
 
     // initialize per heap members.
-    ephemeral_low = (BYTE*)1;
+    ephemeral_low = (uint8_t*)1;
 
     ephemeral_high = MAX_PTR;
 
@@ -10141,7 +10141,7 @@ gc_heap::init_gc_heap (int  h_number)
 #ifdef SEG_MAPPING_TABLE
     seg_mapping_table_add_segment (seg, __this);
 #else //SEG_MAPPING_TABLE
-    seg_table->insert ((BYTE*)seg, sdelta);
+    seg_table->insert ((uint8_t*)seg, sdelta);
 #endif //SEG_MAPPING_TABLE
 
 #ifdef MULTIPLE_HEAPS
@@ -10149,7 +10149,7 @@ gc_heap::init_gc_heap (int  h_number)
 #endif //MULTIPLE_HEAPS
 
     /* todo: Need a global lock for this */
-    DWORD* ct = &g_card_table [card_word (card_of (g_lowest_address))];
+    uint32_t* ct = &g_card_table [card_word (card_of (g_lowest_address))];
     own_card_table (ct);
     card_table = translate_card_table (ct);
     /* End of global lock */
@@ -10171,7 +10171,7 @@ gc_heap::init_gc_heap (int  h_number)
         mark_array = NULL;
 #endif //MARK_ARRAY
 
-    BYTE*  start = heap_segment_mem (seg);
+    uint8_t*  start = heap_segment_mem (seg);
 
     for (int i = 0; i < 1 + max_generation; i++)
     {
@@ -10206,7 +10206,7 @@ gc_heap::init_gc_heap (int  h_number)
 #ifdef SEG_MAPPING_TABLE
     seg_mapping_table_add_segment (lseg, __this);
 #else //SEG_MAPPING_TABLE
-    seg_table->insert ((BYTE*)lseg, sdelta);
+    seg_table->insert ((uint8_t*)lseg, sdelta);
 #endif //SEG_MAPPING_TABLE
 
     generation_table [max_generation].free_list_allocator = allocator(NUM_GEN2_ALIST, BASE_GEN2_ALIST, gen2_alloc_list);
@@ -10242,8 +10242,8 @@ gc_heap::init_gc_heap (int  h_number)
 #ifndef INTERIOR_POINTERS
         //set the brick_table for large objects
         //but default value is clearded
-        //clear_brick_table ((BYTE*)heap_segment_mem (lseg),
-        //                   (BYTE*)heap_segment_reserved (lseg));
+        //clear_brick_table ((uint8_t*)heap_segment_mem (lseg),
+        //                   (uint8_t*)heap_segment_reserved (lseg));
 
 #else //INTERIOR_POINTERS
 
@@ -10278,7 +10278,7 @@ gc_heap::init_gc_heap (int  h_number)
 #ifdef BACKGROUND_GC
     freeable_small_heap_segment = 0;
     gchist_index_per_heap = 0;
-    BYTE** b_arr = new (nothrow) (BYTE* [MARK_STACK_INITIAL_LENGTH]);
+    uint8_t** b_arr = new (nothrow) (uint8_t* [MARK_STACK_INITIAL_LENGTH]);
     if (!b_arr)
         return 0;
 
@@ -10495,8 +10495,8 @@ void gc_heap::shutdown_gc()
 }
 
 inline
-BOOL gc_heap::size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, BYTE* alloc_pointer, BYTE* alloc_limit,
-                          BYTE* old_loc, int use_padding)
+BOOL gc_heap::size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, uint8_t* alloc_pointer, uint8_t* alloc_limit,
+                          uint8_t* old_loc, int use_padding)
 {
     BOOL already_padded = FALSE;
 #ifdef SHORT_PLUGS
@@ -10540,7 +10540,7 @@ BOOL gc_heap::size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, BYTE* alloc_poi
 }
 
 inline
-BOOL gc_heap::a_size_fit_p (size_t size, BYTE* alloc_pointer, BYTE* alloc_limit,
+BOOL gc_heap::a_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit,
                             int align_const)
 {
     // We could have run into cases where this is true when alloc_allocated is the 
@@ -10554,7 +10554,7 @@ BOOL gc_heap::a_size_fit_p (size_t size, BYTE* alloc_pointer, BYTE* alloc_limit,
 }
 
 // Grow by committing more pages
-BOOL gc_heap::grow_heap_segment (heap_segment* seg, BYTE* high_address)
+BOOL gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* high_address)
 {
     assert (high_address <= heap_segment_reserved (seg));
 
@@ -10602,7 +10602,7 @@ BOOL gc_heap::grow_heap_segment (heap_segment* seg, BYTE* high_address)
 }
 
 inline
-int gc_heap::grow_heap_segment (heap_segment* seg, BYTE* allocated, BYTE* old_loc, size_t size, BOOL pad_front_p  REQD_ALIGN_AND_OFFSET_DCL)
+int gc_heap::grow_heap_segment (heap_segment* seg, uint8_t* allocated, uint8_t* old_loc, size_t size, BOOL pad_front_p  REQD_ALIGN_AND_OFFSET_DCL)
 {
 #ifdef SHORT_PLUGS
     if ((old_loc != 0) && pad_front_p)
@@ -10622,7 +10622,7 @@ int gc_heap::grow_heap_segment (heap_segment* seg, BYTE* allocated, BYTE* old_lo
 }
 
 //used only in older generation allocation (i.e during gc).
-void gc_heap::adjust_limit (BYTE* start, size_t limit_size, generation* gen,
+void gc_heap::adjust_limit (uint8_t* start, size_t limit_size, generation* gen,
                             int gennum)
 {
     dprintf (3, ("gc Expanding segment allocation"));
@@ -10637,7 +10637,7 @@ void gc_heap::adjust_limit (BYTE* start, size_t limit_size, generation* gen,
         }
         else
         {
-            BYTE*  hole = generation_allocation_pointer (gen);
+            uint8_t*  hole = generation_allocation_pointer (gen);
             size_t  size = (generation_allocation_limit (gen) - generation_allocation_pointer (gen));
 
             if (size != 0)
@@ -10688,7 +10688,7 @@ void gc_heap::adjust_limit (BYTE* start, size_t limit_size, generation* gen,
     generation_allocation_limit (gen) = (start + limit_size);
 }
 
-void verify_mem_cleared (BYTE* start, size_t size)
+void verify_mem_cleared (uint8_t* start, size_t size)
 {
     if (!Aligned (size))
     {
@@ -10706,7 +10706,7 @@ void verify_mem_cleared (BYTE* start, size_t size)
 }
 
 #if defined (VERIFY_HEAP) && defined (BACKGROUND_GC)
-void gc_heap::set_batch_mark_array_bits (BYTE* start, BYTE* end)
+void gc_heap::set_batch_mark_array_bits (uint8_t* start, uint8_t* end)
 {
     size_t start_mark_bit = mark_bit_of (start);
     size_t end_mark_bit = mark_bit_of (end);
@@ -10749,7 +10749,7 @@ void gc_heap::set_batch_mark_array_bits (BYTE* start, BYTE* end)
 }
 
 // makes sure that the mark array bits between start and end are 0.
-void gc_heap::check_batch_mark_array_bits (BYTE* start, BYTE* end)
+void gc_heap::check_batch_mark_array_bits (uint8_t* start, uint8_t* end)
 {
     size_t start_mark_bit = mark_bit_of (start);
     size_t end_mark_bit = mark_bit_of (end);
@@ -10843,7 +10843,7 @@ size_t& allocator::alloc_list_damage_count_of (unsigned int bn)
         return buckets [bn-1].alloc_list_damage_count();
 }
 
-void allocator::unlink_item (unsigned int bn, BYTE* item, BYTE* prev_item, BOOL use_undo_p)
+void allocator::unlink_item (unsigned int bn, uint8_t* item, uint8_t* prev_item, BOOL use_undo_p)
 {
     //unlink the free_item
     alloc_list* al = &alloc_list_of (bn);
@@ -10859,7 +10859,7 @@ void allocator::unlink_item (unsigned int bn, BYTE* item, BYTE* prev_item, BOOL 
     }
     else
     {
-        al->alloc_list_head() = (BYTE*)free_list_slot(item);
+        al->alloc_list_head() = (uint8_t*)free_list_slot(item);
     }
     if (al->alloc_list_tail() == item)
     {
@@ -10877,7 +10877,7 @@ void allocator::clear()
 }
 
 //always thread to the end.
-void allocator::thread_free_item (BYTE* item, BYTE*& head, BYTE*& tail)
+void allocator::thread_free_item (uint8_t* item, uint8_t*& head, uint8_t*& tail)
 {
     free_list_slot (item) = 0;
     free_list_undo (item) = UNDO_EMPTY;
@@ -10903,7 +10903,7 @@ void allocator::thread_free_item (BYTE* item, BYTE*& head, BYTE*& tail)
     tail = item;
 }
 
-void allocator::thread_item (BYTE* item, size_t size)
+void allocator::thread_item (uint8_t* item, size_t size)
 {
     size_t sz = frst_bucket_size;
     unsigned int a_l_number = 0; 
@@ -10922,7 +10922,7 @@ void allocator::thread_item (BYTE* item, size_t size)
                       al->alloc_list_tail());
 }
 
-void allocator::thread_item_front (BYTE* item, size_t size)
+void allocator::thread_item_front (uint8_t* item, size_t size)
 {
     //find right free list
     size_t sz = frst_bucket_size;
@@ -10956,7 +10956,7 @@ void allocator::copy_to_alloc_list (alloc_list* toalist)
     {
         toalist [i] = alloc_list_of (i);
 #ifdef FL_VERIFICATION
-        BYTE* free_item = alloc_list_head_of (i);
+        uint8_t* free_item = alloc_list_head_of (i);
         size_t count = 0;
         while (free_item)
         {
@@ -10983,7 +10983,7 @@ void allocator::copy_from_alloc_list (alloc_list* fromalist)
             //repair the the list
             //new items may have been added during the plan phase 
             //items may have been unlinked. 
-            BYTE* free_item = alloc_list_head_of (i);
+            uint8_t* free_item = alloc_list_head_of (i);
             while (free_item && count)
             {
                 assert (((CObjectHeader*)free_item)->IsFree());
@@ -11010,7 +11010,7 @@ void allocator::copy_from_alloc_list (alloc_list* fromalist)
 #endif //FL_VERIFICATION
         }
 #ifdef DEBUG
-        BYTE* tail_item = alloc_list_tail_of (i);
+        uint8_t* tail_item = alloc_list_tail_of (i);
         assert ((tail_item == 0) || (free_list_slot (tail_item) == 0));
 #endif
     }
@@ -11024,7 +11024,7 @@ void allocator::commit_alloc_list_changes()
         for (unsigned int i = 0; i < num_buckets; i++)
         {
             //remove the undo info from list. 
-            BYTE* free_item = alloc_list_head_of (i);
+            uint8_t* free_item = alloc_list_head_of (i);
             size_t count = alloc_list_damage_count_of (i);
             while (free_item && count)
             {
@@ -11044,7 +11044,7 @@ void allocator::commit_alloc_list_changes()
     }
 }
 
-void gc_heap::adjust_limit_clr (BYTE* start, size_t limit_size,
+void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size,
                                 alloc_context* acontext, heap_segment* seg,
                                 int align_const, int gen_number)
 {
@@ -11060,7 +11060,7 @@ void gc_heap::adjust_limit_clr (BYTE* start, size_t limit_size,
     if ((acontext->alloc_limit != start) &&
         (acontext->alloc_limit + Align (min_obj_size, align_const))!= start)
     {
-        BYTE*  hole = acontext->alloc_ptr;
+        uint8_t*  hole = acontext->alloc_ptr;
         if (hole != 0)
         {
             size_t  size = (acontext->alloc_limit - acontext->alloc_ptr);
@@ -11084,7 +11084,7 @@ void gc_heap::adjust_limit_clr (BYTE* start, size_t limit_size,
     }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
 
-    BYTE* saved_used = 0;
+    uint8_t* saved_used = 0;
 
     if (seg)
     {
@@ -11108,7 +11108,7 @@ void gc_heap::adjust_limit_clr (BYTE* start, size_t limit_size,
 #ifdef BACKGROUND_GC
     else if (seg)
     {
-        BYTE* old_allocated = heap_segment_allocated (seg) - plug_skew - limit_size;
+        uint8_t* old_allocated = heap_segment_allocated (seg) - plug_skew - limit_size;
 #ifdef FEATURE_LOH_COMPACTION
         old_allocated -= Align (loh_padding_obj_size, align_const);
 #endif //FEATURE_LOH_COMPACTION
@@ -11127,7 +11127,7 @@ void gc_heap::adjust_limit_clr (BYTE* start, size_t limit_size,
     }
     else
     {
-        BYTE* used = heap_segment_used (seg);
+        uint8_t* used = heap_segment_used (seg);
         heap_segment_used (seg) = start + limit_size - plug_skew;
 
         dprintf (SPINLOCK_LOG, ("[%d]Lmsl to clear memory", heap_number));
@@ -11195,7 +11195,7 @@ size_t gc_heap::limit_from_size (size_t size, size_t room, int gen_number,
 }
 
 void gc_heap::handle_oom (int heap_num, oom_reason reason, size_t alloc_size, 
-                          BYTE* allocated, BYTE* reserved)
+                          uint8_t* allocated, uint8_t* reserved)
 {
     if (reason == oom_budget)
     {
@@ -11263,7 +11263,7 @@ void gc_heap::check_for_full_gc (int gen_num, size_t size)
 
     dynamic_data* dd_full = dynamic_data_of (gen_num);
     SSIZE_T new_alloc_remain = 0;
-    DWORD pct = ((gen_num == (max_generation + 1)) ? fgn_loh_percent : fgn_maxgen_percent);
+    uint32_t pct = ((gen_num == (max_generation + 1)) ? fgn_loh_percent : fgn_maxgen_percent);
 
     for (int gen_index = 0; gen_index <= (max_generation + 1); gen_index++)
     {
@@ -11428,7 +11428,7 @@ wait_full_gc_status gc_heap::full_gc_wait (CLREvent *event, int time_out_ms)
         return wait_full_gc_na;
     }
 
-    DWORD wait_result = user_thread_wait(event, FALSE, time_out_ms);
+    uint32_t wait_result = user_thread_wait(event, FALSE, time_out_ms);
 
     if ((wait_result == WAIT_OBJECT_0) || (wait_result == WAIT_TIMEOUT))
     {
@@ -11474,7 +11474,7 @@ BOOL gc_heap::short_on_end_of_seg (int gen_number,
                                    heap_segment* seg,
                                    int align_const)
 {
-    BYTE* allocated = heap_segment_allocated(seg);
+    uint8_t* allocated = heap_segment_allocated(seg);
 
     return (!a_size_fit_p (end_space_after_gc(),
                           allocated,
@@ -11500,8 +11500,8 @@ BOOL gc_heap::a_fit_free_list_p (int gen_number,
     {
         if ((size < sz_list) || (a_l_idx == (gen_allocator->number_of_buckets()-1)))
         {
-            BYTE* free_list = gen_allocator->alloc_list_head_of (a_l_idx);
-            BYTE* prev_free_item = 0; 
+            uint8_t* free_list = gen_allocator->alloc_list_head_of (a_l_idx);
+            uint8_t* prev_free_item = 0;
 
             while (free_list != 0)
             {
@@ -11518,7 +11518,7 @@ BOOL gc_heap::a_fit_free_list_p (int gen_number,
                     // in adjust_limit will set the limit lower
                     size_t limit = limit_from_size (size, free_list_size, gen_number, align_const);
 
-                    BYTE*  remain = (free_list + limit);
+                    uint8_t*  remain = (free_list + limit);
                     size_t remain_size = (free_list_size - limit);
                     if (remain_size >= Align(min_free_list, align_const))
                     {
@@ -11562,7 +11562,7 @@ end:
 
 
 #ifdef BACKGROUND_GC
-void gc_heap::bgc_loh_alloc_clr (BYTE* alloc_start, 
+void gc_heap::bgc_loh_alloc_clr (uint8_t* alloc_start,
                                  size_t size, 
                                  alloc_context* acontext,
                                  int align_const, 
@@ -11590,8 +11590,8 @@ void gc_heap::bgc_loh_alloc_clr (BYTE* alloc_start,
     size_t saved_size_to_clear = size_to_clear;
     if (check_used_p)
     {
-        BYTE* end = alloc_start + size - plug_skew;
-        BYTE* used = heap_segment_used (seg);
+        uint8_t* end = alloc_start + size - plug_skew;
+        uint8_t* used = heap_segment_used (seg);
         if (used < end)
         {
             if ((alloc_start + size_to_skip) < used)
@@ -11666,8 +11666,8 @@ BOOL gc_heap::a_fit_free_list_large_p (size_t size,
     {
         if ((size < sz_list) || (a_l_idx == (loh_allocator->number_of_buckets()-1)))
         {
-            BYTE* free_list = loh_allocator->alloc_list_head_of (a_l_idx);
-            BYTE* prev_free_item = 0; 
+            uint8_t* free_list = loh_allocator->alloc_list_head_of (a_l_idx);
+            uint8_t* prev_free_item = 0;
             while (free_list != 0)
             {
                 dprintf (3, ("considering free list %Ix", (size_t)free_list));
@@ -11699,7 +11699,7 @@ BOOL gc_heap::a_fit_free_list_large_p (size_t size,
                     free_list_size -= loh_pad;
 #endif //FEATURE_LOH_COMPACTION
 
-                    BYTE*  remain = (free_list + limit);
+                    uint8_t*  remain = (free_list + limit);
                     size_t remain_size = (free_list_size - limit);
                     if (remain_size != 0)
                     {
@@ -11760,7 +11760,7 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
     int cookie = -1;
 #endif //BACKGROUND_GC
 
-    BYTE*& allocated = ((gen_number == 0) ? 
+    uint8_t*& allocated = ((gen_number == 0) ?
                         alloc_allocated : 
                         heap_segment_allocated(seg));
 
@@ -11773,7 +11773,7 @@ BOOL gc_heap::a_fit_segment_end_p (int gen_number,
     }
 #endif //FEATURE_LOH_COMPACTION
 
-    BYTE* end = heap_segment_committed (seg) - pad;
+    uint8_t* end = heap_segment_committed (seg) - pad;
 
     if (a_size_fit_p (size, allocated, end, align_const))
     {
@@ -11811,7 +11811,7 @@ found_fit:
     }
 #endif //BACKGROUND_GC
 
-    BYTE* old_alloc;
+    uint8_t* old_alloc;
     old_alloc = allocated;
 #ifdef FEATURE_LOH_COMPACTION
     if (gen_number == (max_generation + 1))
@@ -12289,7 +12289,7 @@ BOOL gc_heap::bgc_loh_should_allocate()
     }
     else
     {
-        bgc_alloc_spin_loh = (DWORD)(((float)bgc_loh_size_increased / (float)bgc_begin_loh_size) * 10);
+        bgc_alloc_spin_loh = (uint32_t)(((float)bgc_loh_size_increased / (float)bgc_begin_loh_size) * 10);
         return TRUE;
     }
 }
@@ -12339,19 +12339,19 @@ BOOL gc_heap::retry_full_compact_gc (size_t size)
 {
     size_t seg_size = get_large_seg_size (size);
 
-    if (loh_alloc_since_cg >= (2 * (UINT64)seg_size))
+    if (loh_alloc_since_cg >= (2 * (uint64_t)seg_size))
     {
         return TRUE;
     }
 
 #ifdef MULTIPLE_HEAPS
-    UINT64 total_alloc_size = 0;
+    uint64_t total_alloc_size = 0;
     for (int i = 0; i < n_heaps; i++)
     {
         total_alloc_size += g_heaps[i]->loh_alloc_since_cg;
     }
 
-    if (total_alloc_size >= (2 * (UINT64)seg_size))
+    if (total_alloc_size >= (2 * (uint64_t)seg_size))
     {
         return TRUE;
     }
@@ -12481,7 +12481,7 @@ exit:
 }
 
 #ifdef RECORD_LOH_STATE
-void gc_heap::add_saved_loh_state (allocation_state loh_state_to_save, DWORD thread_id)
+void gc_heap::add_saved_loh_state (allocation_state loh_state_to_save, uint32_t thread_id)
 {
     // When the state is can_allocate we already have released the more
     // space lock. So we are not logging states here since this code
@@ -12546,7 +12546,7 @@ BOOL gc_heap::allocate_large (int gen_number,
     // That's why there are local variable for each state
     allocation_state loh_alloc_state = a_state_start;
 #ifdef RECORD_LOH_STATE
-    DWORD current_thread_id = GetCurrentThreadId();
+    uint32_t current_thread_id = GetCurrentThreadId();
 #endif //RECORD_LOH_STATE
 
     // If we can get a new seg it means allocation will succeed.
@@ -13024,14 +13024,14 @@ try_again:
                     if (CPUGroupInfo::CanEnableGCCPUGroups())
                     {   //only set ideal processor when max_hp and org_hp are in the same cpu
                         //group. DO NOT MOVE THREADS ACROSS CPU GROUPS
-                        BYTE org_gn = heap_select::find_cpu_group_from_heap_no(org_hp->heap_number);
-                        BYTE max_gn = heap_select::find_cpu_group_from_heap_no(max_hp->heap_number);
+                        uint8_t org_gn = heap_select::find_cpu_group_from_heap_no(org_hp->heap_number);
+                        uint8_t max_gn = heap_select::find_cpu_group_from_heap_no(max_hp->heap_number);
                         if (org_gn == max_gn) //only set within CPU group, so SetThreadIdealProcessor is enough
                         {   
-                            BYTE group_proc_no = heap_select::find_group_proc_from_heap_no(max_hp->heap_number);
+                            uint8_t group_proc_no = heap_select::find_group_proc_from_heap_no(max_hp->heap_number);
 
 #if !defined(FEATURE_CORESYSTEM)
-                            SetThreadIdealProcessor(GetCurrentThread(), (DWORD)group_proc_no);
+                            SetThreadIdealProcessor(GetCurrentThread(), (uint32_t)group_proc_no);
 #else
                             PROCESSOR_NUMBER proc;
                             proc.Group = org_gn;
@@ -13048,10 +13048,10 @@ try_again:
                     }
                     else 
                     {
-                        BYTE proc_no = heap_select::find_proc_no_from_heap_no(max_hp->heap_number);
+                        uint8_t proc_no = heap_select::find_proc_no_from_heap_no(max_hp->heap_number);
 
 #if !defined(FEATURE_CORESYSTEM)
-                        SetThreadIdealProcessor(GetCurrentThread(), (DWORD)proc_no);
+                        SetThreadIdealProcessor(GetCurrentThread(), (uint32_t)proc_no);
 #else
                         PROCESSOR_NUMBER proc;
                         if(GetThreadIdealProcessorEx(GetCurrentThread(), &proc))
@@ -13187,7 +13187,7 @@ CObjectHeader* gc_heap::allocate (size_t jsize, alloc_context* acontext)
     assert (size >= Align (min_obj_size));
     {
     retry:
-        BYTE*  result = acontext->alloc_ptr;
+        uint8_t*  result = acontext->alloc_ptr;
         acontext->alloc_ptr+=size;
         if (acontext->alloc_ptr <= acontext->alloc_limit)
         {
@@ -13221,7 +13221,7 @@ CObjectHeader* gc_heap::try_fast_alloc (size_t jsize)
     size_t size = Align (jsize);
     assert (size >= Align (min_obj_size));
     generation* gen = generation_of (0);
-    BYTE*  result = generation_allocation_pointer (gen);
+    uint8_t*  result = generation_allocation_pointer (gen);
     generation_allocation_pointer (gen) += size;
     if (generation_allocation_pointer (gen) <=
         generation_allocation_limit (gen))
@@ -13373,9 +13373,9 @@ void gc_heap::remove_gen_free (int gen_number, size_t free_size)
 #endif //FREE_USAGE_STATS
 }
 
-BYTE* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
+uint8_t* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
                                              int from_gen_number,
-                                             BYTE* old_loc REQD_ALIGN_AND_OFFSET_DCL)
+                                             uint8_t* old_loc REQD_ALIGN_AND_OFFSET_DCL)
 {
     size = Align (size);
     assert (size >= Align (min_obj_size));
@@ -13399,8 +13399,8 @@ BYTE* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
         {
             if ((real_size < (sz_list / 2)) || (a_l_idx == (gen_allocator->number_of_buckets()-1)))
             {
-                BYTE* free_list = gen_allocator->alloc_list_head_of (a_l_idx);
-                BYTE* prev_free_item = 0; 
+                uint8_t* free_list = gen_allocator->alloc_list_head_of (a_l_idx);
+                uint8_t* prev_free_item = 0;
                 while (free_list != 0)
                 {
                     dprintf (3, ("considering free list %Ix", (size_t)free_list));
@@ -13509,7 +13509,7 @@ BYTE* gc_heap::allocate_in_older_generation (generation* gen, size_t size,
     }
     else
     {
-        BYTE*  result = generation_allocation_pointer (gen);
+        uint8_t*  result = generation_allocation_pointer (gen);
         size_t pad = 0;
 
 #ifdef SHORT_PLUGS
@@ -13598,7 +13598,7 @@ void gc_heap::repair_allocation_in_expanded_heap (generation* consing_gen)
     else
     {
         assert (settings.condemned_generation == max_generation);
-        BYTE* first_address = generation_allocation_limit (consing_gen);
+        uint8_t* first_address = generation_allocation_limit (consing_gen);
         //look through the pinned plugs for relevant ones.
         //Look for the right pinned plug to start from.
         size_t mi = 0;
@@ -13617,10 +13617,10 @@ void gc_heap::repair_allocation_in_expanded_heap (generation* consing_gen)
 }
 
 //tododefrag optimize for new segment (plan_allocated == mem)
-BYTE* gc_heap::allocate_in_expanded_heap (generation* gen, 
+uint8_t* gc_heap::allocate_in_expanded_heap (generation* gen,
                                           size_t size,
                                           BOOL& adjacentp,
-                                          BYTE* old_loc,
+                                          uint8_t* old_loc,
 #ifdef SHORT_PLUGS
                                           BOOL set_padding_on_saved_p,
                                           mark* pinned_plug_entry,
@@ -13659,12 +13659,12 @@ BYTE* gc_heap::allocate_in_expanded_heap (generation* gen,
             generation_allocation_limit (gen)));
 
         adjacentp = FALSE;
-        BYTE* first_address = (generation_allocation_limit (gen) ?
+        uint8_t* first_address = (generation_allocation_limit (gen) ?
                                generation_allocation_limit (gen) :
                                heap_segment_mem (seg));
         assert (in_range_for_segment (first_address, seg));
 
-        BYTE* end_address   = heap_segment_reserved (seg);
+        uint8_t* end_address   = heap_segment_reserved (seg);
 
         dprintf (3, ("aie: first_addr: %Ix, gen alloc limit: %Ix, end_address: %Ix",
             first_address, generation_allocation_limit (gen), end_address));
@@ -13722,7 +13722,7 @@ BYTE* gc_heap::allocate_in_expanded_heap (generation* gen,
         while ((mi != mark_stack_tos) && in_range_for_segment (pinned_plug (m), seg))
         {
             size_t len = pinned_len (m);
-            BYTE*  free_list = (pinned_plug (m) - len);
+            uint8_t*  free_list = (pinned_plug (m) - len);
             dprintf (3, ("aie: testing free item: %Ix->%Ix(%Ix)", 
                 free_list, (free_list + len), len));
             if (size_fit_p (size REQD_ALIGN_AND_OFFSET_ARG, free_list, (free_list + len), old_loc, USE_PADDING_TAIL | pad_in_front))
@@ -13765,7 +13765,7 @@ BYTE* gc_heap::allocate_in_expanded_heap (generation* gen,
 
 allocate_in_free:
     {
-        BYTE*  result = generation_allocation_pointer (gen);
+        uint8_t*  result = generation_allocation_pointer (gen);
         size_t pad = 0;
 
 #ifdef SHORT_PLUGS
@@ -13845,15 +13845,15 @@ generation*  gc_heap::ensure_ephemeral_heap_segment (generation* consing_gen)
         return consing_gen;
 }
 
-BYTE* gc_heap::allocate_in_condemned_generations (generation* gen,
+uint8_t* gc_heap::allocate_in_condemned_generations (generation* gen,
                                                   size_t size,
                                                   int from_gen_number,
 #ifdef SHORT_PLUGS
                                                   BOOL* convert_to_pinned_p,
-                                                  BYTE* next_pinned_plug,
+                                                  uint8_t* next_pinned_plug,
                                                   heap_segment* current_seg,
 #endif //SHORT_PLUGS
-                                                  BYTE* old_loc
+                                                  uint8_t* old_loc
                                                   REQD_ALIGN_AND_OFFSET_DCL)
 {
     // Make sure that the youngest generation gap hasn't been allocated
@@ -13893,7 +13893,7 @@ retry:
                 size_t entry = deque_pinned_plug();
                 mark* pinned_plug_entry = pinned_plug_of (entry);
                 size_t len = pinned_len (pinned_plug_entry);
-                BYTE* plug = pinned_plug (pinned_plug_entry);
+                uint8_t* plug = pinned_plug (pinned_plug_entry);
                 set_new_pin_info (pinned_plug_entry, generation_allocation_pointer (gen));
 
 #ifdef FREE_USAGE_STATS
@@ -14006,7 +14006,7 @@ retry:
     {
         assert (generation_allocation_pointer (gen)>=
                 heap_segment_mem (generation_allocation_segment (gen)));
-        BYTE* result = generation_allocation_pointer (gen);
+        uint8_t* result = generation_allocation_pointer (gen);
         size_t pad = 0;
 #ifdef SHORT_PLUGS
         if ((pad_in_front & USE_PADDING_FRONT) &&
@@ -14838,13 +14838,13 @@ exit:
 #endif //_PREFAST_
 
 inline
-size_t gc_heap::min_reclaim_fragmentation_threshold(ULONGLONG total_mem, DWORD num_heaps)
+size_t gc_heap::min_reclaim_fragmentation_threshold(uint64_t total_mem, uint32_t num_heaps)
 {
      return min ((size_t)((float)total_mem * 0.03), (100*1024*1024)) / num_heaps;
 }
 
 inline
-ULONGLONG gc_heap::min_high_fragmentation_threshold(ULONGLONG available_mem, DWORD num_heaps)
+uint64_t gc_heap::min_high_fragmentation_threshold(uint64_t available_mem, uint32_t num_heaps)
 {
     return min (available_mem, (256*1024*1024)) / num_heaps;
 }
@@ -14902,12 +14902,12 @@ void fire_revisit_event (size_t dirtied_pages,
 }
 
 inline
-void fire_overflow_event (BYTE* overflow_min,
-                          BYTE* overflow_max,
+void fire_overflow_event (uint8_t* overflow_min,
+                          uint8_t* overflow_max,
                           size_t marked_objects, 
                           int large_objects_p)
 {
-    FireEtwBGCOverflow ((UINT64)overflow_min, (UINT64)overflow_max, 
+    FireEtwBGCOverflow ((uint64_t)overflow_min, (uint64_t)overflow_max, 
                         marked_objects, large_objects_p, 
                         GetClrInstanceId());
 }
@@ -14987,7 +14987,7 @@ BOOL gc_heap::should_proceed_with_gc()
 void gc_heap::gc1()
 {
 #ifdef BACKGROUND_GC
-    assert (settings.concurrent == (DWORD)(GetCurrentThreadId() == bgc_thread_id));
+    assert (settings.concurrent == (uint32_t)(GetCurrentThreadId() == bgc_thread_id));
 #endif //BACKGROUND_GC
 
 #ifdef TIME_GC
@@ -15129,7 +15129,7 @@ void gc_heap::gc1()
             }
         }
 
-        get_gc_data_per_heap()->maxgen_size_info.running_free_list_efficiency = (DWORD)(generation_allocator_efficiency (generation_of (max_generation)) * 100);
+        get_gc_data_per_heap()->maxgen_size_info.running_free_list_efficiency = (uint32_t)(generation_allocator_efficiency (generation_of (max_generation)) * 100);
 
         free_list_info (max_generation, "after computing new dynamic data");
         
@@ -15267,7 +15267,7 @@ void gc_heap::gc1()
 #endif //TIME_GC
 
 #ifdef BACKGROUND_GC
-    assert (settings.concurrent == (DWORD)(GetCurrentThreadId() == bgc_thread_id));
+    assert (settings.concurrent == (uint32_t)(GetCurrentThreadId() == bgc_thread_id));
 #endif //BACKGROUND_GC
 
 #if defined(VERIFY_HEAP) || (defined (FEATURE_EVENT_TRACE) && defined(BACKGROUND_GC))
@@ -15317,7 +15317,7 @@ void gc_heap::gc1()
 #endif //BACKGROUND_GC
 
 #ifdef BACKGROUND_GC
-        assert (settings.concurrent == (DWORD)(GetCurrentThreadId() == bgc_thread_id));
+        assert (settings.concurrent == (uint32_t)(GetCurrentThreadId() == bgc_thread_id));
 #ifdef FEATURE_EVENT_TRACE
         if (ETW::GCLog::ShouldTrackMovementForEtw() && settings.concurrent)
         {
@@ -15536,9 +15536,9 @@ void gc_heap::restore_data_for_no_gc()
 #endif //MULTIPLE_HEAPS
 }
 
-start_no_gc_region_status gc_heap::prepare_for_no_gc_region (ULONGLONG total_size, 
+start_no_gc_region_status gc_heap::prepare_for_no_gc_region (uint64_t total_size,
                                                              BOOL loh_size_known, 
-                                                             ULONGLONG loh_size, 
+                                                             uint64_t loh_size,
                                                              BOOL disallow_full_blocking)
 {
     if (current_no_gc_region_info.started)
@@ -15651,7 +15651,7 @@ BOOL gc_heap::find_loh_free_for_no_gc()
     {
         if ((size < sz_list) || (a_l_idx == (loh_allocator->number_of_buckets()-1)))
         {
-            BYTE* free_list = loh_allocator->alloc_list_head_of (a_l_idx);
+            uint8_t* free_list = loh_allocator->alloc_list_head_of (a_l_idx);
             while (free_list)
             {
                 size_t free_list_size = unused_array_size(free_list);
@@ -15724,7 +15724,7 @@ BOOL gc_heap::loh_allocated_for_no_gc()
 
 BOOL gc_heap::commit_loh_for_no_gc (heap_segment* seg)
 {
-    BYTE* end_committed = heap_segment_allocated (seg) + loh_allocation_no_gc;
+    uint8_t* end_committed = heap_segment_allocated (seg) + loh_allocation_no_gc;
     assert (end_committed <= heap_segment_reserved (seg));
     return (grow_heap_segment (seg, end_committed));
 }
@@ -16003,7 +16003,7 @@ BOOL gc_heap::expand_soh_with_minimal_gc()
                                 generation_allocation_start (generation_of (max_generation - 1)));
         heap_segment_next (ephemeral_heap_segment) = new_seg;
         ephemeral_heap_segment = new_seg;
-        BYTE*  start = heap_segment_mem (ephemeral_heap_segment);
+        uint8_t*  start = heap_segment_mem (ephemeral_heap_segment);
 
         for (int i = (max_generation - 1); i >= 0; i--)
         {
@@ -16372,7 +16372,7 @@ int gc_heap::garbage_collect (int n)
             }
 #endif //BACKGROUND_GC
 
-            settings.gc_index = (DWORD)dd_collection_count (dynamic_data_of (0)) + 1;
+            settings.gc_index = (uint32_t)dd_collection_count (dynamic_data_of (0)) + 1;
 
             // Call the EE for start of GC work
             // just one thread for MP GC
@@ -16517,7 +16517,7 @@ int gc_heap::garbage_collect (int n)
 
                         settings.init_mechanisms();
                         settings.condemned_generation = gen;
-                        settings.gc_index = (SIZE_T)dd_collection_count (dynamic_data_of (0)) + 2;
+                        settings.gc_index = (size_t)dd_collection_count (dynamic_data_of (0)) + 2;
                         do_pre_gc();
 
                         // TODO BACKGROUND_GC need to add the profiling stuff here.
@@ -16632,7 +16632,7 @@ size_t& gc_heap::promoted_bytes(int thread)
 }
 
 #ifdef INTERIOR_POINTERS
-heap_segment* gc_heap::find_segment (BYTE* interior, BOOL small_segment_only_p)
+heap_segment* gc_heap::find_segment (uint8_t* interior, BOOL small_segment_only_p)
 {
 #ifdef SEG_MAPPING_TABLE
     heap_segment* seg = seg_mapping_table_segment_of (interior);
@@ -16662,7 +16662,7 @@ heap_segment* gc_heap::find_segment (BYTE* interior, BOOL small_segment_only_p)
 #endif //SEG_MAPPING_TABLE
 }
 
-heap_segment* gc_heap::find_segment_per_heap (BYTE* interior, BOOL small_segment_only_p)
+heap_segment* gc_heap::find_segment_per_heap (uint8_t* interior, BOOL small_segment_only_p)
 {
 #ifdef SEG_MAPPING_TABLE
     return find_segment (interior, small_segment_only_p);
@@ -16723,7 +16723,7 @@ end_find_segment:
 #if !defined(_DEBUG) && !defined(__GNUC__)
 inline // This causes link errors if global optimization is off
 #endif //!_DEBUG && !__GNUC__
-gc_heap* gc_heap::heap_of (BYTE* o)
+gc_heap* gc_heap::heap_of (uint8_t* o)
 {
 #ifdef MULTIPLE_HEAPS
     if (o == 0)
@@ -16742,7 +16742,7 @@ gc_heap* gc_heap::heap_of (BYTE* o)
 }
 
 inline
-gc_heap* gc_heap::heap_of_gc (BYTE* o)
+gc_heap* gc_heap::heap_of_gc (uint8_t* o)
 {
 #ifdef MULTIPLE_HEAPS
     if (o == 0)
@@ -16762,7 +16762,7 @@ gc_heap* gc_heap::heap_of_gc (BYTE* o)
 
 #ifdef INTERIOR_POINTERS
 // will find all heap objects (large and small)
-BYTE* gc_heap::find_object (BYTE* interior, BYTE* low)
+uint8_t* gc_heap::find_object (uint8_t* interior, uint8_t* low)
 {
     if (!gen0_bricks_cleared)
     {
@@ -16809,10 +16809,10 @@ BYTE* gc_heap::find_object (BYTE* interior, BYTE* low)
             //int align_const = get_alignment_constant (heap_segment_read_only_p (seg));
             assert (interior < heap_segment_allocated (seg));
 
-            BYTE* o = heap_segment_mem (seg);
+            uint8_t* o = heap_segment_mem (seg);
             while (o < heap_segment_allocated (seg))
             {
-                BYTE* next_o = o + Align (size (o), align_const);
+                uint8_t* next_o = o + Align (size (o), align_const);
                 assert (next_o > o);
                 if ((o <= interior) && (interior < next_o))
                 return o;
@@ -16836,7 +16836,7 @@ BYTE* gc_heap::find_object (BYTE* interior, BYTE* low)
 #else
             assert (interior < heap_segment_allocated (seg));
 #endif
-            BYTE* o = find_first_object (interior, heap_segment_mem (seg));
+            uint8_t* o = find_first_object (interior, heap_segment_mem (seg));
             return o;
         }
         else
@@ -16846,13 +16846,13 @@ BYTE* gc_heap::find_object (BYTE* interior, BYTE* low)
         return 0;
 }
 
-BYTE*
-gc_heap::find_object_for_relocation (BYTE* interior, BYTE* low, BYTE* high)
+uint8_t*
+gc_heap::find_object_for_relocation (uint8_t* interior, uint8_t* low, uint8_t* high)
 {
-    BYTE* old_address = interior;
+    uint8_t* old_address = interior;
     if (!((old_address >= low) && (old_address < high)))
         return 0;
-    BYTE* plug = 0;
+    uint8_t* plug = 0;
     size_t  brick = brick_of (old_address);
     int    brick_entry =  brick_table [ brick ];
     if (brick_entry != 0)
@@ -16864,8 +16864,8 @@ gc_heap::find_object_for_relocation (BYTE* interior, BYTE* low, BYTE* high)
                 brick = (brick + brick_entry);
                 brick_entry =  brick_table [ brick ];
             }
-            BYTE* old_loc = old_address;
-            BYTE* node = tree_search ((brick_address (brick) + brick_entry-1),
+            uint8_t* old_loc = old_address;
+            uint8_t* node = tree_search ((brick_address (brick) + brick_entry-1),
                                       old_loc);
             if (node <= old_loc)
                 plug = node;
@@ -16879,10 +16879,10 @@ gc_heap::find_object_for_relocation (BYTE* interior, BYTE* low, BYTE* high)
         }
         assert (plug);
         //find the object by going along the plug
-        BYTE* o = plug;
+        uint8_t* o = plug;
         while (o <= interior)
         {
-            BYTE* next_o = o + Align (size (o));
+            uint8_t* next_o = o + Align (size (o));
             assert (next_o > o);
             if (next_o > interior)
             {
@@ -16901,10 +16901,10 @@ gc_heap::find_object_for_relocation (BYTE* interior, BYTE* low, BYTE* high)
         {
             assert (interior < heap_segment_allocated (seg));
 
-            BYTE* o = heap_segment_mem (seg);
+            uint8_t* o = heap_segment_mem (seg);
             while (o < heap_segment_allocated (seg))
             {
-                BYTE* next_o = o + Align (size (o));
+                uint8_t* next_o = o + Align (size (o));
                 assert (next_o > o);
                 if ((o < interior) && (interior < next_o))
                 return o;
@@ -16920,7 +16920,7 @@ gc_heap::find_object_for_relocation (BYTE* interior, BYTE* low, BYTE* high)
 }
 #else //INTERIOR_POINTERS
 inline
-BYTE* gc_heap::find_object (BYTE* o, BYTE* low)
+uint8_t* gc_heap::find_object (uint8_t* o, uint8_t* low)
 {
     return o;
 }
@@ -16941,7 +16941,7 @@ BYTE* gc_heap::find_object (BYTE* o, BYTE* low)
 #define method_table(o) ((CObjectHeader*)(o))->GetMethodTable()
 
 inline
-BOOL gc_heap::gc_mark1 (BYTE* o)
+BOOL gc_heap::gc_mark1 (uint8_t* o)
 {
     BOOL marked = !marked (o);
     set_marked (o);
@@ -16950,7 +16950,7 @@ BOOL gc_heap::gc_mark1 (BYTE* o)
 }
 
 inline
-BOOL gc_heap::gc_mark (BYTE* o, BYTE* low, BYTE* high)
+BOOL gc_heap::gc_mark (uint8_t* o, uint8_t* low, uint8_t* high)
 {
     BOOL marked = FALSE;
     if ((o >= low) && (o < high))
@@ -16984,12 +16984,12 @@ BOOL gc_heap::gc_mark (BYTE* o, BYTE* low, BYTE* high)
 #ifdef BACKGROUND_GC
 
 inline
-BOOL gc_heap::background_marked (BYTE* o)
+BOOL gc_heap::background_marked (uint8_t* o)
 {
     return mark_array_marked (o);
 }
 inline
-BOOL gc_heap::background_mark1 (BYTE* o)
+BOOL gc_heap::background_mark1 (uint8_t* o)
 {
     BOOL to_mark = !mark_array_marked (o);
 
@@ -17007,7 +17007,7 @@ BOOL gc_heap::background_mark1 (BYTE* o)
 // TODO: we could consider filtering out NULL's here instead of going to 
 // look for it on other heaps
 inline
-BOOL gc_heap::background_mark (BYTE* o, BYTE* low, BYTE* high)
+BOOL gc_heap::background_mark (uint8_t* o, uint8_t* low, uint8_t* high)
 {
     BOOL marked = FALSE;
     if ((o >= low) && (o < high))
@@ -17028,7 +17028,7 @@ BOOL gc_heap::background_mark (BYTE* o, BYTE* low, BYTE* high)
 #endif //BACKGROUND_GC
 
 inline
-BYTE* gc_heap::next_end (heap_segment* seg, BYTE* f)
+uint8_t* gc_heap::next_end (heap_segment* seg, uint8_t* f)
 {
     if (seg == ephemeral_heap_segment)
         return  f;
@@ -17049,16 +17049,16 @@ BYTE* gc_heap::next_end (heap_segment* seg, BYTE* f)
     if (cnt >= 0)                                                           \
     {                                                                       \
         CGCDescSeries* last = map->GetLowestSeries();                       \
-        BYTE** parm = 0;                                                    \
+        uint8_t** parm = 0;                                                 \
         do                                                                  \
         {                                                                   \
-            assert (parm <= (BYTE**)((o) + cur->GetSeriesOffset()));        \
-            parm = (BYTE**)((o) + cur->GetSeriesOffset());                  \
-            BYTE** ppstop =                                                 \
-                (BYTE**)((BYTE*)parm + cur->GetSeriesSize() + (size));      \
-            if (!start_useful || (BYTE*)ppstop > (start))                   \
+            assert (parm <= (uint8_t**)((o) + cur->GetSeriesOffset()));     \
+            parm = (uint8_t**)((o) + cur->GetSeriesOffset());               \
+            uint8_t** ppstop =                                              \
+                (uint8_t**)((uint8_t*)parm + cur->GetSeriesSize() + (size));\
+            if (!start_useful || (uint8_t*)ppstop > (start))                \
             {                                                               \
-                if (start_useful && (BYTE*)parm < (start)) parm = (BYTE**)(start);\
+                if (start_useful && (uint8_t*)parm < (start)) parm = (uint8_t**)(start);\
                 while (parm < ppstop)                                       \
                 {                                                           \
                    {exp}                                                    \
@@ -17072,29 +17072,29 @@ BYTE* gc_heap::next_end (heap_segment* seg, BYTE* f)
     else                                                                    \
     {                                                                       \
         /* Handle the repeating case - array of valuetypes */               \
-        BYTE** parm = (BYTE**)((o) + cur->startoffset);                     \
-        if (start_useful && start > (BYTE*)parm)                            \
+        uint8_t** parm = (uint8_t**)((o) + cur->startoffset);               \
+        if (start_useful && start > (uint8_t*)parm)                         \
         {                                                                   \
             SSIZE_T cs = mt->RawGetComponentSize();                         \
-            parm = (BYTE**)((BYTE*)parm + (((start) - (BYTE*)parm)/cs)*cs); \
+            parm = (uint8_t**)((uint8_t*)parm + (((start) - (uint8_t*)parm)/cs)*cs); \
         }                                                                   \
-        while ((BYTE*)parm < ((o)+(size)-plug_skew))                        \
+        while ((uint8_t*)parm < ((o)+(size)-plug_skew))                     \
         {                                                                   \
             for (SSIZE_T __i = 0; __i > cnt; __i--)                         \
             {                                                               \
                 HALF_SIZE_T skip =  cur->val_serie[__i].skip;               \
                 HALF_SIZE_T nptrs = cur->val_serie[__i].nptrs;              \
-                BYTE** ppstop = parm + nptrs;                               \
-                if (!start_useful || (BYTE*)ppstop > (start))               \
+                uint8_t** ppstop = parm + nptrs;                            \
+                if (!start_useful || (uint8_t*)ppstop > (start))            \
                 {                                                           \
-                    if (start_useful && (BYTE*)parm < (start)) parm = (BYTE**)(start);      \
+                    if (start_useful && (uint8_t*)parm < (start)) parm = (uint8_t**)(start);      \
                     do                                                      \
                     {                                                       \
                        {exp}                                                \
                        parm++;                                              \
                     } while (parm < ppstop);                                \
                 }                                                           \
-                parm = (BYTE**)((BYTE*)ppstop + skip);                      \
+                parm = (uint8_t**)((uint8_t*)ppstop + skip);                \
             }                                                               \
         }                                                                   \
     }                                                                       \
@@ -17118,8 +17118,8 @@ BYTE* gc_heap::next_end (heap_segment* seg, BYTE* f)
 {                                                                           \
     if (header(o)->Collectible())                                           \
     {                                                                       \
-        BYTE* class_obj = get_class_object (o);                             \
-        BYTE** parm = &class_obj;                                           \
+        uint8_t* class_obj = get_class_object (o);                             \
+        uint8_t** parm = &class_obj;                                           \
         do {exp} while (false);                                             \
     }                                                                       \
     if (header(o)->ContainsPointers())                                      \
@@ -17130,9 +17130,9 @@ BYTE* gc_heap::next_end (heap_segment* seg, BYTE* f)
 #endif //COLLECTIBLE_CLASS
 
 // This starts a plug. But mark_stack_tos isn't increased until set_pinned_info is called.
-void gc_heap::enque_pinned_plug (BYTE* plug, 
+void gc_heap::enque_pinned_plug (uint8_t* plug,
                                  BOOL save_pre_plug_info_p, 
-                                 BYTE* last_object_in_last_plug)
+                                 uint8_t* last_object_in_last_plug)
 {
     if (mark_stack_array_length <= mark_stack_tos)
     {
@@ -17196,8 +17196,8 @@ void gc_heap::enque_pinned_plug (BYTE* plug,
 
                 go_through_object_nostart (method_table(last_object_in_last_plug), last_object_in_last_plug, last_obj_size, pval,
                     {
-                        size_t gap_offset = (((size_t)pval - (size_t)(plug - sizeof (gap_reloc_pair) - plug_skew))) / sizeof (BYTE*);
-                        dprintf (3, ("member: %Ix->%Ix, %Id ptrs from beginning of gap", (BYTE*)pval, *pval, gap_offset));
+                        size_t gap_offset = (((size_t)pval - (size_t)(plug - sizeof (gap_reloc_pair) - plug_skew))) / sizeof (uint8_t*);
+                        dprintf (3, ("member: %Ix->%Ix, %Id ptrs from beginning of gap", (uint8_t*)pval, *pval, gap_offset));
                         m.set_pre_short_bit (gap_offset);
                     }
                 );
@@ -17208,11 +17208,11 @@ void gc_heap::enque_pinned_plug (BYTE* plug,
     m.saved_post_p = FALSE;
 }
 
-void gc_heap::save_post_plug_info (BYTE* last_pinned_plug, BYTE* last_object_in_last_plug, BYTE* post_plug)
+void gc_heap::save_post_plug_info (uint8_t* last_pinned_plug, uint8_t* last_object_in_last_plug, uint8_t* post_plug)
 {
     mark& m = mark_stack_array[mark_stack_tos - 1];
     assert (last_pinned_plug == m.first);
-    m.saved_post_plug_info_start = (BYTE*)&(((plug_and_gap*)post_plug)[-1]);
+    m.saved_post_plug_info_start = (uint8_t*)&(((plug_and_gap*)post_plug)[-1]);
 
 #ifdef SHORT_PLUGS
     BOOL is_padded = is_plug_padded (last_object_in_last_plug);
@@ -17263,8 +17263,8 @@ void gc_heap::save_post_plug_info (BYTE* last_pinned_plug, BYTE* last_object_in_
             // take care of collectible assemblies here.
             go_through_object_nostart (method_table(last_object_in_last_plug), last_object_in_last_plug, last_obj_size, pval,
                 {
-                    size_t gap_offset = (((size_t)pval - (size_t)(post_plug - sizeof (gap_reloc_pair) - plug_skew))) / sizeof (BYTE*);
-                    dprintf (3, ("member: %Ix->%Ix, %Id ptrs from beginning of gap", (BYTE*)pval, *pval, gap_offset));
+                    size_t gap_offset = (((size_t)pval - (size_t)(post_plug - sizeof (gap_reloc_pair) - plug_skew))) / sizeof (uint8_t*);
+                    dprintf (3, ("member: %Ix->%Ix, %Id ptrs from beginning of gap", (uint8_t*)pval, *pval, gap_offset));
                     m.set_post_short_bit (gap_offset);
                 }
             );
@@ -17289,9 +17289,9 @@ inline void Prefetch (void* addr)
 #endif //PREFETCH
 #ifdef MH_SC_MARK
 inline
-VOLATILE(BYTE*)& gc_heap::ref_mark_stack (gc_heap* hp, int index)
+VOLATILE(uint8_t*)& gc_heap::ref_mark_stack (gc_heap* hp, int index)
 {
-    return ((VOLATILE(BYTE*)*)(hp->mark_stack_array))[index];
+    return ((VOLATILE(uint8_t*)*)(hp->mark_stack_array))[index];
 }
 
 #endif //MH_SC_MARK
@@ -17300,48 +17300,48 @@ VOLATILE(BYTE*)& gc_heap::ref_mark_stack (gc_heap* hp, int index)
 #define partial 1
 #define partial_object 3
 inline 
-BYTE* ref_from_slot (BYTE* r)
+uint8_t* ref_from_slot (uint8_t* r)
 {
-    return (BYTE*)((size_t)r & ~(stolen | partial));
+    return (uint8_t*)((size_t)r & ~(stolen | partial));
 }
 inline
-BOOL stolen_p (BYTE* r)
+BOOL stolen_p (uint8_t* r)
 {
     return (((size_t)r&2) && !((size_t)r&1));
 }
 inline 
-BOOL ready_p (BYTE* r)
+BOOL ready_p (uint8_t* r)
 {
     return ((size_t)r != 1);
 }
 inline
-BOOL partial_p (BYTE* r)
+BOOL partial_p (uint8_t* r)
 {
     return (((size_t)r&1) && !((size_t)r&2));
 }
 inline 
-BOOL straight_ref_p (BYTE* r)
+BOOL straight_ref_p (uint8_t* r)
 {
     return (!stolen_p (r) && !partial_p (r));
 }
 inline 
-BOOL partial_object_p (BYTE* r)
+BOOL partial_object_p (uint8_t* r)
 {
     return (((size_t)r & partial_object) == partial_object);
 }
 inline
-BOOL ref_p (BYTE* r)
+BOOL ref_p (uint8_t* r)
 {
     return (straight_ref_p (r) || partial_object_p (r));
 }
 
-void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
+void gc_heap::mark_object_simple1 (uint8_t* oo, uint8_t* start THREAD_NUMBER_DCL)
 {
-    SERVER_SC_MARK_VOLATILE(BYTE*)* mark_stack_tos = (SERVER_SC_MARK_VOLATILE(BYTE*)*)mark_stack_array;
-    SERVER_SC_MARK_VOLATILE(BYTE*)* mark_stack_limit = (SERVER_SC_MARK_VOLATILE(BYTE*)*)&mark_stack_array[mark_stack_array_length];
-    SERVER_SC_MARK_VOLATILE(BYTE*)* mark_stack_base = mark_stack_tos;
+    SERVER_SC_MARK_VOLATILE(uint8_t*)* mark_stack_tos = (SERVER_SC_MARK_VOLATILE(uint8_t*)*)mark_stack_array;
+    SERVER_SC_MARK_VOLATILE(uint8_t*)* mark_stack_limit = (SERVER_SC_MARK_VOLATILE(uint8_t*)*)&mark_stack_array[mark_stack_array_length];
+    SERVER_SC_MARK_VOLATILE(uint8_t*)* mark_stack_base = mark_stack_tos;
 #ifdef SORT_MARK_STACK
-    SERVER_SC_MARK_VOLATILE(BYTE*)* sorted_tos = mark_stack_base;
+    SERVER_SC_MARK_VOLATILE(uint8_t*)* sorted_tos = mark_stack_base;
 #endif //SORT_MARK_STACK
 
     // If we are doing a full GC we don't use mark list anyway so use m_boundary_fullgc that doesn't 
@@ -17369,11 +17369,11 @@ void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
                 --mark_stack_tos;
                 goto next_level;
             }
-            else if (!partial_p (oo) && ((s = size (oo)) < (partial_size_th*sizeof (BYTE*))))
+            else if (!partial_p (oo) && ((s = size (oo)) < (partial_size_th*sizeof (uint8_t*))))
             {
                 BOOL overflow_p = FALSE;
 
-                if (mark_stack_tos + (s) /sizeof (BYTE*) >= (mark_stack_limit  - 1))
+                if (mark_stack_tos + (s) /sizeof (uint8_t*) >= (mark_stack_limit  - 1))
                 {
                     size_t num_components = ((method_table(oo))->HasComponentSize() ? ((CObjectHeader*)oo)->GetNumComponents() : 0);
                     if (mark_stack_tos + CGCDesc::GetNumPointers(method_table(oo), s, num_components) >= (mark_stack_limit - 1))
@@ -17388,7 +17388,7 @@ void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
 
                     go_through_object_cl (method_table(oo), oo, s, ppslot,
                                           {
-                                              BYTE* o = *ppslot;
+                                              uint8_t* o = *ppslot;
                                               Prefetch(o);
                                               if (gc_mark (o, gc_low, gc_high))
                                               {
@@ -17433,7 +17433,7 @@ void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
                     // we just popped one object off.
                     if (is_collectible (oo))
                     {
-                        BYTE* class_obj = get_class_object (oo);
+                        uint8_t* class_obj = get_class_object (oo);
                         if (gc_mark (class_obj, gc_low, gc_high))
                         {
                             if (full_p)
@@ -17466,19 +17466,19 @@ void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
                     dprintf(3,("pushing mark for %Ix ", (size_t)oo));
 
                     //push the object and its current 
-                    SERVER_SC_MARK_VOLATILE(BYTE*)* place = ++mark_stack_tos;
+                    SERVER_SC_MARK_VOLATILE(uint8_t*)* place = ++mark_stack_tos;
                     mark_stack_tos++;
 #ifdef MH_SC_MARK
                     *(place-1) = 0;
-                    *(place) = (BYTE*)partial;
+                    *(place) = (uint8_t*)partial;
 #endif //MH_SC_MARK
                     int i = num_partial_refs; 
-                    BYTE* ref_to_continue = 0;
+                    uint8_t* ref_to_continue = 0;
 
                     go_through_object (method_table(oo), oo, s, ppslot,
                                        start, use_start, (oo + s),
                                        {
-                                           BYTE* o = *ppslot;
+                                           uint8_t* o = *ppslot;
                                            Prefetch(o);
                                            if (gc_mark (o, gc_low, gc_high))
                                            {
@@ -17497,7 +17497,7 @@ void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
                                                     *(mark_stack_tos++) = o;
                                                     if (--i == 0)
                                                     {
-                                                        ref_to_continue = (BYTE*)((size_t)(ppslot+1) | partial);
+                                                        ref_to_continue = (uint8_t*)((size_t)(ppslot+1) | partial);
                                                         goto more_to_do;
                                                     }
 
@@ -17509,7 +17509,7 @@ void gc_heap::mark_object_simple1 (BYTE* oo, BYTE* start THREAD_NUMBER_DCL)
                     //we are finished with this object
                     assert (ref_to_continue == 0);
 #ifdef MH_SC_MARK
-                    assert ((*(place-1)) == (BYTE*)0);
+                    assert ((*(place-1)) == (uint8_t*)0);
 #else //MH_SC_MARK
                     *(place-1) = 0;
 #endif //MH_SC_MARK
@@ -17521,9 +17521,9 @@ more_to_do:
                     {
                         //update the start
 #ifdef MH_SC_MARK
-                        assert ((*(place-1)) == (BYTE*)0);
-                        *(place-1) = (BYTE*)((size_t)oo | partial_object);
-                        assert (((*place) == (BYTE*)1) || ((*place) == (BYTE*)2));
+                        assert ((*(place-1)) == (uint8_t*)0);
+                        *(place-1) = (uint8_t*)((size_t)oo | partial_object);
+                        assert (((*place) == (uint8_t*)1) || ((*place) == (uint8_t*)2));
 #endif //MH_SC_MARK
                         *place = ref_to_continue;
                     }
@@ -17583,7 +17583,7 @@ gc_heap::mark_steal()
     //clear the mark stack in the snooping range
     for (int i = 0; i < max_snoop_level; i++)
     {
-        ((VOLATILE(BYTE*)*)(mark_stack_array))[i] = 0;
+        ((VOLATILE(uint8_t*)*)(mark_stack_array))[i] = 0;
     }
 
     //pick the next heap as our buddy
@@ -17591,7 +17591,7 @@ gc_heap::mark_steal()
 
 #ifdef SNOOP_STATS
         dprintf (SNOOP_LOG, ("(GC%d)heap%d: start snooping %d", settings.gc_index, heap_number, (heap_number+1)%n_heaps));
-        DWORD begin_tick = GetTickCount();
+        uint32_t begin_tick = GetTickCount();
 #endif //SNOOP_STATS
 
     int idle_loop_count = 0; 
@@ -17609,18 +17609,18 @@ gc_heap::mark_steal()
 #ifdef SNOOP_STATS
             snoop_stat.busy_count++;
             dprintf (SNOOP_LOG, ("heap%d: looking at next heap level %d stack contents: %Ix", 
-                                 heap_number, level, (int)((BYTE**)(hp->mark_stack_array))[level]));
+                                 heap_number, level, (int)((uint8_t**)(hp->mark_stack_array))[level]));
 #endif //SNOOP_STATS
 
-            BYTE* o = ref_mark_stack (hp, level);
+            uint8_t* o = ref_mark_stack (hp, level);
 
-            BYTE* start = o;
+            uint8_t* start = o;
             if (ref_p (o))
             {
                 mark_stack_busy() = 1;
 
                 BOOL success = TRUE;
-                BYTE* next = (ref_mark_stack (hp, level+1));
+                uint8_t* next = (ref_mark_stack (hp, level+1));
                 if (ref_p (next))
                 {
                     if (((size_t)o > 4) && !partial_object_p (o))
@@ -17693,7 +17693,7 @@ gc_heap::mark_steal()
                     dprintf (SNOOP_LOG, ("heap%d: marking %Ix from %d [%d] tl:%dms",
                             heap_number, (size_t)o, (heap_number+1)%n_heaps, level,
                             (GetTickCount()-begin_tick)));
-                    DWORD start_tick = GetTickCount();
+                    uint32_t start_tick = GetTickCount();
 #endif //SNOOP_STATS
 
                     mark_object_simple1 (o, start, heap_number);
@@ -17709,9 +17709,9 @@ gc_heap::mark_steal()
                     //clear the mark stack in snooping range
                     for (int i = 0; i < max_snoop_level; i++)
                     {
-                        if (((BYTE**)mark_stack_array)[i] != 0)
+                        if (((uint8_t**)mark_stack_array)[i] != 0)
                         {
-                            ((VOLATILE(BYTE*)*)(mark_stack_array))[i] = 0;
+                            ((VOLATILE(uint8_t*)*)(mark_stack_array))[i] = 0;
 #ifdef SNOOP_STATS
                             snoop_stat.stack_bottom_clear_count++;
 #endif //SNOOP_STATS
@@ -17839,11 +17839,11 @@ void gc_heap::print_snoop_stat()
 
 #ifdef HEAP_ANALYZE
 void
-gc_heap::ha_mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
+gc_heap::ha_mark_object_simple (uint8_t** po THREAD_NUMBER_DCL)
 {
     if (!internal_root_array)
     {
-        internal_root_array = new (nothrow) BYTE* [internal_root_array_length];
+        internal_root_array = new (nothrow) uint8_t* [internal_root_array_length];
         if (!internal_root_array)
         {
             heap_analyze_success = FALSE;
@@ -17862,11 +17862,11 @@ gc_heap::ha_mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
         }
         else
         {
-            BYTE** tmp = new (nothrow) BYTE* [new_size];
+            uint8_t** tmp = new (nothrow) uint8_t* [new_size];
             if (tmp)
             {
                 memcpy (tmp, internal_root_array,
-                        internal_root_array_length*sizeof (BYTE*));
+                        internal_root_array_length*sizeof (uint8_t*));
                 delete[] internal_root_array;
                 internal_root_array = tmp;
                 internal_root_array_length = new_size;
@@ -17882,7 +17882,7 @@ gc_heap::ha_mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
     {
         PREFIX_ASSUME(internal_root_array_index < internal_root_array_length);
 
-        BYTE* ref = (BYTE*)po;
+        uint8_t* ref = (uint8_t*)po;
         if (!current_obj || 
             !((ref >= current_obj) && (ref < (current_obj + current_obj_size))))
         {
@@ -17901,9 +17901,9 @@ gc_heap::ha_mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
 
 //this method assumes that *po is in the [low. high[ range
 void
-gc_heap::mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
+gc_heap::mark_object_simple (uint8_t** po THREAD_NUMBER_DCL)
 {
-    BYTE* o = *po;
+    uint8_t* o = *po;
 #ifdef MULTIPLE_HEAPS
 #else  //MULTIPLE_HEAPS
     const int thread = 0;
@@ -17921,7 +17921,7 @@ gc_heap::mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
             {
                 go_through_object_cl (method_table(o), o, s, poo,
                                         {
-                                            BYTE* oo = *poo;
+                                            uint8_t* oo = *poo;
                                             if (gc_mark (oo, gc_low, gc_high))
                                             {
                                                 m_boundary (oo);
@@ -17939,7 +17939,7 @@ gc_heap::mark_object_simple (BYTE** po THREAD_NUMBER_DCL)
 }
 
 inline
-BYTE* gc_heap::mark_object (BYTE* o THREAD_NUMBER_DCL)
+uint8_t* gc_heap::mark_object (uint8_t* o THREAD_NUMBER_DCL)
 {
     if ((o >= gc_low) && (o < gc_high))
         mark_object_simple (&o THREAD_NUMBER_ARG);
@@ -17959,12 +17959,12 @@ BYTE* gc_heap::mark_object (BYTE* o THREAD_NUMBER_DCL)
 
 #ifdef BACKGROUND_GC
 
-void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
+void gc_heap::background_mark_simple1 (uint8_t* oo THREAD_NUMBER_DCL)
 {
-    BYTE** mark_stack_limit = &background_mark_stack_array[background_mark_stack_array_length];
+    uint8_t** mark_stack_limit = &background_mark_stack_array[background_mark_stack_array_length];
 
 #ifdef SORT_MARK_STACK
-    BYTE** sorted_tos = background_mark_stack_array;
+    uint8_t** sorted_tos = background_mark_stack_array;
 #endif //SORT_MARK_STACK
 
     background_mark_stack_tos = background_mark_stack_array;
@@ -17978,11 +17978,11 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
         if (oo)
         {
             size_t s = 0; 
-            if ((((size_t)oo & 1) == 0) && ((s = size (oo)) < (partial_size_th*sizeof (BYTE*))))
+            if ((((size_t)oo & 1) == 0) && ((s = size (oo)) < (partial_size_th*sizeof (uint8_t*))))
             {
                 BOOL overflow_p = FALSE;
             
-                if (background_mark_stack_tos + (s) /sizeof (BYTE*) >= (mark_stack_limit - 1))
+                if (background_mark_stack_tos + (s) /sizeof (uint8_t*) >= (mark_stack_limit - 1))
                 {
                     size_t num_components = ((method_table(oo))->HasComponentSize() ? ((CObjectHeader*)oo)->GetNumComponents() : 0);
                     size_t num_pointers = CGCDesc::GetNumPointers(method_table(oo), s, num_components);
@@ -18005,7 +18005,7 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
 
                     go_through_object_cl (method_table(oo), oo, s, ppslot,
                     {
-                        BYTE* o = *ppslot;
+                        uint8_t* o = *ppslot;
                         Prefetch(o);
                         if (background_mark (o, 
                                              background_saved_lowest_address, 
@@ -18032,10 +18032,10 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
             }
             else 
             {
-                BYTE* start = oo;
+                uint8_t* start = oo;
                 if ((size_t)oo & 1)
                 {
-                    oo = (BYTE*)((size_t)oo & ~1);
+                    oo = (uint8_t*)((size_t)oo & ~1);
                     start = *(--background_mark_stack_tos);
                     dprintf (4, ("oo: %Ix, start: %Ix\n", (size_t)oo, (size_t)start));
                 }
@@ -18046,7 +18046,7 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
                     // we just popped one object off.
                     if (is_collectible (oo))
                     {
-                        BYTE* class_obj = get_class_object (oo);
+                        uint8_t* class_obj = get_class_object (oo);
                         if (background_mark (class_obj, 
                                             background_saved_lowest_address, 
                                             background_saved_highest_address))
@@ -18085,16 +18085,16 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
                     dprintf(3,("pushing mark for %Ix ", (size_t)oo));
 
                     //push the object and its current 
-                    BYTE** place = background_mark_stack_tos++;
+                    uint8_t** place = background_mark_stack_tos++;
                     *(place) = start;
-                    *(background_mark_stack_tos++) = (BYTE*)((size_t)oo | 1);
+                    *(background_mark_stack_tos++) = (uint8_t*)((size_t)oo | 1);
 
                     int i = num_partial_refs; 
 
                     go_through_object (method_table(oo), oo, s, ppslot,
                                        start, use_start, (oo + s),
                     {
-                        BYTE* o = *ppslot;
+                        uint8_t* o = *ppslot;
                         Prefetch(o);
 
                         if (background_mark (o, 
@@ -18110,7 +18110,7 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
                                 if (--i == 0)
                                 {
                                     //update the start
-                                    *place = (BYTE*)(ppslot+1);
+                                    *place = (uint8_t*)(ppslot+1);
                                     goto more_to_do;
                                 }
 
@@ -18148,7 +18148,7 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
             oo = *(--background_mark_stack_tos);
 
 #ifdef SORT_MARK_STACK
-            sorted_tos = (BYTE**)min ((size_t)sorted_tos, (size_t)background_mark_stack_tos);
+            sorted_tos = (uint8_t**)min ((size_t)sorted_tos, (size_t)background_mark_stack_tos);
 #endif //SORT_MARK_STACK
         }
         else
@@ -18166,7 +18166,7 @@ void gc_heap::background_mark_simple1 (BYTE* oo THREAD_NUMBER_DCL)
 //by an intervening foreground gc.
 //this method assumes that *po is in the [low. high[ range
 void
-gc_heap::background_mark_simple (BYTE* o THREAD_NUMBER_DCL)
+gc_heap::background_mark_simple (uint8_t* o THREAD_NUMBER_DCL)
 {
 #ifdef MULTIPLE_HEAPS
 #else  //MULTIPLE_HEAPS
@@ -18190,7 +18190,7 @@ gc_heap::background_mark_simple (BYTE* o THREAD_NUMBER_DCL)
 }
 
 inline
-BYTE* gc_heap::background_mark_object (BYTE* o THREAD_NUMBER_DCL)
+uint8_t* gc_heap::background_mark_object (uint8_t* o THREAD_NUMBER_DCL)
 {
     if ((o >= background_saved_lowest_address) && (o < background_saved_highest_address))
     {
@@ -18206,10 +18206,10 @@ BYTE* gc_heap::background_mark_object (BYTE* o THREAD_NUMBER_DCL)
     return o;
 }
 
-void gc_heap::background_verify_mark (Object*& object, ScanContext* sc, DWORD flags)
+void gc_heap::background_verify_mark (Object*& object, ScanContext* sc, uint32_t flags)
 {
     assert (settings.concurrent);
-    BYTE* o = (BYTE*)object;
+    uint8_t* o = (uint8_t*)object;
 
     gc_heap* hp = gc_heap::heap_of (o);
 #ifdef INTERIOR_POINTERS
@@ -18225,7 +18225,7 @@ void gc_heap::background_verify_mark (Object*& object, ScanContext* sc, DWORD fl
     }
 }
 
-void gc_heap::background_promote (Object** ppObject, ScanContext* sc, DWORD flags)
+void gc_heap::background_promote (Object** ppObject, ScanContext* sc, uint32_t flags)
 {
     UNREFERENCED_PARAMETER(sc);
     //in order to save space on the array, mark the object,
@@ -18237,14 +18237,14 @@ void gc_heap::background_promote (Object** ppObject, ScanContext* sc, DWORD flag
     const int thread = 0;
 #endif //!MULTIPLE_HEAPS
 
-    BYTE* o = (BYTE*)*ppObject;
+    uint8_t* o = (uint8_t*)*ppObject;
 
     if (o == 0)
         return;
 
 #ifdef DEBUG_DestroyedHandleValue
     // we can race with destroy handle during concurrent scan
-    if (o == (BYTE*)DEBUG_DestroyedHandleValue)
+    if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
         return;
 #endif //DEBUG_DestroyedHandleValue
 
@@ -18311,7 +18311,7 @@ gc_heap::scan_background_roots (promote_func* fn, int hn, ScanContext *pSC)
     size_t mark_list_finger = 0;
     while (mark_list_finger < c_mark_list_index)
     {
-        BYTE** o = &c_mark_list [mark_list_finger];
+        uint8_t** o = &c_mark_list [mark_list_finger];
         if (!relocate_p)
         {
             // We may not be able to calculate the size during relocate as POPO
@@ -18327,18 +18327,18 @@ gc_heap::scan_background_roots (promote_func* fn, int hn, ScanContext *pSC)
     //scan the mark stack
     dprintf (3, ("Scanning background mark stack"));
 
-    BYTE** finger = background_mark_stack_array;
+    uint8_t** finger = background_mark_stack_array;
     while (finger < background_mark_stack_tos)
     {
         if ((finger + 1) < background_mark_stack_tos)
         {
             // We need to check for the partial mark case here.
-            BYTE* parent_obj = *(finger + 1);
+            uint8_t* parent_obj = *(finger + 1);
             if ((size_t)parent_obj & 1)
             {
-                BYTE* place = *finger;
+                uint8_t* place = *finger;
                 size_t place_offset = 0;
-                BYTE* real_parent_obj = (BYTE*)((size_t)parent_obj & ~1);
+                uint8_t* real_parent_obj = (uint8_t*)((size_t)parent_obj & ~1);
 
                 if (relocate_p)
                 {
@@ -18348,12 +18348,12 @@ gc_heap::scan_background_roots (promote_func* fn, int hn, ScanContext *pSC)
                     (*fn) ((Object**)(finger + 1), pSC, 0);
                     real_parent_obj = *(finger + 1);
                     *finger = real_parent_obj + place_offset;
-                    *(finger + 1) = (BYTE*)((size_t)real_parent_obj | 1);
+                    *(finger + 1) = (uint8_t*)((size_t)real_parent_obj | 1);
                     dprintf(3,("roots changed to %Ix, %Ix", *finger, *(finger + 1)));
                 }
                 else
                 {
-                    BYTE** temp = &real_parent_obj;
+                    uint8_t** temp = &real_parent_obj;
                     dprintf(3,("marking background root %Ix", (size_t)real_parent_obj));
                     (*fn) ((Object**)temp, pSC, 0);
                 }
@@ -18378,11 +18378,11 @@ void gc_heap::fix_card_table ()
 
     PREFIX_ASSUME(seg != NULL);
 
-    DWORD granularity;
+    uint32_t granularity;
 #ifdef BACKGROUND_GC
-    DWORD mode = settings.concurrent ? 1 : 0;
+    uint32_t mode = settings.concurrent ? 1 : 0;
 #else //BACKGROUND_GC
-    DWORD mode = 0;
+    uint32_t mode = 0;
 #endif //BACKGROUND_GC
     BOOL small_object_segments = TRUE;
     while (1)
@@ -18403,8 +18403,8 @@ void gc_heap::fix_card_table ()
                 break;
             }
         }
-        BYTE* base_address = align_lower_page (heap_segment_mem (seg));
-        BYTE* high_address =  align_on_page (
+        uint8_t* base_address = align_lower_page (heap_segment_mem (seg));
+        uint8_t* high_address =  align_on_page (
             (seg != ephemeral_heap_segment) ?
             heap_segment_allocated (seg) :
             generation_allocation_start (generation_of (0))
@@ -18422,8 +18422,8 @@ void gc_heap::fix_card_table ()
 #ifdef TIME_WRITE_WATCH
             unsigned int time_start = GetCycleCount32();
 #endif //TIME_WRITE_WATCH
-            UINT status = GetWriteWatch (mode, base_address, region_size,
-                                          (PVOID*)g_addresses,
+            uint32_t status = GetWriteWatch (mode, base_address, region_size,
+                                          (void**)g_addresses,
                                           &bcount, &granularity);
             assert (status == 0);
 
@@ -18459,7 +18459,7 @@ void gc_heap::fix_card_table ()
     if (settings.concurrent)
     {
         //reset the ephemeral page allocated by generation_of (0)
-        BYTE* base_address =
+        uint8_t* base_address =
             align_on_page (generation_allocation_start (generation_of (0)));
         size_t region_size =
             heap_segment_allocated (ephemeral_heap_segment) - base_address;
@@ -18471,7 +18471,7 @@ void gc_heap::fix_card_table ()
 
 #ifdef BACKGROUND_GC
 inline
-void gc_heap::background_mark_through_object (BYTE* oo THREAD_NUMBER_DCL)
+void gc_heap::background_mark_through_object (uint8_t* oo THREAD_NUMBER_DCL)
 {
     if (contain_pointers (oo))
     {
@@ -18479,7 +18479,7 @@ void gc_heap::background_mark_through_object (BYTE* oo THREAD_NUMBER_DCL)
         size_t s = size (oo);
         go_through_object_nostart (method_table(oo), oo, s, po,
                           {
-                            BYTE* o = *po;
+                            uint8_t* o = *po;
                             total_refs++;
                             background_mark_object (o THREAD_NUMBER_ARG);
                           }
@@ -18491,7 +18491,7 @@ void gc_heap::background_mark_through_object (BYTE* oo THREAD_NUMBER_DCL)
     }
 }
 
-BYTE* gc_heap::background_seg_end (heap_segment* seg, BOOL concurrent_p)
+uint8_t* gc_heap::background_seg_end (heap_segment* seg, BOOL concurrent_p)
 {
     if (concurrent_p && (seg == saved_overflow_ephemeral_seg))
     {
@@ -18504,12 +18504,12 @@ BYTE* gc_heap::background_seg_end (heap_segment* seg, BOOL concurrent_p)
     }
 }
 
-BYTE* gc_heap::background_first_overflow (BYTE* min_add,
+uint8_t* gc_heap::background_first_overflow (uint8_t* min_add,
                                           heap_segment* seg,
                                           BOOL concurrent_p, 
                                           BOOL small_object_p)
 {
-    BYTE* o = 0;
+    uint8_t* o = 0;
 
     if (small_object_p)
     {
@@ -18545,7 +18545,7 @@ BYTE* gc_heap::background_first_overflow (BYTE* min_add,
 }
 
 void gc_heap::background_process_mark_overflow_internal (int condemned_gen_number,
-                                                         BYTE* min_add, BYTE* max_add,
+                                                         uint8_t* min_add, uint8_t* max_add,
                                                          BOOL concurrent_p)
 {
     if (concurrent_p)
@@ -18583,10 +18583,10 @@ void gc_heap::background_process_mark_overflow_internal (int condemned_gen_numbe
         PREFIX_ASSUME(seg != NULL);
         loh_alloc_lock = hp->bgc_alloc_lock;
 
-        BYTE*  o = hp->background_first_overflow (min_add, 
-                                                  seg, 
-                                                  concurrent_p, 
-                                                  small_object_segments);
+        uint8_t* o = hp->background_first_overflow (min_add,
+                                                    seg, 
+                                                    concurrent_p, 
+                                                    small_object_segments);
 
         while (1)
         {
@@ -18618,7 +18618,7 @@ void gc_heap::background_process_mark_overflow_internal (int condemned_gen_numbe
                 {
                     total_marked_objects++;
                     go_through_object_cl (method_table(o), o, s, poo,
-                                          BYTE* oo = *poo;
+                                          uint8_t* oo = *poo;
                                           background_mark_object (oo THREAD_NUMBER_ARG);
                                          );
                 }
@@ -18748,7 +18748,7 @@ recheck:
             {
                 dprintf (2, ("h%d: ov grow to %Id", heap_number, new_size));
 
-                BYTE** tmp = new (nothrow) BYTE* [new_size];
+                uint8_t** tmp = new (nothrow) uint8_t* [new_size];
                 if (tmp)
                 {
                     delete background_mark_stack_array;
@@ -18763,8 +18763,8 @@ recheck:
             grow_mark_array_p = TRUE;
         }
 
-        BYTE*  min_add = background_min_overflow_address;
-        BYTE*  max_add = background_max_overflow_address;
+        uint8_t*  min_add = background_min_overflow_address;
+        uint8_t*  max_add = background_max_overflow_address;
 
         background_max_overflow_address = 0;
         background_min_overflow_address = MAX_PTR;
@@ -18782,7 +18782,7 @@ recheck:
 #endif //BACKGROUND_GC
 
 inline
-void gc_heap::mark_through_object (BYTE* oo, BOOL mark_class_object_p THREAD_NUMBER_DCL)
+void gc_heap::mark_through_object (uint8_t* oo, BOOL mark_class_object_p THREAD_NUMBER_DCL)
 {
 #ifndef COLLECTIBLE_CLASS
     BOOL to_mark_class_object = FALSE;
@@ -18797,7 +18797,7 @@ void gc_heap::mark_through_object (BYTE* oo, BOOL mark_class_object_p THREAD_NUM
 #ifdef COLLECTIBLE_CLASS
         if (to_mark_class_object)
         {
-            BYTE* class_obj = get_class_object (oo);
+            uint8_t* class_obj = get_class_object (oo);
             mark_object (class_obj THREAD_NUMBER_ARG);
         }
 #endif //COLLECTIBLE_CLASS
@@ -18805,7 +18805,7 @@ void gc_heap::mark_through_object (BYTE* oo, BOOL mark_class_object_p THREAD_NUM
         if (contain_pointers (oo))
         {
             go_through_object_nostart (method_table(oo), oo, s, po,
-                                BYTE* o = *po;
+                                uint8_t* o = *po;
                                 mark_object (o THREAD_NUMBER_ARG);
                                 );
         }
@@ -18870,8 +18870,8 @@ recheck:
             }
         }
 
-        BYTE*  min_add = min_overflow_address;
-        BYTE*  max_add = max_overflow_address;
+        uint8_t*  min_add = min_overflow_address;
+        uint8_t*  max_add = max_overflow_address;
         max_overflow_address = 0;
         min_overflow_address = MAX_PTR;
         process_mark_overflow_internal (condemned_gen_number, min_add, max_add);
@@ -18886,7 +18886,7 @@ recheck:
 }
 
 void gc_heap::process_mark_overflow_internal (int condemned_gen_number,
-                                              BYTE* min_add, BYTE* max_add)
+                                              uint8_t* min_add, uint8_t* max_add)
 {
 #ifdef MULTIPLE_HEAPS
     int thread = heap_number;
@@ -18910,10 +18910,10 @@ void gc_heap::process_mark_overflow_internal (int condemned_gen_number,
         heap_segment* seg = heap_segment_in_range (generation_start_segment (gen));
         
         PREFIX_ASSUME(seg != NULL);
-        BYTE*  o = max (heap_segment_mem (seg), min_add);
+        uint8_t*  o = max (heap_segment_mem (seg), min_add);
         while (1)
         {
-            BYTE*  end = heap_segment_allocated (seg);
+            uint8_t*  end = heap_segment_allocated (seg);
 
             while ((o < end) && (o <= max_add))
             {
@@ -19039,8 +19039,8 @@ void gc_heap::scan_dependent_handles (int condemned_gen_number, ScanContext *sc,
                 {
                     // On the second invocation we reconcile all mark overflow ranges across the heaps. This can help
                     // load balance if some of the heaps have an abnormally large workload.
-                    BYTE* all_heaps_max = 0;
-                    BYTE* all_heaps_min = MAX_PTR;
+                    uint8_t* all_heaps_max = 0;
+                    uint8_t* all_heaps_min = MAX_PTR;
                     int i;
                     for (i = 0; i < n_heaps; i++)
                     {
@@ -19191,14 +19191,14 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
         //initialize the mark stack
         for (int i = 0; i < max_snoop_level; i++)
         {
-            ((BYTE**)(mark_stack_array))[i] = 0;
+            ((uint8_t**)(mark_stack_array))[i] = 0;
         }
 
         mark_stack_busy() = 1;
     }
 #endif //MH_SC_MARK
 
-    static DWORD num_sizedrefs = 0;
+    static uint32_t num_sizedrefs = 0;
 
 #ifdef MH_SC_MARK
     static BOOL do_mark_steal_p = FALSE;
@@ -19258,7 +19258,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
         mark_list_index = &mark_list [0];
 #endif //MARK_LIST
 
-        shigh = (BYTE*) 0;
+        shigh = (uint8_t*) 0;
         slow  = MAX_PTR;
 
         //%type%  category = quote (mark);
@@ -19634,7 +19634,7 @@ void gc_heap::mark_phase (int condemned_gen_number, BOOL mark_only_p)
 }
 
 inline
-void gc_heap::pin_object (BYTE* o, BYTE** ppObject, BYTE* low, BYTE* high)
+void gc_heap::pin_object (uint8_t* o, uint8_t** ppObject, uint8_t* low, uint8_t* high)
 {
     dprintf (3, ("Pinning %Ix", (size_t)o));
     if ((o >= low) && (o < high))
@@ -19701,13 +19701,13 @@ C_ASSERT(brick_size == (1 << brick_bits));
 #endif // FEATURE_STRUCTALIGN
 
 inline
-short node_left_child(BYTE* node)
+short node_left_child(uint8_t* node)
 {
     return child_from_short(((plug_and_pair*)node)[-1].m_pair.left);
 }
 
 inline
-void set_node_left_child(BYTE* node, ptrdiff_t val)
+void set_node_left_child(uint8_t* node, ptrdiff_t val)
 {
     assert (val > -(ptrdiff_t)brick_size);
     assert (val < (ptrdiff_t)brick_size);
@@ -19722,13 +19722,13 @@ void set_node_left_child(BYTE* node, ptrdiff_t val)
 }
 
 inline
-short node_right_child(BYTE* node)
+short node_right_child(uint8_t* node)
 {
     return child_from_short(((plug_and_pair*)node)[-1].m_pair.right);
 }
 
 inline
-void set_node_right_child(BYTE* node, ptrdiff_t val)
+void set_node_right_child(uint8_t* node, ptrdiff_t val)
 {
     assert (val > -(ptrdiff_t)brick_size);
     assert (val < (ptrdiff_t)brick_size);
@@ -19743,7 +19743,7 @@ void set_node_right_child(BYTE* node, ptrdiff_t val)
 }
 
 #ifdef FEATURE_STRUCTALIGN
-void node_aligninfo (BYTE* node, int& requiredAlignment, ptrdiff_t& pad)
+void node_aligninfo (uint8_t* node, int& requiredAlignment, ptrdiff_t& pad)
 {
     // Extract the single-number aligninfo from the fields.
     short left = ((plug_and_pair*)node)[-1].m_pair.left;
@@ -19765,7 +19765,7 @@ void node_aligninfo (BYTE* node, int& requiredAlignment, ptrdiff_t& pad)
 }
 
 inline
-ptrdiff_t node_alignpad (BYTE* node)
+ptrdiff_t node_alignpad (uint8_t* node)
 {
     int requiredAlignment;
     ptrdiff_t alignpad;
@@ -19773,13 +19773,13 @@ ptrdiff_t node_alignpad (BYTE* node)
     return alignpad;
 }
 
-void clear_node_aligninfo (BYTE* node)
+void clear_node_aligninfo (uint8_t* node)
 {
     ((plug_and_pair*)node)[-1].m_pair.left &= ~0 << pad_bits;
     ((plug_and_pair*)node)[-1].m_pair.right &= ~0 << pad_bits;
 }
 
-void set_node_aligninfo (BYTE* node, int requiredAlignment, ptrdiff_t pad)
+void set_node_aligninfo (uint8_t* node, int requiredAlignment, ptrdiff_t pad)
 {
     // Encode the alignment requirement and alignment offset as a single number
     // as described above.
@@ -19807,26 +19807,26 @@ void set_node_aligninfo (BYTE* node, int requiredAlignment, ptrdiff_t pad)
 #endif // FEATURE_STRUCTALIGN
 
 inline
-void loh_set_node_relocation_distance(BYTE* node, ptrdiff_t val)
+void loh_set_node_relocation_distance(uint8_t* node, ptrdiff_t val)
 {
     ptrdiff_t* place = &(((loh_obj_and_pad*)node)[-1].reloc);
     *place = val;
 }
 
 inline
-ptrdiff_t loh_node_relocation_distance(BYTE* node)
+ptrdiff_t loh_node_relocation_distance(uint8_t* node)
 {
     return (((loh_obj_and_pad*)node)[-1].reloc);
 }
 
 inline
-ptrdiff_t node_relocation_distance (BYTE* node)
+ptrdiff_t node_relocation_distance (uint8_t* node)
 {
     return (((plug_and_reloc*)(node))[-1].reloc & ~3);
 }
 
 inline
-void set_node_relocation_distance(BYTE* node, ptrdiff_t val)
+void set_node_relocation_distance(uint8_t* node, ptrdiff_t val)
 {
     assert (val == (val & ~3));
     ptrdiff_t* place = &(((plug_and_reloc*)node)[-1].reloc);
@@ -19841,12 +19841,12 @@ void set_node_relocation_distance(BYTE* node, ptrdiff_t val)
 #define set_node_left(node) ((plug_and_reloc*)(node))[-1].reloc |= 2;
 
 #ifndef FEATURE_STRUCTALIGN
-void set_node_realigned(BYTE* node)
+void set_node_realigned(uint8_t* node)
 {
     ((plug_and_reloc*)(node))[-1].reloc |= 1;
 }
 
-void clear_node_realigned(BYTE* node)
+void clear_node_realigned(uint8_t* node)
 {
 #ifdef RESPECT_LARGE_ALIGNMENT
     ((plug_and_reloc*)(node))[-1].reloc &= ~1;
@@ -19855,16 +19855,16 @@ void clear_node_realigned(BYTE* node)
 #endif // FEATURE_STRUCTALIGN
 
 inline
-size_t  node_gap_size (BYTE* node)
+size_t  node_gap_size (uint8_t* node)
 {
     return ((plug_and_gap *)node)[-1].gap;
 }
 
-void set_gap_size (BYTE* node, size_t size)
+void set_gap_size (uint8_t* node, size_t size)
 {
     assert (Aligned (size));
 
-    // clear the 2 DWORD used by the node.
+    // clear the 2 uint32_t used by the node.
     ((plug_and_gap *)node)[-1].reloc = 0;
     ((plug_and_gap *)node)[-1].lr =0;
     ((plug_and_gap *)node)[-1].gap = size;
@@ -19873,8 +19873,8 @@ void set_gap_size (BYTE* node, size_t size)
 
 }
 
-BYTE* gc_heap::insert_node (BYTE* new_node, size_t sequence_number,
-                   BYTE* tree, BYTE* last_node)
+uint8_t* gc_heap::insert_node (uint8_t* new_node, size_t sequence_number,
+                   uint8_t* tree, uint8_t* last_node)
 {
     dprintf (3, ("IN: %Ix(%Ix), T: %Ix(%Ix), L: %Ix(%Ix) [%Ix]",
                  (size_t)new_node, brick_of(new_node), 
@@ -19896,7 +19896,7 @@ BYTE* gc_heap::insert_node (BYTE* new_node, size_t sequence_number,
         }
         else
         {
-            BYTE*  earlier_node = tree;
+            uint8_t*  earlier_node = tree;
             size_t imax = logcount(sequence_number) - 2;
             for (size_t i = 0; i != imax; i++)
             {
@@ -19915,8 +19915,8 @@ BYTE* gc_heap::insert_node (BYTE* new_node, size_t sequence_number,
     return tree;
 }
 
-size_t gc_heap::update_brick_table (BYTE* tree, size_t current_brick,
-                                    BYTE* x, BYTE* plug_end)
+size_t gc_heap::update_brick_table (uint8_t* tree, size_t current_brick,
+                                    uint8_t* x, uint8_t* plug_end)
 {
     dprintf (3, ("tree: %Ix, current b: %Ix, x: %Ix, plug_end: %Ix",
         tree, current_brick, x, plug_end));
@@ -19952,7 +19952,7 @@ size_t gc_heap::update_brick_table (BYTE* tree, size_t current_brick,
     return brick_of (x);
 }
 
-void gc_heap::plan_generation_start (generation* gen, generation* consing_gen, BYTE* next_plug_to_allocate)
+void gc_heap::plan_generation_start (generation* gen, generation* consing_gen, uint8_t* next_plug_to_allocate)
 {
 #ifdef _WIN64
     // We should never demote big plugs to gen0.
@@ -19969,7 +19969,7 @@ void gc_heap::plan_generation_start (generation* gen, generation* consing_gen, B
                 {
                     size_t entry = deque_pinned_plug();
                     size_t len = pinned_len (pinned_plug_of (entry));
-                    BYTE* plug = pinned_plug (pinned_plug_of(entry));
+                    uint8_t* plug = pinned_plug (pinned_plug_of(entry));
                     if (len > demotion_plug_len_th)
                     {
                         dprintf (2, ("ps(%d): S %Ix (%Id)(%Ix)", gen->gen_num, plug, len, (plug+len)));
@@ -20064,7 +20064,7 @@ void gc_heap::plan_generation_starts (generation*& consing_gen)
 
 void gc_heap::advance_pins_for_demotion (generation* gen)
 {
-    BYTE* original_youngest_start = generation_allocation_start (youngest_generation);
+    uint8_t* original_youngest_start = generation_allocation_start (youngest_generation);
     heap_segment* seg = ephemeral_heap_segment;
 
     if ((!(pinned_plug_que_empty_p())))
@@ -20081,7 +20081,7 @@ void gc_heap::advance_pins_for_demotion (generation* gen)
             {
                 size_t entry = deque_pinned_plug();
                 size_t len = pinned_len (pinned_plug_of (entry));
-                BYTE* plug = pinned_plug (pinned_plug_of(entry));
+                uint8_t* plug = pinned_plug (pinned_plug_of(entry));
                 pinned_len (pinned_plug_of (entry)) = plug - generation_allocation_pointer (gen);
                 assert(mark_stack_array[entry].len == 0 ||
                         mark_stack_array[entry].len >= Align(min_obj_size));
@@ -20111,7 +20111,7 @@ void gc_heap::advance_pins_for_demotion (generation* gen)
     }
 }
 
-void gc_heap::process_ephemeral_boundaries (BYTE* x,
+void gc_heap::process_ephemeral_boundaries (uint8_t* x,
                                             int& active_new_gen_number,
                                             int& active_old_gen_number,
                                             generation*& consing_gen,
@@ -20186,7 +20186,7 @@ retry:
             {
                 size_t  entry = deque_pinned_plug();
                 mark*  m = pinned_plug_of (entry);
-                BYTE*  plug = pinned_plug (m);
+                uint8_t*  plug = pinned_plug (m);
                 size_t  len = pinned_len (m);
                 // detect pinned block in different segment (later) than
                 // allocation segment, skip those until the oldest pin is in the ephemeral seg.
@@ -20241,7 +20241,7 @@ retry:
 
             if ((demotion_low == MAX_PTR) && !pinned_plug_que_empty_p())
             {
-                BYTE* pplug = pinned_plug (oldest_pin());
+                uint8_t* pplug = pinned_plug (oldest_pin());
                 if (object_gennum (pplug) > 0)
                 {
                     demotion_low = pplug;
@@ -20259,7 +20259,7 @@ retry:
 inline
 void gc_heap::seg_clear_mark_bits (heap_segment* seg)
 {
-    BYTE* o = heap_segment_mem (seg);
+    uint8_t* o = heap_segment_mem (seg);
     while (o < heap_segment_allocated (seg))
     {
         if (marked (o))
@@ -20325,7 +20325,7 @@ void gc_heap::loh_set_allocator_next_pin()
     if (!(loh_pinned_plug_que_empty_p()))
     {
         mark*  oldest_entry = loh_oldest_pin();
-        BYTE* plug = pinned_plug (oldest_entry);
+        uint8_t* plug = pinned_plug (oldest_entry);
         generation* gen = large_object_generation;
         if ((plug >= generation_allocation_pointer (gen)) &&
             (plug <  generation_allocation_limit (gen)))
@@ -20358,7 +20358,7 @@ mark* gc_heap::loh_oldest_pin()
 }
 
 // If we can't grow the queue, then don't compact.
-BOOL gc_heap::loh_enque_pinned_plug (BYTE* plug, size_t len)
+BOOL gc_heap::loh_enque_pinned_plug (uint8_t* plug, size_t len)
 {
     assert(len >= Align(min_obj_size, get_alignment_constant (FALSE)));
 
@@ -20379,7 +20379,7 @@ BOOL gc_heap::loh_enque_pinned_plug (BYTE* plug, size_t len)
 }
 
 inline
-BOOL gc_heap::loh_size_fit_p (size_t size, BYTE* alloc_pointer, BYTE* alloc_limit)
+BOOL gc_heap::loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit)
 {
     dprintf (1235, ("trying to fit %Id(%Id) between %Ix and %Ix (%Id)", 
         size, 
@@ -20391,7 +20391,7 @@ BOOL gc_heap::loh_size_fit_p (size_t size, BYTE* alloc_pointer, BYTE* alloc_limi
     return ((alloc_pointer + 2* AlignQword (loh_padding_obj_size) +  size) <= alloc_limit);
 }
 
-BYTE* gc_heap::loh_allocate_in_condemned (BYTE* old_loc, size_t size)
+uint8_t* gc_heap::loh_allocate_in_condemned (uint8_t* old_loc, size_t size)
 {
     generation* gen = large_object_generation;
     dprintf (1235, ("E: p:%Ix, l:%Ix, s: %Id", 
@@ -20410,7 +20410,7 @@ retry:
             {
                 mark* m = loh_pinned_plug_of (loh_deque_pinned_plug());
                 size_t len = pinned_len (m);
-                BYTE* plug = pinned_plug (m);
+                uint8_t* plug = pinned_plug (m);
                 dprintf (1235, ("AIC: %Ix->%Ix(%Id)", generation_allocation_pointer (gen), plug, plug - generation_allocation_pointer (gen)));
                 pinned_len (m) = plug - generation_allocation_pointer (gen);
                 generation_allocation_pointer (gen) = plug + len;
@@ -20511,7 +20511,7 @@ retry:
     {
         assert (generation_allocation_pointer (gen)>=
                 heap_segment_mem (generation_allocation_segment (gen)));
-        BYTE* result = generation_allocation_pointer (gen);
+        uint8_t* result = generation_allocation_pointer (gen);
         size_t loh_pad = AlignQword (loh_padding_obj_size);
 
         generation_allocation_pointer (gen) += size + loh_pad;
@@ -20571,7 +20571,7 @@ BOOL gc_heap::plan_loh()
     heap_segment* start_seg = heap_segment_rw (generation_start_segment (gen));
     PREFIX_ASSUME(start_seg != NULL);
     heap_segment* seg      = start_seg;
-    BYTE* o                = generation_allocation_start (gen);
+    uint8_t* o             = generation_allocation_start (gen);
 
     dprintf (1235, ("before GC LOH size: %Id, free list: %Id, free obj: %Id\n", 
         generation_size (max_generation + 1), 
@@ -20594,9 +20594,9 @@ BOOL gc_heap::plan_loh()
     generation_allocation_limit (gen) = generation_allocation_pointer (gen);
     generation_allocation_segment (gen) = start_seg;
 
-    BYTE* free_space_start = o;
-    BYTE* free_space_end = o;
-    BYTE* new_address = 0;
+    uint8_t* free_space_start = o;
+    uint8_t* free_space_end = o;
+    uint8_t* new_address = 0;
 
     while (1)
     {
@@ -20658,7 +20658,7 @@ BOOL gc_heap::plan_loh()
     {
         mark* m = loh_pinned_plug_of (loh_deque_pinned_plug());
         size_t len = pinned_len (m);
-        BYTE* plug = pinned_plug (m);
+        uint8_t* plug = pinned_plug (m);
 
         // detect pinned block in different segment (later) than
         // allocation segment
@@ -20706,13 +20706,13 @@ void gc_heap::compact_loh()
     PREFIX_ASSUME(start_seg != NULL);
     heap_segment* seg      = start_seg;
     heap_segment* prev_seg = 0;
-    BYTE* o                = generation_allocation_start (gen);
+    uint8_t* o             = generation_allocation_start (gen);
 
     //Skip the generation gap object
     o = o + AlignQword (size (o));
     // We don't need to ever realloc gen3 start so don't touch it.
-    BYTE* free_space_start = o;
-    BYTE* free_space_end = o;
+    uint8_t* free_space_start = o;
+    uint8_t* free_space_end = o;
     generation_allocator (gen)->clear();
     generation_free_list_space (gen) = 0;
     generation_free_obj_space (gen) = 0;
@@ -20776,7 +20776,7 @@ void gc_heap::compact_loh()
             size_t size = AlignQword (size (o));
 
             size_t loh_pad;
-            BYTE* reloc = o;
+            uint8_t* reloc = o;
             clear_marked (o);
 
             if (pinned (o))
@@ -20784,7 +20784,7 @@ void gc_heap::compact_loh()
                 // We are relying on the fact the pinned objects are always looked at in the same order 
                 // in plan phase and in compact phase.
                 mark* m = loh_pinned_plug_of (loh_deque_pinned_plug());
-                BYTE* plug = pinned_plug (m);
+                uint8_t* plug = pinned_plug (m);
                 assert (plug == o);
 
                 loh_pad = pinned_len (m);
@@ -20828,7 +20828,7 @@ void gc_heap::relocate_in_loh_compact()
 {
     generation* gen        = large_object_generation;
     heap_segment* seg      = heap_segment_rw (generation_start_segment (gen));
-    BYTE* o                = generation_allocation_start (gen);
+    uint8_t* o             = generation_allocation_start (gen);
 
     //Skip the generation gap object
     o = o + AlignQword (size (o));
@@ -20890,7 +20890,7 @@ void gc_heap::walk_relocation_loh (size_t profiling_context)
 {
     generation* gen        = large_object_generation;
     heap_segment* seg      = heap_segment_rw (generation_start_segment (gen));
-    BYTE* o                = generation_allocation_start (gen);
+    uint8_t* o             = generation_allocation_start (gen);
 
     //Skip the generation gap object
     o = o + AlignQword (size (o));
@@ -20942,7 +20942,7 @@ void gc_heap::walk_relocation_loh (size_t profiling_context)
 }
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
-BOOL gc_heap::loh_object_p (BYTE* o)
+BOOL gc_heap::loh_object_p (uint8_t* o)
 {
 #ifdef MULTIPLE_HEAPS
     gc_heap* hp = gc_heap::g_heaps [0];
@@ -20969,13 +20969,13 @@ void gc_heap::convert_to_pinned_plug (BOOL& last_npinned_plug_p,
 
 // Because we have the artifical pinning, we can't gaurantee that pinned and npinned
 // plugs are always interleaved.
-void gc_heap::store_plug_gap_info (BYTE* plug_start,
-                                   BYTE* plug_end,
+void gc_heap::store_plug_gap_info (uint8_t* plug_start,
+                                   uint8_t* plug_end,
                                    BOOL& last_npinned_plug_p, 
                                    BOOL& last_pinned_plug_p, 
-                                   BYTE*& last_pinned_plug,
+                                   uint8_t*& last_pinned_plug,
                                    BOOL& pinned_plug_p,
-                                   BYTE* last_object_in_last_plug,
+                                   uint8_t* last_object_in_last_plug,
                                    BOOL& merge_with_last_pin_p,
                                    // this is only for verification purpose
                                    size_t last_plug_len)
@@ -21081,7 +21081,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
 #ifdef MARK_LIST
     BOOL use_mark_list = FALSE;
-    BYTE** mark_list_next = &mark_list[0];
+    uint8_t** mark_list_next = &mark_list[0];
 #ifdef GC_CONFIG_DRIVEN
     dprintf (3, ("total number of marked objects: %Id (%Id)",
                  (mark_list_index - &mark_list[0]), ((mark_list_end - &mark_list[0]))));
@@ -21119,7 +21119,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
     }
 
 #ifndef MULTIPLE_HEAPS
-    if (shigh != (BYTE*)0)
+    if (shigh != (uint8_t*)0)
     {
         heap_segment* seg = heap_segment_rw (generation_start_segment (condemned_gen1));
 
@@ -21133,7 +21133,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             {
                 if (seg == fseg)
                 {
-                    BYTE* o = generation_allocation_start (condemned_gen1) +
+                    uint8_t* o = generation_allocation_start (condemned_gen1) +
                         Align (size (generation_allocation_start (condemned_gen1)));
                     if (slow > o)
                     {
@@ -21187,7 +21187,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             if (seg == sseg)
             {
                 // no survivors make all generations look empty
-                BYTE* o = generation_allocation_start (condemned_gen1) +
+                uint8_t* o = generation_allocation_start (condemned_gen1) +
                     Align (size (generation_allocation_start (condemned_gen1)));
 #ifdef BACKGROUND_GC
                 if (current_c_gc_state == c_gc_state_marking)
@@ -21218,15 +21218,15 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
     PREFIX_ASSUME(seg1 != NULL);
 
-    BYTE*  end = heap_segment_allocated (seg1);
-    BYTE*  first_condemned_address = generation_allocation_start (condemned_gen1);
-    BYTE*  x = first_condemned_address;
+    uint8_t*  end = heap_segment_allocated (seg1);
+    uint8_t*  first_condemned_address = generation_allocation_start (condemned_gen1);
+    uint8_t*  x = first_condemned_address;
 
     assert (!marked (x));
-    BYTE*  plug_end = x;
-    BYTE*  tree = 0;
+    uint8_t*  plug_end = x;
+    uint8_t*  tree = 0;
     size_t  sequence_number = 0;
-    BYTE*  last_node = 0;
+    uint8_t*  last_node = 0;
     size_t  current_brick = brick_of (x);
     BOOL  allocate_in_condemned = ((condemned_gen_number == max_generation)||
                                    (settings.promotion == FALSE));
@@ -21242,9 +21242,9 @@ void gc_heap::plan_phase (int condemned_gen_number)
     size_t r_older_gen_free_list_allocated = 0;
     size_t r_older_gen_condemned_allocated = 0;
     size_t r_older_gen_end_seg_allocated = 0;
-    BYTE*  r_allocation_pointer = 0;
-    BYTE*  r_allocation_limit = 0;
-    BYTE* r_allocation_start_region = 0;
+    uint8_t*  r_allocation_pointer = 0;
+    uint8_t*  r_allocation_limit = 0;
+    uint8_t* r_allocation_start_region = 0;
     heap_segment*  r_allocation_segment = 0;
 #ifdef FREE_USAGE_STATS
     size_t r_older_gen_free_space[NUM_GEN_POWER2];
@@ -21415,19 +21415,19 @@ void gc_heap::plan_phase (int condemned_gen_number)
         // last_pinned_plug is the beginning of the last pinned plug. If we merge a plug into a pinned
         // plug we do not change the value of last_pinned_plug. This happens with artificially pinned plugs -
         // it can be merged with a previous pinned plug and a pinned plug after it can be merged with it.
-        BYTE* last_pinned_plug = 0;
+        uint8_t* last_pinned_plug = 0;
         size_t num_pinned_plugs_in_plug = 0;
 
-        BYTE* last_object_in_plug = 0;
+        uint8_t* last_object_in_plug = 0;
 
         while ((x < end) && marked (x))
         {
-            BYTE*  plug_start = x;
-            BYTE*  saved_plug_end = plug_end;
+            uint8_t*  plug_start = x;
+            uint8_t*  saved_plug_end = plug_end;
             BOOL   pinned_plug_p = FALSE;
             BOOL   npin_before_pin_p = FALSE;
             BOOL   saved_last_npinned_plug_p = last_npinned_plug_p;
-            BYTE*  saved_last_object_in_plug = last_object_in_plug;
+            uint8_t*  saved_last_object_in_plug = last_object_in_plug;
             BOOL   merge_with_last_pin_p = FALSE;
 
             size_t added_pinning_size = 0;
@@ -21443,7 +21443,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 #endif // FEATURE_STRUCTALIGN
 
             {
-                BYTE* xl = x;
+                uint8_t* xl = x;
                 while ((xl < end) && marked (xl) && (pinned (xl) == pinned_plug_p))
                 {
                     assert (xl < end);
@@ -21505,7 +21505,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             size_t ps = plug_end - plug_start;
             last_plug_len = ps;
             dprintf (3, ( "%Ix[(%Ix)", (size_t)x, ps));
-            BYTE*  new_address = 0;
+            uint8_t*  new_address = 0;
 
             if (!pinned_plug_p)
             {
@@ -21657,7 +21657,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             {
                 if (fire_pinned_plug_events_p)
                     FireEtwPinPlugAtGCTime(plug_start, plug_end, 
-                                           (merge_with_last_pin_p ? 0 : (BYTE*)node_gap_size (plug_start)), 
+                                           (merge_with_last_pin_p ? 0 : (uint8_t*)node_gap_size (plug_start)),
                                            GetClrInstanceId());
 
                 if (merge_with_last_pin_p)
@@ -21733,9 +21733,9 @@ void gc_heap::plan_phase (int condemned_gen_number)
                         mark& m = mark_stack_array[mark_stack_tos - 1];
                         if (m.has_post_plug_info())
                         {
-                            BYTE* post_plug_info_start = m.saved_post_plug_info_start;
+                            uint8_t* post_plug_info_start = m.saved_post_plug_info_start;
                             size_t* current_plug_gap_start = (size_t*)(plug_start - sizeof (plug_and_gap));
-                            if ((BYTE*)current_plug_gap_start == post_plug_info_start)
+                            if ((uint8_t*)current_plug_gap_start == post_plug_info_start)
                             {
                                 dprintf (3, ("Ginfo: %Ix, %Ix, %Ix",
                                     *current_plug_gap_start, *(current_plug_gap_start + 1),
@@ -21777,7 +21777,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
             else
 #endif //MARK_LIST
             {
-                BYTE* xl = x;
+                uint8_t* xl = x;
 #ifdef BACKGROUND_GC
                 if (current_c_gc_state == c_gc_state_marking)
                 {
@@ -21812,7 +21812,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
     {
         if (settings.promotion)
         {
-            BYTE* pplug = pinned_plug (oldest_pin());
+            uint8_t* pplug = pinned_plug (oldest_pin());
             if (in_range_for_segment (pplug, ephemeral_heap_segment))
             {
                 consing_gen = ensure_ephemeral_heap_segment (consing_gen);
@@ -21849,7 +21849,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
 
         size_t  entry = deque_pinned_plug();
         mark*  m = pinned_plug_of (entry);
-        BYTE*  plug = pinned_plug (m);
+        uint8_t*  plug = pinned_plug (m);
         size_t  len = pinned_len (m);
 
         // detect pinned block in different segment (later) than
@@ -22380,14 +22380,14 @@ void gc_heap::plan_phase (int condemned_gen_number)
             reset_pinned_queue_bos();
             unsigned int  gen_number = min (max_generation, 1 + condemned_gen_number);
             generation*  gen = generation_of (gen_number);
-            BYTE*  low = generation_allocation_start (generation_of (gen_number-1));
-            BYTE*  high =  heap_segment_allocated (ephemeral_heap_segment);
+            uint8_t*  low = generation_allocation_start (generation_of (gen_number-1));
+            uint8_t*  high =  heap_segment_allocated (ephemeral_heap_segment);
             
             while (!pinned_plug_que_empty_p())
             {
                 mark*  m = pinned_plug_of (deque_pinned_plug());
                 size_t len = pinned_len (m);
-                BYTE*  arr = (pinned_plug (m) - len);
+                uint8_t*  arr = (pinned_plug (m) - len);
                 dprintf(3,("free [%Ix %Ix[ pin",
                             (size_t)arr, (size_t)arr + len));
                 if (len != 0)
@@ -22465,7 +22465,7 @@ void gc_heap::plan_phase (int condemned_gen_number)
         }
         if (settings.promotion && !settings.demotion)
         {
-            BYTE* start = generation_allocation_start (youngest_generation);
+            uint8_t* start = generation_allocation_start (youngest_generation);
             MAYBE_UNUSED_VAR(start);
             assert (heap_segment_allocated (ephemeral_heap_segment) ==
                     (start + Align (size (start))));
@@ -22623,7 +22623,7 @@ void gc_heap::fix_generation_bounds (int condemned_gen_number,
     {
         alloc_allocated = heap_segment_plan_allocated(ephemeral_heap_segment);
         //reset the allocated size
-        BYTE* start = generation_allocation_start (youngest_generation);
+        uint8_t* start = generation_allocation_start (youngest_generation);
         MAYBE_UNUSED_VAR(start);
         if (settings.promotion && !settings.demotion)
             assert ((start + Align (size (start))) ==
@@ -22634,7 +22634,7 @@ void gc_heap::fix_generation_bounds (int condemned_gen_number,
     }
 }
 
-BYTE* gc_heap::generation_limit (int gen_number)
+uint8_t* gc_heap::generation_limit (int gen_number)
 {
     if (settings.promotion)
     {
@@ -22654,7 +22654,7 @@ BYTE* gc_heap::generation_limit (int gen_number)
 
 BOOL gc_heap::ensure_gap_allocation (int condemned_gen_number)
 {
-    BYTE* start = heap_segment_allocated (ephemeral_heap_segment);
+    uint8_t* start = heap_segment_allocated (ephemeral_heap_segment);
     size_t size = Align (min_obj_size)*(condemned_gen_number+1);
     assert ((start + size) <=
             heap_segment_reserved (ephemeral_heap_segment));
@@ -22669,11 +22669,11 @@ BOOL gc_heap::ensure_gap_allocation (int condemned_gen_number)
     return TRUE;
 }
 
-BYTE* gc_heap::allocate_at_end (size_t size)
+uint8_t* gc_heap::allocate_at_end (size_t size)
 {
-    BYTE* start = heap_segment_allocated (ephemeral_heap_segment);
+    uint8_t* start = heap_segment_allocated (ephemeral_heap_segment);
     size = Align (size);
-    BYTE* result = start;
+    uint8_t* result = start;
     // only called to allocate a min obj so can't overflow here.
     assert ((start + size) <=
             heap_segment_reserved (ephemeral_heap_segment));
@@ -22697,14 +22697,14 @@ void gc_heap::make_free_lists (int condemned_gen_number)
     assert (settings.promotion);
 
     generation* condemned_gen = generation_of (condemned_gen_number);
-    BYTE* start_address = generation_allocation_start (condemned_gen);
+    uint8_t* start_address = generation_allocation_start (condemned_gen);
 
     size_t  current_brick = brick_of (start_address);
     heap_segment* current_heap_segment = heap_segment_rw (generation_start_segment (condemned_gen));
 
     PREFIX_ASSUME(current_heap_segment != NULL);
 
-    BYTE*  end_address = heap_segment_allocated (current_heap_segment);
+    uint8_t*  end_address = heap_segment_allocated (current_heap_segment);
     size_t  end_brick = brick_of (end_address-1);
     make_free_args args;
     args.free_list_gen_number = min (max_generation, 1 + condemned_gen_number);
@@ -22732,7 +22732,7 @@ void gc_heap::make_free_lists (int condemned_gen_number)
 
                     PREFIX_ASSUME(start_seg != NULL);
 
-                    BYTE* gap = heap_segment_mem (start_seg);
+                    uint8_t* gap = heap_segment_mem (start_seg);
 
                     generation_allocation_start (gen) = gap;
                     heap_segment_allocated (start_seg) = gap + Align (min_obj_size);
@@ -22790,7 +22790,7 @@ void gc_heap::make_free_lists (int condemned_gen_number)
         args.free_list_gen_number--;
         while (args.free_list_gen_number >= bottom_gen)
         {
-            BYTE*  gap = 0;
+            uint8_t*  gap = 0;
             generation* gen2 = generation_of (args.free_list_gen_number);
             gap = allocate_at_end (Align(min_obj_size));
             generation_allocation_start (gen2) = gap;
@@ -22804,7 +22804,7 @@ void gc_heap::make_free_lists (int condemned_gen_number)
         }
 
         //reset the allocated size
-        BYTE* start2 = generation_allocation_start (youngest_generation);
+        uint8_t* start2 = generation_allocation_start (youngest_generation);
         alloc_allocated = start2 + Align (size (start2));
     }
 
@@ -22814,7 +22814,7 @@ void gc_heap::make_free_lists (int condemned_gen_number)
 #endif //TIME_GC
 }
 
-void gc_heap::make_free_list_in_brick (BYTE* tree, make_free_args* args)
+void gc_heap::make_free_list_in_brick (uint8_t* tree, make_free_args* args)
 {
     assert ((tree != NULL));
     {
@@ -22829,9 +22829,9 @@ void gc_heap::make_free_list_in_brick (BYTE* tree, make_free_args* args)
 
             }
             {
-                BYTE*  plug = tree;
+                uint8_t*  plug = tree;
                 size_t  gap_size = node_gap_size (tree);
-                BYTE*  gap = (plug - gap_size);
+                uint8_t*  gap = (plug - gap_size);
                 dprintf (3,("Making free list %Ix len %d in %d",
                 //dprintf (3,("F: %Ix len %Ix in %d",
                         (size_t)gap, gap_size, args->free_list_gen_number));
@@ -22890,7 +22890,7 @@ void gc_heap::make_free_list_in_brick (BYTE* tree, make_free_args* args)
     }
 }
 
-void gc_heap::thread_gap (BYTE* gap_start, size_t size, generation*  gen)
+void gc_heap::thread_gap (uint8_t* gap_start, size_t size, generation*  gen)
 {
     assert (generation_allocation_start (gen));
     if ((size > 0))
@@ -22922,7 +22922,7 @@ void gc_heap::thread_gap (BYTE* gap_start, size_t size, generation*  gen)
     }
 }
 
-void gc_heap::loh_thread_gap_front (BYTE* gap_start, size_t size, generation*  gen)
+void gc_heap::loh_thread_gap_front (uint8_t* gap_start, size_t size, generation*  gen)
 {
     assert (generation_allocation_start (gen));
     if (size >= min_free_list)
@@ -22932,7 +22932,7 @@ void gc_heap::loh_thread_gap_front (BYTE* gap_start, size_t size, generation*  g
     }
 }
 
-void gc_heap::make_unused_array (BYTE* x, size_t size, BOOL clearp, BOOL resetp)
+void gc_heap::make_unused_array (uint8_t* x, size_t size, BOOL clearp, BOOL resetp)
 {
     dprintf (3, ("Making unused array [%Ix, %Ix[",
         (size_t)x, (size_t)(x+size)));
@@ -22953,16 +22953,16 @@ void gc_heap::make_unused_array (BYTE* x, size_t size, BOOL clearp, BOOL resetp)
 #error "This won't work on big endian platforms"
 #endif
 
-    size_t size_as_object = (UINT32)(size - free_object_base_size) + free_object_base_size;
+    size_t size_as_object = (uint32_t)(size - free_object_base_size) + free_object_base_size;
 
     if (size_as_object < size)
     {
         //
         // If the size is more than 4GB, we need to create multiple objects because of
-        // the Array::m_NumComponents is DWORD and the high 32 bits of unused array
+        // the Array::m_NumComponents is uint32_t and the high 32 bits of unused array
         // size is ignored in regular object size computation.
         //
-        BYTE * tmp = x + size_as_object;
+        uint8_t * tmp = x + size_as_object;
         size_t remaining_size = size - size_as_object;
 
         while (remaining_size > UINT32_MAX)
@@ -22986,7 +22986,7 @@ void gc_heap::make_unused_array (BYTE* x, size_t size, BOOL clearp, BOOL resetp)
 }
 
 // Clear memory set by make_unused_array.
-void gc_heap::clear_unused_array (BYTE* x, size_t size)
+void gc_heap::clear_unused_array (uint8_t* x, size_t size)
 {
     // Also clear the sync block
     *(((PTR_PTR)x)-1) = 0;
@@ -23001,11 +23001,11 @@ void gc_heap::clear_unused_array (BYTE* x, size_t size)
 
     // The memory could have been cleared in the meantime. We have to mirror the algorithm
     // from make_unused_array since we cannot depend on the object sizes in memory.
-    size_t size_as_object = (UINT32)(size - free_object_base_size) + free_object_base_size;
+    size_t size_as_object = (uint32_t)(size - free_object_base_size) + free_object_base_size;
 
     if (size_as_object < size)
     {
-        BYTE * tmp = x + size_as_object;
+        uint8_t * tmp = x + size_as_object;
         size_t remaining_size = size - size_as_object;
 
         while (remaining_size > UINT32_MAX)
@@ -23025,9 +23025,9 @@ void gc_heap::clear_unused_array (BYTE* x, size_t size)
 }
 
 inline
-BYTE* tree_search (BYTE* tree, BYTE* old_address)
+uint8_t* tree_search (uint8_t* tree, uint8_t* old_address)
 {
-    BYTE* candidate = 0;
+    uint8_t* candidate = 0;
     int cn;
     while (1)
     {
@@ -23065,9 +23065,9 @@ BYTE* tree_search (BYTE* tree, BYTE* old_address)
         return tree;
 }
 
-void gc_heap::relocate_address (BYTE** pold_address THREAD_NUMBER_DCL)
+void gc_heap::relocate_address (uint8_t** pold_address THREAD_NUMBER_DCL)
 {
-    BYTE* old_address = *pold_address;
+    uint8_t* old_address = *pold_address;
     if (!((old_address >= gc_low) && (old_address < gc_high)))
 #ifdef MULTIPLE_HEAPS
     {
@@ -23084,7 +23084,7 @@ void gc_heap::relocate_address (BYTE** pold_address THREAD_NUMBER_DCL)
     // delta translates old_address into address_gc (old_address);
     size_t  brick = brick_of (old_address);
     int    brick_entry =  brick_table [ brick ];
-    BYTE*  new_address = old_address;
+    uint8_t*  new_address = old_address;
     if (! ((brick_entry == 0)))
     {
     retry:
@@ -23094,9 +23094,9 @@ void gc_heap::relocate_address (BYTE** pold_address THREAD_NUMBER_DCL)
                 brick = (brick + brick_entry);
                 brick_entry =  brick_table [ brick ];
             }
-            BYTE* old_loc = old_address;
+            uint8_t* old_loc = old_address;
 
-            BYTE* node = tree_search ((brick_address (brick) + brick_entry-1),
+            uint8_t* node = tree_search ((brick_address (brick) + brick_entry-1),
                                       old_loc);
             if ((node <= old_loc))
                 new_address = (old_address + node_relocation_distance (node));
@@ -23135,7 +23135,7 @@ void gc_heap::relocate_address (BYTE** pold_address THREAD_NUMBER_DCL)
 }
 
 inline void 
-gc_heap::check_class_object_demotion (BYTE* obj)
+gc_heap::check_class_object_demotion (uint8_t* obj)
 {
 #ifdef COLLECTIBLE_CLASS
     if (is_collectible(obj))
@@ -23147,7 +23147,7 @@ gc_heap::check_class_object_demotion (BYTE* obj)
 
 #ifdef COLLECTIBLE_CLASS
 NOINLINE void 
-gc_heap::check_class_object_demotion_internal (BYTE* obj)
+gc_heap::check_class_object_demotion_internal (uint8_t* obj)
 {
     if (settings.demotion)
     {
@@ -23158,10 +23158,10 @@ gc_heap::check_class_object_demotion_internal (BYTE* obj)
         set_card (card_of (obj));
 #else
         THREAD_FROM_HEAP;
-        BYTE* class_obj = get_class_object (obj);
+        uint8_t* class_obj = get_class_object (obj);
         dprintf (3, ("%Ix: got classobj %Ix", obj, class_obj));
-        BYTE* temp_class_obj = class_obj;
-        BYTE** temp = &temp_class_obj;
+        uint8_t* temp_class_obj = class_obj;
+        uint8_t** temp = &temp_class_obj;
         relocate_address (temp THREAD_NUMBER_ARG);
 
         check_demotion_helper (temp, obj);
@@ -23172,14 +23172,14 @@ gc_heap::check_class_object_demotion_internal (BYTE* obj)
 #endif //COLLECTIBLE_CLASS
 
 inline void
-gc_heap::check_demotion_helper (BYTE** pval, BYTE* parent_obj)
+gc_heap::check_demotion_helper (uint8_t** pval, uint8_t* parent_obj)
 {
     // detect if we are demoting an object
     if ((*pval < demotion_high) &&
         (*pval >= demotion_low))
     {
         dprintf(3, ("setting card %Ix:%Ix",
-                    card_of((BYTE*)pval),
+                    card_of((uint8_t*)pval),
                     (size_t)pval));
 
         set_card (card_of (parent_obj));
@@ -23193,7 +23193,7 @@ gc_heap::check_demotion_helper (BYTE** pval, BYTE* parent_obj)
             (*pval >= hp->demotion_low))
         {
             dprintf(3, ("setting card %Ix:%Ix",
-                        card_of((BYTE*)pval),
+                        card_of((uint8_t*)pval),
                         (size_t)pval));
 
             set_card (card_of (parent_obj));
@@ -23203,16 +23203,16 @@ gc_heap::check_demotion_helper (BYTE** pval, BYTE* parent_obj)
 }
 
 inline void
-gc_heap::reloc_survivor_helper (BYTE** pval)
+gc_heap::reloc_survivor_helper (uint8_t** pval)
 {
     THREAD_FROM_HEAP;
     relocate_address (pval THREAD_NUMBER_ARG);
 
-    check_demotion_helper (pval, (BYTE*)pval);
+    check_demotion_helper (pval, (uint8_t*)pval);
 }
 
 inline void
-gc_heap::relocate_obj_helper (BYTE* x, size_t s)
+gc_heap::relocate_obj_helper (uint8_t* x, size_t s)
 {
     THREAD_FROM_HEAP;
     if (contain_pointers (x))
@@ -23221,11 +23221,11 @@ gc_heap::relocate_obj_helper (BYTE* x, size_t s)
 
         go_through_object_nostart (method_table(x), x, s, pval,
                             {
-                                BYTE* child = *pval;
+                                uint8_t* child = *pval;
                                 reloc_survivor_helper (pval);
                                 if (child)
                                 {
-                                    dprintf (3, ("%Ix->%Ix->%Ix", (BYTE*)pval, child, *pval));
+                                    dprintf (3, ("%Ix->%Ix->%Ix", (uint8_t*)pval, child, *pval));
                                 }
                             });
 
@@ -23234,26 +23234,26 @@ gc_heap::relocate_obj_helper (BYTE* x, size_t s)
 }
 
 inline 
-void gc_heap::reloc_ref_in_shortened_obj (BYTE** address_to_set_card, BYTE** address_to_reloc)
+void gc_heap::reloc_ref_in_shortened_obj (uint8_t** address_to_set_card, uint8_t** address_to_reloc)
 {
     THREAD_FROM_HEAP;
 
-    BYTE* old_val = (address_to_reloc ? *address_to_reloc : 0);
+    uint8_t* old_val = (address_to_reloc ? *address_to_reloc : 0);
     relocate_address (address_to_reloc THREAD_NUMBER_ARG);
     if (address_to_reloc)
     {
-        dprintf (3, ("SR %Ix: %Ix->%Ix", (BYTE*)address_to_reloc, old_val, *address_to_reloc));
+        dprintf (3, ("SR %Ix: %Ix->%Ix", (uint8_t*)address_to_reloc, old_val, *address_to_reloc));
     }
 
-    //check_demotion_helper (current_saved_info_to_relocate, (BYTE*)pval);
-    BYTE* relocated_addr = *address_to_reloc;
+    //check_demotion_helper (current_saved_info_to_relocate, (uint8_t*)pval);
+    uint8_t* relocated_addr = *address_to_reloc;
     if ((relocated_addr < demotion_high) &&
         (relocated_addr >= demotion_low))
     {
         dprintf (3, ("set card for location %Ix(%Ix)",
-                    (size_t)address_to_set_card, card_of((BYTE*)address_to_set_card)));
+                    (size_t)address_to_set_card, card_of((uint8_t*)address_to_set_card)));
 
-        set_card (card_of ((BYTE*)address_to_set_card));
+        set_card (card_of ((uint8_t*)address_to_set_card));
     }
 #ifdef MULTIPLE_HEAPS
     else if (settings.demotion)
@@ -23263,9 +23263,9 @@ void gc_heap::reloc_ref_in_shortened_obj (BYTE** address_to_set_card, BYTE** add
             (relocated_addr >= hp->demotion_low))
         {
             dprintf (3, ("%Ix on h%d, set card for location %Ix(%Ix)",
-                        relocated_addr, hp->heap_number, (size_t)address_to_set_card, card_of((BYTE*)address_to_set_card)));
+                        relocated_addr, hp->heap_number, (size_t)address_to_set_card, card_of((uint8_t*)address_to_set_card)));
 
-            set_card (card_of ((BYTE*)address_to_set_card));
+            set_card (card_of ((uint8_t*)address_to_set_card));
         }
     }
 #endif //MULTIPLE_HEAPS
@@ -23274,8 +23274,8 @@ void gc_heap::reloc_ref_in_shortened_obj (BYTE** address_to_set_card, BYTE** add
 void gc_heap::relocate_pre_plug_info (mark* pinned_plug_entry)
 {
     THREAD_FROM_HEAP;
-    BYTE* plug = pinned_plug (pinned_plug_entry);
-    BYTE* pre_plug_start = plug - sizeof (plug_and_gap);
+    uint8_t* plug = pinned_plug (pinned_plug_entry);
+    uint8_t* pre_plug_start = plug - sizeof (plug_and_gap);
     // Note that we need to add one ptr size here otherwise we may not be able to find the relocated
     // address. Consider this scenario: 
     // gen1 start | 3-ptr sized NP | PP
@@ -23283,25 +23283,25 @@ void gc_heap::relocate_pre_plug_info (mark* pinned_plug_entry)
     // If we are asking for the reloc address of 0x10 we will AV in relocate_address because
     // the first plug we saw in the brick is 0x18 which means 0x10 will cause us to go back a brick
     // which is 0, and then we'll AV in tree_search when we try to do node_right_child (tree). 
-    pre_plug_start += sizeof (BYTE*);
-    BYTE** old_address = &pre_plug_start;
+    pre_plug_start += sizeof (uint8_t*);
+    uint8_t** old_address = &pre_plug_start;
 
-    BYTE* old_val = (old_address ? *old_address : 0);
+    uint8_t* old_val = (old_address ? *old_address : 0);
     relocate_address (old_address THREAD_NUMBER_ARG);
     if (old_address)
     {
         dprintf (3, ("PreR %Ix: %Ix->%Ix, set reloc: %Ix", 
-            (BYTE*)old_address, old_val, *old_address, (pre_plug_start - sizeof (BYTE*))));
+            (uint8_t*)old_address, old_val, *old_address, (pre_plug_start - sizeof (uint8_t*))));
     }
 
-    pinned_plug_entry->set_pre_plug_info_reloc_start (pre_plug_start - sizeof (BYTE*));
+    pinned_plug_entry->set_pre_plug_info_reloc_start (pre_plug_start - sizeof (uint8_t*));
 }
 
 inline
-void gc_heap::relocate_shortened_obj_helper (BYTE* x, size_t s, BYTE* end, mark* pinned_plug_entry, BOOL is_pinned)
+void gc_heap::relocate_shortened_obj_helper (uint8_t* x, size_t s, uint8_t* end, mark* pinned_plug_entry, BOOL is_pinned)
 {
     THREAD_FROM_HEAP;
-    BYTE* plug = pinned_plug (pinned_plug_entry);
+    uint8_t* plug = pinned_plug (pinned_plug_entry);
 
     if (!is_pinned)
     {
@@ -23318,22 +23318,22 @@ void gc_heap::relocate_shortened_obj_helper (BYTE* x, size_t s, BYTE* end, mark*
 
     verify_pins_with_post_plug_info("after relocate_pre_plug_info");
 
-    BYTE* saved_plug_info_start = 0;
-    BYTE** saved_info_to_relocate = 0;
+    uint8_t* saved_plug_info_start = 0;
+    uint8_t** saved_info_to_relocate = 0;
 
     if (is_pinned)
     {
-        saved_plug_info_start = (BYTE*)(pinned_plug_entry->get_post_plug_info_start());
-        saved_info_to_relocate = (BYTE**)(pinned_plug_entry->get_post_plug_reloc_info());
+        saved_plug_info_start = (uint8_t*)(pinned_plug_entry->get_post_plug_info_start());
+        saved_info_to_relocate = (uint8_t**)(pinned_plug_entry->get_post_plug_reloc_info());
     }
     else
     {
         saved_plug_info_start = (plug - sizeof (plug_and_gap));
-        saved_info_to_relocate = (BYTE**)(pinned_plug_entry->get_pre_plug_reloc_info());
+        saved_info_to_relocate = (uint8_t**)(pinned_plug_entry->get_pre_plug_reloc_info());
     }
     
-    BYTE** current_saved_info_to_relocate = 0;
-    BYTE* child = 0;
+    uint8_t** current_saved_info_to_relocate = 0;
+    uint8_t* child = 0;
 
     dprintf (3, ("x: %Ix, pp: %Ix, end: %Ix", x, plug, end));
 
@@ -23343,15 +23343,15 @@ void gc_heap::relocate_shortened_obj_helper (BYTE* x, size_t s, BYTE* end, mark*
 
         go_through_object_nostart (method_table(x), x, s, pval,
         {
-            dprintf (3, ("obj %Ix, member: %Ix->%Ix", x, (BYTE*)pval, *pval));
+            dprintf (3, ("obj %Ix, member: %Ix->%Ix", x, (uint8_t*)pval, *pval));
 
-            if ((BYTE*)pval >= end)
+            if ((uint8_t*)pval >= end)
             {
-                current_saved_info_to_relocate = saved_info_to_relocate + ((BYTE*)pval - saved_plug_info_start) / sizeof (BYTE**);
+                current_saved_info_to_relocate = saved_info_to_relocate + ((uint8_t*)pval - saved_plug_info_start) / sizeof (uint8_t**);
                 child = *current_saved_info_to_relocate;
                 reloc_ref_in_shortened_obj (pval, current_saved_info_to_relocate);
                 dprintf (3, ("last part: R-%Ix(saved: %Ix)->%Ix ->%Ix",
-                    (BYTE*)pval, current_saved_info_to_relocate, child, *current_saved_info_to_relocate));
+                    (uint8_t*)pval, current_saved_info_to_relocate, child, *current_saved_info_to_relocate));
             }
             else
             {
@@ -23363,13 +23363,13 @@ void gc_heap::relocate_shortened_obj_helper (BYTE* x, size_t s, BYTE* end, mark*
     check_class_object_demotion (x);
 }
 
-void gc_heap::relocate_survivor_helper (BYTE* plug, BYTE* plug_end)
+void gc_heap::relocate_survivor_helper (uint8_t* plug, uint8_t* plug_end)
 {
-    BYTE*  x = plug;
+    uint8_t*  x = plug;
     while (x < plug_end)
     {
         size_t s = size (x);
-        BYTE* next_obj = x + Align (s);
+        uint8_t* next_obj = x + Align (s);
         Prefetch (next_obj);
         relocate_obj_helper (x, s);
         assert (s > 0);
@@ -23399,7 +23399,7 @@ void gc_heap::verify_pins_with_post_plug_info (const char* msg)
                 pinned_plug_entry->post_short_p() && 
                 (pinned_plug_entry->saved_post_plug_debug.gap != 1))
             {
-                BYTE* next_obj = pinned_plug_entry->get_post_plug_info_start() + sizeof (plug_and_gap);
+                uint8_t* next_obj = pinned_plug_entry->get_post_plug_info_start() + sizeof (plug_and_gap);
                 // object after pin
                 dprintf (3, ("OFP: %Ix, G: %Ix, R: %Ix, LC: %d, RC: %d", 
                     next_obj, node_gap_size (next_obj), node_relocation_distance (next_obj),
@@ -23439,7 +23439,7 @@ void gc_heap::verify_pins_with_post_plug_info (const char* msg)
 // We don't want to burn another ptr size space for pinned plugs to record this so just 
 // set the card unconditionally for collectible objects if we are demoting.
 inline void
-gc_heap::unconditional_set_card_collectible (BYTE* obj)
+gc_heap::unconditional_set_card_collectible (uint8_t* obj)
 {
     if (settings.demotion)
     {
@@ -23448,10 +23448,10 @@ gc_heap::unconditional_set_card_collectible (BYTE* obj)
 }
 #endif //COLLECTIBLE_CLASS
 
-void gc_heap::relocate_shortened_survivor_helper (BYTE* plug, BYTE* plug_end, mark* pinned_plug_entry)
+void gc_heap::relocate_shortened_survivor_helper (uint8_t* plug, uint8_t* plug_end, mark* pinned_plug_entry)
 {
-    BYTE*  x = plug;
-    BYTE* p_plug = pinned_plug (pinned_plug_entry);
+    uint8_t*  x = plug;
+    uint8_t* p_plug = pinned_plug (pinned_plug_entry);
     BOOL is_pinned = (plug == p_plug);
     BOOL check_short_obj_p = (is_pinned ? pinned_plug_entry->post_short_p() : pinned_plug_entry->pre_short_p());
 
@@ -23476,8 +23476,8 @@ void gc_heap::relocate_shortened_survivor_helper (BYTE* plug, BYTE* plug_end, ma
 #endif //COLLECTIBLE_CLASS
 
                 // Relocate the saved references based on bits set.
-                BYTE** saved_plug_info_start = (BYTE**)(pinned_plug_entry->get_post_plug_info_start());
-                BYTE** saved_info_to_relocate = (BYTE**)(pinned_plug_entry->get_post_plug_reloc_info());
+                uint8_t** saved_plug_info_start = (uint8_t**)(pinned_plug_entry->get_post_plug_info_start());
+                uint8_t** saved_info_to_relocate = (uint8_t**)(pinned_plug_entry->get_post_plug_reloc_info());
                 for (size_t i = 0; i < pinned_plug_entry->get_max_short_bits(); i++)
                 {
                     if (pinned_plug_entry->post_short_bit_p (i))
@@ -23496,8 +23496,8 @@ void gc_heap::relocate_shortened_survivor_helper (BYTE* plug, BYTE* plug_end, ma
                 relocate_pre_plug_info (pinned_plug_entry);
 
                 // Relocate the saved references based on bits set.
-                BYTE** saved_plug_info_start = (BYTE**)(p_plug - sizeof (plug_and_gap));
-                BYTE** saved_info_to_relocate = (BYTE**)(pinned_plug_entry->get_pre_plug_reloc_info());
+                uint8_t** saved_plug_info_start = (uint8_t**)(p_plug - sizeof (plug_and_gap));
+                uint8_t** saved_info_to_relocate = (uint8_t**)(pinned_plug_entry->get_pre_plug_reloc_info());
                 for (size_t i = 0; i < pinned_plug_entry->get_max_short_bits(); i++)
                 {
                     if (pinned_plug_entry->pre_short_bit_p (i))
@@ -23511,7 +23511,7 @@ void gc_heap::relocate_shortened_survivor_helper (BYTE* plug, BYTE* plug_end, ma
         }
 
         size_t s = size (x);
-        BYTE* next_obj = x + Align (s);
+        uint8_t* next_obj = x + Align (s);
         Prefetch (next_obj);
 
         if (next_obj >= plug_end) 
@@ -23535,7 +23535,7 @@ void gc_heap::relocate_shortened_survivor_helper (BYTE* plug, BYTE* plug_end, ma
     verify_pins_with_post_plug_info("end reloc short surv");
 }
 
-void gc_heap::relocate_survivors_in_plug (BYTE* plug, BYTE* plug_end,
+void gc_heap::relocate_survivors_in_plug (uint8_t* plug, uint8_t* plug_end,
                                           BOOL check_last_object_p, 
                                           mark* pinned_plug_entry)
 {
@@ -23552,7 +23552,7 @@ void gc_heap::relocate_survivors_in_plug (BYTE* plug, BYTE* plug_end,
     }
 }
 
-void gc_heap::relocate_survivors_in_brick (BYTE* tree, relocate_args* args)
+void gc_heap::relocate_survivors_in_brick (uint8_t* tree, relocate_args* args)
 {
     assert ((tree != NULL));
 
@@ -23567,7 +23567,7 @@ void gc_heap::relocate_survivors_in_brick (BYTE* tree, relocate_args* args)
         relocate_survivors_in_brick (tree + node_left_child (tree), args);
     }
     {
-        BYTE*  plug = tree;
+        uint8_t*  plug = tree;
         BOOL   has_post_plug_info_p = FALSE;
         BOOL   has_pre_plug_info_p = FALSE;
 
@@ -23582,10 +23582,10 @@ void gc_heap::relocate_survivors_in_brick (BYTE* tree, relocate_args* args)
         if (args->last_plug)
         {
             size_t  gap_size = node_gap_size (tree);
-            BYTE*  gap = (plug - gap_size);
+            uint8_t*  gap = (plug - gap_size);
             dprintf (3, ("tree: %Ix, gap: %Ix (%Ix)", tree, gap, gap_size));
             assert (gap_size >= Align (min_obj_size));
-            BYTE*  last_plug_end = gap;
+            uint8_t*  last_plug_end = gap;
 
             BOOL check_last_object_p = (args->is_shortened || has_pre_plug_info_p);
 
@@ -23619,16 +23619,16 @@ void gc_heap::update_oldest_pinned_plug()
 }
 
 void gc_heap::relocate_survivors (int condemned_gen_number,
-                                  BYTE* first_condemned_address)
+                                  uint8_t* first_condemned_address)
 {
     generation* condemned_gen = generation_of (condemned_gen_number);
-    BYTE*  start_address = first_condemned_address;
+    uint8_t*  start_address = first_condemned_address;
     size_t  current_brick = brick_of (start_address);
     heap_segment*  current_heap_segment = heap_segment_rw (generation_start_segment (condemned_gen));
 
     PREFIX_ASSUME(current_heap_segment != NULL);
 
-    BYTE*  end_address = 0;
+    uint8_t*  end_address = 0;
 
     reset_pinned_queue_bos();
     update_oldest_pinned_plug();
@@ -23686,7 +23686,7 @@ void gc_heap::relocate_survivors (int condemned_gen_number,
 }
 
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-void gc_heap::walk_plug (BYTE* plug, size_t size, BOOL check_last_object_p, walk_relocate_args* args, size_t profiling_context)
+void gc_heap::walk_plug (uint8_t* plug, size_t size, BOOL check_last_object_p, walk_relocate_args* args, size_t profiling_context)
 {
     if (check_last_object_p)
     {
@@ -23733,7 +23733,7 @@ void gc_heap::walk_plug (BYTE* plug, size_t size, BOOL check_last_object_p, walk
     }
 }
 
-void gc_heap::walk_relocation_in_brick (BYTE* tree, walk_relocate_args* args, size_t profiling_context)
+void gc_heap::walk_relocation_in_brick (uint8_t* tree, walk_relocate_args* args, size_t profiling_context)
 {
     assert ((tree != NULL));
     if (node_left_child (tree))
@@ -23741,7 +23741,7 @@ void gc_heap::walk_relocation_in_brick (BYTE* tree, walk_relocate_args* args, si
         walk_relocation_in_brick (tree + node_left_child (tree), args, profiling_context);
     }
 
-    BYTE*  plug = tree;
+    uint8_t*  plug = tree;
     BOOL   has_pre_plug_info_p = FALSE;
     BOOL   has_post_plug_info_p = FALSE;
 
@@ -23755,8 +23755,8 @@ void gc_heap::walk_relocation_in_brick (BYTE* tree, walk_relocate_args* args, si
     if (args->last_plug != 0)
     {
         size_t gap_size = node_gap_size (tree);
-        BYTE*  gap = (plug - gap_size);
-        BYTE*  last_plug_end = gap;
+        uint8_t*  gap = (plug - gap_size);
+        uint8_t*  last_plug_end = gap;
         size_t last_plug_size = (last_plug_end - args->last_plug);
         dprintf (3, ("tree: %Ix, last_plug: %Ix, gap: %Ix(%Ix), last_plug_end: %Ix, size: %Ix", 
             tree, args->last_plug, gap, gap_size, last_plug_end, last_plug_size));
@@ -23784,12 +23784,12 @@ void gc_heap::walk_relocation_in_brick (BYTE* tree, walk_relocate_args* args, si
 }
 
 void gc_heap::walk_relocation (int condemned_gen_number,
-                               BYTE* first_condemned_address,
+                               uint8_t* first_condemned_address,
                                size_t profiling_context)
 
 {
     generation* condemned_gen = generation_of (condemned_gen_number);
-    BYTE*  start_address = first_condemned_address;
+    uint8_t*  start_address = first_condemned_address;
     size_t  current_brick = brick_of (start_address);
     heap_segment*  current_heap_segment = heap_segment_rw (generation_start_segment (condemned_gen));
 
@@ -23872,8 +23872,8 @@ void gc_heap::walk_relocation_for_bgc(size_t profiling_context)
                 break;
         }
 
-        BYTE* o = heap_segment_mem (seg);
-        BYTE* end = heap_segment_allocated (seg);
+        uint8_t* o = heap_segment_mem (seg);
+        uint8_t* end = heap_segment_allocated (seg);
 
         while (o < end)
         {   
@@ -23887,7 +23887,7 @@ void gc_heap::walk_relocation_for_bgc(size_t profiling_context)
             // It's survived. Make a fake plug, starting at o,
             // and send the event
 
-            BYTE* plug_start = o;
+            uint8_t* plug_start = o;
 
             while (method_table(o) != g_pFreeObjectMethodTable)
             {
@@ -23898,7 +23898,7 @@ void gc_heap::walk_relocation_for_bgc(size_t profiling_context)
                 }
             }
                 
-            BYTE* plug_end = o;
+            uint8_t* plug_end = o;
 
             // Note on last parameter: since this is for bgc, only ETW
             // should be sending these events so that existing profapi profilers
@@ -23947,7 +23947,7 @@ void gc_heap::make_free_lists_for_profiler_for_bgc ()
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
 void gc_heap::relocate_phase (int condemned_gen_number,
-                              BYTE* first_condemned_address)
+                              uint8_t* first_condemned_address)
 {
     ScanContext sc;
     sc.thread_number = heap_number;
@@ -24063,7 +24063,7 @@ void gc_heap::relocate_phase (int condemned_gen_number,
 // POPO TODO: We are keeping this temporarily as this is also used by realloc 
 // where it passes FALSE to deque_p, change it to use the same optimization 
 // as relocate. Not as essential since realloc is already a slow path.
-mark* gc_heap::get_next_pinned_entry (BYTE* tree, 
+mark* gc_heap::get_next_pinned_entry (uint8_t* tree,
                                       BOOL* has_pre_plug_info_p, 
                                       BOOL* has_post_plug_info_p,
                                       BOOL deque_p)
@@ -24071,7 +24071,7 @@ mark* gc_heap::get_next_pinned_entry (BYTE* tree,
     if (!pinned_plug_que_empty_p())
     {
         mark* oldest_entry = oldest_pin();
-        BYTE* oldest_plug = pinned_plug (oldest_entry);
+        uint8_t* oldest_plug = pinned_plug (oldest_entry);
         if (tree == oldest_plug)
         {
             *has_pre_plug_info_p =  oldest_entry->has_pre_plug_info();
@@ -24108,7 +24108,7 @@ mark* gc_heap::get_oldest_pinned_entry (BOOL* has_pre_plug_info_p,
 }
 
 inline
-void gc_heap::copy_cards_range (BYTE* dest, BYTE* src, size_t len, BOOL copy_cards_p)
+void gc_heap::copy_cards_range (uint8_t* dest, uint8_t* src, size_t len, BOOL copy_cards_p)
 {
     if (copy_cards_p)
         copy_cards_for_addresses (dest, src, len);
@@ -24120,7 +24120,7 @@ void gc_heap::copy_cards_range (BYTE* dest, BYTE* src, size_t len, BOOL copy_car
 // we always copy the earlier plugs first which means we won't need the gap sizes anymore. This way
 // we won't need to individually recover each overwritten part of plugs.
 inline
-void  gc_heap::gcmemcopy (BYTE* dest, BYTE* src, size_t len, BOOL copy_cards_p)
+void  gc_heap::gcmemcopy (uint8_t* dest, uint8_t* src, size_t len, BOOL copy_cards_p)
 {
     if (dest != src)
     {
@@ -24139,10 +24139,10 @@ void  gc_heap::gcmemcopy (BYTE* dest, BYTE* src, size_t len, BOOL copy_cards_p)
     }
 }
 
-void gc_heap::compact_plug (BYTE* plug, size_t size, BOOL check_last_object_p, compact_args* args)
+void gc_heap::compact_plug (uint8_t* plug, size_t size, BOOL check_last_object_p, compact_args* args)
 {
     args->print();
-    BYTE* reloc_plug = plug + args->last_plug_relocation;
+    uint8_t* reloc_plug = plug + args->last_plug_relocation;
 
     if (check_last_object_p)
     {
@@ -24311,7 +24311,7 @@ void gc_heap::compact_plug (BYTE* plug, size_t size, BOOL check_last_object_p, c
     }
 }
 
-void gc_heap::compact_in_brick (BYTE* tree, compact_args* args)
+void gc_heap::compact_in_brick (uint8_t* tree, compact_args* args)
 {
     assert (tree != NULL);
     int   left_node = node_left_child (tree);
@@ -24326,7 +24326,7 @@ void gc_heap::compact_in_brick (BYTE* tree, compact_args* args)
         compact_in_brick ((tree + left_node), args);
     }
 
-    BYTE*  plug = tree;
+    uint8_t*  plug = tree;
     BOOL   has_pre_plug_info_p = FALSE;
     BOOL   has_post_plug_info_p = FALSE;
 
@@ -24340,8 +24340,8 @@ void gc_heap::compact_in_brick (BYTE* tree, compact_args* args)
     if (args->last_plug != 0)
     {
         size_t gap_size = node_gap_size (tree);
-        BYTE*  gap = (plug - gap_size);
-        BYTE*  last_plug_end = gap;
+        uint8_t*  gap = (plug - gap_size);
+        uint8_t*  last_plug_end = gap;
         size_t last_plug_size = (last_plug_end - args->last_plug);
         dprintf (3, ("tree: %Ix, last_plug: %Ix, gap: %Ix(%Ix), last_plug_end: %Ix, size: %Ix", 
             tree, args->last_plug, gap, gap_size, last_plug_end, last_plug_size));
@@ -24391,7 +24391,7 @@ void gc_heap::recover_saved_pinned_info()
 }
 
 void gc_heap::compact_phase (int condemned_gen_number,
-                             BYTE*  first_condemned_address,
+                             uint8_t*  first_condemned_address,
                              BOOL clear_cards)
 {
 //  %type%  category = quote (compact);
@@ -24401,7 +24401,7 @@ void gc_heap::compact_phase (int condemned_gen_number,
         start = GetCycleCount32();
 #endif //TIME_GC
     generation*   condemned_gen = generation_of (condemned_gen_number);
-    BYTE*  start_address = first_condemned_address;
+    uint8_t*  start_address = first_condemned_address;
     size_t   current_brick = brick_of (start_address);
     heap_segment*  current_heap_segment = heap_segment_rw (generation_start_segment (condemned_gen));
 
@@ -24423,7 +24423,7 @@ void gc_heap::compact_phase (int condemned_gen_number,
         }
     }
 
-    BYTE*  end_address = heap_segment_allocated (current_heap_segment);
+    uint8_t*  end_address = heap_segment_allocated (current_heap_segment);
 
     size_t  end_brick = brick_of (end_address-1);
     compact_args args;
@@ -24541,7 +24541,7 @@ void gc_heap::compact_phase (int condemned_gen_number,
 //
 // Also, any exceptions that escape out of the GC thread are fatal. Thus, once
 // we do our unhandled exception processing, we shall failfast.
-inline LONG GCUnhandledExceptionFilter(EXCEPTION_POINTERS* pExceptionPointers, PVOID pv)
+inline LONG GCUnhandledExceptionFilter(EXCEPTION_POINTERS* pExceptionPointers, void* pv)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -24592,7 +24592,7 @@ inline LONG GCUnhandledExceptionFilter(EXCEPTION_POINTERS* pExceptionPointers, P
 #pragma warning(push)
 #pragma warning(disable:4702) // C4702: unreachable code: gc_thread_function may not return
 #endif //_MSC_VER
-DWORD __stdcall gc_heap::gc_thread_stub (void* arg)
+uint32_t __stdcall gc_heap::gc_thread_stub (void* arg)
 {
     ClrFlsSetThreadType (ThreadType_GC);
     STRESS_LOG_RESERVE_MEM (GC_STRESSLOG_MULTIPLY);
@@ -24642,7 +24642,7 @@ DWORD __stdcall gc_heap::gc_thread_stub (void* arg)
 #pragma warning(push)
 #pragma warning(disable:4702) // C4702: unreachable code: gc_thread_function may not return
 #endif //_MSC_VER
-DWORD __stdcall gc_heap::bgc_thread_stub (void* arg)
+uint32_t __stdcall gc_heap::bgc_thread_stub (void* arg)
 {
     gc_heap* heap = (gc_heap*)arg;
 
@@ -24703,7 +24703,7 @@ void gc_heap::background_drain_mark_list (int thread)
     while (c_mark_list_index != 0)
     {
         size_t current_index = c_mark_list_index - 1;
-        BYTE* o = c_mark_list [current_index];
+        uint8_t* o = c_mark_list [current_index];
         background_mark_object (o THREAD_NUMBER_ARG);
         c_mark_list_index--;
     }
@@ -24779,8 +24779,8 @@ void gc_heap::background_scan_dependent_handles (ScanContext *sc)
 
             if (!s_fScanRequired)
             {
-                BYTE* all_heaps_max = 0;
-                BYTE* all_heaps_min = MAX_PTR;
+                uint8_t* all_heaps_max = 0;
+                uint8_t* all_heaps_min = MAX_PTR;
                 int i;
                 for (i = 0; i < n_heaps; i++)
                 {
@@ -24934,7 +24934,7 @@ void gc_heap::clear_commit_flag_global()
 #endif //MULTIPLE_HEAPS
 }
 
-void gc_heap::verify_mark_array_cleared (BYTE* begin, BYTE* end, DWORD* mark_array_addr)
+void gc_heap::verify_mark_array_cleared (uint8_t* begin, uint8_t* end, uint32_t* mark_array_addr)
 {
 #ifdef _DEBUG
     size_t  markw = mark_word_of (begin);
@@ -24953,23 +24953,23 @@ void gc_heap::verify_mark_array_cleared (BYTE* begin, BYTE* end, DWORD* mark_arr
 #endif //_DEBUG
 }
 
-void gc_heap::verify_mark_array_cleared (heap_segment* seg, DWORD* mark_array_addr)
+void gc_heap::verify_mark_array_cleared (heap_segment* seg, uint32_t* mark_array_addr)
 {
     verify_mark_array_cleared (heap_segment_mem (seg), heap_segment_reserved (seg), mark_array_addr);
 }
 
 BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp, 
                                          heap_segment* seg,
-                                         BYTE* new_lowest_address)
+                                         uint8_t* new_lowest_address)
 {
-    BYTE* start = (BYTE*)seg;
-    BYTE* end = heap_segment_reserved (seg);
+    uint8_t* start = (uint8_t*)seg;
+    uint8_t* end = heap_segment_reserved (seg);
 
-    BYTE* lowest = hp->background_saved_lowest_address;
-    BYTE* highest = hp->background_saved_highest_address;
+    uint8_t* lowest = hp->background_saved_lowest_address;
+    uint8_t* highest = hp->background_saved_highest_address;
 
-    BYTE* commit_start = NULL;
-    BYTE* commit_end = NULL;
+    uint8_t* commit_start = NULL;
+    uint8_t* commit_end = NULL;
     size_t commit_flag = 0;
 
     if ((highest >= start) &&
@@ -25003,8 +25003,8 @@ BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp,
                 new_lowest_address = g_lowest_address;
             }
 
-            DWORD* ct = &g_card_table[card_word (gcard_of (new_lowest_address))];
-            DWORD* ma = (DWORD*)((BYTE*)card_table_mark_array (ct) - size_mark_array_of (0, new_lowest_address));
+            uint32_t* ct = &g_card_table[card_word (gcard_of (new_lowest_address))];
+            uint32_t* ma = (uint32_t*)((uint8_t*)card_table_mark_array (ct) - size_mark_array_of (0, new_lowest_address));
 
             dprintf (GC_TABLE_LOG, ("table realloc-ed: %Ix->%Ix, MA: %Ix->%Ix", 
                                     hp->card_table, g_card_table,
@@ -25022,19 +25022,19 @@ BOOL gc_heap::commit_mark_array_new_seg (gc_heap* hp,
     return TRUE;
 }
 
-BOOL gc_heap::commit_mark_array_by_range (BYTE* begin, BYTE* end, DWORD* mark_array_addr)
+BOOL gc_heap::commit_mark_array_by_range (uint8_t* begin, uint8_t* end, uint32_t* mark_array_addr)
 {
     size_t beg_word = mark_word_of (begin);
     size_t end_word = mark_word_of (align_on_mark_word (end));
-    BYTE* commit_start = align_lower_page ((BYTE*)&mark_array_addr[beg_word]);
-    BYTE* commit_end = align_on_page ((BYTE*)&mark_array_addr[end_word]);
+    uint8_t* commit_start = align_lower_page ((uint8_t*)&mark_array_addr[beg_word]);
+    uint8_t* commit_end = align_on_page ((uint8_t*)&mark_array_addr[end_word]);
     size_t size = (size_t)(commit_end - commit_start);
 
 #ifdef SIMPLE_DPRINTF
     dprintf (GC_TABLE_LOG, ("range: %Ix->%Ix mark word: %Ix->%Ix(%Id), mark array: %Ix->%Ix(%Id), commit %Ix->%Ix(%Id)",
                             begin, end,
                             beg_word, end_word,
-                            (end_word - beg_word) * sizeof (DWORD), 
+                            (end_word - beg_word) * sizeof (uint32_t),
                             &mark_array_addr[beg_word],
                             &mark_array_addr[end_word],
                             (size_t)(&mark_array_addr[end_word] - &mark_array_addr[beg_word]),
@@ -25052,22 +25052,22 @@ BOOL gc_heap::commit_mark_array_by_range (BYTE* begin, BYTE* end, DWORD* mark_ar
     }
     else
     {
-        dprintf (GC_TABLE_LOG, ("failed to commit %Id bytes", (end_word - beg_word) * sizeof (DWORD)));
+        dprintf (GC_TABLE_LOG, ("failed to commit %Id bytes", (end_word - beg_word) * sizeof (uint32_t)));
         return FALSE;
     }
 }
 
-BOOL gc_heap::commit_mark_array_with_check (heap_segment* seg, DWORD* new_mark_array_addr)
+BOOL gc_heap::commit_mark_array_with_check (heap_segment* seg, uint32_t* new_mark_array_addr)
 {
-    BYTE* start = (BYTE*)seg;
-    BYTE* end = heap_segment_reserved (seg);
+    uint8_t* start = (uint8_t*)seg;
+    uint8_t* end = heap_segment_reserved (seg);
 
 #ifdef MULTIPLE_HEAPS
-    BYTE* lowest = heap_segment_heap (seg)->background_saved_lowest_address;
-    BYTE* highest = heap_segment_heap (seg)->background_saved_highest_address;
+    uint8_t* lowest = heap_segment_heap (seg)->background_saved_lowest_address;
+    uint8_t* highest = heap_segment_heap (seg)->background_saved_highest_address;
 #else
-    BYTE* lowest = background_saved_lowest_address;
-    BYTE* highest = background_saved_highest_address;
+    uint8_t* lowest = background_saved_lowest_address;
+    uint8_t* highest = background_saved_highest_address;
 #endif //MULTIPLE_HEAPS
 
     if ((highest >= start) &&
@@ -25084,16 +25084,16 @@ BOOL gc_heap::commit_mark_array_with_check (heap_segment* seg, DWORD* new_mark_a
     return TRUE;
 }
 
-BOOL gc_heap::commit_mark_array_by_seg (heap_segment* seg, DWORD* mark_array_addr)
+BOOL gc_heap::commit_mark_array_by_seg (heap_segment* seg, uint32_t* mark_array_addr)
 {
     dprintf (GC_TABLE_LOG, ("seg: %Ix->%Ix; MA: %Ix", 
                             seg, 
                             heap_segment_reserved (seg),
                             mark_array_addr));
-    return commit_mark_array_by_range ((BYTE*)seg, heap_segment_reserved (seg), mark_array_addr);
+    return commit_mark_array_by_range ((uint8_t*)seg, heap_segment_reserved (seg), mark_array_addr);
 }
 
-BOOL gc_heap::commit_mark_array_bgc_init (DWORD* mark_array_addr)
+BOOL gc_heap::commit_mark_array_bgc_init (uint32_t* mark_array_addr)
 {
     dprintf (GC_TABLE_LOG, ("BGC init commit: lowest: %Ix, highest: %Ix, mark_array: %Ix", 
                             lowest_address, highest_address, mark_array));
@@ -25138,8 +25138,8 @@ BOOL gc_heap::commit_mark_array_bgc_init (DWORD* mark_array_addr)
                 }
                 else
                 {
-                    BYTE* start = max (lowest_address, (BYTE*)seg);
-                    BYTE* end = min (highest_address, heap_segment_reserved (seg));
+                    uint8_t* start = max (lowest_address, (uint8_t*)seg);
+                    uint8_t* end = min (highest_address, heap_segment_reserved (seg));
                     if (commit_mark_array_by_range (start, end, mark_array))
                     {
                         seg->flags |= heap_segment_flags_ma_pcommitted;
@@ -25177,7 +25177,7 @@ BOOL gc_heap::commit_mark_array_bgc_init (DWORD* mark_array_addr)
 
 // This function doesn't check the commit flag since it's for a new array -
 // the mark_array flag for these segments will remain the same.
-BOOL gc_heap::commit_new_mark_array (DWORD* new_mark_array_addr)
+BOOL gc_heap::commit_new_mark_array (uint32_t* new_mark_array_addr)
 {
     dprintf (GC_TABLE_LOG, ("commiting existing segs on MA %Ix", new_mark_array_addr));
     generation* gen = generation_of (max_generation);
@@ -25218,7 +25218,7 @@ BOOL gc_heap::commit_new_mark_array (DWORD* new_mark_array_addr)
     return TRUE;
 }
 
-BOOL gc_heap::commit_new_mark_array_global (DWORD* new_mark_array)
+BOOL gc_heap::commit_new_mark_array_global (uint32_t* new_mark_array)
 {
 #ifdef MULTIPLE_HEAPS
     for (int i = 0; i < n_heaps; i++)
@@ -25254,8 +25254,8 @@ void gc_heap::decommit_mark_array_by_seg (heap_segment* seg)
     if ((flags & heap_segment_flags_ma_committed) ||
         (flags & heap_segment_flags_ma_pcommitted))
     {
-        BYTE* start = (BYTE*)seg;
-        BYTE* end = heap_segment_reserved (seg);
+        uint8_t* start = (uint8_t*)seg;
+        uint8_t* end = heap_segment_reserved (seg);
 
         if (flags & heap_segment_flags_ma_pcommitted)
         {
@@ -25265,15 +25265,15 @@ void gc_heap::decommit_mark_array_by_seg (heap_segment* seg)
 
         size_t beg_word = mark_word_of (start);
         size_t end_word = mark_word_of (align_on_mark_word (end));
-        BYTE* decommit_start = align_on_page ((BYTE*)&mark_array[beg_word]);
-        BYTE* decommit_end = align_lower_page ((BYTE*)&mark_array[end_word]);
+        uint8_t* decommit_start = align_on_page ((uint8_t*)&mark_array[beg_word]);
+        uint8_t* decommit_end = align_lower_page ((uint8_t*)&mark_array[end_word]);
         size_t size = (size_t)(decommit_end - decommit_start);
 
 #ifdef SIMPLE_DPRINTF
         dprintf (GC_TABLE_LOG, ("seg: %Ix mark word: %Ix->%Ix(%Id), mark array: %Ix->%Ix(%Id), decommit %Ix->%Ix(%Id)",
                                 seg,
                                 beg_word, end_word,
-                                (end_word - beg_word) * sizeof (DWORD), 
+                                (end_word - beg_word) * sizeof (uint32_t),
                                 &mark_array[beg_word],
                                 &mark_array[end_word],
                                 (size_t)(&mark_array[end_word] - &mark_array[beg_word]),
@@ -25331,7 +25331,7 @@ void gc_heap::background_mark_phase ()
     bgc_overflow_count = 0;
 
     bpromoted_bytes (heap_number) = 0;
-    static DWORD num_sizedrefs = 0;
+    static uint32_t num_sizedrefs = 0;
 
     background_min_overflow_address = MAX_PTR;
     background_max_overflow_address = 0;
@@ -25351,7 +25351,7 @@ void gc_heap::background_mark_phase ()
 
         c_mark_list_index = 0;
 
-        shigh = (BYTE*) 0;
+        shigh = (uint8_t*) 0;
         slow  = MAX_PTR;
 
         generation*   gen = generation_of (max_generation);
@@ -25517,8 +25517,8 @@ void gc_heap::background_mark_phase ()
         bgc_t_join.join(this, gc_join_concurrent_overflow);
         if (bgc_t_join.joined())
         {
-            BYTE* all_heaps_max = 0;
-            BYTE* all_heaps_min = MAX_PTR;
+            uint8_t* all_heaps_max = 0;
+            uint8_t* all_heaps_min = MAX_PTR;
             int i;
             for (i = 0; i < n_heaps; i++)
             {
@@ -25864,11 +25864,11 @@ gc_heap::restart_EE ()
 #endif //MULTIPLE_HEAPS
 }
 
-inline BYTE* gc_heap::high_page ( heap_segment* seg, BOOL concurrent_p)
+inline uint8_t* gc_heap::high_page ( heap_segment* seg, BOOL concurrent_p)
 {
     if (concurrent_p)
     {
-        BYTE* end = ((seg == ephemeral_heap_segment) ? 
+        uint8_t* end = ((seg == ephemeral_heap_segment) ?
                      generation_allocation_start (generation_of (max_generation-1)) :
                      heap_segment_allocated (seg));
         return align_lower_page (end);
@@ -25879,21 +25879,21 @@ inline BYTE* gc_heap::high_page ( heap_segment* seg, BOOL concurrent_p)
     }
 }
 
-void gc_heap::revisit_written_page (BYTE* page,
-                                    BYTE* end,
+void gc_heap::revisit_written_page (uint8_t* page,
+                                    uint8_t* end,
                                     BOOL concurrent_p,
                                     heap_segment* seg,
-                                    BYTE*& last_page,
-                                    BYTE*& last_object,
+                                    uint8_t*& last_page,
+                                    uint8_t*& last_object,
                                     BOOL large_objects_p,
                                     size_t& num_marked_objects)
 {
-    BYTE*   start_address = page;
-    BYTE*   o             = 0;
+    uint8_t*   start_address = page;
+    uint8_t*   o             = 0;
     int align_const = get_alignment_constant (!large_objects_p);
-    BYTE* high_address = end;
-    BYTE* current_lowest_address = background_saved_lowest_address;
-    BYTE* current_highest_address = background_saved_highest_address;
+    uint8_t* high_address = end;
+    uint8_t* current_lowest_address = background_saved_lowest_address;
+    uint8_t* current_highest_address = background_saved_highest_address;
     BOOL no_more_loop_p = FALSE;
 
     THREAD_FROM_HEAP;
@@ -25950,7 +25950,7 @@ void gc_heap::revisit_written_page (BYTE* page,
 
         assert (Align (s) >= Align (min_obj_size));
 
-        BYTE* next_o =  o + Align (s, align_const);
+        uint8_t* next_o =  o + Align (s, align_const);
 
         if (next_o >= start_address) 
         {
@@ -25979,12 +25979,12 @@ void gc_heap::revisit_written_page (BYTE* page,
             {
                 dprintf (3, ("going through %Ix", (size_t)o));
                 go_through_object (method_table(o), o, s, poo, start_address, use_start, (o + s),
-                                    if ((BYTE*)poo >= min (high_address, page + OS_PAGE_SIZE))
+                                    if ((uint8_t*)poo >= min (high_address, page + OS_PAGE_SIZE))
                                     {
                                         no_more_loop_p = TRUE;
                                         goto end_limit;
                                     }
-                                    BYTE* oo = *poo;
+                                    uint8_t* oo = *poo;
 
                                     num_marked_objects++;
                                     background_mark_object (oo THREAD_NUMBER_ARG);
@@ -26049,7 +26049,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
 
     PREFIX_ASSUME(seg != NULL);
 
-    DWORD granularity;
+    uint32_t granularity;
     int mode = concurrent_p ? 1 : 0;
     BOOL small_object_segments = TRUE;
     int align_const = get_alignment_constant (small_object_segments);
@@ -26100,15 +26100,15 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                 break;
             }
         }
-        BYTE* base_address = (BYTE*)heap_segment_mem (seg);
+        uint8_t* base_address = (uint8_t*)heap_segment_mem (seg);
         //we need to truncate to the base of the page because
         //some newly allocated could exist beyond heap_segment_allocated
         //and if we reset the last page write watch status,
         // they wouldn't be guaranteed to be visited -> gc hole.
         ULONG_PTR bcount = array_size;
-        BYTE* last_page = 0;
-        BYTE* last_object = heap_segment_mem (seg);
-        BYTE* high_address = 0;
+        uint8_t* last_page = 0;
+        uint8_t* last_object = heap_segment_mem (seg);
+        uint8_t* high_address = 0;
 
         BOOL skip_seg_p = FALSE;
 
@@ -26155,8 +26155,8 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                     ptrdiff_t region_size = high_address - base_address;
                     dprintf (3, ("h%d: gw: [%Ix(%Id)", heap_number, (size_t)base_address, (size_t)region_size));
 
-                    UINT status = GetWriteWatch (mode, base_address, region_size,
-                                                (PVOID*)background_written_addresses,
+                    uint32_t status = GetWriteWatch (mode, base_address, region_size,
+                                                (void**)background_written_addresses,
                                                 &bcount, &granularity);
 
     //#ifdef _DEBUG
@@ -26187,7 +26187,7 @@ void gc_heap::revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p)
                                         card_of (background_written_addresses [i]), g_addresses [i],
                                         card_of (background_written_addresses [i]+OS_PAGE_SIZE), background_written_addresses [i]+OS_PAGE_SIZE));
     #endif //NO_WRITE_BARRIER
-                            BYTE* page = (BYTE*)background_written_addresses[i];
+                            uint8_t* page = (uint8_t*)background_written_addresses[i];
                             dprintf (3, ("looking at page %d at %Ix(h: %Ix)", i, 
                                 (size_t)page, (size_t)high_address));
                             if (page < high_address)
@@ -26234,16 +26234,16 @@ void gc_heap::background_grow_c_mark_list()
 #endif //!MULTIPLE_HEAPS
 
     dprintf (2, ("stack copy buffer overflow"));
-    BYTE** new_c_mark_list = 0;
+    uint8_t** new_c_mark_list = 0;
     {
         FAULT_NOT_FATAL();
-        if (c_mark_list_length >= (SIZE_T_MAX / (2 * sizeof (BYTE*))))
+        if (c_mark_list_length >= (SIZE_T_MAX / (2 * sizeof (uint8_t*))))
         {
             should_drain_p = TRUE;
         }
         else
         {
-            new_c_mark_list = new (nothrow) BYTE*[c_mark_list_length*2];
+            new_c_mark_list = new (nothrow) uint8_t*[c_mark_list_length*2];
             if (new_c_mark_list == 0)
             {
                 should_drain_p = TRUE;
@@ -26260,7 +26260,7 @@ void gc_heap::background_grow_c_mark_list()
     else
     {
         assert (new_c_mark_list);
-        memcpy (new_c_mark_list, c_mark_list, c_mark_list_length*sizeof(BYTE*));
+        memcpy (new_c_mark_list, c_mark_list, c_mark_list_length*sizeof(uint8_t*));
         c_mark_list_length = c_mark_list_length*2;
         delete c_mark_list;
         c_mark_list = new_c_mark_list;
@@ -26268,7 +26268,7 @@ void gc_heap::background_grow_c_mark_list()
 }
 
 void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
-                                  DWORD flags)
+                                  uint32_t flags)
 {
     UNREFERENCED_PARAMETER(sc);
     //in order to save space on the array, mark the object,
@@ -26280,7 +26280,7 @@ void gc_heap::background_promote_callback (Object** ppObject, ScanContext* sc,
     const int thread = 0;
 #endif //!MULTIPLE_HEAPS
 
-    BYTE* o = (BYTE*)*ppObject;
+    uint8_t* o = (uint8_t*)*ppObject;
 
     if (o == 0)
         return;
@@ -26428,8 +26428,8 @@ BOOL gc_heap::create_bgc_thread(gc_heap* gh)
         // And since it's a managed thread we also need to make sure that we don't
         // clean up here and are still executing code on that thread (it'll
         // trigger all sorts of asserts.
-        //DWORD res = gh->background_gc_create_event.Wait(20,FALSE);
-        DWORD res = gh->background_gc_create_event.Wait(INFINITE,FALSE);
+        //uint32_t res = gh->background_gc_create_event.Wait(20,FALSE);
+        uint32_t res = gh->background_gc_create_event.Wait(INFINITE,FALSE);
         if (res == WAIT_TIMEOUT)
         {
             dprintf (2, ("waiting for the thread to reach its main loop Timeout."));
@@ -26516,7 +26516,7 @@ cleanup:
 BOOL gc_heap::create_bgc_thread_support()
 {
     BOOL ret = FALSE;
-    BYTE** parr;
+    uint8_t** parr;
     
     gc_lh_block_event.CreateManualEvent(FALSE);
     if (!gc_lh_block_event.IsValid())
@@ -26531,7 +26531,7 @@ BOOL gc_heap::create_bgc_thread_support()
     }
 
     //needs to have room for enough smallest objects fitting on a page
-    parr = new (nothrow) (BYTE* [1 + page_size / MIN_OBJECT_SIZE]);
+    parr = new (nothrow) (uint8_t* [1 + page_size / MIN_OBJECT_SIZE]);
     if (!parr)
     {
         goto cleanup;
@@ -26643,7 +26643,7 @@ void gc_heap::kill_gc_thread()
     recursive_gc_sync::shutdown();
 }
 
-DWORD gc_heap::bgc_thread_function()
+uint32_t gc_heap::bgc_thread_function()
 {
     assert (background_gc_done_event.IsValid());
     assert (bgc_start_event.IsValid());
@@ -26681,7 +26681,7 @@ DWORD gc_heap::bgc_thread_function()
         cooperative_mode = enable_preemptive (current_thread);
         //current_thread->m_fPreemptiveGCDisabled = 0;
 
-        DWORD result = bgc_start_event.Wait(
+        uint32_t result = bgc_start_event.Wait(
 #ifdef _DEBUG
 #ifdef MULTIPLE_HEAPS
                                              INFINITE,
@@ -26871,7 +26871,7 @@ void gc_heap::clear_cards (size_t start_card, size_t end_card)
     }
 }
 
-void gc_heap::clear_card_for_addresses (BYTE* start_address, BYTE* end_address)
+void gc_heap::clear_card_for_addresses (uint8_t* start_address, uint8_t* end_address)
 {
     size_t   start_card = card_of (align_on_card (start_address));
     size_t   end_card = card_of (align_lower_card (end_address));
@@ -26923,7 +26923,7 @@ void gc_heap::copy_cards (size_t dst_card, size_t src_card,
     card_table[dstwrd] = dsttmp;
 }
 
-void gc_heap::copy_cards_for_addresses (BYTE* dest, BYTE* src, size_t len)
+void gc_heap::copy_cards_for_addresses (uint8_t* dest, uint8_t* src, size_t len)
 {
     ptrdiff_t relocation_distance = src - dest;
     size_t start_dest_card = card_of (align_on_card (dest));
@@ -26985,21 +26985,21 @@ void gc_heap::copy_cards_for_addresses (BYTE* dest, BYTE* src, size_t len)
 
 #ifdef BACKGROUND_GC
 // this does not need the Interlocked version of mark_array_set_marked.
-void gc_heap::copy_mark_bits_for_addresses (BYTE* dest, BYTE* src, size_t len)
+void gc_heap::copy_mark_bits_for_addresses (uint8_t* dest, uint8_t* src, size_t len)
 {
     dprintf (3, ("Copying mark_bits for addresses [%Ix->%Ix, %Ix->%Ix[",
                  (size_t)src, (size_t)dest,
                  (size_t)src+len, (size_t)dest+len));
 
-    BYTE* src_o = src;
-    BYTE* dest_o;
-    BYTE* src_end = src + len;
+    uint8_t* src_o = src;
+    uint8_t* dest_o;
+    uint8_t* src_end = src + len;
     int align_const = get_alignment_constant (TRUE);
     ptrdiff_t reloc = dest - src;
 
     while (src_o < src_end)
     {
-        BYTE*  next_o = src_o + Align (size (src_o), align_const);
+        uint8_t*  next_o = src_o + Align (size (src_o), align_const);
 
         if (background_object_marked (src_o, TRUE))
         {
@@ -27022,7 +27022,7 @@ void gc_heap::copy_mark_bits_for_addresses (BYTE* dest, BYTE* src, size_t len)
 }
 #endif //BACKGROUND_GC
 
-void gc_heap::fix_brick_to_highest (BYTE* o, BYTE* next_o)
+void gc_heap::fix_brick_to_highest (uint8_t* o, uint8_t* next_o)
 {
     size_t new_current_brick = brick_of (o);
     set_brick (new_current_brick,
@@ -27040,10 +27040,10 @@ void gc_heap::fix_brick_to_highest (BYTE* o, BYTE* next_o)
 }
 
 // start can not be >= heap_segment_allocated for the segment.
-BYTE* gc_heap::find_first_object (BYTE* start, BYTE* first_object)
+uint8_t* gc_heap::find_first_object (uint8_t* start, uint8_t* first_object)
 {
     size_t brick = brick_of (start);
-    BYTE* o = 0;
+    uint8_t* o = 0;
     //last_object == null -> no search shortcut needed
     if ((brick == brick_of (first_object) || (start <= first_object)))
     {
@@ -27074,7 +27074,7 @@ BYTE* gc_heap::find_first_object (BYTE* start, BYTE* first_object)
     }
 
     assert (Align (size (o)) >= Align (min_obj_size));
-    BYTE*  next_o = o + Align (size (o));
+    uint8_t*  next_o = o + Align (size (o));
     size_t curr_cl = (size_t)next_o / brick_size;
     size_t min_cl = (size_t)first_object / brick_size;
 
@@ -27083,7 +27083,7 @@ BYTE* gc_heap::find_first_object (BYTE* start, BYTE* first_object)
     unsigned int n_o = 1;
 #endif //TRACE_GC
 
-    BYTE* next_b = min (align_lower_brick (next_o) + brick_size, start+1);
+    uint8_t* next_b = min (align_lower_brick (next_o) + brick_size, start+1);
 
     while (next_o <= start)
     {
@@ -27150,8 +27150,8 @@ BOOL gc_heap::find_card_dword (size_t& cardw, size_t cardw_end)
                 return FALSE;
             //find a non empty card word
 
-            DWORD* card_word = &card_table[max(card_bundle_cardw (cardb),cardw)];
-            DWORD* card_word_end = &card_table[min(card_bundle_cardw (cardb+1),cardw_end)];
+            uint32_t* card_word = &card_table[max(card_bundle_cardw (cardb),cardw)];
+            uint32_t* card_word_end = &card_table[min(card_bundle_cardw (cardb+1),cardw_end)];
             while ((card_word < card_word_end) &&
                    !(*card_word))
             {
@@ -27177,8 +27177,8 @@ BOOL gc_heap::find_card_dword (size_t& cardw, size_t cardw_end)
     }
     else
     {
-        DWORD* card_word = &card_table[cardw];
-        DWORD* card_word_end = &card_table [cardw_end];
+        uint32_t* card_word = &card_table[cardw];
+        uint32_t* card_word_end = &card_table [cardw_end];
 
         while (card_word < card_word_end)
         {
@@ -27197,12 +27197,12 @@ BOOL gc_heap::find_card_dword (size_t& cardw, size_t cardw_end)
 
 #endif //CARD_BUNDLE
 
-BOOL gc_heap::find_card (DWORD* card_table, size_t& card,
+BOOL gc_heap::find_card (uint32_t* card_table, size_t& card,
                 size_t card_word_end, size_t& end_card)
 {
-    DWORD* last_card_word;
-    DWORD y;
-    DWORD z;
+    uint32_t* last_card_word;
+    uint32_t y;
+    uint32_t z;
     // Find the first card which is set
 
     last_card_word = &card_table [card_word (card)];
@@ -27279,7 +27279,7 @@ BOOL gc_heap::find_card (DWORD* card_table, size_t& card,
 
 
     //because of heap expansion, computing end is complicated.
-BYTE* compute_next_end (heap_segment* seg, BYTE* low)
+uint8_t* compute_next_end (heap_segment* seg, uint8_t* low)
 {
     if ((low >=  heap_segment_mem (seg)) &&
         (low < heap_segment_allocated (seg)))
@@ -27288,8 +27288,8 @@ BYTE* compute_next_end (heap_segment* seg, BYTE* low)
         return heap_segment_allocated (seg);
 }
 
-BYTE*
-gc_heap::compute_next_boundary (BYTE* low, int gen_number,
+uint8_t*
+gc_heap::compute_next_boundary (uint8_t* low, int gen_number,
                                 BOOL relocating)
 {
     //when relocating, the fault line is the plan start of the younger
@@ -27297,7 +27297,7 @@ gc_heap::compute_next_boundary (BYTE* low, int gen_number,
     if (relocating && (gen_number == (settings.condemned_generation + 1)))
     {
         generation* gen = generation_of (gen_number - 1);
-        BYTE* gen_alloc = generation_plan_allocation_start (gen);
+        uint8_t* gen_alloc = generation_plan_allocation_start (gen);
         assert (gen_alloc);
         return gen_alloc;
     }
@@ -27310,7 +27310,7 @@ gc_heap::compute_next_boundary (BYTE* low, int gen_number,
 }
 
 inline void
-gc_heap::keep_card_live (BYTE* o, size_t& n_gen,
+gc_heap::keep_card_live (uint8_t* o, size_t& n_gen,
                          size_t& cg_pointers_found)
 {
     THREAD_FROM_HEAP;
@@ -27337,10 +27337,10 @@ gc_heap::keep_card_live (BYTE* o, size_t& n_gen,
 }
 
 inline void
-gc_heap::mark_through_cards_helper (BYTE** poo, size_t& n_gen,
+gc_heap::mark_through_cards_helper (uint8_t** poo, size_t& n_gen,
                                     size_t& cg_pointers_found,
-                                    card_fn fn, BYTE* nhigh,
-                                    BYTE* next_boundary)
+                                    card_fn fn, uint8_t* nhigh,
+                                    uint8_t* next_boundary)
 {
     THREAD_FROM_HEAP;
     if ((gc_low <= *poo) && (gc_high > *poo))
@@ -27378,12 +27378,12 @@ gc_heap::mark_through_cards_helper (BYTE** poo, size_t& n_gen,
     }
 }
 
-BOOL gc_heap::card_transition (BYTE* po, BYTE* end, size_t card_word_end,
+BOOL gc_heap::card_transition (uint8_t* po, uint8_t* end, size_t card_word_end,
                                size_t& cg_pointers_found, 
                                size_t& n_eph, size_t& n_card_set,
                                size_t& card, size_t& end_card,
-                               BOOL& foundp, BYTE*& start_address,
-                               BYTE*& limit, size_t& n_cards_cleared)
+                               BOOL& foundp, uint8_t*& start_address,
+                               uint8_t*& limit, size_t& n_cards_cleared)
 {
     dprintf (3, ("pointer %Ix past card %Ix", (size_t)po, (size_t)card));
     dprintf (3, ("ct: %Id cg", cg_pointers_found));
@@ -27443,22 +27443,22 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating)
     }
 #endif //BACKGROUND_GC
 
-    BYTE* low = gc_low;
-    BYTE* high = gc_high;
+    uint8_t* low = gc_low;
+    uint8_t* high = gc_high;
     size_t  end_card          = 0;
     generation*   oldest_gen        = generation_of (max_generation);
     int           curr_gen_number   = max_generation;
-    BYTE*         gen_boundary      = generation_allocation_start
+    uint8_t*         gen_boundary      = generation_allocation_start
         (generation_of (curr_gen_number - 1));
-    BYTE*         next_boundary     = (compute_next_boundary
+    uint8_t*         next_boundary     = (compute_next_boundary
                                        (gc_low, curr_gen_number, relocating));
     heap_segment* seg               = heap_segment_rw (generation_start_segment (oldest_gen));
 
     PREFIX_ASSUME(seg != NULL);
 
-    BYTE*         beg               = generation_allocation_start (oldest_gen);
-    BYTE*         end               = compute_next_end (seg, low);
-    BYTE*         last_object       = beg;
+    uint8_t*         beg               = generation_allocation_start (oldest_gen);
+    uint8_t*         end               = compute_next_end (seg, low);
+    uint8_t*         last_object       = beg;
 
     size_t  cg_pointers_found = 0;
 
@@ -27468,12 +27468,12 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating)
     size_t        n_eph             = 0;
     size_t        n_gen             = 0;
     size_t        n_card_set        = 0;
-    BYTE*         nhigh             = (relocating ?
+    uint8_t*         nhigh             = (relocating ?
                                        heap_segment_plan_allocated (ephemeral_heap_segment) : high);
 
     BOOL          foundp            = FALSE;
-    BYTE*         start_address     = 0;
-    BYTE*         limit             = 0;
+    uint8_t*         start_address     = 0;
+    uint8_t*         limit             = 0;
     size_t        card              = card_of (beg);
 #ifdef BACKGROUND_GC
     BOOL consider_bgc_mark_p        = FALSE;
@@ -27544,7 +27544,7 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating)
 
         assert (card_set_p (card));
         {
-            BYTE*   o             = last_object;
+            uint8_t*   o             = last_object;
 
             o = find_first_object (start_address, last_object);
                 //Never visit an object twice.
@@ -27559,7 +27559,7 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating)
                 assert (Align (size (o)) >= Align (min_obj_size));
                 size_t s = size (o);
 
-                BYTE* next_o =  o + Align (s);
+                uint8_t* next_o =  o + Align (s);
                 Prefetch (next_o);
 
                 if ((o >= gen_boundary) &&
@@ -27612,7 +27612,7 @@ void gc_heap::mark_through_cards_for_segments (card_fn fn, BOOL relocating)
                         }
                         else
                         {
-                            BYTE* class_obj = get_class_object (o);
+                            uint8_t* class_obj = get_class_object (o);
                             mark_through_cards_helper (&class_obj, n_gen,
                                                     cg_pointers_found, fn,
                                                     nhigh, next_boundary);
@@ -27649,9 +27649,9 @@ go_through_refs:
                              start_address, use_start, (o + s),
                              {
                                  dprintf (4, ("<%Ix>:%Ix", (size_t)poo, (size_t)*poo));
-                                 if (card_of ((BYTE*)poo) > card)
+                                 if (card_of ((uint8_t*)poo) > card)
                                  {
-                                    BOOL passed_end_card_p  = card_transition ((BYTE*)poo, end,
+                                    BOOL passed_end_card_p  = card_transition ((uint8_t*)poo, end,
                                             card_word_end,
                                             cg_pointers_found, 
                                             n_eph, n_card_set,
@@ -27665,10 +27665,10 @@ go_through_refs:
                                         {
                                              //new_start();
                                              {
-                                                 if (ppstop <= (BYTE**)start_address)
+                                                 if (ppstop <= (uint8_t**)start_address)
                                                      {break;}
-                                                 else if (poo < (BYTE**)start_address)
-                                                     {poo = (BYTE**)start_address;}
+                                                 else if (poo < (uint8_t**)start_address)
+                                                     {poo = (uint8_t**)start_address;}
                                              }
                                         }
                                         else if (foundp && (start_address < limit))
@@ -27731,7 +27731,7 @@ size_t gc_heap::dump_buckets (size_t* ordered_indices, int count, size_t* total_
 }
 #endif // SEG_REUSE_STATS
 
-void gc_heap::count_plug (size_t last_plug_size, BYTE*& last_plug)
+void gc_heap::count_plug (size_t last_plug_size, uint8_t*& last_plug)
 {
     // detect pinned plugs
     if (!pinned_plug_que_empty_p() && (last_plug == pinned_plug (oldest_pin())))
@@ -27765,7 +27765,7 @@ void gc_heap::count_plug (size_t last_plug_size, BYTE*& last_plug)
     }
 }
 
-void gc_heap::count_plugs_in_brick (BYTE* tree, BYTE*& last_plug)
+void gc_heap::count_plugs_in_brick (uint8_t* tree, uint8_t*& last_plug)
 {
     assert ((tree != NULL));
     if (node_left_child (tree))
@@ -27775,10 +27775,10 @@ void gc_heap::count_plugs_in_brick (BYTE* tree, BYTE*& last_plug)
 
     if (last_plug != 0)
     {
-        BYTE*  plug = tree;
+        uint8_t*  plug = tree;
         size_t gap_size = node_gap_size (plug);
-        BYTE*   gap = (plug - gap_size);
-        BYTE*  last_plug_end = gap;
+        uint8_t*   gap = (plug - gap_size);
+        uint8_t*  last_plug_end = gap;
         size_t  last_plug_size = (last_plug_end - last_plug);
         dprintf (3, ("tree: %Ix, last plug: %Ix, gap size: %Ix, gap: %Ix, last plug size: %Ix",
             tree, last_plug, gap_size, gap, last_plug_size));
@@ -27813,11 +27813,11 @@ void gc_heap::build_ordered_plug_indices ()
     memset (ordered_plug_indices, 0, sizeof(ordered_plug_indices));
     memset (saved_ordered_plug_indices, 0, sizeof(saved_ordered_plug_indices));
 
-    BYTE*  start_address = generation_limit (max_generation);
-    BYTE* end_address = heap_segment_allocated (ephemeral_heap_segment);
+    uint8_t*  start_address = generation_limit (max_generation);
+    uint8_t* end_address = heap_segment_allocated (ephemeral_heap_segment);
     size_t  current_brick = brick_of (start_address);
     size_t  end_brick = brick_of (end_address - 1);
-    BYTE* last_plug = 0;
+    uint8_t* last_plug = 0;
 
     //Look for the right pinned plug to start from.
     reset_pinned_queue_bos();
@@ -28067,8 +28067,8 @@ void gc_heap::build_ordered_free_spaces (heap_segment* seg)
 
     assert (settings.condemned_generation == max_generation);
 
-    BYTE* first_address = heap_segment_mem (seg);
-    BYTE* end_address   = heap_segment_reserved (seg);
+    uint8_t* first_address = heap_segment_mem (seg);
+    uint8_t* end_address   = heap_segment_reserved (seg);
     //look through the pinned plugs for relevant ones.
     //Look for the right pinned plug to start from.
     reset_pinned_queue_bos();
@@ -28375,8 +28375,8 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
     use_bestfit = FALSE;
     commit_end_of_seg = FALSE;
     bestfit_first_pin = 0;
-    BYTE* first_address = heap_segment_mem (seg);
-    BYTE* end_address   = heap_segment_reserved (seg);
+    uint8_t* first_address = heap_segment_mem (seg);
+    uint8_t* end_address   = heap_segment_reserved (seg);
     size_t end_extra_space = end_space_after_gc();
 
     if ((heap_segment_reserved (seg) - end_extra_space) <= heap_segment_plan_allocated (seg))
@@ -28569,7 +28569,7 @@ BOOL gc_heap::can_expand_into_p (heap_segment* seg, size_t min_free_size, size_t
         //find the first free list in range of the current segment
         size_t sz_list = gen_allocator->first_bucket_size();
         unsigned int a_l_idx = 0;
-        BYTE* free_list = 0; 
+        uint8_t* free_list = 0;
         for (; a_l_idx < gen_allocator->number_of_buckets(); a_l_idx++)
         {
             if ((eph_gen_starts <= sz_list) || (a_l_idx == (gen_allocator->number_of_buckets()-1)))
@@ -28655,10 +28655,10 @@ next:
     }
 }
 
-void gc_heap::realloc_plug (size_t last_plug_size, BYTE*& last_plug,
-                            generation* gen, BYTE* start_address,
+void gc_heap::realloc_plug (size_t last_plug_size, uint8_t*& last_plug,
+                            generation* gen, uint8_t* start_address,
                             unsigned int& active_new_gen_number,
-                            BYTE*& last_pinned_gap, BOOL& leftp,
+                            uint8_t*& last_pinned_gap, BOOL& leftp,
                             BOOL shortened_p
 #ifdef SHORT_PLUGS
                             , mark* pinned_plug_entry
@@ -28722,7 +28722,7 @@ void gc_heap::realloc_plug (size_t last_plug_size, BYTE*& last_plug,
 
         // from how we previously aligned the plug's destination address,
         // compute the actual alignment offset.
-        BYTE* reloc_plug = last_plug + node_relocation_distance (last_plug);
+        uint8_t* reloc_plug = last_plug + node_relocation_distance (last_plug);
         ptrdiff_t alignmentOffset = ComputeStructAlignPad(reloc_plug, requiredAlignment, 0);
         if (!alignmentOffset)
         {
@@ -28758,7 +28758,7 @@ void gc_heap::realloc_plug (size_t last_plug_size, BYTE*& last_plug,
         clear_padding_in_expand (last_plug, set_padding_on_saved_p, pinned_plug_entry);
 #endif //SHORT_PLUGS
 
-        BYTE* new_address = allocate_in_expanded_heap(gen, last_plug_size, adjacentp, last_plug, 
+        uint8_t* new_address = allocate_in_expanded_heap(gen, last_plug_size, adjacentp, last_plug,
 #ifdef SHORT_PLUGS
                                      set_padding_on_saved_p,
                                      pinned_plug_entry,
@@ -28782,11 +28782,11 @@ void gc_heap::realloc_plug (size_t last_plug_size, BYTE*& last_plug,
     }
 }
 
-void gc_heap::realloc_in_brick (BYTE* tree, BYTE*& last_plug,
-                                BYTE* start_address,
+void gc_heap::realloc_in_brick (uint8_t* tree, uint8_t*& last_plug,
+                                uint8_t* start_address,
                                 generation* gen,
                                 unsigned int& active_new_gen_number,
-                                BYTE*& last_pinned_gap, BOOL& leftp)
+                                uint8_t*& last_pinned_gap, BOOL& leftp)
 {
     assert (tree != NULL);
     int   left_node = node_left_child (tree);
@@ -28805,7 +28805,7 @@ void gc_heap::realloc_in_brick (BYTE* tree, BYTE*& last_plug,
 
     if (last_plug != 0)
     {
-        BYTE*  plug = tree;
+        uint8_t*  plug = tree;
 
         BOOL has_pre_plug_info_p = FALSE;
         BOOL has_post_plug_info_p = FALSE;
@@ -28817,8 +28817,8 @@ void gc_heap::realloc_in_brick (BYTE* tree, BYTE*& last_plug,
         // We only care about the pre plug info 'cause that's what decides if the last plug is shortened.
         // The pinned plugs are handled in realloc_plug.
         size_t gap_size = node_gap_size (plug);
-        BYTE*   gap = (plug - gap_size);
-        BYTE*  last_plug_end = gap;
+        uint8_t*   gap = (plug - gap_size);
+        uint8_t*  last_plug_end = gap;
         size_t  last_plug_size = (last_plug_end - last_plug);
         // Cannot assert this - a plug could be less than that due to the shortened ones.
         //assert (last_plug_size >= Align (min_obj_size));
@@ -28846,7 +28846,7 @@ void gc_heap::realloc_in_brick (BYTE* tree, BYTE*& last_plug,
 
 void
 gc_heap::realloc_plugs (generation* consing_gen, heap_segment* seg,
-                        BYTE* start_address, BYTE* end_address,
+                        uint8_t* start_address, uint8_t* end_address,
                         unsigned active_new_gen_number)
 {
     dprintf (3, ("--- Reallocing ---"));
@@ -28869,10 +28869,10 @@ gc_heap::realloc_plugs (generation* consing_gen, heap_segment* seg,
         }
     }
 
-    BYTE* first_address = start_address;
+    uint8_t* first_address = start_address;
     //Look for the right pinned plug to start from.
     reset_pinned_queue_bos();
-    BYTE* planned_ephemeral_seg_end = heap_segment_plan_allocated (seg);
+    uint8_t* planned_ephemeral_seg_end = heap_segment_plan_allocated (seg);
     while (!pinned_plug_que_empty_p())
     {
         mark* m = oldest_pin();
@@ -28890,9 +28890,9 @@ gc_heap::realloc_plugs (generation* consing_gen, heap_segment* seg,
 
     size_t  current_brick = brick_of (first_address);
     size_t  end_brick = brick_of (end_address-1);
-    BYTE*  last_plug = 0;
+    uint8_t*  last_plug = 0;
 
-    BYTE* last_pinned_gap = heap_segment_plan_allocated (seg);
+    uint8_t* last_pinned_gap = heap_segment_plan_allocated (seg);
     BOOL leftp = FALSE;
 
     dprintf (3, ("start addr: %Ix, first addr: %Ix, current oldest pin: %Ix",
@@ -28929,7 +28929,7 @@ gc_heap::realloc_plugs (generation* consing_gen, heap_segment* seg,
     heap_segment_plan_allocated (seg) = last_pinned_gap;
 }
 
-void gc_heap::verify_no_pins (BYTE* start, BYTE* end)
+void gc_heap::verify_no_pins (uint8_t* start, uint8_t* end)
 {
 #ifdef VERIFY_HEAP
     if (g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
@@ -28987,8 +28987,8 @@ generation* gc_heap::expand_heap (int condemned_generation,
 {
     assert (condemned_generation >= (max_generation -1));
     unsigned int active_new_gen_number = max_generation; //Set one too high to get generation gap
-    BYTE*  start_address = generation_limit (max_generation);
-    BYTE*  end_address = heap_segment_allocated (ephemeral_heap_segment);
+    uint8_t*  start_address = generation_limit (max_generation);
+    uint8_t*  end_address = heap_segment_allocated (ephemeral_heap_segment);
     BOOL should_promote_ephemeral = FALSE;
     ptrdiff_t eph_size = total_ephemeral_size;
 #ifdef BACKGROUND_GC
@@ -29200,7 +29200,7 @@ bool gc_heap::init_dynamic_data()
         FATAL_GC_ERROR();
     }
 
-    DWORD now = (DWORD)(ts.QuadPart/(qpf.QuadPart/1000));
+    uint32_t now = (uint32_t)(ts.QuadPart/(qpf.QuadPart/1000));
 
     //clear some fields
     for (int i = 0; i < max_generation+1; i++)
@@ -29421,15 +29421,15 @@ size_t gc_heap::desired_new_allocation (dynamic_data* dd,
             {
                 MEMORYSTATUSEX ms;
                 GetProcessMemoryLoad (&ms);
-                ULONGLONG available_ram = ms.ullAvailPhys;
+                uint64_t available_ram = ms.ullAvailPhys;
 
                 if (ms.ullAvailPhys > 1024*1024)
                     available_ram -= 1024*1024;
 
-                ULONGLONG available_free = available_ram + (ULONGLONG)generation_free_list_space (generation_of (gen_number));
-                if (available_free > (ULONGLONG)MAX_PTR)
+                uint64_t available_free = available_ram + (uint64_t)generation_free_list_space (generation_of (gen_number));
+                if (available_free > (uint64_t)MAX_PTR)
                 {
-                    available_free = (ULONGLONG)MAX_PTR;
+                    available_free = (uint64_t)MAX_PTR;
                 }
 
                 //try to avoid OOM during large object allocation
@@ -29617,7 +29617,7 @@ void  gc_heap::compute_promoted_allocation (int gen_number)
 
 #ifdef _WIN64
 inline
-size_t gc_heap::trim_youngest_desired (DWORD memory_load, 
+size_t gc_heap::trim_youngest_desired (uint32_t memory_load,
                                        size_t total_new_allocation,
                                        size_t total_min_allocation)
 {
@@ -29642,7 +29642,7 @@ size_t gc_heap::joined_youngest_desired (size_t new_allocation)
     size_t final_new_allocation = new_allocation;
     if (new_allocation > MIN_YOUNGEST_GEN_DESIRED)
     {
-        DWORD num_heaps = 1;
+        uint32_t num_heaps = 1;
 
 #ifdef MULTIPLE_HEAPS
         num_heaps = gc_heap::n_heaps;
@@ -29654,7 +29654,7 @@ size_t gc_heap::joined_youngest_desired (size_t new_allocation)
         if ((settings.entry_memory_load >= MAX_ALLOWED_MEM_LOAD) ||
             (total_new_allocation > max (youngest_gen_desired_th, total_min_allocation)))
         {
-            DWORD dwMemoryLoad = 0;
+            uint32_t dwMemoryLoad = 0;
             MEMORYSTATUSEX ms;
             GetProcessMemoryLoad(&ms);
             dprintf (2, ("Current memory load: %d", ms.dwMemoryLoad));
@@ -29895,10 +29895,10 @@ size_t gc_heap::new_allocation_limit (size_t size, size_t free_size, int gen_num
 
 size_t gc_heap::generation_fragmentation (generation* gen,
                                           generation* consing_gen,
-                                          BYTE* end)
+                                          uint8_t* end)
 {
     size_t frag;
-    BYTE* alloc = generation_allocation_pointer (consing_gen);
+    uint8_t* alloc = generation_allocation_pointer (consing_gen);
     // If the allocation pointer has reached the ephemeral segment
     // fine, otherwise the whole ephemeral segment is considered
     // fragmentation
@@ -30080,7 +30080,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
         // check for high memory situation
         if(!should_compact)
         {
-            DWORD num_heaps = 1;
+            uint32_t num_heaps = 1;
 #ifdef MULTIPLE_HEAPS
             num_heaps = gc_heap::n_heaps;
 #endif // MULTIPLE_HEAPS
@@ -30088,7 +30088,7 @@ BOOL gc_heap::decide_on_compacting (int condemned_gen_number,
             SSIZE_T reclaim_space = generation_size(max_generation) - generation_plan_size(max_generation);
             if((settings.entry_memory_load >= 90) && (settings.entry_memory_load < 97))
             {
-                if(reclaim_space > (LONGLONG)(min_high_fragmentation_threshold(available_physical_mem, num_heaps)))
+                if(reclaim_space > (int64_t)(min_high_fragmentation_threshold(available_physical_mem, num_heaps)))
                 {
                     dprintf(GTC_LOG,("compacting due to fragmentation in high memory"));
                     should_compact = TRUE;
@@ -30172,7 +30172,7 @@ size_t gc_heap::end_space_after_gc()
 
 BOOL gc_heap::ephemeral_gen_fit_p (gc_tuning_point tp)
 {
-    BYTE* start = 0;
+    uint8_t* start = 0;
     
     if ((tp == tuning_deciding_condemned_gen) ||
         (tp == tuning_deciding_compaction))
@@ -30239,7 +30239,7 @@ BOOL gc_heap::ephemeral_gen_fit_p (gc_tuning_point tp)
             size_t largest_alloc = END_SPACE_AFTER_GC + Align (min_obj_size);
             bool large_chunk_found = FALSE;
             size_t bos = 0;
-            BYTE* gen0start = generation_plan_allocation_start (youngest_generation);
+            uint8_t* gen0start = generation_plan_allocation_start (youngest_generation);
             dprintf (3, ("ephemeral_gen_fit_p: gen0 plan start: %Ix", (size_t)gen0start));
             if (gen0start == 0)
                 return FALSE;
@@ -30248,7 +30248,7 @@ BOOL gc_heap::ephemeral_gen_fit_p (gc_tuning_point tp)
             while ((bos < mark_stack_bos) &&
                    !((room >= gen0size) && large_chunk_found))
             {
-                BYTE* plug = pinned_plug (pinned_plug_of (bos));
+                uint8_t* plug = pinned_plug (pinned_plug_of (bos));
                 if (in_range_for_segment (plug, ephemeral_heap_segment))
                 {
                     if (plug >= gen0start)
@@ -30311,7 +30311,7 @@ BOOL gc_heap::ephemeral_gen_fit_p (gc_tuning_point tp)
     }
 }
 
-CObjectHeader* gc_heap::allocate_large_object (size_t jsize, INT64& alloc_bytes)
+CObjectHeader* gc_heap::allocate_large_object (size_t jsize, int64_t& alloc_bytes)
 {
     //create a new alloc context because gen3context is shared.
     alloc_context acontext;
@@ -30323,8 +30323,8 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, INT64& alloc_bytes)
 #endif //MULTIPLE_HEAPS
 
 #ifdef MARK_ARRAY
-    BYTE* current_lowest_address = lowest_address;
-    BYTE* current_highest_address = highest_address;
+    uint8_t* current_lowest_address = lowest_address;
+    uint8_t* current_highest_address = highest_address;
 #ifdef BACKGROUND_GC
     if (recursive_gc_sync::background_running_p())
     {
@@ -30334,7 +30334,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, INT64& alloc_bytes)
 #endif //BACKGROUND_GC
 #endif // MARK_ARRAY
 
-    SIZE_T maxObjectSize = (INT32_MAX - 7 - Align(min_obj_size));
+    size_t maxObjectSize = (INT32_MAX - 7 - Align(min_obj_size));
 
 #ifdef _WIN64
     if (g_pConfig->GetGCAllowVeryLargeObjects())
@@ -30383,7 +30383,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, INT64& alloc_bytes)
     // adjusted the alloc_ptr accordingly.
 #endif //FEATURE_LOH_COMPACTION
 
-    BYTE*  result = acontext.alloc_ptr;
+    uint8_t*  result = acontext.alloc_ptr;
 
     assert ((size_t)(acontext.alloc_limit - acontext.alloc_ptr) == size);
 
@@ -30400,7 +30400,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, INT64& alloc_bytes)
             mark_array_clear_marked (result);
         }
 #ifdef BACKGROUND_GC
-        //the object has to cover one full mark DWORD
+        //the object has to cover one full mark uint32_t
         assert (size > mark_word_size);
         if (current_c_gc_state == c_gc_state_marking)
         {
@@ -30426,7 +30426,7 @@ CObjectHeader* gc_heap::allocate_large_object (size_t jsize, INT64& alloc_bytes)
     return obj;
 }
 
-void reset_memory (BYTE* o, size_t sizeo)
+void reset_memory (uint8_t* o, size_t sizeo)
 {
 #ifndef FEATURE_PAL
     if (sizeo > 128 * 1024)
@@ -30442,13 +30442,13 @@ void reset_memory (BYTE* o, size_t sizeo)
 #endif //!FEATURE_PAL
 }
 
-void gc_heap::reset_large_object (BYTE* o)
+void gc_heap::reset_large_object (uint8_t* o)
 {
     // If it's a large object, allow the O/S to discard the backing store for these pages.
     reset_memory (o, size(o));
 }
 
-BOOL gc_heap::large_object_marked (BYTE* o, BOOL clearp)
+BOOL gc_heap::large_object_marked (uint8_t* o, BOOL clearp)
 {
     BOOL m = FALSE;
     // It shouldn't be necessary to do these comparisons because this is only used for blocking
@@ -30474,7 +30474,7 @@ BOOL gc_heap::large_object_marked (BYTE* o, BOOL clearp)
 }
 
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
-void gc_heap::record_survived_for_profiler(int condemned_gen_number, BYTE * start_address)
+void gc_heap::record_survived_for_profiler(int condemned_gen_number, uint8_t * start_address)
 {
     size_t profiling_context = 0;
 
@@ -30507,9 +30507,9 @@ void gc_heap::notify_profiler_of_surviving_large_objects ()
 
     PREFIX_ASSUME(seg != NULL);
 
-    BYTE* o                = generation_allocation_start (gen);
-    BYTE* plug_end         = o;
-    BYTE* plug_start       = o;
+    uint8_t* o                = generation_allocation_start (gen);
+    uint8_t* plug_end         = o;
+    uint8_t* plug_start       = o;
 
     // Generally, we can only get here if this is TRUE:
     // (CORProfilerTrackGC() || ETW::GCLog::ShouldTrackMovementForEtw())
@@ -30566,7 +30566,7 @@ void gc_heap::notify_profiler_of_surviving_large_objects ()
 
 #ifdef BACKGROUND_GC
 
-BOOL gc_heap::background_object_marked (BYTE* o, BOOL clearp)
+BOOL gc_heap::background_object_marked (uint8_t* o, BOOL clearp)
 {
     BOOL m = FALSE;
     if ((o >= background_saved_lowest_address) && (o < background_saved_highest_address))
@@ -30591,13 +30591,13 @@ BOOL gc_heap::background_object_marked (BYTE* o, BOOL clearp)
     return m;
 }
 
-BYTE* gc_heap::background_next_end (heap_segment* seg, BOOL large_objects_p)
+uint8_t* gc_heap::background_next_end (heap_segment* seg, BOOL large_objects_p)
 {
     return
         (large_objects_p ? heap_segment_allocated (seg) : heap_segment_background_allocated (seg));
 }
 
-void gc_heap::set_mem_verify (BYTE* start, BYTE* end, BYTE b)
+void gc_heap::set_mem_verify (uint8_t* start, uint8_t* end, uint8_t b)
 {
 #ifdef VERIFY_HEAP
     if (end > start)
@@ -30649,13 +30649,13 @@ void gc_heap::generation_delete_heap_segment (generation* gen,
 
 void gc_heap::process_background_segment_end (heap_segment* seg, 
                                           generation* gen,
-                                          BYTE* last_plug_end,
+                                          uint8_t* last_plug_end,
                                           heap_segment* start_seg,
                                           BOOL* delete_p)
 {
     *delete_p = FALSE;
-    BYTE* allocated = heap_segment_allocated (seg);
-    BYTE* background_allocated = heap_segment_background_allocated (seg);
+    uint8_t* allocated = heap_segment_allocated (seg);
+    uint8_t* background_allocated = heap_segment_background_allocated (seg);
 
     dprintf (3, ("Processing end of background segment [%Ix, %Ix[(%Ix[)", 
                 (size_t)heap_segment_mem (seg), background_allocated, allocated));
@@ -30756,7 +30756,7 @@ void gc_heap::process_n_background_segments (heap_segment* seg,
 }
 
 inline
-BOOL gc_heap::fgc_should_consider_object (BYTE* o, 
+BOOL gc_heap::fgc_should_consider_object (uint8_t* o,
                                           heap_segment* seg,
                                           BOOL consider_bgc_mark_p, 
                                           BOOL check_current_sweep_p, 
@@ -30787,7 +30787,7 @@ BOOL gc_heap::fgc_should_consider_object (BYTE* o,
 
             if (!check_saved_sweep_p)
             {
-                BYTE* background_allocated = heap_segment_background_allocated (seg);
+                uint8_t* background_allocated = heap_segment_background_allocated (seg);
                 // if this was the saved ephemeral segment, check_saved_sweep_p 
                 // would've been true.
                 assert (heap_segment_background_allocated (seg) != saved_sweep_ephemeral_start);
@@ -30883,15 +30883,15 @@ void gc_heap::background_ephemeral_sweep()
     for (int i = (max_generation - 1); i >= 0; i--)
     {
         generation* current_gen = generation_of (i);
-        BYTE* o = generation_allocation_start (current_gen);
+        uint8_t* o = generation_allocation_start (current_gen);
         //Skip the generation gap object
         o = o + Align(size (o), align_const);
-        BYTE* end = ((i > 0) ? 
+        uint8_t* end = ((i > 0) ?
                      generation_allocation_start (generation_of (i - 1)) : 
                      heap_segment_allocated (ephemeral_heap_segment));
 
-        BYTE* plug_end = o;
-        BYTE* plug_start = o;
+        uint8_t* plug_end = o;
+        uint8_t* plug_start = o;
         BOOL marked_p = FALSE;
 
         while (o < end)
@@ -30991,7 +30991,7 @@ void gc_heap::background_sweep()
     PREFIX_ASSUME(start_seg != NULL);
     heap_segment* fseg      = heap_segment_rw (generation_start_segment (generation_of (max_generation)));
     heap_segment* seg       = start_seg;
-    BYTE* o                 = heap_segment_mem (seg);
+    uint8_t* o                 = heap_segment_mem (seg);
 
     heap_segment* prev_seg = heap_segment_next (seg);
     int align_const        = get_alignment_constant (TRUE);
@@ -31001,13 +31001,13 @@ void gc_heap::background_sweep()
         o = o + Align(size (o), align_const);
     }
 
-    BYTE* plug_end         = o;
-    BYTE* plug_start       = o;
+    uint8_t* plug_end      = o;
+    uint8_t* plug_start    = o;
     next_sweep_obj         = o;
     current_sweep_pos      = o;
 
-    //BYTE* end              = background_next_end (seg, (gen == large_object_generation));
-    BYTE* end              = heap_segment_background_allocated (seg);
+    //uint8_t* end              = background_next_end (seg, (gen == large_object_generation));
+    uint8_t* end              = heap_segment_background_allocated (seg);
     BOOL delete_p          = FALSE;
 
     //concurrent_print_time_delta ("finished with mark and start with sweep");
@@ -31363,14 +31363,14 @@ void gc_heap::sweep_large_objects ()
 
     heap_segment* seg      = start_seg;
     heap_segment* prev_seg = 0;
-    BYTE* o                = generation_allocation_start (gen);
+    uint8_t* o             = generation_allocation_start (gen);
     int align_const        = get_alignment_constant (FALSE);
 
     //Skip the generation gap object
     o = o + Align(size (o), align_const);
 
-    BYTE* plug_end         = o;
-    BYTE* plug_start       = o;
+    uint8_t* plug_end         = o;
+    uint8_t* plug_start       = o;
 
     generation_allocator (gen)->clear();
     generation_free_list_space (gen) = 0;
@@ -31468,7 +31468,7 @@ void gc_heap::relocate_in_large_objects ()
 
     PREFIX_ASSUME(seg != NULL);
 
-    BYTE* o = generation_allocation_start (gen);
+    uint8_t* o = generation_allocation_start (gen);
 
     while (1)
     {
@@ -31501,15 +31501,15 @@ void gc_heap::relocate_in_large_objects ()
 void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
                                                     BOOL relocating)
 {
-    BYTE*         low               = gc_low;
+    uint8_t*      low               = gc_low;
     size_t        end_card          = 0;
     generation*   oldest_gen        = generation_of (max_generation+1);
     heap_segment* seg               = heap_segment_rw (generation_start_segment (oldest_gen));
 
     PREFIX_ASSUME(seg != NULL);
 
-    BYTE*         beg               = generation_allocation_start (oldest_gen);
-    BYTE*         end               = heap_segment_allocated (seg);
+    uint8_t*      beg               = generation_allocation_start (oldest_gen);
+    uint8_t*      end               = heap_segment_allocated (seg);
 
     size_t  cg_pointers_found = 0;
 
@@ -31518,20 +31518,20 @@ void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
 
     size_t      n_eph             = 0;
     size_t      n_gen             = 0;
-    size_t        n_card_set        = 0;
-    BYTE*    next_boundary = (relocating ?
+    size_t      n_card_set        = 0;
+    uint8_t*    next_boundary = (relocating ?
                               generation_plan_allocation_start (generation_of (max_generation -1)) :
                               ephemeral_low);
 
-    BYTE*    nhigh         = (relocating ?
+    uint8_t*    nhigh         = (relocating ?
                               heap_segment_plan_allocated (ephemeral_heap_segment) :
                               ephemeral_high);
 
     BOOL          foundp            = FALSE;
-    BYTE*         start_address     = 0;
-    BYTE*         limit             = 0;
+    uint8_t*      start_address     = 0;
+    uint8_t*      limit             = 0;
     size_t        card              = card_of (beg);
-    BYTE*         o                 = beg;
+    uint8_t*      o                 = beg;
 #ifdef BACKGROUND_GC
     BOOL consider_bgc_mark_p        = FALSE;
     BOOL check_current_sweep_p      = FALSE;
@@ -31551,12 +31551,12 @@ void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
             if (cg_pointers_found == 0)
             {
                 dprintf(3,(" Clearing cards [%Ix, %Ix[ ", (size_t)card_address(card), (size_t)o));
-                clear_cards (card, card_of((BYTE*)o));
-                total_cards_cleared += (card_of((BYTE*)o) - card);
+                clear_cards (card, card_of((uint8_t*)o));
+                total_cards_cleared += (card_of((uint8_t*)o) - card);
             }
             n_eph +=cg_pointers_found;
             cg_pointers_found = 0;
-            card = card_of ((BYTE*)o);
+            card = card_of ((uint8_t*)o);
         }
         if ((o < end) &&(card >= end_card))
         {
@@ -31605,7 +31605,7 @@ void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
 
             assert (Align (size (o)) >= Align (min_obj_size));
             size_t s = size (o);
-            BYTE* next_o =  o + AlignQword (s);
+            uint8_t* next_o =  o + AlignQword (s);
             Prefetch (next_o);
 
             while (o < limit)
@@ -31652,7 +31652,7 @@ void gc_heap::mark_through_cards_for_large_objects (card_fn fn,
                         }
                         else
                         {
-                            BYTE* class_obj = get_class_object (o);
+                            uint8_t* class_obj = get_class_object (o);
                             mark_through_cards_helper (&class_obj, n_gen,
                                                     cg_pointers_found, fn,
                                                     nhigh, next_boundary);
@@ -31682,9 +31682,9 @@ go_through_refs:
                     go_through_object (method_table(o), o, s, poo,
                                        start_address, use_start, (o + s),
                        {
-                           if (card_of ((BYTE*)poo) > card)
+                           if (card_of ((uint8_t*)poo) > card)
                            {
-                                BOOL passed_end_card_p  = card_transition ((BYTE*)poo, end,
+                                BOOL passed_end_card_p  = card_transition ((uint8_t*)poo, end,
                                         card_word_end,
                                         cg_pointers_found, 
                                         n_eph, n_card_set,
@@ -31698,10 +31698,10 @@ go_through_refs:
                                     {
                                         //new_start();
                                         {
-                                            if (ppstop <= (BYTE**)start_address)
+                                            if (ppstop <= (uint8_t**)start_address)
                                             {break;}
-                                            else if (poo < (BYTE**)start_address)
-                                            {poo = (BYTE**)start_address;}
+                                            else if (poo < (uint8_t**)start_address)
+                                            {poo = (uint8_t**)start_address;}
                                         }
                                     }
                                     else
@@ -31746,7 +31746,7 @@ void gc_heap::descr_segment (heap_segment* seg )
 {
 
 #ifdef TRACE_GC
-    BYTE*  x = heap_segment_mem (seg);
+    uint8_t*  x = heap_segment_mem (seg);
     while (x < heap_segment_allocated (seg))
     {
         dprintf(2, ( "%Ix: %d ", (size_t)x, size (x)));
@@ -31875,8 +31875,8 @@ void gc_heap::print_free_list (int gen, heap_segment* seg)
 /*
     if (settings.concurrent == FALSE)
     {
-        BYTE* seg_start = heap_segment_mem (seg);
-        BYTE* seg_end = heap_segment_allocated (seg);
+        uint8_t* seg_start = heap_segment_mem (seg);
+        uint8_t* seg_end = heap_segment_allocated (seg);
 
         dprintf (3, ("Free list in seg %Ix:", seg_start));
 
@@ -31885,7 +31885,7 @@ void gc_heap::print_free_list (int gen, heap_segment* seg)
         allocator* gen_allocator = generation_allocator (generation_of (gen));
         for (unsigned int b = 0; b < gen_allocator->number_of_buckets(); b++)
         {
-            BYTE* fo = gen_allocator->alloc_list_head_of (b);
+            uint8_t* fo = gen_allocator->alloc_list_head_of (b);
             while (fo)
             {
                 if (fo >= seg_start && fo < seg_end)
@@ -32160,7 +32160,7 @@ public:
 
 
 
-BOOL IsValidObject99(BYTE *pObject)
+BOOL IsValidObject99(uint8_t *pObject)
 {
 #ifdef VERIFY_HEAP
     if (!((CObjectHeader*)pObject)->IsFree())
@@ -32172,11 +32172,11 @@ BOOL IsValidObject99(BYTE *pObject)
 #ifdef BACKGROUND_GC 
 BOOL gc_heap::bgc_mark_array_range (heap_segment* seg, 
                                     BOOL whole_seg_p,
-                                    BYTE** range_beg,
-                                    BYTE** range_end)
+                                    uint8_t** range_beg,
+                                    uint8_t** range_end)
 {
-    BYTE* seg_start = heap_segment_mem (seg);
-    BYTE* seg_end = (whole_seg_p ? heap_segment_reserved (seg) : align_on_mark_word (heap_segment_allocated (seg)));
+    uint8_t* seg_start = heap_segment_mem (seg);
+    uint8_t* seg_end = (whole_seg_p ? heap_segment_reserved (seg) : align_on_mark_word (heap_segment_allocated (seg)));
 
     if ((seg_start < background_saved_highest_address) &&
         (seg_end > background_saved_lowest_address))
@@ -32196,8 +32196,8 @@ void gc_heap::bgc_verify_mark_array_cleared (heap_segment* seg)
 #if defined (VERIFY_HEAP) && defined (MARK_ARRAY)
     if (recursive_gc_sync::background_running_p() && g_pConfig->GetHeapVerifyLevel() & EEConfig::HEAPVERIFY_GC)
     {
-        BYTE* range_beg = 0;
-        BYTE* range_end = 0;
+        uint8_t* range_beg = 0;
+        uint8_t* range_end = 0;
 
         if (bgc_mark_array_range (seg, TRUE, &range_beg, &range_end))
         {
@@ -32213,7 +32213,7 @@ void gc_heap::bgc_verify_mark_array_cleared (heap_segment* seg)
                 }
                 markw++;
             }
-            BYTE* p = mark_word_address (markw_end);
+            uint8_t* p = mark_word_address (markw_end);
             while (p < range_end)
             {
                 assert (!(mark_array_marked (p)));
@@ -32224,7 +32224,7 @@ void gc_heap::bgc_verify_mark_array_cleared (heap_segment* seg)
 #endif //VERIFY_HEAP && MARK_ARRAY
 }
 
-void gc_heap::verify_mark_bits_cleared (BYTE* obj, size_t s)
+void gc_heap::verify_mark_bits_cleared (uint8_t* obj, size_t s)
 {
 #if defined (VERIFY_HEAP) && defined (MARK_ARRAY)
     size_t start_mark_bit = mark_bit_of (obj) + 1;
@@ -32309,14 +32309,14 @@ void gc_heap::clear_all_mark_array()
             }
         }
 
-        BYTE* range_beg = 0;
-        BYTE* range_end = 0;
+        uint8_t* range_beg = 0;
+        uint8_t* range_end = 0;
 
         if (bgc_mark_array_range (seg, (seg == ephemeral_heap_segment), &range_beg, &range_end))
         { 
             size_t markw = mark_word_of (range_beg);
             size_t markw_end = mark_word_of (range_end);
-            size_t size_total = (markw_end - markw) * sizeof (DWORD);
+            size_t size_total = (markw_end - markw) * sizeof (uint32_t);
             //num_dwords_written = markw_end - markw;
             size_t size = 0;
             size_t size_left = 0;
@@ -32327,19 +32327,19 @@ void gc_heap::clear_all_mark_array()
             {
                 size = (size_total & ~(sizeof(PTR_PTR) - 1));
                 size_left = size_total - size;
-                assert ((size_left & (sizeof (DWORD) - 1)) == 0);
+                assert ((size_left & (sizeof (uint32_t) - 1)) == 0);
             }
             else
             {
                 size = size_total;
             }
 
-            memclr ((BYTE*)&mark_array[markw], size);
+            memclr ((uint8_t*)&mark_array[markw], size);
 
             if (size_left != 0)
             {
-                DWORD* markw_to_clear = &mark_array[markw + size / sizeof (DWORD)];
-                for (size_t i = 0; i < (size_left / sizeof (DWORD)); i++)
+                uint32_t* markw_to_clear = &mark_array[markw + size / sizeof (uint32_t)];
+                for (size_t i = 0; i < (size_left / sizeof (uint32_t)); i++)
                 {
                     *markw_to_clear = 0;
                     markw_to_clear++;
@@ -32355,7 +32355,7 @@ void gc_heap::clear_all_mark_array()
     //
     //size_t end_time = (size_t) (ts.QuadPart/(qpf.QuadPart/1000)) - begin_time; 
 
-    //printf ("took %Id ms to clear %Id bytes\n", end_time, num_dwords_written*sizeof(DWORD));
+    //printf ("took %Id ms to clear %Id bytes\n", end_time, num_dwords_written*sizeof(uint32_t));
 
 #endif //MARK_ARRAY
 }
@@ -32437,7 +32437,7 @@ void gc_heap::verify_seg_end_mark_array_cleared()
 
             // We already cleared all mark array bits for ephemeral generations
             // at the beginning of bgc sweep
-            BYTE* from = ((seg == ephemeral_heap_segment) ? 
+            uint8_t* from = ((seg == ephemeral_heap_segment) ?
                           generation_allocation_start (generation_of (max_generation - 1)) :
                           heap_segment_allocated (seg));
             size_t  markw = mark_word_of (align_on_mark_word (from));
@@ -32509,8 +32509,8 @@ void gc_heap::verify_partial ()
     heap_segment* seg = heap_segment_rw (generation_start_segment (gen));
     int align_const = get_alignment_constant (gen != large_object_generation);
 
-    BYTE* o = 0;
-    BYTE* end = 0;
+    uint8_t* o = 0;
+    uint8_t* end = 0;
     size_t s = 0;
 
     // Different ways to fail.
@@ -32605,8 +32605,8 @@ gc_heap::verify_free_lists ()
 
         for (unsigned int a_l_number = 0; a_l_number < gen_alloc->number_of_buckets(); a_l_number++)
         {
-            BYTE* free_list = gen_alloc->alloc_list_head_of (a_l_number);
-            BYTE* prev = 0;
+            uint8_t* free_list = gen_alloc->alloc_list_head_of (a_l_number);
+            uint8_t* prev = 0;
             while (free_list)
             {
                 if (!((CObjectHeader*)free_list)->IsFree())
@@ -32639,7 +32639,7 @@ gc_heap::verify_free_lists ()
                 free_list = free_list_slot (free_list);
             }
             //verify the sanity of the tail 
-            BYTE* tail = gen_alloc->alloc_list_tail_of (a_l_number);
+            uint8_t* tail = gen_alloc->alloc_list_tail_of (a_l_number);
             if (!((tail == 0) || (tail == prev)))
             {
                 dprintf (3, ("Verifying Heap: tail of free list is not correct"));
@@ -32647,7 +32647,7 @@ gc_heap::verify_free_lists ()
             }
             if (tail == 0)
             {
-                BYTE* head = gen_alloc->alloc_list_head_of (a_l_number);
+                uint8_t* head = gen_alloc->alloc_list_head_of (a_l_number);
                 if ((head != 0) && (free_list_slot (head) != 0))
                 {
                     dprintf (3, ("Verifying Heap: tail of free list is not correct"));
@@ -32674,11 +32674,11 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 
     PREFIX_ASSUME(seg != NULL);
 
-    BYTE*           curr_object = heap_segment_mem (seg);
-    BYTE*           prev_object = 0;
-    BYTE*           begin_youngest = generation_allocation_start(generation_of(0));
-    BYTE*           end_youngest = heap_segment_allocated (ephemeral_heap_segment);
-    BYTE*           next_boundary = generation_allocation_start (generation_of (max_generation - 1));
+    uint8_t*        curr_object = heap_segment_mem (seg);
+    uint8_t*        prev_object = 0;
+    uint8_t*        begin_youngest = generation_allocation_start(generation_of(0));
+    uint8_t*        end_youngest = heap_segment_allocated (ephemeral_heap_segment);
+    uint8_t*        next_boundary = generation_allocation_start (generation_of (max_generation - 1));
     int             align_const = get_alignment_constant (FALSE);
     size_t          total_objects_verified = 0;
     size_t          total_objects_verified_deep = 0;
@@ -32735,7 +32735,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
             {
                 if (seg1)
                 {
-                    BYTE* clear_start = heap_segment_allocated (seg1) - plug_skew;
+                    uint8_t* clear_start = heap_segment_allocated (seg1) - plug_skew;
                     if (heap_segment_used (seg1) > clear_start)
                     {
                         dprintf (3, ("setting end of seg %Ix: [%Ix-[%Ix to 0xaa", 
@@ -32987,7 +32987,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
             }
         }
 
-        if (*((BYTE**)curr_object) != (BYTE *) g_pFreeObjectMethodTable)
+        if (*((uint8_t**)curr_object) != (uint8_t *) g_pFreeObjectMethodTable)
         {
 #ifdef FEATURE_LOH_COMPACTION
             if ((curr_gen_num == (max_generation+1)) && (prev_object != 0))
@@ -33023,7 +33023,7 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 #ifdef COLLECTIBLE_CLASS
                         if (is_collectible(curr_object))
                         {
-                            BYTE* class_obj = get_class_object (curr_object);
+                            uint8_t* class_obj = get_class_object (curr_object);
                             if ((class_obj < ephemeral_high) && (class_obj >= next_boundary))
                             {
                                 if (!found_card_p)
@@ -33042,9 +33042,9 @@ gc_heap::verify_heap (BOOL begin_gc_p)
                             go_through_object_nostart
                                 (method_table(curr_object), curr_object, s, oo,
                                 {
-                                    if ((crd != card_of ((BYTE*)oo)) && !found_card_p)
+                                    if ((crd != card_of ((uint8_t*)oo)) && !found_card_p)
                                     {
-                                        crd = card_of ((BYTE*)oo);
+                                        crd = card_of ((uint8_t*)oo);
                                         found_card_p = card_set_p (crd);
                                         need_card_p = FALSE;
                                     }
@@ -33151,11 +33151,11 @@ gc_heap::verify_heap (BOOL begin_gc_p)
 void GCHeap::ValidateObjectMember (Object* obj)
 {
     size_t s = size (obj);
-    BYTE* o = (BYTE*)obj;
+    uint8_t* o = (uint8_t*)obj;
 
     go_through_object_cl (method_table (obj), o, s, oo,
                                 {
-                                    BYTE* child_o = *oo;
+                                    uint8_t* child_o = *oo;
                                     if (child_o)
                                     {
                                         dprintf (3, ("VOM: m: %Ix obj %Ix", (size_t)child_o, o));
@@ -33202,7 +33202,7 @@ HRESULT GCHeap::Shutdown ()
     //CloseHandle (WaitForGCEvent);
 
     //find out if the global card table hasn't been used yet
-    DWORD* ct = &g_card_table[card_word (gcard_of (g_lowest_address))];
+    uint32_t* ct = &g_card_table[card_word (gcard_of (g_lowest_address))];
     if (card_table_refcount (ct) == 0)
     {
         destroy_card_table (ct);
@@ -33250,8 +33250,8 @@ void CGCDescGcScan(LPVOID pvCGCDesc, promote_func* fn, ScanContext* sc)
     assert (cur >= last);
     do
     {
-        BYTE** ppslot = (BYTE**)((PBYTE)pvCGCDesc + cur->GetSeriesOffset());
-        BYTE**ppstop = (BYTE**)((PBYTE)ppslot + cur->GetSeriesSize());
+        uint8_t** ppslot = (uint8_t**)((uint8_t*)pvCGCDesc + cur->GetSeriesOffset());
+        uint8_t**ppstop = (uint8_t**)((uint8_t*)ppslot + cur->GetSeriesSize());
 
         while (ppslot < ppstop)
         {
@@ -33410,7 +33410,7 @@ BOOL GCHeap::IsPromoted(Object* object)
     ((CObjectHeader*)object)->Validate();
 #endif //_DEBUG
 
-    BYTE* o = (BYTE*)object;
+    uint8_t* o = (uint8_t*)object;
 
     if (gc_heap::settings.condemned_generation == max_generation)
     {
@@ -33458,15 +33458,15 @@ size_t GCHeap::GetPromotedBytes(int heap_index)
 
 unsigned int GCHeap::WhichGeneration (Object* object)
 {
-    gc_heap* hp = gc_heap::heap_of ((BYTE*)object);
-    unsigned int g = hp->object_gennum ((BYTE*)object);
+    gc_heap* hp = gc_heap::heap_of ((uint8_t*)object);
+    unsigned int g = hp->object_gennum ((uint8_t*)object);
     dprintf (3, ("%Ix is in gen %d", (size_t)object, g));
     return g;
 }
 
 BOOL    GCHeap::IsEphemeral (Object* object)
 {
-    BYTE* o = (BYTE*)object;
+    uint8_t* o = (uint8_t*)object;
     gc_heap* hp = gc_heap::heap_of (o);
     return hp->ephemeral_pointer_p (o);
 }
@@ -33477,7 +33477,7 @@ BOOL    GCHeap::IsEphemeral (Object* object)
 // return zeroed out memory as next object
 Object * GCHeap::NextObj (Object * object)
 {
-    BYTE* o = (BYTE*)object;
+    uint8_t* o = (uint8_t*)object;
     heap_segment * hs = gc_heap::find_segment (o, FALSE);
     if (!hs)
     {
@@ -33492,11 +33492,11 @@ Object * GCHeap::NextObj (Object * object)
 #else //MULTIPLE_HEAPS
     gc_heap* hp = 0;
 #endif //MULTIPLE_HEAPS
-    unsigned int g = hp->object_gennum ((BYTE*)object);
+    unsigned int g = hp->object_gennum ((uint8_t*)object);
     if ((g == 0) && hp->settings.demotion)
         return NULL;//could be racing with another core allocating. 
     int align_const = get_alignment_constant (!large_object_p);
-    BYTE* nextobj = o + Align (size (o), align_const);
+    uint8_t* nextobj = o + Align (size (o), align_const);
     if (nextobj <= o) // either overflow or 0 sized object.
     {
         return NULL;
@@ -33515,7 +33515,7 @@ Object * GCHeap::NextObj (Object * object)
 #ifdef FEATURE_BASICFREEZE
 BOOL GCHeap::IsInFrozenSegment (Object * object)
 {
-    BYTE* o = (BYTE*)object;
+    uint8_t* o = (uint8_t*)object;
     heap_segment * hs = gc_heap::find_segment (o, FALSE);
     //We create a frozen object for each frozen segment before the segment is inserted
     //to segment list; during ngen, we could also create frozen objects in segments which
@@ -33536,7 +33536,7 @@ BOOL GCHeap::IsHeapPointer (void* vpObject, BOOL small_heap_only)
     // removed STATIC_CONTRACT_CAN_TAKE_LOCK here because find_segment 
     // no longer calls CLREvent::Wait which eventually takes a lock.
 
-    BYTE* object = (BYTE*) vpObject;
+    uint8_t* object = (uint8_t*) vpObject;
 #ifndef FEATURE_BASICFREEZE
     if (!((object < g_highest_address) && (object >= g_lowest_address)))
         return FALSE;
@@ -33550,21 +33550,21 @@ BOOL GCHeap::IsHeapPointer (void* vpObject, BOOL small_heap_only)
 static n_promote = 0;
 #endif //STRESS_PINNING
 // promote an object
-void GCHeap::Promote(Object** ppObject, ScanContext* sc, DWORD flags)
+void GCHeap::Promote(Object** ppObject, ScanContext* sc, uint32_t flags)
 {
     THREAD_NUMBER_FROM_CONTEXT;
 #ifndef MULTIPLE_HEAPS
     const int thread = 0;
 #endif //!MULTIPLE_HEAPS
 
-    BYTE* o = (BYTE*)*ppObject;
+    uint8_t* o = (uint8_t*)*ppObject;
 
     if (o == 0)
         return;
 
 #ifdef DEBUG_DestroyedHandleValue
     // we can race with destroy handle during concurrent scan
-    if (o == (BYTE*)DEBUG_DestroyedHandleValue)
+    if (o == (uint8_t*)DEBUG_DestroyedHandleValue)
         return;
 #endif //DEBUG_DestroyedHandleValue
 
@@ -33604,11 +33604,11 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, DWORD flags)
 #endif //_DEBUG
 
     if (flags & GC_CALL_PINNED)
-        hp->pin_object (o, (BYTE**) ppObject, hp->gc_low, hp->gc_high);
+        hp->pin_object (o, (uint8_t**) ppObject, hp->gc_low, hp->gc_high);
 
 #ifdef STRESS_PINNING
     if ((++n_promote % 20) == 1)
-            hp->pin_object (o, (BYTE**) ppObject, hp->gc_low, hp->gc_high);
+            hp->pin_object (o, (uint8_t**) ppObject, hp->gc_low, hp->gc_high);
 #endif //STRESS_PINNING
 
 #ifdef FEATURE_APPDOMAIN_RESOURCE_MONITORING
@@ -33635,9 +33635,9 @@ void GCHeap::Promote(Object** ppObject, ScanContext* sc, DWORD flags)
 }
 
 void GCHeap::Relocate (Object** ppObject, ScanContext* sc,
-                       DWORD flags)
+                       uint32_t flags)
 {
-    BYTE* object = (BYTE*)(Object*)(*ppObject);
+    uint8_t* object = (uint8_t*)(Object*)(*ppObject);
     
     THREAD_NUMBER_FROM_CONTEXT;
 
@@ -33663,7 +33663,7 @@ void GCHeap::Relocate (Object** ppObject, ScanContext* sc,
 
     dprintf (3, ("Relocate %Ix\n", (size_t)object));
 
-    BYTE* pheader;
+    uint8_t* pheader;
 
     if ((flags & GC_CALL_INTERIOR) && gc_heap::settings.loh_compaction)
     {
@@ -33887,7 +33887,7 @@ BOOL GCHeap::StressHeap(alloc_context * acontext)
                 if (str->GetStringLength() > sizeOfNewObj / sizeof(WCHAR))
                 {
                     unsigned sizeToNextObj = (unsigned)Align(size(str));
-                    BYTE* freeObj = ((BYTE*) str) + sizeToNextObj - sizeOfNewObj;
+                    uint8_t* freeObj = ((uint8_t*) str) + sizeToNextObj - sizeOfNewObj;
                     pGenGCHeap->make_unused_array (freeObj, sizeOfNewObj);                    
                     str->SetStringLength(str->GetStringLength() - (sizeOfNewObj / sizeof(WCHAR)));
                 }
@@ -33967,7 +33967,7 @@ BOOL GCHeap::StressHeap(alloc_context * acontext)
 //
 //
 Object *
-GCHeap::Alloc( size_t size, DWORD flags REQD_ALIGN_DCL)
+GCHeap::Alloc( size_t size, uint32_t flags REQD_ALIGN_DCL)
 {
     CONTRACTL {
 #ifdef FEATURE_REDHAWK
@@ -34033,7 +34033,7 @@ GCHeap::Alloc( size_t size, DWORD flags REQD_ALIGN_DCL)
 #endif //TRACE_GC
             newAlloc = (Object*) hp->allocate (size + ComputeMaxStructAlignPad(requiredAlignment), acontext);
 #ifdef FEATURE_STRUCTALIGN
-            newAlloc = (Object*) hp->pad_for_alignment ((BYTE*) newAlloc, requiredAlignment, size, acontext);
+            newAlloc = (Object*) hp->pad_for_alignment ((uint8_t*) newAlloc, requiredAlignment, size, acontext);
 #endif // FEATURE_STRUCTALIGN
             // ASSERT (newAlloc);
         }
@@ -34043,7 +34043,7 @@ GCHeap::Alloc( size_t size, DWORD flags REQD_ALIGN_DCL)
 
             newAlloc = (Object*) hp->allocate_large_object (size + ComputeMaxStructAlignPadLarge(requiredAlignment), acontext->alloc_bytes_loh);
 #ifdef FEATURE_STRUCTALIGN
-            newAlloc = (Object*) hp->pad_for_alignment_large ((BYTE*) newAlloc, requiredAlignment, size);
+            newAlloc = (Object*) hp->pad_for_alignment_large ((uint8_t*) newAlloc, requiredAlignment, size);
 #endif // FEATURE_STRUCTALIGN
         }
     }
@@ -34065,7 +34065,7 @@ GCHeap::Alloc( size_t size, DWORD flags REQD_ALIGN_DCL)
 #ifdef FEATURE_64BIT_ALIGNMENT
 // Allocate small object with an alignment requirement of 8-bytes. Non allocation context version.
 Object *
-GCHeap::AllocAlign8( size_t size, DWORD flags)
+GCHeap::AllocAlign8( size_t size, uint32_t flags)
 {
     CONTRACTL {
 #ifdef FEATURE_REDHAWK
@@ -34099,7 +34099,7 @@ GCHeap::AllocAlign8( size_t size, DWORD flags)
 
 // Allocate small object with an alignment requirement of 8-bytes. Allocation context version.
 Object*
-GCHeap::AllocAlign8(alloc_context* acontext, size_t size, DWORD flags )
+GCHeap::AllocAlign8(alloc_context* acontext, size_t size, uint32_t flags )
 {
     CONTRACTL {
 #ifdef FEATURE_REDHAWK
@@ -34128,7 +34128,7 @@ GCHeap::AllocAlign8(alloc_context* acontext, size_t size, DWORD flags )
 
 // Common code used by both variants of AllocAlign8 above.
 Object*
-GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, DWORD flags)
+GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, uint32_t flags)
 {
     CONTRACTL {
 #ifdef FEATURE_REDHAWK
@@ -34181,7 +34181,7 @@ GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, DWORD
 
         // Retrieve the address of the next allocation from the context (note that we're inside the alloc
         // lock at this point).
-        BYTE*  result = acontext->alloc_ptr;
+        uint8_t*  result = acontext->alloc_ptr;
 
         // Will an allocation at this point yield the correct alignment and fit into the remainder of the
         // context?
@@ -34209,13 +34209,13 @@ GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, DWORD
                     // New allocation has desired alignment, return this one and place the free object at the
                     // end of the allocated space.
                     newAlloc = (Object*)freeobj;
-                    freeobj = (CObjectHeader*)((BYTE*)freeobj + Align(size));
+                    freeobj = (CObjectHeader*)((uint8_t*)freeobj + Align(size));
                 }
                 else
                 {
                     // New allocation is still mis-aligned, format the initial space as a free object and the
                     // rest of the space should be correctly aligned for the real object.
-                    newAlloc = (Object*)((BYTE*)freeobj + Align(min_obj_size));
+                    newAlloc = (Object*)((uint8_t*)freeobj + Align(min_obj_size));
                     ASSERT(((size_t)newAlloc & 7) == desiredAlignment);
                 }
                 freeobj->SetFree(min_obj_size);
@@ -34253,7 +34253,7 @@ GCHeap::AllocAlign8Common(void* _hp, alloc_context* acontext, size_t size, DWORD
 #endif // FEATURE_64BIT_ALIGNMENT
 
 Object *
-GCHeap::AllocLHeap( size_t size, DWORD flags REQD_ALIGN_DCL)
+GCHeap::AllocLHeap( size_t size, uint32_t flags REQD_ALIGN_DCL)
 {
     CONTRACTL {
 #ifdef FEATURE_REDHAWK
@@ -34307,7 +34307,7 @@ GCHeap::AllocLHeap( size_t size, DWORD flags REQD_ALIGN_DCL)
 
     newAlloc = (Object*) hp->allocate_large_object (size + ComputeMaxStructAlignPadLarge(requiredAlignment), acontext->alloc_bytes_loh);
 #ifdef FEATURE_STRUCTALIGN
-    newAlloc = (Object*) hp->pad_for_alignment_large ((BYTE*) newAlloc, requiredAlignment, size);
+    newAlloc = (Object*) hp->pad_for_alignment_large ((uint8_t*) newAlloc, requiredAlignment, size);
 #endif // FEATURE_STRUCTALIGN
     CHECK_ALLOC_AND_POSSIBLY_REGISTER_FOR_FINALIZATION(newAlloc, size, flags & GC_ALLOC_FINALIZE);
 
@@ -34324,7 +34324,7 @@ GCHeap::AllocLHeap( size_t size, DWORD flags REQD_ALIGN_DCL)
 }
 
 Object*
-GCHeap::Alloc(alloc_context* acontext, size_t size, DWORD flags REQD_ALIGN_DCL)
+GCHeap::Alloc(alloc_context* acontext, size_t size, uint32_t flags REQD_ALIGN_DCL)
 {
     CONTRACTL {
 #ifdef FEATURE_REDHAWK
@@ -34389,7 +34389,7 @@ GCHeap::Alloc(alloc_context* acontext, size_t size, DWORD flags REQD_ALIGN_DCL)
 #endif //TRACE_GC
         newAlloc = (Object*) hp->allocate (size + ComputeMaxStructAlignPad(requiredAlignment), acontext);
 #ifdef FEATURE_STRUCTALIGN
-        newAlloc = (Object*) hp->pad_for_alignment ((BYTE*) newAlloc, requiredAlignment, size, acontext);
+        newAlloc = (Object*) hp->pad_for_alignment ((uint8_t*) newAlloc, requiredAlignment, size, acontext);
 #endif // FEATURE_STRUCTALIGN
 //        ASSERT (newAlloc);
     }
@@ -34397,7 +34397,7 @@ GCHeap::Alloc(alloc_context* acontext, size_t size, DWORD flags REQD_ALIGN_DCL)
     {
         newAlloc = (Object*) hp->allocate_large_object (size + ComputeMaxStructAlignPadLarge(requiredAlignment), acontext->alloc_bytes_loh);
 #ifdef FEATURE_STRUCTALIGN
-        newAlloc = (Object*) hp->pad_for_alignment_large ((BYTE*) newAlloc, requiredAlignment, size);
+        newAlloc = (Object*) hp->pad_for_alignment_large ((uint8_t*) newAlloc, requiredAlignment, size);
 #endif // FEATURE_STRUCTALIGN
     }
 
@@ -34423,7 +34423,7 @@ GCHeap::FixAllocContext (alloc_context* acontext, BOOL lockp, void* arg, void *h
     if (arg != 0)
         acontext->alloc_count = 0;
 
-    BYTE * alloc_ptr = acontext->alloc_ptr;
+    uint8_t * alloc_ptr = acontext->alloc_ptr;
 
     if (!alloc_ptr)
         return;
@@ -34453,7 +34453,7 @@ GCHeap::FixAllocContext (alloc_context* acontext, BOOL lockp, void* arg, void *h
 Object*
 GCHeap::GetContainingObject (void *pInteriorPtr)
 {
-    BYTE *o = (BYTE*)pInteriorPtr;
+    uint8_t *o = (uint8_t*)pInteriorPtr;
 
     gc_heap* hp = gc_heap::heap_of (o);
     if (o >= hp->lowest_address && o < hp->highest_address)
@@ -35336,8 +35336,8 @@ void GCHeap::SetLOHCompactionMode (int newLOHCompactionyMode)
 #endif //FEATURE_LOH_COMPACTION
 }
 
-BOOL GCHeap::RegisterForFullGCNotification(DWORD gen2Percentage,
-                                           DWORD lohPercentage)
+BOOL GCHeap::RegisterForFullGCNotification(uint32_t gen2Percentage,
+                                           uint32_t lohPercentage)
 {
 #ifdef MULTIPLE_HEAPS
     for (int hn = 0; hn < gc_heap::n_heaps; hn++)
@@ -35386,7 +35386,7 @@ int GCHeap::WaitForFullGCComplete(int millisecondsTimeout)
     return result;
 }
 
-int GCHeap::StartNoGCRegion(ULONGLONG totalSize, BOOL lohSizeKnown, ULONGLONG lohSize, BOOL disallowFullBlockingGC)
+int GCHeap::StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC)
 {
     AllocLockHolder lh;
 
@@ -35410,7 +35410,7 @@ int GCHeap::EndNoGCRegion()
     return (int)gc_heap::end_no_gc_region();
 }
 
-void GCHeap::PublishObject (BYTE* Obj)
+void GCHeap::PublishObject (uint8_t* Obj)
 {
 #ifdef BACKGROUND_GC
     gc_heap* hp = gc_heap::heap_of (Obj);
@@ -35647,7 +35647,7 @@ bool GCHeap::RegisterForFinalization (int gen, Object* obj)
     }
     else
     {
-        gc_heap* hp = gc_heap::heap_of ((BYTE*)obj);
+        gc_heap* hp = gc_heap::heap_of ((uint8_t*)obj);
         return hp->finalize_queue->RegisterForFinalization (gen, obj);
     }
 }
@@ -35680,7 +35680,7 @@ void GCHeap::SetFinalizationRun (Object* obj)
 #pragma optimize("y", on)        // Small critical routines, don't put in EBP frame 
 #endif //_MSC_VER && _TARGET_X86_
 
-VOID
+void
 GCHeap::SetCardsAfterBulkCopy( Object **StartPoint, size_t len )
 {
     Object **rover;
@@ -35710,15 +35710,15 @@ GCHeap::SetCardsAfterBulkCopy( Object **StartPoint, size_t len )
     end = StartPoint + (len/sizeof(Object*));
     while (rover < end)
     {
-        if ( (((BYTE*)*rover) >= g_ephemeral_low) && (((BYTE*)*rover) < g_ephemeral_high) )
+        if ( (((uint8_t*)*rover) >= g_ephemeral_low) && (((uint8_t*)*rover) < g_ephemeral_high) )
         {
             // Set Bit For Card and advance to next card
-            size_t card = gcard_of ((BYTE*)rover);
+            size_t card = gcard_of ((uint8_t*)rover);
 
-            FastInterlockOr ((DWORD RAW_KEYWORD(volatile) *)&g_card_table[card/card_word_width],
-                             (1 << (DWORD)(card % card_word_width)));
+            FastInterlockOr ((uint32_t RAW_KEYWORD(volatile) *)&g_card_table[card/card_word_width],
+                             (1 << (uint32_t)(card % card_word_width)));
             // Skip to next card for the object
-            rover = (Object**)align_on_card ((BYTE*)(rover+1));
+            rover = (Object**)align_on_card ((uint8_t*)(rover+1));
         }
         else
         {
@@ -35775,7 +35775,7 @@ bool CFinalize::Initialize()
     m_PromotedCount = 0;
     lock = -1;
 #ifdef _DEBUG
-    lockowner_threadid = (DWORD) -1;
+    lockowner_threadid = (uint32_t) -1;
 #endif // _DEBUG
 
     return true;
@@ -35826,7 +35826,7 @@ void CFinalize::LeaveFinalizeLock()
              GCToEEInterface::IsPreemptiveGCDisabled(GetThread()));
 
 #ifdef _DEBUG
-    lockowner_threadid = (DWORD) -1;
+    lockowner_threadid = (uint32_t) -1;
 #endif // _DEBUG
     lock = -1;
 }
@@ -36254,7 +36254,7 @@ CFinalize::ScanForFinalization (promote_func* pfn, int gen, BOOL mark_only_p,
                     if ((gen == max_generation) && (recursive_gc_sync::background_running_p()))
                     {
                         // TODO - fix the following line.
-                        //assert (gc_heap::background_object_marked ((BYTE*)obj, FALSE));
+                        //assert (gc_heap::background_object_marked ((uint8_t*)obj, FALSE));
                         dprintf (3, ("%Ix is marked", (size_t)obj));
                     }
                 }
@@ -36419,10 +36419,10 @@ void gc_heap::walk_heap (walk_fn fn, void* context, int gen_number, BOOL walk_la
 {
     generation* gen = gc_heap::generation_of (gen_number);
     heap_segment*    seg = generation_start_segment (gen);
-    BYTE*       x = ((gen_number == max_generation) ? heap_segment_mem (seg) :
+    uint8_t*       x = ((gen_number == max_generation) ? heap_segment_mem (seg) :
                      generation_allocation_start (gen));
 
-    BYTE*       end = heap_segment_allocated (seg);
+    uint8_t*       end = heap_segment_allocated (seg);
     BOOL small_object_segments = TRUE;
     int align_const = get_alignment_constant (small_object_segments);
 
@@ -36474,7 +36474,7 @@ void gc_heap::walk_heap (walk_fn fn, void* context, int gen_number, BOOL walk_la
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 void GCHeap::WalkObject (Object* obj, walk_fn fn, void* context)
 {
-    BYTE* o = (BYTE*)obj;
+    uint8_t* o = (uint8_t*)obj;
     if (o)
     {
         go_through_object_cl (method_table (o), o, size(o), oo,
@@ -36492,9 +36492,9 @@ void GCHeap::WalkObject (Object* obj, walk_fn fn, void* context)
 #endif //defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
 // Go through and touch (read) each page straddled by a memory block.
-void TouchPages(LPVOID pStart, UINT cb)
+void TouchPages(LPVOID pStart, uint32_t cb)
 {
-    const UINT pagesize = OS_PAGE_SIZE;
+    const uint32_t pagesize = OS_PAGE_SIZE;
     _ASSERTE(0 == (pagesize & (pagesize-1))); // Must be a power of 2.
     if (cb)
     {
@@ -36539,7 +36539,7 @@ void initGCShadow()
     if (len > (size_t)(g_GCShadowEnd - g_GCShadow)) 
     {
         deleteGCShadow();
-        g_GCShadowEnd = g_GCShadow = (BYTE*) VirtualAlloc(0, len, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        g_GCShadowEnd = g_GCShadow = (uint8_t*) VirtualAlloc(0, len, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
         if (g_GCShadow)
         {
             g_GCShadowEnd += len;
@@ -36584,8 +36584,8 @@ void initGCShadow()
                 break;
         }
             // Copy the segment
-        BYTE* start = heap_segment_mem(seg);
-        BYTE* end = heap_segment_allocated (seg);
+        uint8_t* start = heap_segment_mem(seg);
+        uint8_t* end = heap_segment_allocated (seg);
         memcpy(start + delta, start, end - start);
         seg = heap_segment_next_rw (seg);
     }
@@ -36596,8 +36596,8 @@ void initGCShadow()
     // test to see if 'ptr' was only updated via the write barrier.
 inline void testGCShadow(Object** ptr)
 {
-    Object** shadow = (Object**) &g_GCShadow[((BYTE*) ptr - g_lowest_address)];
-    if (*ptr != 0 && (BYTE*) shadow < g_GCShadowEnd && *ptr != *shadow) 
+    Object** shadow = (Object**) &g_GCShadow[((uint8_t*) ptr - g_lowest_address)];
+    if (*ptr != 0 && (uint8_t*) shadow < g_GCShadowEnd && *ptr != *shadow)
     {
 
         // If you get this assertion, someone updated a GC poitner in the heap without
@@ -36636,7 +36636,7 @@ inline void testGCShadow(Object** ptr)
     }
 }
 
-void testGCShadowHelper (BYTE* x)
+void testGCShadowHelper (uint8_t* x)
 {
     size_t s = size (x);
     if (contain_pointers (x))
@@ -36665,7 +36665,7 @@ void checkGCWriteBarrier()
 
         while(seg)
         {
-            BYTE* x = heap_segment_mem(seg);
+            uint8_t* x = heap_segment_mem(seg);
             while (x < heap_segment_allocated (seg))
             {
                 size_t s = size (x);
@@ -36686,7 +36686,7 @@ void checkGCWriteBarrier()
 
         while(seg)
         {
-            BYTE* x = heap_segment_mem(seg);
+            uint8_t* x = heap_segment_mem(seg);
             while (x < heap_segment_allocated (seg))
             {
                 size_t s = size (x);
@@ -36705,7 +36705,7 @@ void checkGCWriteBarrier()
 void gc_heap::walk_read_only_segment(heap_segment *seg, void *pvContext, object_callback_func pfnMethodTable, object_callback_func pfnObjRef)
 {
 #ifndef DACCESS_COMPILE
-    BYTE *o = heap_segment_mem(seg);
+    uint8_t *o = heap_segment_mem(seg);
 
     // small heap alignment constant
     int alignment = get_alignment_constant(TRUE);
@@ -36736,7 +36736,7 @@ HRESULT GCHeap::WaitUntilConcurrentGCCompleteAsync(int millisecondsTimeout)
 #ifdef BACKGROUND_GC
     if (recursive_gc_sync::background_running_p())
     {
-        DWORD dwRet = pGenGCHeap->background_gc_wait(awr_ignored, millisecondsTimeout);
+        uint32_t dwRet = pGenGCHeap->background_gc_wait(awr_ignored, millisecondsTimeout);
         if (dwRet == WAIT_OBJECT_0)
             return S_OK;
         else if (dwRet == WAIT_TIMEOUT)

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -660,13 +660,13 @@ public:
 #endif //VERIFY_HEAP    
 };
 
-extern VOLATILE(LONG) m_GCLock;
+extern VOLATILE(int32_t) m_GCLock;
 
 // Go through and touch (read) each page straddled by a memory block.
 void TouchPages(LPVOID pStart, uint32_t cb);
 
 // For low memory notification from host
-extern LONG g_bLowMemoryFromHost;
+extern int32_t g_bLowMemoryFromHost;
 
 #ifdef WRITE_BARRIER_CHECK
 void updateGCShadow(Object** ptr, Object* val);

--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -89,8 +89,8 @@ struct oom_history
 {
     oom_reason reason;
     size_t alloc_size;
-    BYTE* reserved;
-    BYTE* allocated;
+    uint8_t* reserved;
+    uint8_t* allocated;
     size_t gc_index;
     failure_get_memory fgm;
     size_t size;
@@ -117,9 +117,9 @@ GARY_DECL(size_t, gc_global_mechanisms, MAX_GLOBAL_GC_MECHANISMS_COUNT);
 #ifndef DACCESS_COMPILE
 extern "C" {
 #endif
-GPTR_DECL(BYTE,g_lowest_address);
-GPTR_DECL(BYTE,g_highest_address);
-GPTR_DECL(DWORD,g_card_table);
+GPTR_DECL(uint8_t,g_lowest_address);
+GPTR_DECL(uint8_t,g_highest_address);
+GPTR_DECL(uint32_t,g_card_table);
 #ifndef DACCESS_COMPILE
 }
 #endif
@@ -134,16 +134,16 @@ class DacHeapWalker;
 
 #ifdef WRITE_BARRIER_CHECK
 //always defined, but should be 0 in Server GC
-extern BYTE* g_GCShadow;
-extern BYTE* g_GCShadowEnd;
+extern uint8_t* g_GCShadow;
+extern uint8_t* g_GCShadowEnd;
 // saves the g_lowest_address in between GCs to verify the consistency of the shadow segment
-extern BYTE* g_shadow_lowest_address;
+extern uint8_t* g_shadow_lowest_address;
 #endif
 
 #define MP_LOCKS
 
-extern "C" BYTE* g_ephemeral_low;
-extern "C" BYTE* g_ephemeral_high;
+extern "C" uint8_t* g_ephemeral_low;
+extern "C" uint8_t* g_ephemeral_high;
 
 namespace WKS {
     ::GCHeap* CreateGCHeap();
@@ -173,10 +173,10 @@ struct alloc_context
 #endif // defined(FEATURE_SVR_GC)
     friend struct ClassDumpInfo;
 
-    BYTE*          alloc_ptr;
-    BYTE*          alloc_limit;
-    INT64          alloc_bytes; //Number of bytes allocated on SOH by this context
-    INT64          alloc_bytes_loh; //Number of bytes allocated on LOH by this context
+    uint8_t*       alloc_ptr;
+    uint8_t*       alloc_limit;
+    int64_t        alloc_bytes; //Number of bytes allocated on SOH by this context
+    int64_t        alloc_bytes_loh; //Number of bytes allocated on LOH by this context
 #if defined(FEATURE_SVR_GC)
     SVR::GCHeap*   alloc_heap;
     SVR::GCHeap*   home_heap;
@@ -235,7 +235,7 @@ struct ScanContext
 };
 
 typedef BOOL (* walk_fn)(Object*, void*);
-typedef void (* gen_walk_fn)(void *context, int generation, BYTE *range_start, BYTE * range_end, BYTE *range_reserved);
+typedef void (* gen_walk_fn)(void *context, int generation, uint8_t *range_start, uint8_t * range_end, uint8_t *range_reserved);
 
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 struct ProfilingScanContext : ScanContext
@@ -344,8 +344,8 @@ enum changed_seg_state
     seg_added
 };
 
-void record_changed_seg (BYTE* start, BYTE* end, 
-                         size_t current_gc_index, 
+void record_changed_seg (uint8_t* start, uint8_t* end,
+                         size_t current_gc_index,
                          bgc_state current_bgc_state,
                          changed_seg_state changed_state);
 
@@ -511,13 +511,13 @@ private:
     } GC_HEAP_TYPE;
     
 #ifdef FEATURE_SVR_GC
-    SVAL_DECL(DWORD,gcHeapType);
+    SVAL_DECL(uint32_t,gcHeapType);
 #endif // FEATURE_SVR_GC
 
 public:
         // TODO Synchronization, should be moved out
     virtual BOOL    IsGCInProgressHelper (BOOL bConsiderGCStart = FALSE) = 0;
-    virtual DWORD    WaitUntilGCComplete (BOOL bConsiderGCStart = FALSE) = 0;
+    virtual uint32_t    WaitUntilGCComplete (BOOL bConsiderGCStart = FALSE) = 0;
     virtual void SetGCInProgress(BOOL fInProgress) = 0;
     virtual CLREventStatic * GetWaitForGCEvent() = 0;
 
@@ -542,7 +542,7 @@ public:
     virtual BOOL IsConcurrentGCEnabled() = 0;
 
     virtual void FixAllocContext (alloc_context* acontext, BOOL lockp, void* arg, void *heap) = 0;
-    virtual Object* Alloc (alloc_context* acontext, size_t size, DWORD flags) = 0;
+    virtual Object* Alloc (alloc_context* acontext, size_t size, uint32_t flags) = 0;
 
     // This is safe to call only when EE is suspended.
     virtual Object* GetContainingObject(void *pInteriorPtr) = 0;
@@ -551,15 +551,15 @@ public:
     virtual HRESULT Initialize () = 0;
 
     virtual HRESULT GarbageCollect (int generation = -1, BOOL low_memory_p=FALSE, int mode = collection_blocking) = 0;
-    virtual Object*  Alloc (size_t size, DWORD flags) = 0;
+    virtual Object*  Alloc (size_t size, uint32_t flags) = 0;
 #ifdef FEATURE_64BIT_ALIGNMENT
-    virtual Object*  AllocAlign8 (size_t size, DWORD flags) = 0;
-    virtual Object*  AllocAlign8 (alloc_context* acontext, size_t size, DWORD flags) = 0;
+    virtual Object*  AllocAlign8 (size_t size, uint32_t flags) = 0;
+    virtual Object*  AllocAlign8 (alloc_context* acontext, size_t size, uint32_t flags) = 0;
 private:
-    virtual Object*  AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, DWORD flags) = 0;
+    virtual Object*  AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags) = 0;
 public:
 #endif // FEATURE_64BIT_ALIGNMENT
-    virtual Object*  AllocLHeap (size_t size, DWORD flags) = 0;
+    virtual Object*  AllocLHeap (size_t size, uint32_t flags) = 0;
     virtual void     SetReservedVMLimit (size_t vmlimit) = 0;
     virtual void SetCardsAfterBulkCopy( Object**, size_t ) = 0;
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
@@ -588,13 +588,13 @@ public:
     virtual int GetLOHCompactionMode() = 0;
     virtual void SetLOHCompactionMode(int newLOHCompactionyMode) = 0;
 
-    virtual BOOL RegisterForFullGCNotification(DWORD gen2Percentage, 
-                                               DWORD lohPercentage) = 0;
+    virtual BOOL RegisterForFullGCNotification(uint32_t gen2Percentage,
+                                               uint32_t lohPercentage) = 0;
     virtual BOOL CancelFullGCNotification() = 0;
     virtual int WaitForFullGCApproach(int millisecondsTimeout) = 0;
     virtual int WaitForFullGCComplete(int millisecondsTimeout) = 0;
 
-    virtual int StartNoGCRegion(ULONGLONG totalSize, BOOL lohSizeKnown, ULONGLONG lohSize, BOOL disallowFullBlockingGC) = 0;
+    virtual int StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC) = 0;
     virtual int EndNoGCRegion() = 0;
 
     virtual BOOL IsObjectInFixedHeap(Object *pObj) = 0;
@@ -606,7 +606,7 @@ public:
     virtual unsigned GetGcCount() = 0;
     virtual void TraceGCSegments() = 0;
 
-    virtual void PublishObject(BYTE* obj) = 0;
+    virtual void PublishObject(uint8_t* obj) = 0;
 
     // static if since restricting for all heaps is fine
     virtual size_t GetValidSegmentSize(BOOL large_seg = FALSE) = 0;
@@ -663,7 +663,7 @@ public:
 extern VOLATILE(LONG) m_GCLock;
 
 // Go through and touch (read) each page straddled by a memory block.
-void TouchPages(LPVOID pStart, UINT cb);
+void TouchPages(LPVOID pStart, uint32_t cb);
 
 // For low memory notification from host
 extern LONG g_bLowMemoryFromHost;

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -43,7 +43,7 @@ uint8_t* g_GCShadowEnd;
 uint8_t* g_shadow_lowest_address = NULL;
 #endif
 
-VOLATILE(LONG) m_GCLock = -1;
+VOLATILE(int32_t) m_GCLock = -1;
 
 #ifdef GC_CONFIG_DRIVEN
 void record_global_mechanism (int mech_index)
@@ -52,7 +52,7 @@ void record_global_mechanism (int mech_index)
 }
 #endif //GC_CONFIG_DRIVEN
 
-LONG g_bLowMemoryFromHost = 0;
+int32_t g_bLowMemoryFromHost = 0;
 
 #ifdef WRITE_BARRIER_CHECK
 

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -16,17 +16,17 @@
 #include "gc.h"
 
 #ifdef FEATURE_SVR_GC
-SVAL_IMPL_INIT(DWORD,GCHeap,gcHeapType,GCHeap::GC_HEAP_INVALID);
+SVAL_IMPL_INIT(uint32_t,GCHeap,gcHeapType,GCHeap::GC_HEAP_INVALID);
 #endif // FEATURE_SVR_GC
 
 GPTR_IMPL(GCHeap,g_pGCHeap);
 
 /* global versions of the card table and brick table */ 
-GPTR_IMPL(DWORD,g_card_table);
+GPTR_IMPL(uint32_t,g_card_table);
 
 /* absolute bounds of the GC memory */
-GPTR_IMPL_INIT(BYTE,g_lowest_address,0);
-GPTR_IMPL_INIT(BYTE,g_highest_address,0);
+GPTR_IMPL_INIT(uint8_t,g_lowest_address,0);
+GPTR_IMPL_INIT(uint8_t,g_highest_address,0);
 
 #ifdef GC_CONFIG_DRIVEN
 GARY_IMPL(size_t, gc_global_mechanisms, MAX_GLOBAL_GC_MECHANISMS_COUNT);
@@ -34,13 +34,13 @@ GARY_IMPL(size_t, gc_global_mechanisms, MAX_GLOBAL_GC_MECHANISMS_COUNT);
 
 #ifndef DACCESS_COMPILE
 
-BYTE* g_ephemeral_low = (BYTE*)1; 
-BYTE* g_ephemeral_high = (BYTE*)~0;
+uint8_t* g_ephemeral_low = (uint8_t*)1;
+uint8_t* g_ephemeral_high = (uint8_t*)~0;
 
 #ifdef WRITE_BARRIER_CHECK
-BYTE* g_GCShadow;
-BYTE* g_GCShadowEnd;
-BYTE* g_shadow_lowest_address = NULL;
+uint8_t* g_GCShadow;
+uint8_t* g_GCShadowEnd;
+uint8_t* g_shadow_lowest_address = NULL;
 #endif
 
 VOLATILE(LONG) m_GCLock = -1;
@@ -61,8 +61,8 @@ LONG g_bLowMemoryFromHost = 0;
     // called by the write barrier to update the shadow heap
 void updateGCShadow(Object** ptr, Object* val)
 {
-    Object** shadow = (Object**) &g_GCShadow[((BYTE*) ptr - g_lowest_address)];
-    if ((BYTE*) shadow < g_GCShadowEnd)
+    Object** shadow = (Object**) &g_GCShadow[((uint8_t*) ptr - g_lowest_address)];
+    if ((uint8_t*) shadow < g_GCShadowEnd)
     {
         *shadow = val;
 
@@ -80,8 +80,8 @@ void updateGCShadow(Object** ptr, Object* val)
 
 struct changed_seg
 {
-    BYTE              * start;
-    BYTE              * end;
+    uint8_t             * start;
+    uint8_t             * end;
     size_t              gc_index;
     bgc_state           bgc;
     changed_seg_state   changed;
@@ -93,8 +93,8 @@ const int max_saved_changed_segs = 128;
 changed_seg saved_changed_segs[max_saved_changed_segs];
 int saved_changed_segs_count = 0;
 
-void record_changed_seg (BYTE* start, BYTE* end, 
-                         size_t current_gc_index, 
+void record_changed_seg (uint8_t* start, uint8_t* end,
+                         size_t current_gc_index,
                          bgc_state current_bgc_state,
                          changed_seg_state changed_state)
 {

--- a/src/gc/gccommon.cpp
+++ b/src/gc/gccommon.cpp
@@ -80,8 +80,8 @@ void updateGCShadow(Object** ptr, Object* val)
 
 struct changed_seg
 {
-    uint8_t             * start;
-    uint8_t             * end;
+    uint8_t           * start;
+    uint8_t           * end;
     size_t              gc_index;
     bgc_state           bgc;
     changed_seg_state   changed;

--- a/src/gc/gcdesc.h
+++ b/src/gc/gcdesc.h
@@ -139,7 +139,7 @@ class CGCDesc
 public:
     static size_t ComputeSize (size_t NumSeries)
     {
-        _ASSERTE (SSIZE_T(NumSeries) > 0);
+        _ASSERTE (ptrdiff_t(NumSeries) > 0);
         
         return sizeof(size_t) + NumSeries*sizeof(CGCDescSeries);
     }
@@ -147,7 +147,7 @@ public:
     // For value type array
     static size_t ComputeSizeRepeating (size_t NumSeries)
     {
-        _ASSERTE (SSIZE_T(NumSeries) > 0);
+        _ASSERTE (ptrdiff_t(NumSeries) > 0);
         
         return sizeof(size_t) + sizeof(CGCDescSeries) +
                (NumSeries-1)*sizeof(val_serie_item);
@@ -161,7 +161,7 @@ public:
 
     static void InitValueClassSeries (void* mem, size_t NumSeries)
     {
-        *((SSIZE_T*)mem-1) = -((SSIZE_T)NumSeries);
+        *((ptrdiff_t*)mem-1) = -((ptrdiff_t)NumSeries);
     }
 #endif
 
@@ -184,7 +184,7 @@ public:
     // Cannot be used for valuetype arrays
     PTR_CGCDescSeries GetLowestSeries ()
     {
-        _ASSERTE (SSIZE_T(GetNumSeries()) > 0);
+        _ASSERTE (ptrdiff_t(GetNumSeries()) > 0);
         return PTR_CGCDescSeries(PTR_uint8_t(PTR_CGCDesc(this))
                                  - ComputeSize(GetNumSeries()));
     }
@@ -203,7 +203,7 @@ public:
         size_t NumOfPointers = 0;
         CGCDesc* map = GetCGCDescFromMT(pMT);
         CGCDescSeries* cur = map->GetHighestSeries();
-        SSIZE_T cnt = (SSIZE_T) map->GetNumSeries();
+        ptrdiff_t cnt = (ptrdiff_t) map->GetNumSeries();
 
         if (cnt > 0)
         {
@@ -217,7 +217,7 @@ public:
         else
         {
             /* Handle the repeating case - array of valuetypes */
-            for (SSIZE_T __i = 0; __i > cnt; __i--)
+            for (ptrdiff_t __i = 0; __i > cnt; __i--)
             {
                 NumOfPointers += cur->val_serie[__i].nptrs;
             }
@@ -232,7 +232,7 @@ public:
     // Size of the entire slot map.
     size_t GetSize ()
     {
-        SSIZE_T numSeries = (SSIZE_T) GetNumSeries();
+        ptrdiff_t numSeries = (ptrdiff_t) GetNumSeries();
         if (numSeries < 0)
         {
             return ComputeSizeRepeating(-numSeries);
@@ -252,7 +252,7 @@ private:
     
     BOOL IsValueClassSeries()
     {
-        return ((SSIZE_T) GetNumSeries()) < 0;
+        return ((ptrdiff_t) GetNumSeries()) < 0;
     }
 
 };

--- a/src/gc/gcdesc.h
+++ b/src/gc/gcdesc.h
@@ -13,9 +13,9 @@
 #define _GCDESC_H_
 
 #ifdef _WIN64
-typedef UINT32 HALF_SIZE_T;
+typedef uint32_t HALF_SIZE_T;
 #else   // _WIN64
-typedef UINT16 HALF_SIZE_T;
+typedef uint16_t HALF_SIZE_T;
 #endif
 
 
@@ -86,12 +86,12 @@ public:
         return seriessize/sizeof(JSlot); 
     }
 
-    VOID SetSeriesCount (size_t newcount)
+    void SetSeriesCount (size_t newcount)
     {
         seriessize = newcount * sizeof(JSlot);
     }
 
-    VOID IncSeriesCount (size_t increment = 1)
+    void IncSeriesCount (size_t increment = 1)
     {
         seriessize += increment * sizeof(JSlot);
     }
@@ -101,17 +101,17 @@ public:
         return seriessize;
     }
 
-    VOID SetSeriesSize (size_t newsize)
+    void SetSeriesSize (size_t newsize)
     {
         seriessize = newsize;
     }
 
-    VOID SetSeriesValItem (val_serie_item item, int index)
+    void SetSeriesValItem (val_serie_item item, int index)
     {
         val_serie [index] = item;
     }
 
-    VOID SetSeriesOffset (size_t newoffset)
+    void SetSeriesOffset (size_t newoffset)
     {
         startoffset = newoffset;
     }
@@ -154,12 +154,12 @@ public:
     }
 
 #ifndef DACCESS_COMPILE
-    static VOID Init (PVOID mem, size_t NumSeries)
+    static void Init (void* mem, size_t NumSeries)
     {
         *((size_t*)mem-1) = NumSeries;
     }
 
-    static VOID InitValueClassSeries (PVOID mem, size_t NumSeries)
+    static void InitValueClassSeries (void* mem, size_t NumSeries)
     {
         *((SSIZE_T*)mem-1) = -((SSIZE_T)NumSeries);
     }
@@ -185,7 +185,7 @@ public:
     PTR_CGCDescSeries GetLowestSeries ()
     {
         _ASSERTE (SSIZE_T(GetNumSeries()) > 0);
-        return PTR_CGCDescSeries(PTR_BYTE(PTR_CGCDesc(this))
+        return PTR_CGCDescSeries(PTR_uint8_t(PTR_CGCDesc(this))
                                  - ComputeSize(GetNumSeries()));
     }
 
@@ -243,9 +243,9 @@ public:
         }
     }
 
-    BYTE *GetStartOfGCData()
+    uint8_t *GetStartOfGCData()
     {
-        return ((BYTE *)this) - GetSize();
+        return ((uint8_t *)this) - GetSize();
     }
 
 private:

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -84,8 +84,8 @@ void GCHeap::UpdatePreGCCounters()
 #ifdef FEATURE_EVENT_TRACE
     ETW::GCLog::ETW_GC_INFO Info;
 
-    Info.GCStart.Count = (ULONG)pSettings->gc_index;
-    Info.GCStart.Depth = (ULONG)pSettings->condemned_generation;
+    Info.GCStart.Count = (uint32_t)pSettings->gc_index;
+    Info.GCStart.Depth = (uint32_t)pSettings->condemned_generation;
     Info.GCStart.Reason = (ETW::GCLog::ETW_GC_INFO::GC_REASON)((int)(pSettings->reason));
 
     Info.GCStart.Type = ETW::GCLog::ETW_GC_INFO::GC_NGC;
@@ -119,7 +119,7 @@ void GCHeap::UpdatePostGCCounters()
 
     int condemned_gen = pSettings->condemned_generation;
     Info.GCEnd.Depth = condemned_gen;
-    Info.GCEnd.Count = (ULONG)pSettings->gc_index;
+    Info.GCEnd.Count = (uint32_t)pSettings->gc_index;
     ETW::GCLog::FireGcEndAndGenerationRanges(Info.GCEnd.Count, Info.GCEnd.Depth);
 
     int xGen;
@@ -334,9 +334,9 @@ void GCHeap::UpdatePostGCCounters()
     
     g_TotalTimeSinceLastGCEnd = _currentPerfCounterTimer;
 
-    HeapInfo.HeapStats.PinnedObjectCount = (ULONG)(GetPerfCounters().m_GC.cPinnedObj);
-    HeapInfo.HeapStats.SinkBlockCount =  (ULONG)(GetPerfCounters().m_GC.cSinkBlocks);
-    HeapInfo.HeapStats.GCHandleCount =  (ULONG)(GetPerfCounters().m_GC.cHandles);
+    HeapInfo.HeapStats.PinnedObjectCount = (uint32_t)(GetPerfCounters().m_GC.cPinnedObj);
+    HeapInfo.HeapStats.SinkBlockCount =  (uint32_t)(GetPerfCounters().m_GC.cSinkBlocks);
+    HeapInfo.HeapStats.GCHandleCount =  (uint32_t)(GetPerfCounters().m_GC.cHandles);
 #endif //ENABLE_PERF_COUNTERS
 
     FireEtwGCHeapStats_V1(HeapInfo.HeapStats.GenInfo[0].GenerationSize, HeapInfo.HeapStats.GenInfo[0].TotalPromotedSize,
@@ -634,7 +634,7 @@ void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_numbe
         InlineSString<MAX_CLASSNAME_LENGTH> strTypeName; 
         th.GetName(strTypeName);
 
-        FireEtwGCAllocationTick_V3((ULONG)allocation_amount,
+        FireEtwGCAllocationTick_V3((uint32_t)allocation_amount,
                                    ((gen_number == 0) ? ETW::GCLog::ETW_GC_INFO::AllocationSmall : ETW::GCLog::ETW_GC_INFO::AllocationLarge), 
                                    GetClrInstanceId(),
                                    allocation_amount,

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -326,8 +326,8 @@ void GCHeap::UpdatePostGCCounters()
     }
 
     // Update Total Time    
-    GetPerfCounters().m_GC.timeInGC = (DWORD)g_TotalTimeInGC;
-    GetPerfCounters().m_GC.timeInGCBase = (DWORD)_timeInGCBase;
+    GetPerfCounters().m_GC.timeInGC = (uint32_t)g_TotalTimeInGC;
+    GetPerfCounters().m_GC.timeInGCBase = (uint32_t)_timeInGCBase;
 
     if (!GetPerfCounters().m_GC.cProcessID)
         GetPerfCounters().m_GC.cProcessID = (size_t)GetCurrentProcessId();
@@ -391,14 +391,14 @@ size_t GCHeap::GetNow()
 }
 
 #if defined(GC_PROFILING) //UNIXTODO: Enable this for FEATURE_EVENT_TRACE
-void ProfScanRootsHelper(Object** ppObject, ScanContext *pSC, DWORD dwFlags)
+void ProfScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
 {
 #if  defined(FEATURE_EVENT_TRACE)
     Object *pObj = *ppObject;
 #ifdef INTERIOR_POINTERS
     if (dwFlags & GC_CALL_INTERIOR)
     {
-        BYTE *o = (BYTE*)pObj;
+        uint8_t *o = (uint8_t*)pObj;
         gc_heap* hp = gc_heap::heap_of (o);
 
         if ((o < hp->gc_low) || (o >= hp->gc_high))
@@ -556,7 +556,7 @@ BOOL GCHeap::IsGCInProgressHelper (BOOL bConsiderGCStart)
     return GcInProgress || (bConsiderGCStart? VolatileLoad(&gc_heap::gc_started) : FALSE);
 }
 
-DWORD GCHeap::WaitUntilGCComplete(BOOL bConsiderGCStart)
+uint32_t GCHeap::WaitUntilGCComplete(BOOL bConsiderGCStart)
 {
     if (bConsiderGCStart)
     {
@@ -566,7 +566,7 @@ DWORD GCHeap::WaitUntilGCComplete(BOOL bConsiderGCStart)
         }
     }
 
-    DWORD dwWaitResult = NOERROR;
+    uint32_t dwWaitResult = NOERROR;
 
     if (GcInProgress) 
     {
@@ -625,7 +625,7 @@ BOOL GCHeap::IsConcurrentGCInProgress()
 }
 
 #ifdef FEATURE_EVENT_TRACE
-void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_number, BYTE* object_address)
+void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_number, uint8_t* object_address)
 {
     TypeHandle th = GetThread()->GetTHAllocContextObj();
 
@@ -645,7 +645,7 @@ void gc_heap::fire_etw_allocation_event (size_t allocation_amount, int gen_numbe
                                    );
     }
 }
-void gc_heap::fire_etw_pin_object_event (BYTE* object, BYTE** ppObject)
+void gc_heap::fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject)
 {
     Object* obj = (Object*)object;
 
@@ -672,11 +672,11 @@ void gc_heap::fire_etw_pin_object_event (BYTE* object, BYTE** ppObject)
 }
 #endif // FEATURE_EVENT_TRACE
 
-DWORD gc_heap::user_thread_wait (CLREvent *event, BOOL no_mode_change, int time_out_ms)
+uint32_t gc_heap::user_thread_wait (CLREvent *event, BOOL no_mode_change, int time_out_ms)
 {
     Thread* pCurThread = NULL;
     bool mode = false;
-    DWORD dwWaitResult = NOERROR;
+    uint32_t dwWaitResult = NOERROR;
     
     if (!no_mode_change)
     {
@@ -700,12 +700,12 @@ DWORD gc_heap::user_thread_wait (CLREvent *event, BOOL no_mode_change, int time_
 
 #ifdef BACKGROUND_GC
 // Wait for background gc to finish
-DWORD gc_heap::background_gc_wait (alloc_wait_reason awr, int time_out_ms)
+uint32_t gc_heap::background_gc_wait (alloc_wait_reason awr, int time_out_ms)
 {
     dprintf(2, ("Waiting end of background gc"));
     assert (background_gc_done_event.IsValid());
     fire_alloc_wait_event_begin (awr);
-    DWORD dwRet = user_thread_wait (&background_gc_done_event, FALSE, time_out_ms);
+    uint32_t dwRet = user_thread_wait (&background_gc_done_event, FALSE, time_out_ms);
     fire_alloc_wait_event_end (awr);
     dprintf(2, ("Waiting end of background gc is done"));
 
@@ -779,7 +779,7 @@ void GCHeap::DescrGenerationsToProfiler (gen_walk_fn fn, void *context)
 
 // Helper used to wrap the start routine of background GC threads so we can do things like initialize the
 // Redhawk thread state which requires running in the new thread's context.
-DWORD WINAPI gc_heap::rh_bgc_thread_stub(void * pContext)
+uint32_t WINAPI gc_heap::rh_bgc_thread_stub(void * pContext)
 {
     rh_bgc_thread_ctx * pStartContext = (rh_bgc_thread_ctx*)pContext;
 
@@ -807,7 +807,7 @@ segment_handle GCHeap::RegisterFrozenSegment(segment_info *pseginfo)
         return NULL;
     }
 
-    BYTE* base_mem = (BYTE*)pseginfo->pvMem;
+    uint8_t* base_mem = (uint8_t*)pseginfo->pvMem;
     heap_segment_mem(seg) = base_mem + pseginfo->ibFirstObject;
     heap_segment_allocated(seg) = base_mem + pseginfo->ibAllocated;
     heap_segment_committed(seg) = base_mem + pseginfo->ibCommit;

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -233,7 +233,7 @@ public:	// FIX
 
     // Lock for finalization
     PER_HEAP_ISOLATED   
-        VOLATILE(LONG)          m_GCFLock;
+        VOLATILE(int32_t)          m_GCFLock;
 
     PER_HEAP_ISOLATED   BOOL    GcCollectClasses;
     PER_HEAP_ISOLATED

--- a/src/gc/gcimpl.h
+++ b/src/gc/gcimpl.h
@@ -74,7 +74,7 @@ protected:
     friend struct ::alloc_context;
     friend void EnterAllocLock();
     friend void LeaveAllocLock();
-    friend void ProfScanRootsHelper(Object** object, ScanContext *pSC, DWORD dwFlags);
+    friend void ProfScanRootsHelper(Object** object, ScanContext *pSC, uint32_t dwFlags);
     friend void GCProfileWalkHeap();
 
 public:
@@ -98,11 +98,11 @@ public:
     size_t  GetNow();
 
     void  TraceGCSegments ();    
-    void PublishObject(BYTE* obj);
+    void PublishObject(uint8_t* obj);
     
     BOOL    IsGCInProgressHelper (BOOL bConsiderGCStart = FALSE);
 
-    DWORD    WaitUntilGCComplete (BOOL bConsiderGCStart = FALSE);
+    uint32_t    WaitUntilGCComplete (BOOL bConsiderGCStart = FALSE);
 
     void     SetGCInProgress(BOOL fInProgress);
 
@@ -111,16 +111,16 @@ public:
     HRESULT Initialize ();
 
     //flags can be GC_ALLOC_CONTAINS_REF GC_ALLOC_FINALIZE
-    Object*  Alloc (size_t size, DWORD flags);
+    Object*  Alloc (size_t size, uint32_t flags);
 #ifdef FEATURE_64BIT_ALIGNMENT
-    Object*  AllocAlign8 (size_t size, DWORD flags);
-    Object*  AllocAlign8 (alloc_context* acontext, size_t size, DWORD flags);
+    Object*  AllocAlign8 (size_t size, uint32_t flags);
+    Object*  AllocAlign8 (alloc_context* acontext, size_t size, uint32_t flags);
 private:
-    Object*  AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, DWORD flags);
+    Object*  AllocAlign8Common (void* hp, alloc_context* acontext, size_t size, uint32_t flags);
 public:
 #endif // FEATURE_64BIT_ALIGNMENT
-    Object*  AllocLHeap (size_t size, DWORD flags);
-    Object* Alloc (alloc_context* acontext, size_t size, DWORD flags);
+    Object*  AllocLHeap (size_t size, uint32_t flags);
+    Object* Alloc (alloc_context* acontext, size_t size, uint32_t flags);
 
     void FixAllocContext (alloc_context* acontext,
                                             BOOL lockp, void* arg, void *heap);
@@ -155,12 +155,12 @@ public:
     // promote an object
     PER_HEAP_ISOLATED void    Promote (Object** object, 
                                           ScanContext* sc,
-                                          DWORD flags=0);
+                                          uint32_t flags=0);
 
     // Find the relocation address for an object
     PER_HEAP_ISOLATED void    Relocate (Object** object,
                                            ScanContext* sc, 
-                                           DWORD flags=0);
+                                           uint32_t flags=0);
 
 
     HRESULT Init (size_t heapSize);
@@ -192,13 +192,13 @@ public:
     int GetLOHCompactionMode();
     void SetLOHCompactionMode(int newLOHCompactionyMode);
 
-    BOOL RegisterForFullGCNotification(DWORD gen2Percentage,
-                                       DWORD lohPercentage);
+    BOOL RegisterForFullGCNotification(uint32_t gen2Percentage,
+                                       uint32_t lohPercentage);
     BOOL CancelFullGCNotification();
     int WaitForFullGCApproach(int millisecondsTimeout);
     int WaitForFullGCComplete(int millisecondsTimeout);
 
-    int StartNoGCRegion(ULONGLONG totalSize, BOOL lohSizeKnown, ULONGLONG lohSize, BOOL disallowFullBlockingGC);
+    int StartNoGCRegion(uint64_t totalSize, BOOL lohSizeKnown, uint64_t lohSize, BOOL disallowFullBlockingGC);
     int EndNoGCRegion();
 
     PER_HEAP_ISOLATED     unsigned GetMaxGeneration();

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -559,13 +559,13 @@ enum gc_type
 class gc_mechanisms
 {
 public:
-    VOLATILE(SIZE_T) gc_index; // starts from 1 for the first GC, like dd_collection_count 
+    VOLATILE(size_t) gc_index; // starts from 1 for the first GC, like dd_collection_count
     int condemned_generation;
     BOOL promotion;
     BOOL compaction;
     BOOL loh_compaction;
     BOOL heap_expansion;
-    DWORD concurrent;
+    uint32_t concurrent;
     BOOL demotion;
     BOOL card_bundles;
     int  gen0_reduction_count;
@@ -587,7 +587,7 @@ public:
     BOOL stress_induced;
 #endif // STRESS_HEAP
 
-    DWORD entry_memory_load;
+    uint32_t entry_memory_load;
 
     void init_mechanisms(); //for each GC
     void first_init(); // for the life of the EE
@@ -627,7 +627,7 @@ public:
 #endif // STRESS_HEAP
 
 #ifdef _WIN64
-    DWORD entry_memory_load;
+    uint32_t entry_memory_load;
 #endif //_WIN64
 
     void store (gc_mechanisms* gm)
@@ -729,8 +729,8 @@ typedef DPTR(class CFinalize)                  PTR_CFinalize;
 #define MAX_BUCKET_COUNT (13)//Max number of buckets for the small generations. 
 class alloc_list 
 {
-    BYTE* head;
-    BYTE* tail;
+    uint8_t* head;
+    uint8_t* tail;
 
     size_t damage_count;
 public:
@@ -738,8 +738,8 @@ public:
     size_t item_count;
 #endif //FL_VERIFICATION
 
-    BYTE*& alloc_list_head () { return head;}
-    BYTE*& alloc_list_tail () { return tail;}
+    uint8_t*& alloc_list_head () { return head;}
+    uint8_t*& alloc_list_tail () { return tail;}
     size_t& alloc_list_damage_count(){ return damage_count; }
     alloc_list()
     {
@@ -769,11 +769,11 @@ public:
     unsigned int number_of_buckets() {return (unsigned int)num_buckets;}
 
     size_t first_bucket_size() {return frst_bucket_size;}
-    BYTE*& alloc_list_head_of (unsigned int bn)
+    uint8_t*& alloc_list_head_of (unsigned int bn)
     {
         return alloc_list_of (bn).alloc_list_head();
     }
-    BYTE*& alloc_list_tail_of (unsigned int bn)
+    uint8_t*& alloc_list_tail_of (unsigned int bn)
     {
         return alloc_list_of (bn).alloc_list_tail();
     }
@@ -805,10 +805,10 @@ public:
         }
     }
 
-    void unlink_item (unsigned int bucket_number, BYTE* item, BYTE* previous_item, BOOL use_undo_p);
-    void thread_item (BYTE* item, size_t size);
-    void thread_item_front (BYTE* itme, size_t size);
-    void thread_free_item (BYTE* free_item, BYTE*& head, BYTE*& tail);
+    void unlink_item (unsigned int bucket_number, uint8_t* item, uint8_t* previous_item, BOOL use_undo_p);
+    void thread_item (uint8_t* item, size_t size);
+    void thread_item_front (uint8_t* itme, size_t size);
+    void thread_free_item (uint8_t* free_item, uint8_t*& head, uint8_t*& tail);
     void copy_to_alloc_list (alloc_list* toalist);
     void copy_from_alloc_list (alloc_list* fromalist);
     void commit_alloc_list_changes();
@@ -826,8 +826,8 @@ public:
     alloc_context   allocation_context;
     heap_segment*   allocation_segment;
     PTR_heap_segment start_segment;
-    BYTE*           allocation_context_start_region;
-    BYTE*           allocation_start;
+    uint8_t*        allocation_context_start_region;
+    uint8_t*        allocation_start;
     allocator       free_list_allocator;
     size_t          free_list_allocated;
     size_t          end_seg_allocated;
@@ -836,7 +836,7 @@ public:
     size_t          free_list_space;
     size_t          free_obj_space;
     size_t          allocation_size;
-    BYTE*           plan_allocation_start;
+    uint8_t*        plan_allocation_start;
     size_t          plan_allocation_start_size;
 
     // this is the pinned plugs that got allocated into this gen.
@@ -921,7 +921,7 @@ struct seg_mapping
     // since we init h0 and h1 to 0, if we get 0 it means that
     // address doesn't exist on managed segments. And heap_of 
     // would just return heap0 which is what it does now.
-    BYTE* boundary;
+    uint8_t* boundary;
 #ifdef MULTIPLE_HEAPS
     gc_heap* h0;
     gc_heap* h1;
@@ -1044,7 +1044,7 @@ struct spinlock_info
 {
     msl_enter_state enter_state;
     msl_take_state take_state;
-    DWORD thread_id;
+    uint32_t thread_id;
 };
 
 const unsigned HS_CACHE_LINE_SIZE = 128;
@@ -1156,7 +1156,7 @@ class gc_heap
     friend class CFinalize;
 #endif // FEATURE_PREMORTEM_FINALIZATION
     friend struct ::alloc_context;
-    friend void ProfScanRootsHelper(Object** object, ScanContext *pSC, DWORD dwFlags);
+    friend void ProfScanRootsHelper(Object** object, ScanContext *pSC, uint32_t dwFlags);
     friend void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForEtw, BOOL fShouldWalkHeapObjectsForEtw);
     friend class t_join;
     friend class gc_mechanisms;
@@ -1173,11 +1173,11 @@ class gc_heap
 #endif //defined (WRITE_BARRIER_CHECK) && !defined (SERVER_GC)
 
 #ifdef MULTIPLE_HEAPS
-    typedef void (gc_heap::* card_fn) (BYTE**, int);
+    typedef void (gc_heap::* card_fn) (uint8_t**, int);
 #define call_fn(fn) (this->*fn)
 #define __this this
 #else
-    typedef void (* card_fn) (BYTE**);
+    typedef void (* card_fn) (uint8_t**);
 #define call_fn(fn) (*fn)
 #define __this (gc_heap*)0
 #endif
@@ -1255,11 +1255,11 @@ public:
 #endif
 
     static
-    heap_segment* make_heap_segment (BYTE* new_pages, 
+    heap_segment* make_heap_segment (uint8_t* new_pages,
                                      size_t size, 
                                      int h_number);
     static
-    l_heap* make_large_heap (BYTE* new_pages, size_t size, BOOL managed);
+    l_heap* make_large_heap (uint8_t* new_pages, size_t size, BOOL managed);
 
     static
     gc_heap* make_gc_heap(
@@ -1292,7 +1292,7 @@ public:
     static 
     gc_heap* balance_heaps_loh (alloc_context* acontext, size_t size);
     static
-    DWORD __stdcall gc_thread_stub (void* arg);
+    uint32_t __stdcall gc_thread_stub (void* arg);
 #endif //MULTIPLE_HEAPS
 
     CObjectHeader* try_fast_alloc (size_t jsize);
@@ -1301,11 +1301,11 @@ public:
     // context - we don't actually use the ptr/limit from it so I am
     // making this explicit by not passing in the alloc_context.
     PER_HEAP
-    CObjectHeader* allocate_large_object (size_t size, INT64& alloc_bytes);
+    CObjectHeader* allocate_large_object (size_t size, int64_t& alloc_bytes);
 
 #ifdef FEATURE_STRUCTALIGN
     PER_HEAP
-    BYTE* pad_for_alignment_large (BYTE* newAlloc, int requiredAlignment, size_t size);
+    uint8_t* pad_for_alignment_large (uint8_t* newAlloc, int requiredAlignment, size_t size);
 #endif // FEATURE_STRUCTALIGN
 
     PER_HEAP_ISOLATED
@@ -1327,21 +1327,21 @@ public:
     void init_records();
 
     static 
-    DWORD* make_card_table (BYTE* start, BYTE* end);
+    uint32_t* make_card_table (uint8_t* start, uint8_t* end);
 
     static
     void set_fgm_result (failure_get_memory f, size_t s, BOOL loh_p);
 
     static
-    int grow_brick_card_tables (BYTE* start, 
-                                BYTE* end, 
+    int grow_brick_card_tables (uint8_t* start,
+                                uint8_t* end,
                                 size_t size,
                                 heap_segment* new_seg, 
                                 gc_heap* hp,
                                 BOOL loh_p);
 
     PER_HEAP
-    BOOL is_mark_set (BYTE* o);
+    BOOL is_mark_set (uint8_t* o);
 
 protected:
 
@@ -1350,21 +1350,21 @@ protected:
 
     struct walk_relocate_args
     {
-        BYTE* last_plug;
+        uint8_t* last_plug;
         BOOL is_shortened;
         mark* pinned_plug_entry;
     };
 
     PER_HEAP
-    void walk_plug (BYTE* plug, size_t size, BOOL check_last_object_p, 
+    void walk_plug (uint8_t* plug, size_t size, BOOL check_last_object_p,
                     walk_relocate_args* args, size_t profiling_context);
 
     PER_HEAP
     void walk_relocation (int condemned_gen_number,
-                          BYTE* first_condemned_address, size_t profiling_context);
+                          uint8_t* first_condemned_address, size_t profiling_context);
 
     PER_HEAP
-    void walk_relocation_in_brick (BYTE* tree, walk_relocate_args* args, size_t profiling_context);
+    void walk_relocation_in_brick (uint8_t* tree, walk_relocate_args* args, size_t profiling_context);
 
 #if defined(BACKGROUND_GC) && defined(FEATURE_EVENT_TRACE)
     PER_HEAP
@@ -1385,10 +1385,10 @@ protected:
                                         STRESS_HEAP_ARG(int n_original));
 
     PER_HEAP_ISOLATED
-    size_t min_reclaim_fragmentation_threshold(ULONGLONG total_mem, DWORD num_heaps);
+    size_t min_reclaim_fragmentation_threshold(uint64_t total_mem, uint32_t num_heaps);
 
     PER_HEAP_ISOLATED
-    ULONGLONG min_high_fragmentation_threshold(ULONGLONG available_mem, DWORD num_heaps);
+    uint64_t min_high_fragmentation_threshold(uint64_t available_mem, uint32_t num_heaps);
 
     PER_HEAP
     void concurrent_print_time_delta (const char* msg);
@@ -1425,9 +1425,9 @@ protected:
     BOOL commit_loh_for_no_gc (heap_segment* seg);
 
     PER_HEAP_ISOLATED
-    start_no_gc_region_status prepare_for_no_gc_region (ULONGLONG total_size, 
-                                                        BOOL loh_size_known, 
-                                                        ULONGLONG loh_size, 
+    start_no_gc_region_status prepare_for_no_gc_region (uint64_t total_size,
+                                                        BOOL loh_size_known,
+                                                        uint64_t loh_size,
                                                         BOOL disallow_full_blocking);
 
     PER_HEAP
@@ -1467,10 +1467,10 @@ protected:
     void handle_failure_for_no_gc();
 
     PER_HEAP
-    void fire_etw_allocation_event (size_t allocation_amount, int gen_number, BYTE* object_address);
+    void fire_etw_allocation_event (size_t allocation_amount, int gen_number, uint8_t* object_address);
 
     PER_HEAP
-    void fire_etw_pin_object_event (BYTE* object, BYTE** ppObject);
+    void fire_etw_pin_object_event (uint8_t* object, uint8_t** ppObject);
 
     PER_HEAP
     size_t limit_from_size (size_t size, size_t room, int gen_number,
@@ -1504,7 +1504,7 @@ protected:
     void wait_for_bgc_high_memory (alloc_wait_reason awr);
 
     PER_HEAP
-    void bgc_loh_alloc_clr (BYTE* alloc_start, 
+    void bgc_loh_alloc_clr (uint8_t* alloc_start,
                             size_t size, 
                             alloc_context* acontext,
                             int align_const, 
@@ -1615,13 +1615,13 @@ protected:
     struct loh_state_info
     {
         allocation_state alloc_state;
-        DWORD thread_id;
+        uint32_t thread_id;
     };
 
     PER_HEAP
     loh_state_info last_loh_states[max_saved_loh_states];
     PER_HEAP
-    void add_saved_loh_state (allocation_state loh_state_to_save, DWORD thread_id);
+    void add_saved_loh_state (allocation_state loh_state_to_save, uint32_t thread_id);
 #endif //RECORD_LOH_STATE
     PER_HEAP
     BOOL allocate_large (int gen_number,
@@ -1653,11 +1653,11 @@ protected:
     PER_HEAP
     void set_allocation_heap_segment (generation* gen);
     PER_HEAP
-    void reset_allocation_pointers (generation* gen, BYTE* start);
+    void reset_allocation_pointers (generation* gen, uint8_t* start);
     PER_HEAP
-    int object_gennum (BYTE* o);
+    int object_gennum (uint8_t* o);
     PER_HEAP
-    int object_gennum_plan (BYTE* o);
+    int object_gennum_plan (uint8_t* o);
     PER_HEAP_ISOLATED
     void init_heap_segment (heap_segment* seg);
     PER_HEAP
@@ -1709,7 +1709,7 @@ protected:
     PER_HEAP
     void switch_one_quantum();
     PER_HEAP
-    void reset_ww_by_chunk (BYTE* start_address, size_t total_reset_size);
+    void reset_ww_by_chunk (uint8_t* start_address, size_t total_reset_size);
     PER_HEAP
     void switch_on_reset (BOOL concurrent_p, size_t* current_total_reset_size, size_t last_reset_size);
     PER_HEAP
@@ -1718,31 +1718,31 @@ protected:
     void adjust_ephemeral_limits ();
     PER_HEAP
     void make_generation (generation& gen, heap_segment* seg,
-                          BYTE* start, BYTE* pointer);
+                          uint8_t* start, uint8_t* pointer);
 
 
 #define USE_PADDING_FRONT 1
 #define USE_PADDING_TAIL  2
 
     PER_HEAP
-    BOOL size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, BYTE* alloc_pointer, BYTE* alloc_limit,
-                     BYTE* old_loc=0, int use_padding=USE_PADDING_TAIL);
+    BOOL size_fit_p (size_t size REQD_ALIGN_AND_OFFSET_DCL, uint8_t* alloc_pointer, uint8_t* alloc_limit,
+                     uint8_t* old_loc=0, int use_padding=USE_PADDING_TAIL);
     PER_HEAP
-    BOOL a_size_fit_p (size_t size, BYTE* alloc_pointer, BYTE* alloc_limit,
+    BOOL a_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit,
                        int align_const);
 
     PER_HEAP
     void handle_oom (int heap_num, oom_reason reason, size_t alloc_size, 
-                     BYTE* allocated, BYTE* reserved);
+                     uint8_t* allocated, uint8_t* reserved);
 
     PER_HEAP
-    size_t card_of ( BYTE* object);
+    size_t card_of ( uint8_t* object);
     PER_HEAP
-    BYTE* brick_address (size_t brick);
+    uint8_t* brick_address (size_t brick);
     PER_HEAP
-    size_t brick_of (BYTE* add);
+    size_t brick_of (uint8_t* add);
     PER_HEAP
-    BYTE* card_address (size_t card);
+    uint8_t* card_address (size_t card);
     PER_HEAP
     size_t card_to_brick (size_t card);
     PER_HEAP
@@ -1752,7 +1752,7 @@ protected:
     PER_HEAP
     BOOL  card_set_p (size_t card);
     PER_HEAP
-    void card_table_set_bit (BYTE* location);
+    void card_table_set_bit (uint8_t* location);
 
 #ifdef CARD_BUNDLE
     PER_HEAP
@@ -1775,17 +1775,17 @@ protected:
 #endif //CARD_BUNDLE
 
     PER_HEAP
-    BOOL find_card (DWORD* card_table, size_t& card,
+    BOOL find_card (uint32_t* card_table, size_t& card,
                     size_t card_word_end, size_t& end_card);
     PER_HEAP
-    BOOL grow_heap_segment (heap_segment* seg, BYTE* high_address);
+    BOOL grow_heap_segment (heap_segment* seg, uint8_t* high_address);
     PER_HEAP
-    int grow_heap_segment (heap_segment* seg, BYTE* high_address, BYTE* old_loc, size_t size, BOOL pad_front_p REQD_ALIGN_AND_OFFSET_DCL);
+    int grow_heap_segment (heap_segment* seg, uint8_t* high_address, uint8_t* old_loc, size_t size, BOOL pad_front_p REQD_ALIGN_AND_OFFSET_DCL);
     PER_HEAP
-    void copy_brick_card_range (BYTE* la, DWORD* old_card_table,
+    void copy_brick_card_range (uint8_t* la, uint32_t* old_card_table,
                                 short* old_brick_table,
                                 heap_segment* seg,
-                                BYTE* start, BYTE* end);
+                                uint8_t* start, uint8_t* end);
     PER_HEAP
     void init_brick_card_range (heap_segment* seg);
     PER_HEAP
@@ -1793,48 +1793,48 @@ protected:
     PER_HEAP
     void copy_brick_card_table();
     PER_HEAP
-    void clear_brick_table (BYTE* from, BYTE* end);
+    void clear_brick_table (uint8_t* from, uint8_t* end);
     PER_HEAP
     void set_brick (size_t index, ptrdiff_t val);
     PER_HEAP
     int brick_entry (size_t index);
 #ifdef MARK_ARRAY
     PER_HEAP
-    unsigned int mark_array_marked (BYTE* add);
+    unsigned int mark_array_marked (uint8_t* add);
     PER_HEAP
-    void mark_array_set_marked (BYTE* add);
+    void mark_array_set_marked (uint8_t* add);
     PER_HEAP
-    BOOL is_mark_bit_set (BYTE* add);
+    BOOL is_mark_bit_set (uint8_t* add);
     PER_HEAP
-    void gmark_array_set_marked (BYTE* add);
+    void gmark_array_set_marked (uint8_t* add);
     PER_HEAP
     void set_mark_array_bit (size_t mark_bit);
     PER_HEAP
     BOOL mark_array_bit_set (size_t mark_bit);
     PER_HEAP
-    void mark_array_clear_marked (BYTE* add);
+    void mark_array_clear_marked (uint8_t* add);
     PER_HEAP
-    void clear_mark_array (BYTE* from, BYTE* end, BOOL check_only=TRUE);
+    void clear_mark_array (uint8_t* from, uint8_t* end, BOOL check_only=TRUE);
 #ifdef BACKGROUND_GC
     PER_HEAP
     void seg_clear_mark_array_bits_soh (heap_segment* seg);
     PER_HEAP
-    void clear_batch_mark_array_bits (BYTE* start, BYTE* end);
+    void clear_batch_mark_array_bits (uint8_t* start, uint8_t* end);
     PER_HEAP
-    void bgc_clear_batch_mark_array_bits (BYTE* start, BYTE* end);
+    void bgc_clear_batch_mark_array_bits (uint8_t* start, uint8_t* end);
     PER_HEAP
-    void clear_mark_array_by_objects (BYTE* from, BYTE* end, BOOL loh_p);
+    void clear_mark_array_by_objects (uint8_t* from, uint8_t* end, BOOL loh_p);
 #ifdef VERIFY_HEAP
     PER_HEAP
-    void set_batch_mark_array_bits (BYTE* start, BYTE* end);
+    void set_batch_mark_array_bits (uint8_t* start, uint8_t* end);
     PER_HEAP
-    void check_batch_mark_array_bits (BYTE* start, BYTE* end);
+    void check_batch_mark_array_bits (uint8_t* start, uint8_t* end);
 #endif //VERIFY_HEAP
 #endif //BACKGROUND_GC
 #endif //MARK_ARRAY
 
     PER_HEAP
-    BOOL large_object_marked (BYTE* o, BOOL clearp);
+    BOOL large_object_marked (uint8_t* o, BOOL clearp);
 
 #ifdef BACKGROUND_GC
     PER_HEAP
@@ -1848,10 +1848,10 @@ protected:
     void check_for_full_gc (int gen_num, size_t size);
 
     PER_HEAP
-    void adjust_limit (BYTE* start, size_t limit_size, generation* gen,
+    void adjust_limit (uint8_t* start, size_t limit_size, generation* gen,
                        int gen_number);
     PER_HEAP
-    void adjust_limit_clr (BYTE* start, size_t limit_size,
+    void adjust_limit_clr (uint8_t* start, size_t limit_size,
                            alloc_context* acontext, heap_segment* seg,
                            int align_const, int gen_number);
     PER_HEAP
@@ -1876,47 +1876,47 @@ protected:
     void remove_gen_free (int gen_number, size_t free_size);
 
     PER_HEAP
-    BYTE* allocate_in_older_generation (generation* gen, size_t size,
+    uint8_t* allocate_in_older_generation (generation* gen, size_t size,
                                         int from_gen_number,
-                                        BYTE* old_loc=0
+                                        uint8_t* old_loc=0
                                         REQD_ALIGN_AND_OFFSET_DEFAULT_DCL);
     PER_HEAP
     generation*  ensure_ephemeral_heap_segment (generation* consing_gen);
     PER_HEAP
-    BYTE* allocate_in_condemned_generations (generation* gen,
+    uint8_t* allocate_in_condemned_generations (generation* gen,
                                              size_t size,
                                              int from_gen_number,
 #ifdef SHORT_PLUGS
                                              BOOL* convert_to_pinned_p=NULL,
-                                             BYTE* next_pinned_plug=0,
+                                             uint8_t* next_pinned_plug=0,
                                              heap_segment* current_seg=0,
 #endif //SHORT_PLUGS
-                                             BYTE* old_loc=0
+                                             uint8_t* old_loc=0
                                              REQD_ALIGN_AND_OFFSET_DEFAULT_DCL);
 #ifdef INTERIOR_POINTERS
     // Verifies that interior is actually in the range of seg; otherwise 
     // returns 0.
     PER_HEAP_ISOLATED
-    heap_segment* find_segment (BYTE* interior, BOOL small_segment_only_p);
+    heap_segment* find_segment (uint8_t* interior, BOOL small_segment_only_p);
 
     PER_HEAP
-    heap_segment* find_segment_per_heap (BYTE* interior, BOOL small_segment_only_p);
+    heap_segment* find_segment_per_heap (uint8_t* interior, BOOL small_segment_only_p);
 
     PER_HEAP
-    BYTE* find_object_for_relocation (BYTE* o, BYTE* low, BYTE* high);
+    uint8_t* find_object_for_relocation (uint8_t* o, uint8_t* low, uint8_t* high);
 #endif //INTERIOR_POINTERS
 
     PER_HEAP_ISOLATED
-    gc_heap* heap_of (BYTE* object);
+    gc_heap* heap_of (uint8_t* object);
 
     PER_HEAP_ISOLATED
-    gc_heap* heap_of_gc (BYTE* object);
+    gc_heap* heap_of_gc (uint8_t* object);
 
     PER_HEAP_ISOLATED
     size_t&  promoted_bytes (int);
 
     PER_HEAP
-    BYTE* find_object (BYTE* o, BYTE* low);
+    uint8_t* find_object (uint8_t* o, uint8_t* low);
 
     PER_HEAP
     dynamic_data* dynamic_data_of (int gen_number);
@@ -1941,24 +1941,24 @@ protected:
     PER_HEAP
     void set_allocator_next_pin (generation* gen);
     PER_HEAP
-    void set_allocator_next_pin (BYTE* alloc_pointer, BYTE*& alloc_limit);
+    void set_allocator_next_pin (uint8_t* alloc_pointer, uint8_t*& alloc_limit);
     PER_HEAP
-    void enque_pinned_plug (generation* gen, BYTE* plug, size_t len);
+    void enque_pinned_plug (generation* gen, uint8_t* plug, size_t len);
     PER_HEAP
-    void enque_pinned_plug (BYTE* plug, 
-                            BOOL save_pre_plug_info_p, 
-                            BYTE* last_object_in_last_plug);
+    void enque_pinned_plug (uint8_t* plug,
+                            BOOL save_pre_plug_info_p,
+                            uint8_t* last_object_in_last_plug);
     PER_HEAP
-    void merge_with_last_pinned_plug (BYTE* last_pinned_plug, size_t plug_size);
+    void merge_with_last_pinned_plug (uint8_t* last_pinned_plug, size_t plug_size);
     PER_HEAP
-    void set_pinned_info (BYTE* last_pinned_plug, 
-                          size_t plug_len, 
-                          BYTE* alloc_pointer, 
-                          BYTE*& alloc_limit);
+    void set_pinned_info (uint8_t* last_pinned_plug,
+                          size_t plug_len,
+                          uint8_t* alloc_pointer,
+                          uint8_t*& alloc_limit);
     PER_HEAP
-    void set_pinned_info (BYTE* last_pinned_plug, size_t plug_len, generation* gen);
+    void set_pinned_info (uint8_t* last_pinned_plug, size_t plug_len, generation* gen);
     PER_HEAP
-    void save_post_plug_info (BYTE* last_pinned_plug, BYTE* last_object_in_last_plug, BYTE* post_plug);
+    void save_post_plug_info (uint8_t* last_pinned_plug, uint8_t* last_object_in_last_plug, uint8_t* post_plug);
     PER_HEAP
     size_t deque_pinned_plug ();
     PER_HEAP
@@ -1975,32 +1975,32 @@ protected:
     PER_HEAP
     int& mark_stack_busy();
     PER_HEAP
-    VOLATILE(BYTE*)& ref_mark_stack (gc_heap* hp, int index);
+    VOLATILE(uint8_t*)& ref_mark_stack (gc_heap* hp, int index);
 #endif
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED
     size_t&  bpromoted_bytes (int);
     PER_HEAP
-    void make_background_mark_stack (BYTE** arr);
+    void make_background_mark_stack (uint8_t** arr);
     PER_HEAP
-    void make_c_mark_list (BYTE** arr);
+    void make_c_mark_list (uint8_t** arr);
 #endif //BACKGROUND_GC
     PER_HEAP
     generation* generation_of (int  n);
     PER_HEAP
-    BOOL gc_mark1 (BYTE* o);
+    BOOL gc_mark1 (uint8_t* o);
     PER_HEAP
-    BOOL gc_mark (BYTE* o, BYTE* low, BYTE* high);
+    BOOL gc_mark (uint8_t* o, uint8_t* low, uint8_t* high);
     PER_HEAP
-    BYTE* mark_object(BYTE* o THREAD_NUMBER_DCL);
+    uint8_t* mark_object(uint8_t* o THREAD_NUMBER_DCL);
 #ifdef HEAP_ANALYZE
     PER_HEAP
-    void ha_mark_object_simple (BYTE** o THREAD_NUMBER_DCL);
+    void ha_mark_object_simple (uint8_t** o THREAD_NUMBER_DCL);
 #endif //HEAP_ANALYZE
     PER_HEAP
-    void mark_object_simple (BYTE** o THREAD_NUMBER_DCL);
+    void mark_object_simple (uint8_t** o THREAD_NUMBER_DCL);
     PER_HEAP
-    void mark_object_simple1 (BYTE* o, BYTE* start THREAD_NUMBER_DCL);
+    void mark_object_simple1 (uint8_t* o, uint8_t* start THREAD_NUMBER_DCL);
 
 #ifdef MH_SC_MARK
     PER_HEAP
@@ -2010,39 +2010,39 @@ protected:
 #ifdef BACKGROUND_GC
 
     PER_HEAP
-    BOOL background_marked (BYTE* o);
+    BOOL background_marked (uint8_t* o);
     PER_HEAP
-    BOOL background_mark1 (BYTE* o);
+    BOOL background_mark1 (uint8_t* o);
     PER_HEAP
-    BOOL background_mark (BYTE* o, BYTE* low, BYTE* high);
+    BOOL background_mark (uint8_t* o, uint8_t* low, uint8_t* high);
     PER_HEAP
-    BYTE* background_mark_object (BYTE* o THREAD_NUMBER_DCL);
+    uint8_t* background_mark_object (uint8_t* o THREAD_NUMBER_DCL);
     PER_HEAP
-    void background_mark_simple (BYTE* o THREAD_NUMBER_DCL);
+    void background_mark_simple (uint8_t* o THREAD_NUMBER_DCL);
     PER_HEAP
-    void background_mark_simple1 (BYTE* o THREAD_NUMBER_DCL);
+    void background_mark_simple1 (uint8_t* o THREAD_NUMBER_DCL);
     PER_HEAP_ISOLATED
-    void background_promote (Object**, ScanContext* , DWORD);
+    void background_promote (Object**, ScanContext* , uint32_t);
     PER_HEAP
-    BOOL background_object_marked (BYTE* o, BOOL clearp);
+    BOOL background_object_marked (uint8_t* o, BOOL clearp);
     PER_HEAP
     void init_background_gc();
     PER_HEAP
-    BYTE* background_next_end (heap_segment*, BOOL);
+    uint8_t* background_next_end (heap_segment*, BOOL);
     PER_HEAP
     void generation_delete_heap_segment (generation*, 
                                          heap_segment*, heap_segment*, heap_segment*);
     PER_HEAP
-    void set_mem_verify (BYTE*, BYTE*, BYTE);
+    void set_mem_verify (uint8_t*, uint8_t*, uint8_t);
     PER_HEAP
-    void process_background_segment_end (heap_segment*, generation*, BYTE*,
+    void process_background_segment_end (heap_segment*, generation*, uint8_t*,
                                      heap_segment*, BOOL*);
     PER_HEAP
     void process_n_background_segments (heap_segment*, heap_segment*, generation* gen);
     PER_HEAP
-    BOOL fgc_should_consider_object (BYTE* o, 
+    BOOL fgc_should_consider_object (uint8_t* o,
                                      heap_segment* seg,
-                                     BOOL consider_bgc_mark_p, 
+                                     BOOL consider_bgc_mark_p,
                                      BOOL check_current_sweep_p,
                                      BOOL check_saved_sweep_p);
     PER_HEAP
@@ -2055,17 +2055,17 @@ protected:
     PER_HEAP
     void background_sweep ();
     PER_HEAP
-    void background_mark_through_object (BYTE* oo THREAD_NUMBER_DCL);
+    void background_mark_through_object (uint8_t* oo THREAD_NUMBER_DCL);
     PER_HEAP
-    BYTE* background_seg_end (heap_segment* seg, BOOL concurrent_p);
+    uint8_t* background_seg_end (heap_segment* seg, BOOL concurrent_p);
     PER_HEAP
-    BYTE* background_first_overflow (BYTE* min_add,
+    uint8_t* background_first_overflow (uint8_t* min_add,
                                      heap_segment* seg,
                                      BOOL concurrent_p, 
                                      BOOL small_object_p);
     PER_HEAP
     void background_process_mark_overflow_internal (int condemned_gen_number,
-                                                    BYTE* min_add, BYTE* max_add,
+                                                    uint8_t* min_add, uint8_t* max_add,
                                                     BOOL concurrent_p);
     PER_HEAP
     BOOL background_process_mark_overflow (BOOL concurrent_p);
@@ -2078,27 +2078,27 @@ protected:
     PER_HEAP
     BOOL bgc_mark_array_range (heap_segment* seg, 
                                BOOL whole_seg_p,
-                               BYTE** range_beg,
-                               BYTE** range_end);
+                               uint8_t** range_beg,
+                               uint8_t** range_end);
     PER_HEAP
     void bgc_verify_mark_array_cleared (heap_segment* seg);
     PER_HEAP
-    void verify_mark_bits_cleared (BYTE* obj, size_t s);
+    void verify_mark_bits_cleared (uint8_t* obj, size_t s);
     PER_HEAP
     void clear_all_mark_array();
 #endif //BACKGROUND_GC
 
     PER_HEAP
-    BYTE* next_end (heap_segment* seg, BYTE* f);
+    uint8_t* next_end (heap_segment* seg, uint8_t* f);
     PER_HEAP
     void fix_card_table ();
     PER_HEAP
-    void mark_through_object (BYTE* oo, BOOL mark_class_object_p THREAD_NUMBER_DCL);
+    void mark_through_object (uint8_t* oo, BOOL mark_class_object_p THREAD_NUMBER_DCL);
     PER_HEAP
     BOOL process_mark_overflow (int condemned_gen_number);
     PER_HEAP
     void process_mark_overflow_internal (int condemned_gen_number,
-                                         BYTE* min_address, BYTE* max_address);
+                                         uint8_t* min_address, uint8_t* max_address);
 
 #ifdef SNOOP_STATS
     PER_HEAP
@@ -2119,18 +2119,18 @@ protected:
     void mark_phase (int condemned_gen_number, BOOL mark_only_p);
 
     PER_HEAP
-    void pin_object (BYTE* o, BYTE** ppObject, BYTE* low, BYTE* high);
+    void pin_object (uint8_t* o, uint8_t** ppObject, uint8_t* low, uint8_t* high);
     PER_HEAP
     void reset_mark_stack ();
     PER_HEAP
-    BYTE* insert_node (BYTE* new_node, size_t sequence_number,
-                       BYTE* tree, BYTE* last_node);
+    uint8_t* insert_node (uint8_t* new_node, size_t sequence_number,
+                       uint8_t* tree, uint8_t* last_node);
     PER_HEAP
-    size_t update_brick_table (BYTE* tree, size_t current_brick,
-                               BYTE* x, BYTE* plug_end);
+    size_t update_brick_table (uint8_t* tree, size_t current_brick,
+                               uint8_t* x, uint8_t* plug_end);
 
     PER_HEAP
-    void plan_generation_start (generation* gen, generation* consing_gen, BYTE* next_plug_to_allocate);
+    void plan_generation_start (generation* gen, generation* consing_gen, uint8_t* next_plug_to_allocate);
 
     PER_HEAP
     void realloc_plan_generation_start (generation* gen, generation* consing_gen);
@@ -2142,7 +2142,7 @@ protected:
     void advance_pins_for_demotion (generation* gen);
 
     PER_HEAP
-    void process_ephemeral_boundaries(BYTE* x, int& active_new_gen_number,
+    void process_ephemeral_boundaries(uint8_t* x, int& active_new_gen_number,
                                       int& active_old_gen_number,
                                       generation*& consing_gen,
                                       BOOL& allocate_in_condemned);
@@ -2157,13 +2157,13 @@ protected:
                                  size_t ps,
                                  size_t& artificial_pinned_size);
     PER_HEAP
-    void store_plug_gap_info (BYTE* plug_start,
-                              BYTE* plug_end,
+    void store_plug_gap_info (uint8_t* plug_start,
+                              uint8_t* plug_end,
                               BOOL& last_npinned_plug_p, 
                               BOOL& last_pinned_plug_p, 
-                              BYTE*& last_pinned_plug,
+                              uint8_t*& last_pinned_plug,
                               BOOL& pinned_plug_p,
-                              BYTE* last_object_in_last_plug,
+                              uint8_t* last_object_in_last_plug,
                               BOOL& merge_with_last_pin_p,
                               // this is only for verification purpose
                               size_t last_plug_len);
@@ -2200,7 +2200,7 @@ protected:
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
     PER_HEAP
-    BOOL loh_enque_pinned_plug (BYTE* plug, size_t len);
+    BOOL loh_enque_pinned_plug (uint8_t* plug, size_t len);
 
     PER_HEAP
     void loh_set_allocator_next_pin();
@@ -2218,13 +2218,13 @@ protected:
     mark* loh_oldest_pin();
 
     PER_HEAP
-    BOOL loh_size_fit_p (size_t size, BYTE* alloc_pointer, BYTE* alloc_limit);
+    BOOL loh_size_fit_p (size_t size, uint8_t* alloc_pointer, uint8_t* alloc_limit);
 
     PER_HEAP
-    BYTE* loh_allocate_in_condemned (BYTE* old_loc, size_t size);
+    uint8_t* loh_allocate_in_condemned (uint8_t* old_loc, size_t size);
 
     PER_HEAP_ISOLATED
-    BOOL loh_object_p (BYTE* o);
+    BOOL loh_object_p (uint8_t* o);
 
     PER_HEAP_ISOLATED
     BOOL should_compact_loh();
@@ -2242,102 +2242,102 @@ protected:
     void fix_generation_bounds (int condemned_gen_number,
                                 generation* consing_gen);
     PER_HEAP
-    BYTE* generation_limit (int gen_number);
+    uint8_t* generation_limit (int gen_number);
 
     struct make_free_args
     {
         int free_list_gen_number;
-        BYTE* current_gen_limit;
+        uint8_t* current_gen_limit;
         generation* free_list_gen;
-        BYTE* highest_plug;
+        uint8_t* highest_plug;
     };
     PER_HEAP
-    BYTE* allocate_at_end (size_t size);
+    uint8_t* allocate_at_end (size_t size);
     PER_HEAP
     BOOL ensure_gap_allocation (int condemned_gen_number);
     // make_free_lists is only called by blocking GCs.
     PER_HEAP
     void make_free_lists (int condemned_gen_number);
     PER_HEAP
-    void make_free_list_in_brick (BYTE* tree, make_free_args* args);
+    void make_free_list_in_brick (uint8_t* tree, make_free_args* args);
     PER_HEAP
-    void thread_gap (BYTE* gap_start, size_t size, generation*  gen);
+    void thread_gap (uint8_t* gap_start, size_t size, generation*  gen);
     PER_HEAP
-    void loh_thread_gap_front (BYTE* gap_start, size_t size, generation*  gen);
+    void loh_thread_gap_front (uint8_t* gap_start, size_t size, generation*  gen);
     PER_HEAP
-    void make_unused_array (BYTE* x, size_t size, BOOL clearp=FALSE, BOOL resetp=FALSE);
+    void make_unused_array (uint8_t* x, size_t size, BOOL clearp=FALSE, BOOL resetp=FALSE);
     PER_HEAP
-    void clear_unused_array (BYTE* x, size_t size);
+    void clear_unused_array (uint8_t* x, size_t size);
     PER_HEAP
-    void relocate_address (BYTE** old_address THREAD_NUMBER_DCL);
+    void relocate_address (uint8_t** old_address THREAD_NUMBER_DCL);
     struct relocate_args
     {
-        BYTE* last_plug;
-        BYTE* low;
-        BYTE* high;
+        uint8_t* last_plug;
+        uint8_t* low;
+        uint8_t* high;
         BOOL is_shortened;
         mark* pinned_plug_entry;
     };
 
     PER_HEAP
-    void reloc_survivor_helper (BYTE** pval);
+    void reloc_survivor_helper (uint8_t** pval);
     PER_HEAP
-    void check_class_object_demotion (BYTE* obj);
+    void check_class_object_demotion (uint8_t* obj);
     PER_HEAP
-    void check_class_object_demotion_internal (BYTE* obj);
+    void check_class_object_demotion_internal (uint8_t* obj);
 
     PER_HEAP 
-    void check_demotion_helper (BYTE** pval, BYTE* parent_obj);
+    void check_demotion_helper (uint8_t** pval, uint8_t* parent_obj);
 
     PER_HEAP
-    void relocate_survivor_helper (BYTE* plug, BYTE* plug_end);
+    void relocate_survivor_helper (uint8_t* plug, uint8_t* plug_end);
 
     PER_HEAP
     void verify_pins_with_post_plug_info (const char* msg);
 
 #ifdef COLLECTIBLE_CLASS
     PER_HEAP
-    void unconditional_set_card_collectible (BYTE* obj);
+    void unconditional_set_card_collectible (uint8_t* obj);
 #endif //COLLECTIBLE_CLASS
 
     PER_HEAP
-    void relocate_shortened_survivor_helper (BYTE* plug, BYTE* plug_end, mark* pinned_plug_entry);
+    void relocate_shortened_survivor_helper (uint8_t* plug, uint8_t* plug_end, mark* pinned_plug_entry);
     
     PER_HEAP
-    void relocate_obj_helper (BYTE* x, size_t s);
+    void relocate_obj_helper (uint8_t* x, size_t s);
 
     PER_HEAP
-    void reloc_ref_in_shortened_obj (BYTE** address_to_set_card, BYTE** address_to_reloc);
+    void reloc_ref_in_shortened_obj (uint8_t** address_to_set_card, uint8_t** address_to_reloc);
 
     PER_HEAP
     void relocate_pre_plug_info (mark* pinned_plug_entry);
 
     PER_HEAP
-    void relocate_shortened_obj_helper (BYTE* x, size_t s, BYTE* end, mark* pinned_plug_entry, BOOL is_pinned);
+    void relocate_shortened_obj_helper (uint8_t* x, size_t s, uint8_t* end, mark* pinned_plug_entry, BOOL is_pinned);
 
     PER_HEAP
-    void relocate_survivors_in_plug (BYTE* plug, BYTE* plug_end,
+    void relocate_survivors_in_plug (uint8_t* plug, uint8_t* plug_end,
                                      BOOL check_last_object_p, 
                                      mark* pinned_plug_entry);
     PER_HEAP
-    void relocate_survivors_in_brick (BYTE* tree, relocate_args* args);
+    void relocate_survivors_in_brick (uint8_t* tree, relocate_args* args);
 
     PER_HEAP
     void update_oldest_pinned_plug();
 
     PER_HEAP
     void relocate_survivors (int condemned_gen_number,
-                             BYTE* first_condemned_address );
+                             uint8_t* first_condemned_address );
     PER_HEAP
     void relocate_phase (int condemned_gen_number,
-                         BYTE* first_condemned_address);
+                         uint8_t* first_condemned_address);
 
     struct compact_args
     {
         BOOL copy_cards_p;
-        BYTE* last_plug;
+        uint8_t* last_plug;
         ptrdiff_t last_plug_relocation;
-        BYTE* before_last_plug;
+        uint8_t* before_last_plug;
         size_t current_compacted_brick;
         BOOL is_shortened;
         mark* pinned_plug_entry;
@@ -2352,17 +2352,17 @@ protected:
     };
 
     PER_HEAP
-    void copy_cards_range (BYTE* dest, BYTE* src, size_t len, BOOL copy_cards_p);
+    void copy_cards_range (uint8_t* dest, uint8_t* src, size_t len, BOOL copy_cards_p);
     PER_HEAP
-    void  gcmemcopy (BYTE* dest, BYTE* src, size_t len, BOOL copy_cards_p);
+    void  gcmemcopy (uint8_t* dest, uint8_t* src, size_t len, BOOL copy_cards_p);
     PER_HEAP
-    void compact_plug (BYTE* plug, size_t size, BOOL check_last_object_p, compact_args* args);
+    void compact_plug (uint8_t* plug, size_t size, BOOL check_last_object_p, compact_args* args);
     PER_HEAP
-    void compact_in_brick (BYTE* tree, compact_args* args);
+    void compact_in_brick (uint8_t* tree, compact_args* args);
 
     PER_HEAP
-    mark* get_next_pinned_entry (BYTE* tree, 
-                                 BOOL* has_pre_plug_info_p, 
+    mark* get_next_pinned_entry (uint8_t* tree,
+                                 BOOL* has_pre_plug_info_p,
                                  BOOL* has_post_plug_info_p,
                                  BOOL deque_p=TRUE);
 
@@ -2373,50 +2373,50 @@ protected:
     void recover_saved_pinned_info();
 
     PER_HEAP
-    void compact_phase (int condemned_gen_number, BYTE*
+    void compact_phase (int condemned_gen_number, uint8_t*
                         first_condemned_address, BOOL clear_cards);
     PER_HEAP
     void clear_cards (size_t start_card, size_t end_card);
     PER_HEAP
-    void clear_card_for_addresses (BYTE* start_address, BYTE* end_address);
+    void clear_card_for_addresses (uint8_t* start_address, uint8_t* end_address);
     PER_HEAP
     void copy_cards (size_t dst_card, size_t src_card,
                      size_t end_card, BOOL nextp);
     PER_HEAP
-    void copy_cards_for_addresses (BYTE* dest, BYTE* src, size_t len);
+    void copy_cards_for_addresses (uint8_t* dest, uint8_t* src, size_t len);
 
 #ifdef BACKGROUND_GC
     PER_HEAP
     void copy_mark_bits (size_t dst_mark_bit, size_t src_mark_bit, size_t end_mark_bit);
     PER_HEAP
-    void copy_mark_bits_for_addresses (BYTE* dest, BYTE* src, size_t len);
+    void copy_mark_bits_for_addresses (uint8_t* dest, uint8_t* src, size_t len);
 #endif //BACKGROUND_GC
 
 
     PER_HEAP
-    BOOL ephemeral_pointer_p (BYTE* o);
+    BOOL ephemeral_pointer_p (uint8_t* o);
     PER_HEAP
-    void fix_brick_to_highest (BYTE* o, BYTE* next_o);
+    void fix_brick_to_highest (uint8_t* o, uint8_t* next_o);
     PER_HEAP
-    BYTE* find_first_object (BYTE* start_address, BYTE* first_object);
+    uint8_t* find_first_object (uint8_t* start_address, uint8_t* first_object);
     PER_HEAP
-    BYTE* compute_next_boundary (BYTE* low, int gen_number, BOOL relocating);
+    uint8_t* compute_next_boundary (uint8_t* low, int gen_number, BOOL relocating);
     PER_HEAP
-    void keep_card_live (BYTE* o, size_t& n_gen,
+    void keep_card_live (uint8_t* o, size_t& n_gen,
                          size_t& cg_pointers_found);
     PER_HEAP
-    void mark_through_cards_helper (BYTE** poo, size_t& ngen,
+    void mark_through_cards_helper (uint8_t** poo, size_t& ngen,
                                     size_t& cg_pointers_found,
-                                    card_fn fn, BYTE* nhigh,
-                                    BYTE* next_boundary);
+                                    card_fn fn, uint8_t* nhigh,
+                                    uint8_t* next_boundary);
 
     PER_HEAP
-    BOOL card_transition (BYTE* po, BYTE* end, size_t card_word_end,
+    BOOL card_transition (uint8_t* po, uint8_t* end, size_t card_word_end,
                                size_t& cg_pointers_found, 
                                size_t& n_eph, size_t& n_card_set,
                                size_t& card, size_t& end_card,
-                               BOOL& foundp, BYTE*& start_address,
-                               BYTE*& limit, size_t& n_cards_cleared);
+                               BOOL& foundp, uint8_t*& start_address,
+                               uint8_t*& limit, size_t& n_cards_cleared);
     PER_HEAP
     void mark_through_cards_for_segments (card_fn fn, BOOL relocating);
 
@@ -2435,9 +2435,9 @@ protected:
     PER_HEAP
     void build_ordered_free_spaces (heap_segment* seg);
     PER_HEAP
-    void count_plug (size_t last_plug_size, BYTE*& last_plug);
+    void count_plug (size_t last_plug_size, uint8_t*& last_plug);
     PER_HEAP
-    void count_plugs_in_brick (BYTE* tree, BYTE*& last_plug);
+    void count_plugs_in_brick (uint8_t* tree, uint8_t*& last_plug);
     PER_HEAP
     void build_ordered_plug_indices ();
     PER_HEAP
@@ -2463,8 +2463,8 @@ protected:
     BOOL can_expand_into_p (heap_segment* seg, size_t min_free_size,
                             size_t min_cont_size, allocator* al);
     PER_HEAP
-    BYTE* allocate_in_expanded_heap (generation* gen, size_t size,
-                                     BOOL& adjacentp, BYTE* old_loc,
+    uint8_t* allocate_in_expanded_heap (generation* gen, size_t size,
+                                     BOOL& adjacentp, uint8_t* old_loc,
 #ifdef SHORT_PLUGS
                                      BOOL set_padding_on_saved_p,
                                      mark* pinned_plug_entry,
@@ -2472,30 +2472,30 @@ protected:
                                      BOOL consider_bestfit, int active_new_gen_number
                                      REQD_ALIGN_AND_OFFSET_DEFAULT_DCL);
     PER_HEAP
-    void realloc_plug (size_t last_plug_size, BYTE*& last_plug,
-                       generation* gen, BYTE* start_address,
+    void realloc_plug (size_t last_plug_size, uint8_t*& last_plug,
+                       generation* gen, uint8_t* start_address,
                        unsigned int& active_new_gen_number,
-                       BYTE*& last_pinned_gap, BOOL& leftp, 
+                       uint8_t*& last_pinned_gap, BOOL& leftp,
                        BOOL shortened_p
 #ifdef SHORT_PLUGS
                        , mark* pinned_plug_entry
 #endif //SHORT_PLUGS
                        );
     PER_HEAP
-    void realloc_in_brick (BYTE* tree, BYTE*& last_plug, BYTE* start_address,
+    void realloc_in_brick (uint8_t* tree, uint8_t*& last_plug, uint8_t* start_address,
                            generation* gen,
                            unsigned int& active_new_gen_number,
-                           BYTE*& last_pinned_gap, BOOL& leftp);
+                           uint8_t*& last_pinned_gap, BOOL& leftp);
     PER_HEAP
     void realloc_plugs (generation* consing_gen, heap_segment* seg,
-                        BYTE* start_address, BYTE* end_address,
+                        uint8_t* start_address, uint8_t* end_address,
                         unsigned active_new_gen_number);
 
     PER_HEAP
     void set_expand_in_full_gc (int condemned_gen_number);
 
     PER_HEAP
-    void verify_no_pins (BYTE* start, BYTE* end);
+    void verify_no_pins (uint8_t* start, uint8_t* end);
 
     PER_HEAP
     generation* expand_heap (int condemned_generation,
@@ -2523,7 +2523,7 @@ protected:
 
 #ifdef _WIN64
     PER_HEAP_ISOLATED
-    size_t trim_youngest_desired (DWORD memory_load, 
+    size_t trim_youngest_desired (uint32_t memory_load,
                                   size_t total_new_allocation,
                                   size_t total_min_allocation);
     PER_HEAP_ISOLATED
@@ -2556,7 +2556,7 @@ protected:
     PER_HEAP
     size_t generation_fragmentation (generation* gen,
                                      generation* consing_gen,
-                                     BYTE* end);
+                                     uint8_t* end);
     PER_HEAP
     size_t generation_sizes (generation* gen);
     PER_HEAP
@@ -2570,7 +2570,7 @@ protected:
     PER_HEAP
     BOOL ephemeral_gen_fit_p (gc_tuning_point tp);
     PER_HEAP
-    void reset_large_object (BYTE* o);
+    void reset_large_object (uint8_t* o);
     PER_HEAP
     void sweep_large_objects ();
     PER_HEAP
@@ -2588,7 +2588,7 @@ protected:
     PER_HEAP_ISOLATED
     void descr_generations_to_profiler (gen_walk_fn fn, void *context);
     PER_HEAP
-    void record_survived_for_profiler(int condemned_gen_number, BYTE * first_condemned_address);
+    void record_survived_for_profiler(int condemned_gen_number, uint8_t * first_condemned_address);
     PER_HEAP
     void notify_profiler_of_surviving_large_objects ();
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
@@ -2602,7 +2602,7 @@ protected:
     PER_HEAP
     HANDLE create_gc_thread();
     PER_HEAP
-    DWORD gc_thread_function();
+    uint32_t gc_thread_function();
 #ifdef MARK_LIST
 #ifdef PARALLEL_MARK_LIST_SORT
     PER_HEAP
@@ -2610,7 +2610,7 @@ protected:
     PER_HEAP
     void merge_mark_lists();
     PER_HEAP
-    void append_to_mark_list(BYTE **start, BYTE **end);
+    void append_to_mark_list(uint8_t **start, uint8_t **end);
 #else //PARALLEL_MARK_LIST_SORT
     PER_HEAP_ISOLATED
     void combine_mark_lists();
@@ -2622,7 +2622,7 @@ protected:
 
 #ifndef SEG_MAPPING_TABLE
     PER_HEAP_ISOLATED
-    heap_segment* segment_of (BYTE* add,  ptrdiff_t & delta,
+    heap_segment* segment_of (uint8_t* add,  ptrdiff_t & delta,
                               BOOL verify_p = FALSE);
 #endif //SEG_MAPPING_TABLE
 
@@ -2630,12 +2630,12 @@ protected:
 
     //this is called by revisit....
     PER_HEAP
-    BYTE* high_page (heap_segment* seg, BOOL concurrent_p);
+    uint8_t* high_page (heap_segment* seg, BOOL concurrent_p);
 
     PER_HEAP
-    void revisit_written_page (BYTE* page, BYTE* end, BOOL concurrent_p,
-                               heap_segment* seg,  BYTE*& last_page,
-                               BYTE*& last_object, BOOL large_objects_p,
+    void revisit_written_page (uint8_t* page, uint8_t* end, BOOL concurrent_p,
+                               heap_segment* seg,  uint8_t*& last_page,
+                               uint8_t*& last_object, BOOL large_objects_p,
                                size_t& num_marked_objects);
     PER_HEAP
     void revisit_written_pages (BOOL concurrent_p, BOOL reset_only_p=FALSE);
@@ -2653,7 +2653,7 @@ protected:
     void restart_EE ();
 
     PER_HEAP
-    void background_verify_mark (Object*& object, ScanContext* sc, DWORD flags);
+    void background_verify_mark (Object*& object, ScanContext* sc, uint32_t flags);
 
     PER_HEAP
     void background_scan_dependent_handles (ScanContext *sc);
@@ -2678,47 +2678,47 @@ protected:
     void clear_commit_flag_global();
 
     PER_HEAP_ISOLATED
-    void verify_mark_array_cleared (heap_segment* seg, DWORD* mark_array_addr);
+    void verify_mark_array_cleared (heap_segment* seg, uint32_t* mark_array_addr);
 
     PER_HEAP_ISOLATED
-    void verify_mark_array_cleared (BYTE* begin, BYTE* end, DWORD* mark_array_addr);
+    void verify_mark_array_cleared (uint8_t* begin, uint8_t* end, uint32_t* mark_array_addr);
 
     PER_HEAP_ISOLATED
-    BOOL commit_mark_array_by_range (BYTE* begin, 
-                                     BYTE* end, 
-                                     DWORD* mark_array_addr);
+    BOOL commit_mark_array_by_range (uint8_t* begin,
+                                     uint8_t* end,
+                                     uint32_t* mark_array_addr);
 
     PER_HEAP_ISOLATED
     BOOL commit_mark_array_new_seg (gc_heap* hp, 
                                     heap_segment* seg,
-                                    BYTE* new_lowest_address = 0);
+                                    uint8_t* new_lowest_address = 0);
 
     PER_HEAP_ISOLATED
-    BOOL commit_mark_array_with_check (heap_segment* seg, DWORD* mark_array_addr);
+    BOOL commit_mark_array_with_check (heap_segment* seg, uint32_t* mark_array_addr);
 
     // commit the portion of the mark array that corresponds to 
     // this segment (from beginning to reserved).
     // seg and heap_segment_reserved (seg) are guaranteed to be 
     // page aligned.
     PER_HEAP_ISOLATED
-    BOOL commit_mark_array_by_seg (heap_segment* seg, DWORD* mark_array_addr);
+    BOOL commit_mark_array_by_seg (heap_segment* seg, uint32_t* mark_array_addr);
 
     // During BGC init, we commit the mark array for all in range
     // segments whose mark array hasn't been committed or fully
     // committed. All rw segments are in range, only ro segments
     // can be partial in range.
     PER_HEAP
-    BOOL commit_mark_array_bgc_init (DWORD* mark_array_addr);
+    BOOL commit_mark_array_bgc_init (uint32_t* mark_array_addr);
 
     PER_HEAP
-    BOOL commit_new_mark_array (DWORD* new_mark_array);
+    BOOL commit_new_mark_array (uint32_t* new_mark_array);
 
     // We need to commit all segments that intersect with the bgc
     // range. If a segment is only partially in range, we still
     // should commit the mark array for the whole segment as 
     // we will set the mark array commit flag for this segment.
     PER_HEAP_ISOLATED
-    BOOL commit_new_mark_array_global (DWORD* new_mark_array);
+    BOOL commit_new_mark_array_global (uint32_t* new_mark_array);
 
     // We can't decommit the first and the last page in the mark array
     // if the beginning and ending don't happen to be page aligned.
@@ -2735,7 +2735,7 @@ protected:
     void background_grow_c_mark_list();
 
     PER_HEAP_ISOLATED
-    void background_promote_callback(Object** object, ScanContext* sc, DWORD flags);
+    void background_promote_callback(Object** object, ScanContext* sc, uint32_t flags);
 
     PER_HEAP
     void mark_absorb_new_alloc();
@@ -2762,22 +2762,22 @@ protected:
     PER_HEAP
     void background_gc_wait_lh (alloc_wait_reason awr = awr_ignored);
     PER_HEAP
-    DWORD background_gc_wait (alloc_wait_reason awr = awr_ignored, int time_out_ms = INFINITE);
+    uint32_t background_gc_wait (alloc_wait_reason awr = awr_ignored, int time_out_ms = INFINITE);
     PER_HEAP_ISOLATED
     void start_c_gc();
     PER_HEAP
     void kill_gc_thread();
     PER_HEAP
-    DWORD bgc_thread_function();
+    uint32_t bgc_thread_function();
     PER_HEAP_ISOLATED
     void do_background_gc();
     static
-    DWORD __stdcall bgc_thread_stub (void* arg);
+    uint32_t __stdcall bgc_thread_stub (void* arg);
 
 #ifdef FEATURE_REDHAWK
     // Helper used to wrap the start routine of background GC threads so we can do things like initialize the
     // Redhawk thread state which requires running in the new thread's context.
-    static DWORD WINAPI rh_bgc_thread_stub(void * pContext);
+    static uint32_t WINAPI rh_bgc_thread_stub(void * pContext);
 
     // Context passed to the above.
     struct rh_bgc_thread_ctx
@@ -2796,7 +2796,7 @@ public:
 
 #ifdef BACKGROUND_GC
     PER_HEAP_ISOLATED
-    DWORD cm_in_progress;
+    uint32_t cm_in_progress;
 
     PER_HEAP
     BOOL expanded_in_fgc;
@@ -2811,7 +2811,7 @@ public:
 #endif //BACKGROUND_GC
 
     PER_HEAP_ISOLATED
-    DWORD wait_for_gc_done(INT32 timeOut = INFINITE);
+    uint32_t wait_for_gc_done(int32_t timeOut = INFINITE);
 
     // Returns TRUE if the thread used to be in cooperative mode 
     // before calling this function.
@@ -2849,14 +2849,14 @@ public:
 
 #ifdef MULTIPLE_HEAPS
     PER_HEAP
-    BYTE*  ephemeral_low;      //lowest ephemeral address
+    uint8_t*  ephemeral_low;      //lowest ephemeral address
 
     PER_HEAP
-    BYTE*  ephemeral_high;     //highest ephemeral address
+    uint8_t*  ephemeral_high;     //highest ephemeral address
 #endif //MULTIPLE_HEAPS
 
     PER_HEAP
-    DWORD* card_table;
+    uint32_t* card_table;
 
     PER_HEAP
     short* brick_table;
@@ -2864,15 +2864,15 @@ public:
 #ifdef MARK_ARRAY
 #ifdef MULTIPLE_HEAPS
     PER_HEAP
-    DWORD* mark_array;
+    uint32_t* mark_array;
 #else
-    SPTR_DECL(DWORD, mark_array);
+    SPTR_DECL(uint32_t, mark_array);
 #endif //MULTIPLE_HEAPS
 #endif //MARK_ARRAY
 
 #ifdef CARD_BUNDLE
     PER_HEAP
-    DWORD* card_bundle_table;
+    uint32_t* card_bundle_table;
 #endif //CARD_BUNDLE
 
 #if !defined(SEG_MAPPING_TABLE) || defined(FEATURE_BASICFREEZE)
@@ -2894,10 +2894,10 @@ public:
 
     // Full GC Notification percentages.
     PER_HEAP_ISOLATED
-    DWORD fgn_maxgen_percent;
+    uint32_t fgn_maxgen_percent;
 
     PER_HEAP_ISOLATED
-    DWORD fgn_loh_percent;
+    uint32_t fgn_loh_percent;
 
     PER_HEAP_ISOLATED
     VOLATILE(bool) full_gc_approach_event_set;
@@ -2910,21 +2910,21 @@ public:
     PER_HEAP
     size_t fgn_last_alloc;
 
-    static DWORD user_thread_wait (CLREvent *event, BOOL no_mode_change, int time_out_ms=INFINITE);
+    static uint32_t user_thread_wait (CLREvent *event, BOOL no_mode_change, int time_out_ms=INFINITE);
 
     static wait_full_gc_status full_gc_wait (CLREvent *event, int time_out_ms);
 
     PER_HEAP
-    BYTE* demotion_low;
+    uint8_t* demotion_low;
 
     PER_HEAP
-    BYTE* demotion_high;
+    uint8_t* demotion_high;
 
     PER_HEAP
     BOOL demote_gen1_p;
 
     PER_HEAP
-    BYTE* last_gen1_pin_end;
+    uint8_t* last_gen1_pin_end;
 
     PER_HEAP
     gen_to_condemn_tuning gen_to_condemn_reasons;
@@ -2987,10 +2987,10 @@ public:
     size_t mem_one_percent;
 
     PER_HEAP_ISOLATED
-    ULONGLONG total_physical_mem;
+    uint64_t total_physical_mem;
 
     PER_HEAP_ISOLATED
-    ULONGLONG available_physical_mem;
+    uint64_t available_physical_mem;
 #endif //_WIN64
 
     PER_HEAP_ISOLATED
@@ -3000,15 +3000,15 @@ public:
     size_t min_segment_size;
 
     PER_HEAP
-    BYTE* lowest_address;
+    uint8_t* lowest_address;
 
     PER_HEAP
-    BYTE* highest_address;
+    uint8_t* highest_address;
 
     PER_HEAP
     BOOL ephemeral_promotion;
     PER_HEAP
-    BYTE* saved_ephemeral_plan_start[NUMBERGENERATIONS-1];
+    uint8_t* saved_ephemeral_plan_start[NUMBERGENERATIONS-1];
     PER_HEAP
     size_t saved_ephemeral_plan_start_size[NUMBERGENERATIONS-1];
 
@@ -3036,10 +3036,10 @@ protected:
     size_t time_bgc_last;
 
     PER_HEAP
-    BYTE*       gc_low; // lowest address being condemned
+    uint8_t*       gc_low; // lowest address being condemned
 
     PER_HEAP
-    BYTE*       gc_high; //highest address being condemned
+    uint8_t*       gc_high; //highest address being condemned
 
     PER_HEAP
     size_t      mark_stack_tos;
@@ -3057,7 +3057,7 @@ protected:
     BOOL       verify_pinned_queue_p;
 
     PER_HEAP
-    BYTE*       oldest_pinned_plug;
+    uint8_t*       oldest_pinned_plug;
 
 #ifdef FEATURE_LOH_COMPACTION
     PER_HEAP
@@ -3094,11 +3094,11 @@ protected:
 #ifdef BACKGROUND_GC
 
     PER_HEAP
-    DWORD bgc_thread_id;
+    uint32_t bgc_thread_id;
 
 #ifdef WRITE_WATCH
     PER_HEAP
-    BYTE* background_written_addresses [array_size+2];
+    uint8_t* background_written_addresses [array_size+2];
 #endif //WRITE_WATCH
 
 #if defined (DACCESS_COMPILE) && !defined (MULTIPLE_HEAPS)
@@ -3170,19 +3170,19 @@ protected:
     {
         size_t gc_index;
         bgc_state current_bgc_state;
-        DWORD gc_time_ms;
+        uint32_t gc_time_ms;
         // This is in bytes per ms; consider breaking it 
         // into the efficiency per phase.
         size_t gc_efficiency; 
-        BYTE* eph_low;
-        BYTE* gen0_start;
-        BYTE* eph_high;
-        BYTE* bgc_highest;
-        BYTE* bgc_lowest;
-        BYTE* fgc_highest;
-        BYTE* fgc_lowest;
-        BYTE* g_highest;
-        BYTE* g_lowest;
+        uint8_t* eph_low;
+        uint8_t* gen0_start;
+        uint8_t* eph_high;
+        uint8_t* bgc_highest;
+        uint8_t* bgc_lowest;
+        uint8_t* fgc_highest;
+        uint8_t* fgc_lowest;
+        uint8_t* g_highest;
+        uint8_t* g_lowest;
     };
 
 #define max_history_count 64
@@ -3223,7 +3223,7 @@ protected:
     // ms. So we are already 30% over the original heap size the thread will
     // sleep for 3ms.
     PER_HEAP
-    DWORD      bgc_alloc_spin_loh;
+    uint32_t   bgc_alloc_spin_loh;
 
     // This includes what we allocate at the end of segment - allocating
     // in free list doesn't increase the heap size.
@@ -3240,19 +3240,19 @@ protected:
     size_t     background_loh_alloc_count;
 
     PER_HEAP
-    BYTE**     background_mark_stack_tos;
+    uint8_t**  background_mark_stack_tos;
 
     PER_HEAP
-    BYTE**     background_mark_stack_array;
+    uint8_t**  background_mark_stack_array;
 
     PER_HEAP
     size_t    background_mark_stack_array_length;
 
     PER_HEAP
-    BYTE*     background_min_overflow_address;
+    uint8_t*  background_min_overflow_address;
 
     PER_HEAP
-    BYTE*     background_max_overflow_address;
+    uint8_t*  background_max_overflow_address;
 
     // We can't process the soh range concurrently so we
     // wait till final mark to process it.
@@ -3260,10 +3260,10 @@ protected:
     BOOL      processed_soh_overflow_p;
 
     PER_HEAP
-    BYTE*     background_min_soh_overflow_address;
+    uint8_t*  background_min_soh_overflow_address;
 
     PER_HEAP
-    BYTE*     background_max_soh_overflow_address;
+    uint8_t*  background_max_soh_overflow_address;
 
     PER_HEAP
     heap_segment* saved_overflow_ephemeral_seg;
@@ -3271,24 +3271,24 @@ protected:
 #ifndef MULTIPLE_HEAPS
     SPTR_DECL(heap_segment, saved_sweep_ephemeral_seg);
 
-    SPTR_DECL(BYTE, saved_sweep_ephemeral_start);
+    SPTR_DECL(uint8_t, saved_sweep_ephemeral_start);
 
-    SPTR_DECL(BYTE, background_saved_lowest_address);
+    SPTR_DECL(uint8_t, background_saved_lowest_address);
 
-    SPTR_DECL(BYTE, background_saved_highest_address);
+    SPTR_DECL(uint8_t, background_saved_highest_address);
 #else
 
     PER_HEAP
     heap_segment* saved_sweep_ephemeral_seg;
 
     PER_HEAP
-    BYTE* saved_sweep_ephemeral_start;
+    uint8_t* saved_sweep_ephemeral_start;
 
     PER_HEAP
-    BYTE* background_saved_lowest_address;
+    uint8_t* background_saved_lowest_address;
 
     PER_HEAP
-    BYTE* background_saved_highest_address;
+    uint8_t* background_saved_highest_address;
 #endif //!MULTIPLE_HEAPS
 
     // This is used for synchronization between the bgc thread
@@ -3304,7 +3304,7 @@ protected:
 
 
     PER_HEAP
-    BYTE**          c_mark_list;
+    uint8_t**          c_mark_list;
 
     PER_HEAP
     size_t          c_mark_list_length;
@@ -3315,39 +3315,39 @@ protected:
 
 #ifdef MARK_LIST
     PER_HEAP
-    BYTE** mark_list;
+    uint8_t** mark_list;
 
     PER_HEAP_ISOLATED
     size_t mark_list_size;
 
     PER_HEAP
-    BYTE** mark_list_end;
+    uint8_t** mark_list_end;
 
     PER_HEAP
-    BYTE** mark_list_index;
+    uint8_t** mark_list_index;
 
     PER_HEAP_ISOLATED
-    BYTE** g_mark_list;
+    uint8_t** g_mark_list;
 #ifdef PARALLEL_MARK_LIST_SORT
     PER_HEAP_ISOLATED
-    BYTE** g_mark_list_copy;
+    uint8_t** g_mark_list_copy;
     PER_HEAP
-    BYTE*** mark_list_piece_start;
-    BYTE*** mark_list_piece_end;
+    uint8_t*** mark_list_piece_start;
+    uint8_t*** mark_list_piece_end;
 #endif //PARALLEL_MARK_LIST_SORT
 #endif //MARK_LIST
 
     PER_HEAP
-    BYTE*  min_overflow_address;
+    uint8_t*  min_overflow_address;
 
     PER_HEAP
-    BYTE*  max_overflow_address;
+    uint8_t*  max_overflow_address;
 
     PER_HEAP
-    BYTE*  shigh; //keeps track of the highest marked object
+    uint8_t*  shigh; //keeps track of the highest marked object
 
     PER_HEAP
-    BYTE*  slow; //keeps track of the lowest marked object
+    uint8_t*  slow; //keeps track of the lowest marked object
 
     PER_HEAP
     size_t allocation_quantum;
@@ -3374,10 +3374,10 @@ protected:
 #define large_object_generation (generation_of (max_generation+1))
 
 #ifndef MULTIPLE_HEAPS
-    SPTR_DECL(BYTE,alloc_allocated);
+    SPTR_DECL(uint8_t,alloc_allocated);
 #else
     PER_HEAP
-    BYTE* alloc_allocated; //keeps track of the highest
+    uint8_t* alloc_allocated; //keeps track of the highest
     //address allocated by alloc
 #endif // !MULTIPLE_HEAPS
 
@@ -3415,7 +3415,7 @@ protected:
 
     // Total cycles it takes to acquire the more_space_lock.
     PER_HEAP
-    ULONGLONG total_msl_acquire;
+    uint64_t total_msl_acquire;
 
     PER_HEAP
     void init_heap_sync_stats()
@@ -3491,9 +3491,9 @@ protected:
     BOOL dt_high_frag_p (gc_tuning_point tp, int gen_number, BOOL elevate_p=FALSE);
     PER_HEAP
     BOOL 
-    dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number, ULONGLONG total_mem);
+    dt_estimate_reclaim_space_p (gc_tuning_point tp, int gen_number, uint64_t total_mem);
     PER_HEAP
-    BOOL dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, ULONGLONG available_mem);
+    BOOL dt_estimate_high_frag_p (gc_tuning_point tp, int gen_number, uint64_t available_mem);
     PER_HEAP
     BOOL dt_low_card_table_efficiency_p (gc_tuning_point tp);
 
@@ -3512,7 +3512,7 @@ protected:
 
     // the # of bytes allocates since the last full compacting GC.
     PER_HEAP
-    UINT64 loh_alloc_since_cg;
+    uint64_t loh_alloc_since_cg;
 
     PER_HEAP
     BOOL elevation_requested;
@@ -3533,14 +3533,14 @@ protected:
     BOOL alloc_wait_event_p;
 
 #ifndef MULTIPLE_HEAPS
-    SPTR_DECL(BYTE, next_sweep_obj);
+    SPTR_DECL(uint8_t, next_sweep_obj);
 #else
     PER_HEAP
-    BYTE* next_sweep_obj;
+    uint8_t* next_sweep_obj;
 #endif //MULTIPLE_HEAPS
 
     PER_HEAP
-    BYTE* current_sweep_pos;
+    uint8_t* current_sweep_pos;
 
 #endif //BACKGROUND_GC
 
@@ -3629,7 +3629,7 @@ protected:
     BOOL use_bestfit;
 
     PER_HEAP
-    BYTE* bestfit_first_pin;
+    uint8_t* bestfit_first_pin;
 
     PER_HEAP
     BOOL commit_end_of_seg;
@@ -3675,12 +3675,12 @@ public:
     size_t internal_root_array_length;
 
 #ifndef MULTIPLE_HEAPS
-    SPTR_DECL(PTR_BYTE, internal_root_array);
+    SPTR_DECL(PTR_uint8_t, internal_root_array);
     SVAL_DECL(size_t, internal_root_array_index);
     SVAL_DECL(BOOL,   heap_analyze_success);
 #else
     PER_HEAP
-    BYTE** internal_root_array;
+    uint8_t** internal_root_array;
 
     PER_HEAP
     size_t internal_root_array_index;
@@ -3692,7 +3692,7 @@ public:
     // next two fields are used to optimize the search for the object 
     // enclosing the current reference handled by ha_mark_object_simple.
     PER_HEAP
-    BYTE*  current_obj;
+    uint8_t*  current_obj;
 
     PER_HEAP
     size_t current_obj_size;
@@ -3769,7 +3769,7 @@ private:
     
     VOLATILE(LONG) lock;
 #ifdef _DEBUG
-    DWORD lockowner_threadid;
+    uint32_t lockowner_threadid;
 #endif // _DEBUG
 
     BOOL GrowArray();
@@ -3985,17 +3985,17 @@ alloc_context* generation_alloc_context (generation* inst)
 }
 
 inline
-BYTE*& generation_allocation_start (generation* inst)
+uint8_t*& generation_allocation_start (generation* inst)
 {
   return inst->allocation_start;
 }
 inline
-BYTE*& generation_allocation_pointer (generation* inst)
+uint8_t*& generation_allocation_pointer (generation* inst)
 {
   return inst->allocation_context.alloc_ptr;
 }
 inline
-BYTE*& generation_allocation_limit (generation* inst)
+uint8_t*& generation_allocation_limit (generation* inst)
 {
   return inst->allocation_context.alloc_limit;
 }
@@ -4016,7 +4016,7 @@ heap_segment*& generation_allocation_segment (generation* inst)
   return inst->allocation_segment;
 }
 inline
-BYTE*& generation_plan_allocation_start (generation* inst)
+uint8_t*& generation_plan_allocation_start (generation* inst)
 {
   return inst->plan_allocation_start;
 }
@@ -4026,7 +4026,7 @@ size_t& generation_plan_allocation_start_size (generation* inst)
   return inst->plan_allocation_start_size;
 }
 inline
-BYTE*& generation_allocation_context_start_region (generation* inst)
+uint8_t*& generation_allocation_context_start_region (generation* inst)
 {
   return inst->allocation_context_start_region;
 }
@@ -4116,14 +4116,14 @@ size_t generation_unusable_fragmentation (generation* inst)
 }
 
 #define plug_skew           sizeof(ObjHeader)
-#define min_obj_size        (sizeof(BYTE*)+plug_skew+sizeof(size_t))//syncblock + vtable+ first field
-//Note that this encodes the fact that plug_skew is a multiple of BYTE*.
+#define min_obj_size        (sizeof(uint8_t*)+plug_skew+sizeof(size_t))//syncblock + vtable+ first field
+//Note that this encodes the fact that plug_skew is a multiple of uint8_t*.
 // We always use USE_PADDING_TAIL when fitting so items on the free list should be
 // twice the min_obj_size.
 #define min_free_list       (2*min_obj_size)
 struct plug
 {
-    BYTE *  skew[plug_skew / sizeof(BYTE *)];
+    uint8_t *  skew[plug_skew / sizeof(uint8_t *)];
 };
 
 class pair
@@ -4133,7 +4133,7 @@ public:
     short right;
 };
 
-//Note that these encode the fact that plug_skew is a multiple of BYTE*.
+//Note that these encode the fact that plug_skew is a multiple of uint8_t*.
 // Each of new field is prepended to the prior struct.
 
 struct plug_and_pair
@@ -4183,7 +4183,7 @@ struct loh_obj_and_pad
 
 struct loh_padding_obj
 {
-    BYTE*       mt;
+    uint8_t*    mt;
     size_t      len;
     ptrdiff_t   reloc;
     plug        m_plug;
@@ -4209,17 +4209,17 @@ struct loh_padding_obj
 class heap_segment
 {
 public:
-    BYTE*           allocated;
-    BYTE*           committed;
-    BYTE*           reserved;
-    BYTE*           used;
-    BYTE*           mem;
+    uint8_t*        allocated;
+    uint8_t*        committed;
+    uint8_t*        reserved;
+    uint8_t*        used;
+    uint8_t*        mem;
     size_t          flags;
     PTR_heap_segment next;
-    BYTE*           plan_allocated;
+    uint8_t*        plan_allocated;
 #ifdef BACKGROUND_GC
-    BYTE*           background_allocated;
-    BYTE*           saved_bg_allocated;
+    uint8_t*        background_allocated;
+    uint8_t*        saved_bg_allocated;
 #endif //BACKGROUND_GC
 
 #ifdef MULTIPLE_HEAPS
@@ -4237,22 +4237,22 @@ public:
 };
 
 inline
-BYTE*& heap_segment_reserved (heap_segment* inst)
+uint8_t*& heap_segment_reserved (heap_segment* inst)
 {
   return inst->reserved;
 }
 inline
-BYTE*& heap_segment_committed (heap_segment* inst)
+uint8_t*& heap_segment_committed (heap_segment* inst)
 {
   return inst->committed;
 }
 inline
-BYTE*& heap_segment_used (heap_segment* inst)
+uint8_t*& heap_segment_used (heap_segment* inst)
 {
   return inst->used;
 }
 inline
-BYTE*& heap_segment_allocated (heap_segment* inst)
+uint8_t*& heap_segment_allocated (heap_segment* inst)
 {
   return inst->allocated;
 }
@@ -4297,24 +4297,24 @@ PTR_heap_segment & heap_segment_next (heap_segment* inst)
   return inst->next;
 }
 inline
-BYTE*& heap_segment_mem (heap_segment* inst)
+uint8_t*& heap_segment_mem (heap_segment* inst)
 {
   return inst->mem;
 }
 inline
-BYTE*& heap_segment_plan_allocated (heap_segment* inst)
+uint8_t*& heap_segment_plan_allocated (heap_segment* inst)
 {
   return inst->plan_allocated;
 }
 
 #ifdef BACKGROUND_GC
 inline
-BYTE*& heap_segment_background_allocated (heap_segment* inst)
+uint8_t*& heap_segment_background_allocated (heap_segment* inst)
 {
   return inst->background_allocated;
 }
 inline
-BYTE*& heap_segment_saved_bg_allocated (heap_segment* inst)
+uint8_t*& heap_segment_saved_bg_allocated (heap_segment* inst)
 {
   return inst->saved_bg_allocated;
 }
@@ -4362,14 +4362,14 @@ dynamic_data* gc_heap::dynamic_data_of (int gen_number)
     return &dynamic_data_table [ gen_number ];
 }
 
-extern "C" BYTE* g_ephemeral_low;
-extern "C" BYTE* g_ephemeral_high;
+extern "C" uint8_t* g_ephemeral_low;
+extern "C" uint8_t* g_ephemeral_high;
 
 #define card_word_width ((size_t)32)
 
 //
 // The value of card_size is determined empirically according to the average size of an object
-// In the code we also rely on the assumption that one card_table entry (DWORD) covers an entire os page
+// In the code we also rely on the assumption that one card_table entry (uint32_t) covers an entire os page
 //
 #if defined (_WIN64)
 #define card_size ((size_t)(2*OS_PAGE_SIZE/card_word_width))
@@ -4390,7 +4390,7 @@ unsigned card_bit (size_t card)
 }
 
 inline
-size_t gcard_of (BYTE* object)
+size_t gcard_of (uint8_t* object)
 {
     return (size_t)(object) / card_size;
 }

--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -400,7 +400,7 @@ void GCLog (const char *fmt, ... );
 #ifdef _DEBUG
 
 struct GCDebugSpinLock {
-    VOLATILE(LONG) lock;                   // -1 if free, 0 if held
+    VOLATILE(int32_t) lock;                   // -1 if free, 0 if held
     VOLATILE(Thread *) holding_thread;     // -1 if no thread holds the lock.
     VOLATILE(BOOL) released_by_gc_p;       // a GC thread released the lock.
 
@@ -414,7 +414,7 @@ typedef GCDebugSpinLock GCSpinLock;
 #elif defined (SYNCHRONIZATION_STATS)
 
 struct GCSpinLockInstru {
-    VOLATILE(LONG) lock;
+    VOLATILE(int32_t) lock;
     // number of times we went into SwitchToThread in enter_spin_lock.
     unsigned int num_switch_thread;
     // number of times we went into WaitLonger.
@@ -443,7 +443,7 @@ typedef GCSpinLockInstru GCSpinLock;
 #else
 
 struct GCDebugSpinLock {
-    VOLATILE(LONG) lock;                   // -1 if free, 0 if held
+    VOLATILE(int32_t) lock;                   // -1 if free, 0 if held
 
     GCDebugSpinLock()
         : lock(-1)
@@ -2830,7 +2830,7 @@ public:
 #endif // MULTIPLE_HEAPS
 
     PER_HEAP
-    VOLATILE(LONG) gc_done_event_lock;
+    VOLATILE(int32_t) gc_done_event_lock;
 
     PER_HEAP
     VOLATILE(bool) gc_done_event_set;
@@ -3767,7 +3767,7 @@ private:
     PTR_PTR_Object m_EndArray;
     size_t   m_PromotedCount;
     
-    VOLATILE(LONG) lock;
+    VOLATILE(int32_t) lock;
 #ifdef _DEBUG
     uint32_t lockowner_threadid;
 #endif // _DEBUG

--- a/src/gc/gcrecord.h
+++ b/src/gc/gcrecord.h
@@ -16,7 +16,7 @@ Module Name:
 
 #define max_generation 2
 
-// We pack the dynamic tuning for deciding which gen to condemn in a DWORD.
+// We pack the dynamic tuning for deciding which gen to condemn in a uint32_t.
 // We assume that 2 bits are enough to represent the generation. 
 #define bits_generation 2
 #define generation_mask (~(~0u << bits_generation))
@@ -27,7 +27,7 @@ Module Name:
 
 // These are condemned reasons related to generations.
 // Each reason takes up 2 bits as we have 3 generations.
-// So we can store up to 16 reasons in this DWORD.
+// So we can store up to 16 reasons in this uint32_t.
 // They need processing before being used.
 // See the set and the get method for details.
 enum gc_condemn_reason_gen
@@ -73,8 +73,8 @@ static char char_gen_number[4] = {'0', '1', '2', '3'};
 
 class gen_to_condemn_tuning
 {
-    DWORD condemn_reasons_gen;
-    DWORD condemn_reasons_condition;
+    uint32_t condemn_reasons_gen;
+    uint32_t condemn_reasons_condition;
 
 #ifdef DT_LOG
     char str_reasons_gen[64];
@@ -106,7 +106,7 @@ public:
         init_str();
     }
 
-    void set_gen (gc_condemn_reason_gen condemn_gen_reason, DWORD value)
+    void set_gen (gc_condemn_reason_gen condemn_gen_reason, uint32_t value)
     {
         assert ((value & (~generation_mask)) == 0);
         condemn_reasons_gen |= (value << (condemn_gen_reason * 2));
@@ -120,38 +120,38 @@ public:
     // This checks if condition_to_check is the only condition set.
     BOOL is_only_condition (gc_condemn_reason_condition condition_to_check)
     {
-        DWORD temp_conditions = 1 << condition_to_check;
+        uint32_t temp_conditions = 1 << condition_to_check;
         return !(condemn_reasons_condition ^ temp_conditions);
     }
 
-    DWORD get_gen (gc_condemn_reason_gen condemn_gen_reason)
+    uint32_t get_gen (gc_condemn_reason_gen condemn_gen_reason)
     {
-        DWORD value = ((condemn_reasons_gen >> (condemn_gen_reason * 2)) & generation_mask);
+        uint32_t value = ((condemn_reasons_gen >> (condemn_gen_reason * 2)) & generation_mask);
         return value;
     }
 
-    DWORD get_condition (gc_condemn_reason_condition condemn_gen_reason)
+    uint32_t get_condition (gc_condemn_reason_condition condemn_gen_reason)
     {
-        DWORD value = (condemn_reasons_condition & (1 << condemn_gen_reason));
+        uint32_t value = (condemn_reasons_condition & (1 << condemn_gen_reason));
         return value;
     }
 
-    DWORD get_reasons0()
+    uint32_t get_reasons0()
     {
         return condemn_reasons_gen;
     }
 
-    DWORD get_reasons1()
+    uint32_t get_reasons1()
     {
         return condemn_reasons_condition;
     }
 
 #ifdef DT_LOG
-    char get_gen_char (DWORD value)
+    char get_gen_char (uint32_t value)
     {
         return char_gen_number[value];
     }
-    char get_condition_char (DWORD value)
+    char get_condition_char (uint32_t value)
     {
         return (value ? 'Y' : 'N');
     }
@@ -190,7 +190,7 @@ struct maxgen_size_increase
     size_t condemned_allocated;
     size_t pinned_allocated;
     size_t pinned_allocated_advance;
-    DWORD running_free_list_efficiency;
+    uint32_t running_free_list_efficiency;
 };
 
 // The following indicates various mechanisms and one value
@@ -314,7 +314,7 @@ static gc_mechanism_descr gc_mechanisms_descr[max_mechanism_per_heap] =
 
 int index_of_set_bit (size_t power2);
 
-#define mechanism_mask (1 << (sizeof (DWORD) * 8 - 1))
+#define mechanism_mask (1 << (sizeof (uint32_t) * 8 - 1))
 // interesting per heap data we want to record for each GC.
 class gc_history_per_heap
 {
@@ -335,16 +335,16 @@ public:
     // because we might want to know all reasons (at least all mandatory ones) for 
     // compact.
     // TODO: no need to the MSB for this
-    DWORD mechanisms[max_mechanism_per_heap];
+    uint32_t mechanisms[max_mechanism_per_heap];
 
-    // Each bit in this DWORD represent if a mechanism was used or not.
-    DWORD machanism_bits;
+    // Each bit in this uint32_t represent if a mechanism was used or not.
+    uint32_t machanism_bits;
 
-    DWORD heap_index; 
+    uint32_t heap_index; 
 
     size_t extra_gen0_committed;
 
-    void set_mechanism (gc_mechanism_per_heap mechanism_per_heap, DWORD value);
+    void set_mechanism (gc_mechanism_per_heap mechanism_per_heap, uint32_t value);
 
     void set_mechanism_bit (gc_mechanism_bit_per_heap mech_bit)
     {
@@ -363,13 +363,13 @@ public:
     
     void clear_mechanism(gc_mechanism_per_heap mechanism_per_heap)
     {
-        DWORD* mechanism = &mechanisms[mechanism_per_heap];
+        uint32_t* mechanism = &mechanisms[mechanism_per_heap];
         *mechanism = 0;
     }
 
     int get_mechanism (gc_mechanism_per_heap mechanism_per_heap)
     {
-        DWORD mechanism = mechanisms[mechanism_per_heap];
+        uint32_t mechanism = mechanisms[mechanism_per_heap];
 
         if (mechanism & mechanism_mask)
         {
@@ -402,13 +402,13 @@ struct gc_history_global
     // desired_new_allocation such as equalization or smoothing so
     // record the final budget here. 
     size_t final_youngest_desired;
-    DWORD num_heaps;
+    uint32_t num_heaps;
     int condemned_generation;
     int gen0_reduction_count;
     gc_reason reason;
     int pause_mode;
-    DWORD mem_pressure;
-    DWORD global_mechanims_p;
+    uint32_t mem_pressure;
+    uint32_t global_mechanims_p;
 
     void set_mechanism_p (gc_global_mechanism_p mechanism)
     {

--- a/src/gc/gcscan.cpp
+++ b/src/gc/gcscan.cpp
@@ -22,17 +22,17 @@
 
 //#define CATCH_GC  //catches exception during GC
 #ifdef DACCESS_COMPILE
-SVAL_IMPL_INIT(LONG, CNameSpace, m_GcStructuresInvalidCnt, 1);
+SVAL_IMPL_INIT(int32_t, CNameSpace, m_GcStructuresInvalidCnt, 1);
 #else //DACCESS_COMPILE
-VOLATILE(LONG) CNameSpace::m_GcStructuresInvalidCnt = 1;
+VOLATILE(int32_t) CNameSpace::m_GcStructuresInvalidCnt = 1;
 #endif //DACCESS_COMPILE
 
 BOOL CNameSpace::GetGcRuntimeStructuresValid ()
 {
     LIMITED_METHOD_CONTRACT;
     SUPPORTS_DAC;
-    _ASSERTE ((LONG)m_GcStructuresInvalidCnt >= 0);
-    return (LONG)m_GcStructuresInvalidCnt == 0;
+    _ASSERTE ((int32_t)m_GcStructuresInvalidCnt >= 0);
+    return (int32_t)m_GcStructuresInvalidCnt == 0;
 }
 
 #ifdef DACCESS_COMPILE
@@ -291,13 +291,13 @@ void CNameSpace::GcRuntimeStructuresValid (BOOL bValid)
     WRAPPER_NO_CONTRACT;
     if (!bValid)
     {
-        LONG result;
+        int32_t result;
         result = FastInterlockIncrement (&m_GcStructuresInvalidCnt);
         _ASSERTE (result > 0);
     }
     else
     {
-        LONG result;
+        int32_t result;
         result = FastInterlockDecrement (&m_GcStructuresInvalidCnt);
         _ASSERTE (result >= 0);
     }

--- a/src/gc/gcscan.cpp
+++ b/src/gc/gcscan.cpp
@@ -292,13 +292,13 @@ void CNameSpace::GcRuntimeStructuresValid (BOOL bValid)
     if (!bValid)
     {
         int32_t result;
-        result = FastInterlockIncrement (&m_GcStructuresInvalidCnt);
+        result = FastInterlockIncrement ((LONG*)&m_GcStructuresInvalidCnt);
         _ASSERTE (result > 0);
     }
     else
     {
         int32_t result;
-        result = FastInterlockDecrement (&m_GcStructuresInvalidCnt);
+        result = FastInterlockDecrement ((LONG*)&m_GcStructuresInvalidCnt);
         _ASSERTE (result >= 0);
     }
 }

--- a/src/gc/gcscan.cpp
+++ b/src/gc/gcscan.cpp
@@ -113,13 +113,13 @@ bool CNameSpace::GcDhReScan(ScanContext* sc)
 void CNameSpace::GcWeakPtrScan( promote_func* fn, int condemned, int max_gen, ScanContext* sc )
 {
     // Clear out weak pointers that are no longer live.
-    Ref_CheckReachable(condemned, max_gen, (LPARAM)sc);
+    Ref_CheckReachable(condemned, max_gen, (uintptr_t)sc);
 
     // Clear any secondary objects whose primary object is now definitely dead.
     Ref_ScanDependentHandlesForClearing(condemned, max_gen, sc, fn);
 }
 
-static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -140,7 +140,7 @@ static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtra
 
 void CNameSpace::GcWeakPtrScanBySingleThread( int condemned, int max_gen, ScanContext* sc )
 {
-    GCToEEInterface::SyncBlockCacheWeakPtrScan(&CheckPromoted, (LPARAM)sc, 0);
+    GCToEEInterface::SyncBlockCacheWeakPtrScan(&CheckPromoted, (uintptr_t)sc, 0);
 }
 
 void CNameSpace::GcScanSizedRefs(promote_func* fn, int condemned, int max_gen, ScanContext* sc)
@@ -151,7 +151,7 @@ void CNameSpace::GcScanSizedRefs(promote_func* fn, int condemned, int max_gen, S
 void CNameSpace::GcShortWeakPtrScan(promote_func* fn,  int condemned, int max_gen, 
                                      ScanContext* sc)
 {
-    Ref_CheckAlive(condemned, max_gen, (LPARAM)sc);
+    Ref_CheckAlive(condemned, max_gen, (uintptr_t)sc);
 }
 
 /*
@@ -261,7 +261,7 @@ void CNameSpace::GcScanHandlesForProfilerAndETW (int max_gen, ScanContext* sc)
 #endif // _DEBUG && CATCH_GC
     {
         LOG((LF_GC|LF_GCROOTS, LL_INFO10, "Profiler Root Scan Phase, Handles\n"));
-        Ref_ScanPointersForProfilerAndETW(max_gen, (LPARAM)sc);
+        Ref_ScanPointersForProfilerAndETW(max_gen, (uintptr_t)sc);
     }
     
 #if defined ( _DEBUG) && defined (CATCH_GC)
@@ -305,14 +305,14 @@ void CNameSpace::GcRuntimeStructuresValid (BOOL bValid)
 
 void CNameSpace::GcDemote (int condemned, int max_gen, ScanContext* sc)
 {
-    Ref_RejuvenateHandles (condemned, max_gen, (LPARAM)sc);
+    Ref_RejuvenateHandles (condemned, max_gen, (uintptr_t)sc);
     if (!GCHeap::IsServerHeap() || sc->thread_number == 0)
         GCToEEInterface::SyncBlockCacheDemote(max_gen);
 }
 
 void CNameSpace::GcPromotionsGranted (int condemned, int max_gen, ScanContext* sc)
 {
-    Ref_AgeHandles(condemned, max_gen, (LPARAM)sc);
+    Ref_AgeHandles(condemned, max_gen, (uintptr_t)sc);
     if (!GCHeap::IsServerHeap() || sc->thread_number == 0)
         GCToEEInterface::SyncBlockCachePromotionsGranted(max_gen);
 }

--- a/src/gc/gcscan.cpp
+++ b/src/gc/gcscan.cpp
@@ -110,7 +110,7 @@ bool CNameSpace::GcDhReScan(ScanContext* sc)
  * Scan for dead weak pointers
  */
 
-VOID CNameSpace::GcWeakPtrScan( promote_func* fn, int condemned, int max_gen, ScanContext* sc )
+void CNameSpace::GcWeakPtrScan( promote_func* fn, int condemned, int max_gen, ScanContext* sc )
 {
     // Clear out weak pointers that are no longer live.
     Ref_CheckReachable(condemned, max_gen, (LPARAM)sc);
@@ -138,17 +138,17 @@ static void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtra
     }
 }
 
-VOID CNameSpace::GcWeakPtrScanBySingleThread( int condemned, int max_gen, ScanContext* sc )
+void CNameSpace::GcWeakPtrScanBySingleThread( int condemned, int max_gen, ScanContext* sc )
 {
     GCToEEInterface::SyncBlockCacheWeakPtrScan(&CheckPromoted, (LPARAM)sc, 0);
 }
 
-VOID CNameSpace::GcScanSizedRefs(promote_func* fn, int condemned, int max_gen, ScanContext* sc)
+void CNameSpace::GcScanSizedRefs(promote_func* fn, int condemned, int max_gen, ScanContext* sc)
 {
     Ref_ScanSizedRefHandles(condemned, max_gen, sc, fn);
 }
 
-VOID CNameSpace::GcShortWeakPtrScan(promote_func* fn,  int condemned, int max_gen, 
+void CNameSpace::GcShortWeakPtrScan(promote_func* fn,  int condemned, int max_gen, 
                                      ScanContext* sc)
 {
     Ref_CheckAlive(condemned, max_gen, (LPARAM)sc);
@@ -158,7 +158,7 @@ VOID CNameSpace::GcShortWeakPtrScan(promote_func* fn,  int condemned, int max_ge
  * Scan all stack roots in this 'namespace'
  */
  
-VOID CNameSpace::GcScanRoots(promote_func* fn,  int condemned, int max_gen, 
+void CNameSpace::GcScanRoots(promote_func* fn,  int condemned, int max_gen, 
                              ScanContext* sc)
 {
 #if defined ( _DEBUG) && defined (CATCH_GC)
@@ -212,7 +212,7 @@ VOID CNameSpace::GcScanRoots(promote_func* fn,  int condemned, int max_gen,
  */
 
 
-VOID CNameSpace::GcScanHandles (promote_func* fn,  int condemned, int max_gen, 
+void CNameSpace::GcScanHandles (promote_func* fn,  int condemned, int max_gen, 
                                 ScanContext* sc)
 {
 
@@ -251,7 +251,7 @@ VOID CNameSpace::GcScanHandles (promote_func* fn,  int condemned, int max_gen,
  * Scan all handle roots in this 'namespace' for profiling
  */
 
-VOID CNameSpace::GcScanHandlesForProfilerAndETW (int max_gen, ScanContext* sc)
+void CNameSpace::GcScanHandlesForProfilerAndETW (int max_gen, ScanContext* sc)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -360,7 +360,7 @@ size_t CNameSpace::AskForMoreReservedMemory (size_t old_size, size_t need_size)
     {
         size_t new_max_limit_size = need_size;
         pGCHostControl->RequestVirtualMemLimit (old_size, 
-                                                (SIZE_T*)&new_max_limit_size);
+                                                (size_t*)&new_max_limit_size);
         return new_max_limit_size;
     }
 #endif

--- a/src/gc/gcscan.h
+++ b/src/gc/gcscan.h
@@ -110,9 +110,9 @@ class CNameSpace
     
 private:
 #ifdef DACCESS_COMPILE    
-    SVAL_DECL(LONG, m_GcStructuresInvalidCnt);
+    SVAL_DECL(int32_t, m_GcStructuresInvalidCnt);
 #else
-    static VOLATILE(LONG) m_GcStructuresInvalidCnt;
+    static VOLATILE(int32_t) m_GcStructuresInvalidCnt;
 #endif //DACCESS_COMPILE
 };
 

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -1184,8 +1184,8 @@ uint32_t HndCountHandles(HHANDLETABLE hTable)
     for (; pCache != pCacheEnd; ++pCache)
     {
         // get relevant indexes for the reserve bank and the free bank
-        LONG lFreeIndex = pCache->lFreeIndex;
-        LONG lReserveIndex = pCache->lReserveIndex;
+        int32_t lFreeIndex = pCache->lFreeIndex;
+        int32_t lReserveIndex = pCache->lReserveIndex;
 
         // clamp the min free index and min reserve index to be non-negative;
         // this is necessary since interlocked operations can set these variables

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -32,8 +32,8 @@
  ****************************************************************************/
 
 #ifdef _DEBUG
-void DEBUG_PostGCScanHandler(HandleTable *pTable, const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, ScanCallbackInfo *info);
-void DEBUG_LogScanningStatistics(HandleTable *pTable, DWORD level);
+void DEBUG_PostGCScanHandler(HandleTable *pTable, const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, ScanCallbackInfo *info);
+void DEBUG_LogScanningStatistics(HandleTable *pTable, uint32_t level);
 #endif
 
 /*--------------------------------------------------------------------------*/
@@ -83,7 +83,7 @@ __inline PTR_HandleTable Table(HHANDLETABLE hTable)
  * Alocates and initializes a handle table.
  *
  */
-HHANDLETABLE HndCreateHandleTable(const UINT *pTypeFlags, UINT uTypeCount, ADIndex uADIndex)
+HHANDLETABLE HndCreateHandleTable(const uint32_t *pTypeFlags, uint32_t uTypeCount, ADIndex uADIndex)
 {
     CONTRACTL
     {
@@ -105,10 +105,10 @@ HHANDLETABLE HndCreateHandleTable(const UINT *pTypeFlags, UINT uTypeCount, ADInd
     // if you hit this then TABLE LAYOUT IS BROKEN
 
     // compute the size of the handle table allocation
-    ULONG32 dwSize = sizeof(HandleTable) + (uTypeCount * sizeof(HandleTypeCache));
+    uint32_t dwSize = sizeof(HandleTable) + (uTypeCount * sizeof(HandleTypeCache));
 
     // allocate the table
-    HandleTable *pTable = (HandleTable *) new (nothrow) BYTE[dwSize];
+    HandleTable *pTable = (HandleTable *) new (nothrow) uint8_t[dwSize];
     if (pTable == NULL)
         return NULL;
 
@@ -121,7 +121,7 @@ HHANDLETABLE HndCreateHandleTable(const UINT *pTypeFlags, UINT uTypeCount, ADInd
     if (!pTable->pSegmentList)
     {
         // free the table's memory and get out
-        delete [] (BYTE*)pTable;
+        delete [] (uint8_t*)pTable;
         return NULL;
     }
 
@@ -132,7 +132,7 @@ HHANDLETABLE HndCreateHandleTable(const UINT *pTypeFlags, UINT uTypeCount, ADInd
     if (!pTable->Lock.InitNoThrow(CrstHandleTable, CrstFlags(CRST_REENTRANCY | CRST_UNSAFE_ANYMODE | CRST_DEBUGGER_THREAD | CRST_UNSAFE_SAMELEVEL)))
     {
         SegmentFree(pTable->pSegmentList);
-        delete [] (BYTE*)pTable;
+        delete [] (uint8_t*)pTable;
         return NULL;
     }
 
@@ -140,11 +140,11 @@ HHANDLETABLE HndCreateHandleTable(const UINT *pTypeFlags, UINT uTypeCount, ADInd
     pTable->uTypeCount = uTypeCount;
 
     // Store user data
-    pTable->uTableIndex = (UINT) -1;
+    pTable->uTableIndex = (uint32_t) -1;
     pTable->uADIndex = uADIndex;
 
     // loop over various arrays an initialize them
-    UINT u;
+    uint32_t u;
 
     // initialize the type flags for the types we were passed
     for (u = 0; u < uTypeCount; u++)
@@ -210,14 +210,14 @@ void HndDestroyHandleTable(HHANDLETABLE hTable)
     }
 
     // free the table's memory
-    delete [] (BYTE*) pTable;
+    delete [] (uint8_t*) pTable;
 }
 /*
  * HndSetHandleTableIndex
  *
  * Sets the index associated with a handle table at creation
  */
-void HndSetHandleTableIndex(HHANDLETABLE hTable, UINT uTableIndex)
+void HndSetHandleTableIndex(HHANDLETABLE hTable, uint32_t uTableIndex)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -233,14 +233,14 @@ void HndSetHandleTableIndex(HHANDLETABLE hTable, UINT uTableIndex)
  *
  * Retrieves the index associated with a handle table at creation
  */
-UINT HndGetHandleTableIndex(HHANDLETABLE hTable)
+uint32_t HndGetHandleTableIndex(HHANDLETABLE hTable)
 {
     WRAPPER_NO_CONTRACT;
 
     // fetch the handle table pointer
     HandleTable *pTable = Table(hTable);
 
-    _ASSERTE (pTable->uTableIndex != (UINT) -1);  // We have not set uTableIndex yet.
+    _ASSERTE (pTable->uTableIndex != (uint32_t) -1);  // We have not set uTableIndex yet.
     return pTable->uTableIndex;
 }
 
@@ -282,7 +282,7 @@ ADIndex HndGetHandleADIndex(OBJECTHANDLE handle)
  * Entrypoint for allocating an individual handle.
  *
  */
-OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, UINT uType, OBJECTREF object, LPARAM lExtraInfo)
+OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF object, LPARAM lExtraInfo)
 {
     CONTRACTL
     {
@@ -360,7 +360,7 @@ OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, UINT uType, OBJECTREF object, 
 #ifdef GC_PROFILING
     {
         BEGIN_PIN_PROFILER(CORProfilerTrackGC());
-        g_profControlBlock.pProfInterface->HandleCreated((UINT_PTR)handle, (ObjectID)OBJECTREF_TO_UNCHECKED_OBJECTREF(object));
+        g_profControlBlock.pProfInterface->HandleCreated((uintptr_t)handle, (ObjectID)OBJECTREF_TO_UNCHECKED_OBJECTREF(object));
         END_PIN_PROFILER();
     }
 #endif //GC_PROFILING
@@ -468,7 +468,7 @@ void ValidateAppDomainForHandle(OBJECTHANDLE handle)
  * Entrypoint for freeing an individual handle.
  *
  */
-void HndDestroyHandle(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE handle)
+void HndDestroyHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE handle)
 {
     CONTRACTL
     {
@@ -498,7 +498,7 @@ void HndDestroyHandle(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE handle)
 #ifdef GC_PROFILING
     {
         BEGIN_PIN_PROFILER(CORProfilerTrackGC());
-        g_profControlBlock.pProfInterface->HandleDestroyed((UINT_PTR)handle);
+        g_profControlBlock.pProfInterface->HandleDestroyed((uintptr_t)handle);
         END_PIN_PROFILER();
     }        
 #endif //GC_PROFILING
@@ -554,7 +554,7 @@ void HndDestroyHandleOfUnknownType(HHANDLETABLE hTable, OBJECTHANDLE handle)
  * Entrypoint for allocating handles in bulk.
  *
  */
-UINT HndCreateHandles(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE *pHandles, UINT uCount)
+uint32_t HndCreateHandles(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE *pHandles, uint32_t uCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -565,7 +565,7 @@ UINT HndCreateHandles(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE *pHandles, U
     _ASSERTE(uType < pTable->uTypeCount);
 
     // keep track of the number of handles we've allocated
-    UINT uSatisfied = 0;
+    uint32_t uSatisfied = 0;
 
     // if this is a large number of handles then bypass the cache
     if (uCount > SMALL_ALLOC_COUNT)
@@ -589,8 +589,8 @@ UINT HndCreateHandles(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE *pHandles, U
 #ifdef GC_PROFILING
     {
         BEGIN_PIN_PROFILER(CORProfilerTrackGC());
-        for (UINT i = 0; i < uSatisfied; i++)
-            g_profControlBlock.pProfInterface->HandleCreated((UINT_PTR)pHandles[i], 0);
+        for (uint32_t i = 0; i < uSatisfied; i++)
+            g_profControlBlock.pProfInterface->HandleCreated((uintptr_t)pHandles[i], 0);
         END_PIN_PROFILER();
     }
 #endif //GC_PROFILING
@@ -606,7 +606,7 @@ UINT HndCreateHandles(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE *pHandles, U
  * Entrypoint for freeing handles in bulk.
  *
  */
-void HndDestroyHandles(HHANDLETABLE hTable, UINT uType, const OBJECTHANDLE *pHandles, UINT uCount)
+void HndDestroyHandles(HHANDLETABLE hTable, uint32_t uType, const OBJECTHANDLE *pHandles, uint32_t uCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -623,8 +623,8 @@ void HndDestroyHandles(HHANDLETABLE hTable, UINT uType, const OBJECTHANDLE *pHan
 #ifdef GC_PROFILING
     {
         BEGIN_PIN_PROFILER(CORProfilerTrackGC());
-        for (UINT i = 0; i < uCount; i++)
-            g_profControlBlock.pProfInterface->HandleDestroyed((UINT_PTR)pHandles[i]);
+        for (uint32_t i = 0; i < uCount; i++)
+            g_profControlBlock.pProfInterface->HandleDestroyed((uintptr_t)pHandles[i]);
         END_PIN_PROFILER();
     }
 #endif
@@ -655,7 +655,7 @@ void HndDestroyHandles(HHANDLETABLE hTable, UINT uType, const OBJECTHANDLE *pHan
  * Stores owner data with handle.
  *
  */
-void HndSetHandleExtraInfo(OBJECTHANDLE handle, UINT uType, LPARAM lExtraInfo)
+void HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lExtraInfo)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -676,7 +676,7 @@ void HndSetHandleExtraInfo(OBJECTHANDLE handle, UINT uType, LPARAM lExtraInfo)
 * Stores owner data with handle.
 *
 */
-LPARAM HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, UINT uType, LPARAM lOldExtraInfo, LPARAM lNewExtraInfo)
+LPARAM HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lOldExtraInfo, LPARAM lNewExtraInfo)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -687,7 +687,7 @@ LPARAM HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, UINT uType, LPARAM
     if (pUserData)
     {
         // yes - attempt to store the info
-        return (LPARAM)FastInterlockCompareExchangePointer((PVOID*)pUserData, (PVOID)lNewExtraInfo, (PVOID)lOldExtraInfo);
+        return (LPARAM)FastInterlockCompareExchangePointer((void**)pUserData, (void*)lNewExtraInfo, (void*)lOldExtraInfo);
     }
 
     _ASSERTE(!"Shouldn't be trying to call HndCompareExchangeHandleExtraInfo on handle types without extra info");
@@ -748,12 +748,12 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
     if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PRIVATE_PROVIDER_Context, SetGCHandle) ||
         ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, SetGCHandle))
     {
-        UINT hndType = HandleFetchType(handle);
+        uint32_t hndType = HandleFetchType(handle);
         ADIndex appDomainIndex = HndGetHandleADIndex(handle);   
         AppDomain* pAppDomain = SystemDomain::GetAppDomainAtIndex(appDomainIndex);
-        UINT generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
-        FireEtwSetGCHandle((void*) handle, value, hndType, generation, (LONGLONG) pAppDomain, GetClrInstanceId());
-        FireEtwPrvSetGCHandle((void*) handle, value, hndType, generation, (LONGLONG) pAppDomain, GetClrInstanceId());
+        uint32_t generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
+        FireEtwSetGCHandle((void*) handle, value, hndType, generation, (int64_t) pAppDomain, GetClrInstanceId());
+        FireEtwPrvSetGCHandle((void*) handle, value, hndType, generation, (int64_t) pAppDomain, GetClrInstanceId());
 
         // Also fire the things pinned by Async pinned handles
         if (hndType == HNDTYPE_ASYNCPINNED)
@@ -765,19 +765,19 @@ void HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value)
                 {
                     ArrayBase* pUserObject = (ArrayBase*)OBJECTREFToObject(overlapped->m_userObject);
                     Object **ppObj = (Object**)pUserObject->GetDataPtr(TRUE);
-                    SIZE_T num = pUserObject->GetNumComponents();
-                    for (SIZE_T i = 0; i < num; i ++)
+                    size_t num = pUserObject->GetNumComponents();
+                    for (size_t i = 0; i < num; i ++)
                     {
                         value = ppObj[i];
-                        UINT generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
-                        FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (LONGLONG) pAppDomain, GetClrInstanceId());
+                        uint32_t generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
+                        FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (int64_t) pAppDomain, GetClrInstanceId());
                     }
                 }
                 else
                 {
                     value = OBJECTREF_TO_UNCHECKED_OBJECTREF(overlapped->m_userObject);
-                    UINT generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
-                    FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (LONGLONG) pAppDomain, GetClrInstanceId());
+                    uint32_t generation = value != 0 ? GCHeap::GetGCHeap()->WhichGeneration(value) : 0;
+                    FireEtwSetGCHandle(overlapped, value, HNDTYPE_PINNED, generation, (int64_t) pAppDomain, GetClrInstanceId());
                 }
             }
         }
@@ -804,13 +804,13 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
     _ASSERTE (objref != NULL);
 
     // find the write barrier for this handle
-    BYTE *barrier = (BYTE *)((UINT_PTR)handle & HANDLE_SEGMENT_ALIGN_MASK);
+    uint8_t *barrier = (uint8_t *)((uintptr_t)handle & HANDLE_SEGMENT_ALIGN_MASK);
     
     // sanity
     _ASSERTE(barrier);
     
     // find the offset of this handle into the segment
-    UINT_PTR offset = (UINT_PTR)handle & HANDLE_SEGMENT_CONTENT_MASK;
+    uintptr_t offset = (uintptr_t)handle & HANDLE_SEGMENT_CONTENT_MASK;
     
     // make sure it is in the handle area and not the header
     _ASSERTE(offset >= HANDLE_HEADER_SIZE);
@@ -823,14 +823,14 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
     // (utilizing a conditional register move to determine whether the write is an update or simply writes
     // back what was read). This is a legal transformation for non-volatile accesses but obviously leads to a
     // race condition where we can lose an update (see the comment below for the race condition).
-    volatile BYTE * pClumpAge = barrier + offset;
+    volatile uint8_t * pClumpAge = barrier + offset;
 
     // if this age is smaller than age of the clump, update the clump age
     if (*pClumpAge != 0) // Perf optimization: if clumpAge is 0, nothing more to do
     {
         // find out generation
         int generation = GCHeap::GetGCHeap()->WhichGeneration(value);
-        UINT uType = HandleFetchType(handle);
+        uint32_t uType = HandleFetchType(handle);
 
 #ifndef FEATURE_REDHAWK
         //OverlappedData need special treatment: because all user data pointed by it needs to be reported by this handle,
@@ -846,7 +846,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
             generation = 0;
         }
 
-        if (*pClumpAge > (BYTE) generation)
+        if (*pClumpAge > (uint8_t) generation)
         {
             // We have to be careful here. HndWriteBarrier is not under any synchronization
             // Consider the scenario where 2 threads are hitting the line below at the same
@@ -855,7 +855,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
             // youngest handle in the clump, thus GC may skip the clump). To fix this
             // we just set the clump age to 0, which means that whoever wins the race
             // results are the same, as GC will always look at the clump
-            *pClumpAge = (BYTE)0;
+            *pClumpAge = (uint8_t)0;
         }
     }
 }
@@ -869,7 +869,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
  * needs to enumerate all roots in the handle table.
  *
  */
-void HndEnumHandles(HHANDLETABLE hTable, const UINT *puType, UINT uTypeCount,
+void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeCount,
                     HANDLESCANPROC pfnEnum, LPARAM lParam1, LPARAM lParam2, BOOL fAsync)
 {
     WRAPPER_NO_CONTRACT;
@@ -930,7 +930,7 @@ void HndEnumHandles(HHANDLETABLE hTable, const UINT *puType, UINT uTypeCount,
  *
  */
 void HndScanHandlesForGC(HHANDLETABLE hTable, HANDLESCANPROC scanProc, LPARAM param1, LPARAM param2,
-                         const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, UINT flags)
+                         const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1057,7 +1057,7 @@ void HndScanHandlesForGC(HHANDLETABLE hTable, HANDLESCANPROC scanProc, LPARAM pa
  * generation to a lower one.
  *
  */
-void HndResetAgeMap(HHANDLETABLE hTable, const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, UINT flags)
+void HndResetAgeMap(HHANDLETABLE hTable, const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1097,7 +1097,7 @@ void HndResetAgeMap(HHANDLETABLE hTable, const UINT *types, UINT typeCount, UINT
  * 16 handles.
  *
  */
-void HndVerifyTable(HHANDLETABLE hTable, const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, UINT flags)
+void HndVerifyTable(HHANDLETABLE hTable, const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1131,7 +1131,7 @@ void HndVerifyTable(HHANDLETABLE hTable, const UINT *types, UINT typeCount, UINT
  * Informs the handle table that a GC has completed.
  *
  */
-void HndNotifyGcCycleComplete(HHANDLETABLE hTable, UINT condemned, UINT maxgen)
+void HndNotifyGcCycleComplete(HHANDLETABLE hTable, uint32_t condemned, uint32_t maxgen)
 {
 #ifdef _DEBUG
     WRAPPER_NO_CONTRACT;
@@ -1166,17 +1166,17 @@ extern int getNumberOfSlots();
  * it is necessary.
  *
  */
-UINT HndCountHandles(HHANDLETABLE hTable)
+uint32_t HndCountHandles(HHANDLETABLE hTable)
 {
     WRAPPER_NO_CONTRACT;
     // fetch the handle table pointer
     HandleTable *pTable = Table(hTable);
     
     // initialize the count of handles in the cache to 0
-    UINT uCacheCount = 0;
+    uint32_t uCacheCount = 0;
 
     // fetch the count of handles marked as "used"
-    UINT uCount = pTable->dwCount;
+    uint32_t uCount = pTable->dwCount;
 
     // loop through the main cache for each handle type
     HandleTypeCache *pCache = pTable->rgMainCache;
@@ -1195,7 +1195,7 @@ UINT HndCountHandles(HHANDLETABLE hTable)
         if (lReserveIndex < 0) lReserveIndex = 0;
 
         // compute the number of handles
-        UINT uHandleCount = (UINT)lReserveIndex + (HANDLES_PER_CACHE_BANK - (UINT)lFreeIndex);
+        uint32_t uHandleCount = (uint32_t)lReserveIndex + (HANDLES_PER_CACHE_BANK - (uint32_t)lFreeIndex);
 
         // add the number of handles to the total handle count and update
         // dwCount in this HandleTable
@@ -1227,9 +1227,9 @@ UINT HndCountHandles(HHANDLETABLE hTable)
  * while its handles are being counted.
  *
  */
-UINT HndCountAllHandles(BOOL fUseLocks)
+uint32_t HndCountAllHandles(BOOL fUseLocks)
 {
-    UINT uCount = 0;
+    uint32_t uCount = 0;
     int offset = 0;
     
     // get number of HandleTables per HandleTableBucket
@@ -1351,7 +1351,7 @@ BOOL Ref_ContainHandle(HandleTableBucket *pBucket, OBJECTHANDLE handle)
  ****************************************************************************/
 #ifdef _DEBUG
 
-void DEBUG_PostGCScanHandler(HandleTable *pTable, const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, ScanCallbackInfo *info)
+void DEBUG_PostGCScanHandler(HandleTable *pTable, const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, ScanCallbackInfo *info)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1378,18 +1378,18 @@ void DEBUG_PostGCScanHandler(HandleTable *pTable, const UINT *types, UINT typeCo
 
         // dump the handle types we were asked to scan
         LOG((LF_GC, LL_INFO1000, "    Handle Type(s)        = %u", *types));
-        for (UINT u = 1; u < typeCount; u++)
+        for (uint32_t u = 1; u < typeCount; u++)
             LOG((LF_GC, LL_INFO1000, ",%u", types[u]));
         LOG((LF_GC, LL_INFO1000,  "\n"));
 
         // dump the number of blocks and slots we scanned
-        ULONG32 blockHandles = info->DEBUG_BlocksScanned * HANDLE_HANDLES_PER_BLOCK;
+        uint32_t blockHandles = info->DEBUG_BlocksScanned * HANDLE_HANDLES_PER_BLOCK;
         LOG((LF_GC, LL_INFO1000, "    Blocks Scanned        = %u (%u slots)\n", info->DEBUG_BlocksScanned, blockHandles));
 
         // if we scanned any blocks then summarize some stats
         if (blockHandles)
         {
-            ULONG32 nonTrivialBlockHandles = info->DEBUG_BlocksScannedNonTrivially * HANDLE_HANDLES_PER_BLOCK;
+            uint32_t nonTrivialBlockHandles = info->DEBUG_BlocksScannedNonTrivially * HANDLE_HANDLES_PER_BLOCK;
             LOG((LF_GC, LL_INFO1000, "    Blocks Examined       = %u (%u slots)\n", info->DEBUG_BlocksScannedNonTrivially, nonTrivialBlockHandles));
 
             LOG((LF_GC, LL_INFO1000, "    Slots Scanned         = %u\n", info->DEBUG_HandleSlotsScanned));
@@ -1405,7 +1405,7 @@ void DEBUG_PostGCScanHandler(HandleTable *pTable, const UINT *types, UINT typeCo
     }
 }
 
-void DEBUG_LogScanningStatistics(HandleTable *pTable, DWORD level)
+void DEBUG_LogScanningStatistics(HandleTable *pTable, uint32_t level)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1419,7 +1419,7 @@ void DEBUG_LogScanningStatistics(HandleTable *pTable, DWORD level)
         // for each generation we've collected,  dump the current stats
         for (int i = 0; i <= pTable->_DEBUG_iMaxGen; i++)
         {
-            INT64 totalBlocksScanned = pTable->_DEBUG_TotalBlocksScanned[i];
+            int64_t totalBlocksScanned = pTable->_DEBUG_TotalBlocksScanned[i];
 
             // dump the generation number and the number of blocks scanned
             LOG((LF_GC, level,     "--------------------------------------------------------------\n"));

--- a/src/gc/handletable.cpp
+++ b/src/gc/handletable.cpp
@@ -282,7 +282,7 @@ ADIndex HndGetHandleADIndex(OBJECTHANDLE handle)
  * Entrypoint for allocating an individual handle.
  *
  */
-OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF object, LPARAM lExtraInfo)
+OBJECTHANDLE HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF object, uintptr_t lExtraInfo)
 {
     CONTRACTL
     {
@@ -655,12 +655,12 @@ void HndDestroyHandles(HHANDLETABLE hTable, uint32_t uType, const OBJECTHANDLE *
  * Stores owner data with handle.
  *
  */
-void HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lExtraInfo)
+void HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, uintptr_t lExtraInfo)
 {
     WRAPPER_NO_CONTRACT;
 
     // fetch the user data slot for this handle if we have the right type
-    LPARAM *pUserData = HandleValidateAndFetchUserDataPointer(handle, uType);
+    uintptr_t *pUserData = HandleValidateAndFetchUserDataPointer(handle, uType);
 
     // is there a slot?
     if (pUserData)
@@ -676,18 +676,18 @@ void HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lExtraInf
 * Stores owner data with handle.
 *
 */
-LPARAM HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lOldExtraInfo, LPARAM lNewExtraInfo)
+uintptr_t HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, uintptr_t lOldExtraInfo, uintptr_t lNewExtraInfo)
 {
     WRAPPER_NO_CONTRACT;
 
     // fetch the user data slot for this handle if we have the right type
-    LPARAM *pUserData = HandleValidateAndFetchUserDataPointer(handle, uType);
+    uintptr_t *pUserData = HandleValidateAndFetchUserDataPointer(handle, uType);
 
     // is there a slot?
     if (pUserData)
     {
         // yes - attempt to store the info
-        return (LPARAM)FastInterlockCompareExchangePointer((void**)pUserData, (void*)lNewExtraInfo, (void*)lOldExtraInfo);
+        return (uintptr_t)FastInterlockCompareExchangePointer((void**)pUserData, (void*)lNewExtraInfo, (void*)lOldExtraInfo);
     }
 
     _ASSERTE(!"Shouldn't be trying to call HndCompareExchangeHandleExtraInfo on handle types without extra info");
@@ -701,15 +701,15 @@ LPARAM HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LP
  * Retrieves owner data from handle.
  *
  */
-LPARAM HndGetHandleExtraInfo(OBJECTHANDLE handle)
+uintptr_t HndGetHandleExtraInfo(OBJECTHANDLE handle)
 {
     WRAPPER_NO_CONTRACT;
 
     // assume zero until we actually get it
-    LPARAM lExtraInfo = 0L;
+    uintptr_t lExtraInfo = 0L;
 
     // fetch the user data slot for this handle
-    PTR_LPARAM pUserData = HandleQuickFetchUserDataPointer(handle);
+    PTR_uintptr_t pUserData = HandleQuickFetchUserDataPointer(handle);
 
     // if we did then copy the value
     if (pUserData)
@@ -870,7 +870,7 @@ void HndWriteBarrier(OBJECTHANDLE handle, OBJECTREF objref)
  *
  */
 void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeCount,
-                    HANDLESCANPROC pfnEnum, LPARAM lParam1, LPARAM lParam2, BOOL fAsync)
+                    HANDLESCANPROC pfnEnum, uintptr_t lParam1, uintptr_t lParam2, BOOL fAsync)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -929,7 +929,7 @@ void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeC
  * as it scans.
  *
  */
-void HndScanHandlesForGC(HHANDLETABLE hTable, HANDLESCANPROC scanProc, LPARAM param1, LPARAM param2,
+void HndScanHandlesForGC(HHANDLETABLE hTable, HANDLESCANPROC scanProc, uintptr_t param1, uintptr_t param2,
                          const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;

--- a/src/gc/handletable.h
+++ b/src/gc/handletable.h
@@ -53,15 +53,15 @@ typedef PTR_PTR_HandleTable PTR_HHANDLETABLE;
 /*
  * handle manager init and shutdown routines
  */
-HHANDLETABLE    HndCreateHandleTable(const UINT *pTypeFlags, UINT uTypeCount, ADIndex uADIndex);
+HHANDLETABLE    HndCreateHandleTable(const uint32_t *pTypeFlags, uint32_t uTypeCount, ADIndex uADIndex);
 void            HndDestroyHandleTable(HHANDLETABLE hTable);
 #endif // !DACCESS_COMPILE
 
 /*
  * retrieve index stored in table at creation 
  */
-void            HndSetHandleTableIndex(HHANDLETABLE hTable, UINT uTableIndex);
-UINT            HndGetHandleTableIndex(HHANDLETABLE hTable);
+void            HndSetHandleTableIndex(HHANDLETABLE hTable, uint32_t uTableIndex);
+uint32_t        HndGetHandleTableIndex(HHANDLETABLE hTable);
 ADIndex         HndGetHandleTableADIndex(HHANDLETABLE hTable);
 ADIndex         HndGetHandleADIndex(OBJECTHANDLE handle);
 
@@ -69,22 +69,22 @@ ADIndex         HndGetHandleADIndex(OBJECTHANDLE handle);
 /*
  * individual handle allocation and deallocation
  */
-OBJECTHANDLE    HndCreateHandle(HHANDLETABLE hTable, UINT uType, OBJECTREF object, LPARAM lExtraInfo = 0);
-void            HndDestroyHandle(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE handle);
+OBJECTHANDLE    HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF object, LPARAM lExtraInfo = 0);
+void            HndDestroyHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE handle);
 
 void            HndDestroyHandleOfUnknownType(HHANDLETABLE hTable, OBJECTHANDLE handle);
 
 /*
  * bulk handle allocation and deallocation
  */
-UINT            HndCreateHandles(HHANDLETABLE hTable, UINT uType, OBJECTHANDLE *pHandles, UINT uCount);
-void            HndDestroyHandles(HHANDLETABLE hTable, UINT uType, const OBJECTHANDLE *pHandles, UINT uCount);
+uint32_t        HndCreateHandles(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE *pHandles, uint32_t uCount);
+void            HndDestroyHandles(HHANDLETABLE hTable, uint32_t uType, const OBJECTHANDLE *pHandles, uint32_t uCount);
 
 /*
  * owner data associated with handles
  */
-void            HndSetHandleExtraInfo(OBJECTHANDLE handle, UINT uType, LPARAM lExtraInfo);
-LPARAM          HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, UINT uType, LPARAM lOldExtraInfo, LPARAM lNewExtraInfo);
+void            HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lExtraInfo);
+LPARAM          HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lOldExtraInfo, LPARAM lNewExtraInfo);
 #endif // !DACCESS_COMPILE
 
 LPARAM          HndGetHandleExtraInfo(OBJECTHANDLE handle);
@@ -112,7 +112,7 @@ typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pE
 /*
  * NON-GC handle enumeration
  */
-void HndEnumHandles(HHANDLETABLE hTable, const UINT *puType, UINT uTypeCount,
+void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeCount,
                     HANDLESCANPROC pfnEnum, LPARAM lParam1, LPARAM lParam2, BOOL fAsync);
 
 /*
@@ -128,23 +128,23 @@ void            HndScanHandlesForGC(HHANDLETABLE hTable,
                                     HANDLESCANPROC scanProc,
                                     LPARAM param1,
                                     LPARAM param2,
-                                    const UINT *types,
-                                    UINT typeCount,
-                                    UINT condemned,
-                                    UINT maxgen,
-                                    UINT flags);
+                                    const uint32_t *types,
+                                    uint32_t typeCount,
+                                    uint32_t condemned,
+                                    uint32_t maxgen,
+                                    uint32_t flags);
 
-void            HndResetAgeMap(HHANDLETABLE hTable, const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, UINT flags);
-void            HndVerifyTable(HHANDLETABLE hTable, const UINT *types, UINT typeCount, UINT condemned, UINT maxgen, UINT flags);
+void            HndResetAgeMap(HHANDLETABLE hTable, const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, uint32_t flags);
+void            HndVerifyTable(HHANDLETABLE hTable, const uint32_t *types, uint32_t typeCount, uint32_t condemned, uint32_t maxgen, uint32_t flags);
 
-void            HndNotifyGcCycleComplete(HHANDLETABLE hTable, UINT condemned, UINT maxgen);
+void            HndNotifyGcCycleComplete(HHANDLETABLE hTable, uint32_t condemned, uint32_t maxgen);
 
 /*
  * Handle counting
  */
 
-UINT            HndCountHandles(HHANDLETABLE hTable);
-UINT            HndCountAllHandles(BOOL fUseLocks);
+uint32_t        HndCountHandles(HHANDLETABLE hTable);
+uint32_t        HndCountAllHandles(BOOL fUseLocks);
 
 /*--------------------------------------------------------------------------*/
 

--- a/src/gc/handletable.h
+++ b/src/gc/handletable.h
@@ -69,7 +69,7 @@ ADIndex         HndGetHandleADIndex(OBJECTHANDLE handle);
 /*
  * individual handle allocation and deallocation
  */
-OBJECTHANDLE    HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF object, LPARAM lExtraInfo = 0);
+OBJECTHANDLE    HndCreateHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTREF object, uintptr_t lExtraInfo = 0);
 void            HndDestroyHandle(HHANDLETABLE hTable, uint32_t uType, OBJECTHANDLE handle);
 
 void            HndDestroyHandleOfUnknownType(HHANDLETABLE hTable, OBJECTHANDLE handle);
@@ -83,11 +83,11 @@ void            HndDestroyHandles(HHANDLETABLE hTable, uint32_t uType, const OBJ
 /*
  * owner data associated with handles
  */
-void            HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lExtraInfo);
-LPARAM          HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, LPARAM lOldExtraInfo, LPARAM lNewExtraInfo);
+void            HndSetHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, uintptr_t lExtraInfo);
+uintptr_t          HndCompareExchangeHandleExtraInfo(OBJECTHANDLE handle, uint32_t uType, uintptr_t lOldExtraInfo, uintptr_t lNewExtraInfo);
 #endif // !DACCESS_COMPILE
 
-LPARAM          HndGetHandleExtraInfo(OBJECTHANDLE handle);
+uintptr_t          HndGetHandleExtraInfo(OBJECTHANDLE handle);
 
 /*
  * get parent table of handle
@@ -107,13 +107,13 @@ void            HndLogSetEvent(OBJECTHANDLE handle, _UNCHECKED_OBJECTREF value);
  /*
   * Scanning callback.
   */
-typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2);
+typedef void (CALLBACK *HANDLESCANPROC)(PTR_UNCHECKED_OBJECTREF pref, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2);
 
 /*
  * NON-GC handle enumeration
  */
 void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeCount,
-                    HANDLESCANPROC pfnEnum, LPARAM lParam1, LPARAM lParam2, BOOL fAsync);
+                    HANDLESCANPROC pfnEnum, uintptr_t lParam1, uintptr_t lParam2, BOOL fAsync);
 
 /*
  * GC-time handle scanning
@@ -126,8 +126,8 @@ void HndEnumHandles(HHANDLETABLE hTable, const uint32_t *puType, uint32_t uTypeC
 
 void            HndScanHandlesForGC(HHANDLETABLE hTable,
                                     HANDLESCANPROC scanProc,
-                                    LPARAM param1,
-                                    LPARAM param2,
+                                    uintptr_t param1,
+                                    uintptr_t param2,
                                     const uint32_t *types,
                                     uint32_t typeCount,
                                     uint32_t condemned,

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -28,7 +28,7 @@
  *
  ****************************************************************************/
 
-const BYTE c_rgLowBitIndex[256] =
+const uint8_t c_rgLowBitIndex[256] =
 {
     0xff, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01, 0x00,
     0x03, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01, 0x00,
@@ -70,8 +70,8 @@ const BYTE c_rgLowBitIndex[256] =
  * A 32/64 neutral quicksort
  */
 //<TODO>@TODO: move/merge into common util file</TODO>
-typedef int (*PFNCOMPARE)(UINT_PTR p, UINT_PTR q);
-void QuickSort(UINT_PTR *pData, int left, int right, PFNCOMPARE pfnCompare)
+typedef int (*PFNCOMPARE)(uintptr_t p, uintptr_t q);
+void QuickSort(uintptr_t *pData, int left, int right, PFNCOMPARE pfnCompare)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -80,7 +80,7 @@ void QuickSort(UINT_PTR *pData, int left, int right, PFNCOMPARE pfnCompare)
         int i = left;
         int j = right;
 
-        UINT_PTR x = pData[(i + j + 1) / 2];
+        uintptr_t x = pData[(i + j + 1) / 2];
 
         do
         {
@@ -95,7 +95,7 @@ void QuickSort(UINT_PTR *pData, int left, int right, PFNCOMPARE pfnCompare)
 
             if (i < j)
             {
-                UINT_PTR t = pData[i];
+                uintptr_t t = pData[i];
                 pData[i] = pData[j];
                 pData[j] = t;
             }
@@ -133,7 +133,7 @@ void QuickSort(UINT_PTR *pData, int left, int right, PFNCOMPARE pfnCompare)
  *  >0 - handle Q should be freed before handle P
  *
  */
-int CompareHandlesByFreeOrder(UINT_PTR p, UINT_PTR q)
+int CompareHandlesByFreeOrder(uintptr_t p, uintptr_t q)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -145,7 +145,7 @@ int CompareHandlesByFreeOrder(UINT_PTR p, UINT_PTR q)
     if (pSegmentP == pSegmentQ)
     {
         // return the in-segment handle free order
-        return (int)((INT_PTR)q - (INT_PTR)p);
+        return (int)((intptr_t)q - (intptr_t)p);
     }
     else if (pSegmentP)
     {
@@ -153,7 +153,7 @@ int CompareHandlesByFreeOrder(UINT_PTR p, UINT_PTR q)
         if (pSegmentQ)
         {
             // return the sequence order of the two segments
-            return (int)(UINT)pSegmentQ->bSequence - (int)(UINT)pSegmentP->bSequence;
+            return (int)(uint32_t)pSegmentQ->bSequence - (int)(uint32_t)pSegmentP->bSequence;
         }
         else
         {
@@ -178,7 +178,7 @@ int CompareHandlesByFreeOrder(UINT_PTR p, UINT_PTR q)
  * Zeroes the object pointers for an array of handles.
  *
  */
-void ZeroHandles(OBJECTHANDLE *pHandleBase, UINT uCount)
+void ZeroHandles(OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -200,7 +200,7 @@ void ZeroHandles(OBJECTHANDLE *pHandleBase, UINT uCount)
 }
 
 #ifdef _DEBUG
-void CALLBACK DbgCountEnumeratedBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK DbgCountEnumeratedBlocks(TableSegment *pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -266,14 +266,14 @@ BOOL TableCanFreeSegmentNow(HandleTable *pTable, TableSegment *pSegment)
  * Gets the user data pointer for the first handle in a block.
  *
  */
-PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, UINT uBlock, BOOL fAssertOnError)
+PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t uBlock, BOOL fAssertOnError)
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     // assume NULL until we actually find the data
     PTR_LPARAM pUserData = NULL;
     // get the user data index for this block
-    UINT blockIndex = pSegment->rgUserData[uBlock];
+    uint32_t blockIndex = pSegment->rgUserData[uBlock];
 
     // is there user data for the block?
     if (blockIndex != BLOCK_INVALID)
@@ -311,7 +311,7 @@ __inline PTR__TableSegmentHeader HandleFetchSegmentPointer(OBJECTHANDLE handle)
     LIMITED_METHOD_DAC_CONTRACT;
 
     // find the segment for this handle
-    PTR__TableSegmentHeader pSegment = PTR__TableSegmentHeader((UINT_PTR)handle & HANDLE_SEGMENT_ALIGN_MASK);
+    PTR__TableSegmentHeader pSegment = PTR__TableSegmentHeader((uintptr_t)handle & HANDLE_SEGMENT_ALIGN_MASK);
 
     // sanity
     _ASSERTE(pSegment);
@@ -328,7 +328,7 @@ __inline PTR__TableSegmentHeader HandleFetchSegmentPointer(OBJECTHANDLE handle)
  * ASSERTs and returns NULL if handle is not of the expected type.
  *
  */
-LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, UINT uTypeExpected)
+LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTypeExpected)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -336,16 +336,16 @@ LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, UINT uTypeExp
     PTR__TableSegmentHeader pSegment = HandleFetchSegmentPointer(handle);
 
     // find the offset of this handle into the segment
-    UINT_PTR offset = (UINT_PTR)handle & HANDLE_SEGMENT_CONTENT_MASK;
+    uintptr_t offset = (uintptr_t)handle & HANDLE_SEGMENT_CONTENT_MASK;
 
     // make sure it is in the handle area and not the header
     _ASSERTE(offset >= HANDLE_HEADER_SIZE);
 
     // convert the offset to a handle index
-    UINT uHandle = (UINT)((offset - HANDLE_HEADER_SIZE) / HANDLE_SIZE);
+    uint32_t uHandle = (uint32_t)((offset - HANDLE_HEADER_SIZE) / HANDLE_SIZE);
 
     // compute the block this handle resides in
-    UINT uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
+    uint32_t uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
 
     // fetch the user data for this block
     PTR_LPARAM pUserData = BlockFetchUserDataPointer(pSegment, uBlock, TRUE);
@@ -393,16 +393,16 @@ PTR_LPARAM HandleQuickFetchUserDataPointer(OBJECTHANDLE handle)
     PTR__TableSegmentHeader pSegment = HandleFetchSegmentPointer(handle);
 
     // find the offset of this handle into the segment
-    UINT_PTR offset = (UINT_PTR)handle & HANDLE_SEGMENT_CONTENT_MASK;
+    uintptr_t offset = (uintptr_t)handle & HANDLE_SEGMENT_CONTENT_MASK;
 
     // make sure it is in the handle area and not the header
     _ASSERTE(offset >= HANDLE_HEADER_SIZE);
 
     // convert the offset to a handle index
-    UINT uHandle = (UINT)((offset - HANDLE_HEADER_SIZE) / HANDLE_SIZE);
+    uint32_t uHandle = (uint32_t)((offset - HANDLE_HEADER_SIZE) / HANDLE_SIZE);
 
     // compute the block this handle resides in
-    UINT uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
+    uint32_t uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
 
     // fetch the user data for this block
     PTR_LPARAM pUserData = BlockFetchUserDataPointer(pSegment, uBlock, TRUE);
@@ -451,7 +451,7 @@ void HandleQuickSetUserData(OBJECTHANDLE handle, LPARAM lUserData)
  * Computes the type index for a given handle.
  *
  */
-UINT HandleFetchType(OBJECTHANDLE handle)
+uint32_t HandleFetchType(OBJECTHANDLE handle)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -459,16 +459,16 @@ UINT HandleFetchType(OBJECTHANDLE handle)
     PTR__TableSegmentHeader pSegment = HandleFetchSegmentPointer(handle);
 
     // find the offset of this handle into the segment
-    UINT_PTR offset = (UINT_PTR)handle & HANDLE_SEGMENT_CONTENT_MASK;
+    uintptr_t offset = (uintptr_t)handle & HANDLE_SEGMENT_CONTENT_MASK;
 
     // make sure it is in the handle area and not the header
     _ASSERTE(offset >= HANDLE_HEADER_SIZE);
 
     // convert the offset to a handle index
-    UINT uHandle = (UINT)((offset - HANDLE_HEADER_SIZE) / HANDLE_SIZE);
+    uint32_t uHandle = (uint32_t)((offset - HANDLE_HEADER_SIZE) / HANDLE_SIZE);
 
     // compute the block this handle resides in
-    UINT uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
+    uint32_t uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
 
     // return the block's type
     return pSegment->rgBlockType[uBlock];
@@ -510,11 +510,11 @@ BOOL SegmentInitialize(TableSegment *pSegment, HandleTable *pTable)
     */
     
     // we want to commit enough for the header PLUS some handles
-    DWORD dwCommit = HANDLE_HEADER_SIZE;
+    uint32_t dwCommit = HANDLE_HEADER_SIZE;
 
 #ifndef FEATURE_REDHAWK // todo: implement SafeInt
     // Prefast overflow sanity check the addition
-    if (!ClrSafeInt<DWORD>::addition(dwCommit, g_SystemInfo.dwPageSize, dwCommit))
+    if (!ClrSafeInt<uint32_t>::addition(dwCommit, g_SystemInfo.dwPageSize, dwCommit))
     {
         return FALSE;
     }
@@ -531,7 +531,7 @@ BOOL SegmentInitialize(TableSegment *pSegment, HandleTable *pTable)
     }
 
     // remember how many blocks we commited
-    pSegment->bCommitLine = (BYTE)((dwCommit - HANDLE_HEADER_SIZE) / HANDLE_BYTES_PER_BLOCK);
+    pSegment->bCommitLine = (uint8_t)((dwCommit - HANDLE_HEADER_SIZE) / HANDLE_BYTES_PER_BLOCK);
 
     // now preinitialize the 0xFF guys
     memset(pSegment->rgGeneration, 0xFF,            sizeof(pSegment->rgGeneration));
@@ -543,10 +543,10 @@ BOOL SegmentInitialize(TableSegment *pSegment, HandleTable *pTable)
 
     // prelink the free chain
     _ASSERTE(FitsInU1(HANDLE_BLOCKS_PER_SEGMENT));
-    BYTE u = 0;
+    uint8_t u = 0;
     while (u < (HANDLE_BLOCKS_PER_SEGMENT - 1))
     {
-        BYTE next = u + 1;
+        uint8_t next = u + 1;
         pSegment->rgAllocation[u] = next;
         u = next;
     }
@@ -640,8 +640,8 @@ __inline void SegmentMarkFreeMask(TableSegment *pSegment, _UNCHECKED_OBJECTREF* 
     }
     CONTRACTL_END;
     
-    UINT uMask = (UINT)(h - pSegment->rgValue);
-    UINT uBit = uMask % HANDLE_HANDLES_PER_MASK;
+    uint32_t uMask = (uint32_t)(h - pSegment->rgValue);
+    uint32_t uBit = uMask % HANDLE_HANDLES_PER_MASK;
     uMask = uMask / HANDLE_HANDLES_PER_MASK;
     pSegment->rgFreeMask[uMask] |= (1<<uBit);
 }
@@ -657,8 +657,8 @@ __inline void SegmentUnMarkFreeMask(TableSegment *pSegment, _UNCHECKED_OBJECTREF
     }
     CONTRACTL_END;
     
-    UINT uMask = (UINT)(h - pSegment->rgValue);
-    UINT uBit = uMask % HANDLE_HANDLES_PER_MASK;
+    uint32_t uMask = (uint32_t)(h - pSegment->rgValue);
+    uint32_t uBit = uMask % HANDLE_HANDLES_PER_MASK;
     uMask = uMask / HANDLE_HANDLES_PER_MASK;
     pSegment->rgFreeMask[uMask] &= ~(1<<uBit);
 }
@@ -680,7 +680,7 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
     pSegment->fNeedsScavenging = true;
     
     // Zero out all non-async pin handles
-    UINT uBlock;
+    uint32_t uBlock;
     for (uBlock = 0; uBlock < pSegment->bEmptyLine; uBlock ++)
     {
         if (pSegment->rgBlockType[uBlock]  == TYPE_INVALID)
@@ -697,10 +697,10 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
                 pValue ++;
             } while (pValue < pLast);
 
-            ((ULONG32*)pSegment->rgGeneration)[uBlock] = (ULONG32)-1;
+            ((uint32_t*)pSegment->rgGeneration)[uBlock] = (uint32_t)-1;
 
-            ULONG32 *pdwMask = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
-            ULONG32 *pdwMaskLast = pdwMask + HANDLE_MASKS_PER_BLOCK;
+            uint32_t *pdwMask = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
+            uint32_t *pdwMaskLast = pdwMask + HANDLE_MASKS_PER_BLOCK;
             do
             {
                 *pdwMask = MASK_EMPTY;
@@ -714,7 +714,7 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
     }
 
     // Return all non-async pin handles to free list
-    UINT uType;
+    uint32_t uType;
     for (uType = 0; uType < HANDLE_MAX_INTERNAL_TYPES; uType ++)
     {
         if (uType == HNDTYPE_ASYNCPINNED)
@@ -724,8 +724,8 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
         pSegment->rgFreeCount[uType] = 0;
         if (pSegment->rgHint[uType] != BLOCK_INVALID)
         {
-            UINT uLast = pSegment->rgHint[uType];
-            BYTE uFirst = pSegment->rgAllocation[uLast];
+            uint32_t uLast = pSegment->rgHint[uType];
+            uint8_t uFirst = pSegment->rgAllocation[uLast];
             pSegment->rgAllocation[uLast] = pSegment->bFreeList;
             pSegment->bFreeList = uFirst;
             pSegment->rgHint[uType] = BLOCK_INVALID;
@@ -739,14 +739,14 @@ void SegmentPreCompactAsyncPinHandles(TableSegment *pSegment)
     {
         return;
     }
-    UINT freeCount = 0;
+    uint32_t freeCount = 0;
     for (uBlock = 0; uBlock < pSegment->bEmptyLine; uBlock ++)
     {
         if (pSegment->rgBlockType[uBlock] != HNDTYPE_ASYNCPINNED)
         {
             continue;
         }
-        if (pSegment->rgFreeMask[uBlock*2] == (ULONG32)-1 && pSegment->rgFreeMask[uBlock*2+1] == (ULONG32)-1)
+        if (pSegment->rgFreeMask[uBlock*2] == (uint32_t)-1 && pSegment->rgFreeMask[uBlock*2+1] == (uint32_t)-1)
         {
             continue;
         }
@@ -795,7 +795,7 @@ BOOL SegmentCopyAsyncPinHandle(TableSegment *pSegment, _UNCHECKED_OBJECTREF *h)
 
     if (pSegment->rgFreeCount[HNDTYPE_ASYNCPINNED] == 0)
     {
-        BYTE uBlock = pSegment->bFreeList;
+        uint8_t uBlock = pSegment->bFreeList;
         if (uBlock == BLOCK_INVALID)
         {
             // All slots are used up.
@@ -807,12 +807,12 @@ BOOL SegmentCopyAsyncPinHandle(TableSegment *pSegment, _UNCHECKED_OBJECTREF *h)
         pSegment->rgHint[HNDTYPE_ASYNCPINNED] = uBlock;
         pSegment->rgFreeCount[HNDTYPE_ASYNCPINNED] += HANDLE_HANDLES_PER_BLOCK;
     }
-    BYTE uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
-    BYTE uLast = uBlock;
+    uint8_t uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
+    uint8_t uLast = uBlock;
     do
     {
-        UINT n = uBlock * (HANDLE_HANDLES_PER_BLOCK/HANDLE_HANDLES_PER_MASK);
-        ULONG32* pMask = pSegment->rgFreeMask + n;
+        uint32_t n = uBlock * (HANDLE_HANDLES_PER_BLOCK/HANDLE_HANDLES_PER_MASK);
+        uint32_t* pMask = pSegment->rgFreeMask + n;
         if (pMask[0] != 0 || pMask[1] != 0)
         {
             break;
@@ -849,7 +849,7 @@ void SegmentCompactAsyncPinHandles(TableSegment *pSegment, TableSegment **ppWork
     }
     CONTRACTL_END;
 
-    UINT uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
+    uint32_t uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
     if (uBlock == BLOCK_INVALID)
     {
         return;
@@ -860,7 +860,7 @@ void SegmentCompactAsyncPinHandles(TableSegment *pSegment, TableSegment **ppWork
         {
             continue;
         }
-        if (pSegment->rgFreeMask[uBlock*2] == (ULONG32)-1 && pSegment->rgFreeMask[uBlock*2+1] == (ULONG32)-1)
+        if (pSegment->rgFreeMask[uBlock*2] == (uint32_t)-1 && pSegment->rgFreeMask[uBlock*2+1] == (uint32_t)-1)
         {
             continue;
         }
@@ -916,7 +916,7 @@ BOOL SegmentHandleAsyncPinHandles (TableSegment *pSegment)
     }
     CONTRACTL_END;
     
-    UINT uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
+    uint32_t uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
     if (uBlock == BLOCK_INVALID)
     {
         // There is no pinning handles.
@@ -931,7 +931,7 @@ BOOL SegmentHandleAsyncPinHandles (TableSegment *pSegment)
         {
             continue;
         }
-        if (pSegment->rgFreeMask[uBlock*2] == (ULONG32)-1 && pSegment->rgFreeMask[uBlock*2+1] == (ULONG32)-1)
+        if (pSegment->rgFreeMask[uBlock*2] == (uint32_t)-1 && pSegment->rgFreeMask[uBlock*2+1] == (uint32_t)-1)
         {
             continue;
         }
@@ -969,7 +969,7 @@ void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
     }
     CONTRACTL_END;
     
-    UINT uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
+    uint32_t uBlock = pSegment->rgHint[HNDTYPE_ASYNCPINNED];
     if (uBlock == BLOCK_INVALID)
     {
         // There is no pinning handles.
@@ -981,7 +981,7 @@ void SegmentRelocateAsyncPinHandles (TableSegment *pSegment, HandleTable *pTarge
         {
             continue;
         }
-        if (pSegment->rgFreeMask[uBlock*2] == (ULONG32)-1 && pSegment->rgFreeMask[uBlock*2+1] == (ULONG32)-1)
+        if (pSegment->rgFreeMask[uBlock*2] == (uint32_t)-1 && pSegment->rgFreeMask[uBlock*2+1] == (uint32_t)-1)
         {
             continue;
         }
@@ -1143,7 +1143,7 @@ SLOW_PATH:
         pSegment = pWorkerSegment->pNextSegment;
         while (pSegment)
         {
-            memset(pSegment->rgValue, 0, (UINT)pSegment->bCommitLine * HANDLE_BYTES_PER_BLOCK);
+            memset(pSegment->rgValue, 0, (uint32_t)pSegment->bCommitLine * HANDLE_BYTES_PER_BLOCK);
             pSegment = pSegment->pNextSegment;
         }
 
@@ -1160,12 +1160,12 @@ SLOW_PATH:
 
             // Take the worker segments and point them to their new handle table and recalculate their
             // sequence numbers to be consistent with the queue they're moving to.
-            BYTE bLastSequence = pTargetSegment->bSequence;
+            uint8_t bLastSequence = pTargetSegment->bSequence;
             pSegment = pTable->pSegmentList;
             while (pSegment != pWorkerSegment->pNextSegment)
             {
                 pSegment->pHandleTable = pTargetTable;
-                pSegment->bSequence = (BYTE)(((UINT)bLastSequence + 1) % 0x100);
+                pSegment->bSequence = (uint8_t)(((uint32_t)bLastSequence + 1) % 0x100);
                 bLastSequence = pSegment->bSequence;
                 pSegment = pSegment->pNextSegment;
             }
@@ -1216,7 +1216,7 @@ BOOL TableContainHandle(HandleTable *pTable, OBJECTHANDLE handle)
  * and moves them to the segment's free list.
  *
  */
-void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScavengeLater)
+void SegmentRemoveFreeBlocks(TableSegment *pSegment, uint32_t uType, BOOL *pfScavengeLater)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1227,7 +1227,7 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
     */
     
     // fetch the tail block for the specified chain
-    UINT uPrev = pSegment->rgTail[uType];
+    uint32_t uPrev = pSegment->rgTail[uType];
 
     // if it's a terminator then there are no blocks in the chain
     if (uPrev == BLOCK_INVALID)
@@ -1237,33 +1237,33 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
     BOOL fCleanupUserData = FALSE;
 
     // start iterating with the head block
-    UINT uStart = pSegment->rgAllocation[uPrev];
-    UINT uBlock = uStart;
+    uint32_t uStart = pSegment->rgAllocation[uPrev];
+    uint32_t uBlock = uStart;
 
     // keep track of how many blocks we removed
-    UINT uRemoved = 0;
+    uint32_t uRemoved = 0;
 
     // we want to preserve the relative order of any blocks we free
     // this is the best we can do until the free list is resorted
-    UINT uFirstFreed = BLOCK_INVALID;
-    UINT uLastFreed  = BLOCK_INVALID;
+    uint32_t uFirstFreed = BLOCK_INVALID;
+    uint32_t uLastFreed  = BLOCK_INVALID;
 
     // loop until we've processed the whole chain
     for (;;)
     {
         // fetch the next block index
-        UINT uNext = pSegment->rgAllocation[uBlock];
+        uint32_t uNext = pSegment->rgAllocation[uBlock];
 
 #ifdef HANDLE_OPTIMIZE_FOR_64_HANDLE_BLOCKS
         // determine whether this block is empty
-        if (((UINT64*)pSegment->rgFreeMask)[uBlock] == UI64(0xFFFFFFFFFFFFFFFF))
+        if (((uint64_t*)pSegment->rgFreeMask)[uBlock] == UI64(0xFFFFFFFFFFFFFFFF))
 #else
         // assume this block is empty until we know otherwise
         BOOL fEmpty = TRUE;
 
         // get the first mask for this block
-        ULONG32 *pdwMask     = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
-        ULONG32 *pdwMaskLast = pdwMask              + HANDLE_MASKS_PER_BLOCK;
+        uint32_t *pdwMask     = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
+        uint32_t *pdwMaskLast = pdwMask              + HANDLE_MASKS_PER_BLOCK;
 
         // loop through the masks until we've processed them all or we've found handles
         do
@@ -1295,7 +1295,7 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
             else
             {
                 // safe to free - did it have user data associated?
-                UINT uData = pSegment->rgUserData[uBlock];
+                uint32_t uData = pSegment->rgUserData[uBlock];
                 if (uData != BLOCK_INVALID)
                 {
                     // data blocks are 'empty' so we keep them locked
@@ -1321,7 +1321,7 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
                 else
                 {
                     // yes - link this block to the other ones in order
-                    pSegment->rgAllocation[uLastFreed] = (BYTE)uBlock;
+                    pSegment->rgAllocation[uLastFreed] = (uint8_t)uBlock;
                 }
 
                 // remember this block for later
@@ -1331,15 +1331,15 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
                 if (uPrev != uBlock)
                 {
                     // yes - unlink this block from the chain
-                    pSegment->rgAllocation[uPrev] = (BYTE)uNext;
+                    pSegment->rgAllocation[uPrev] = (uint8_t)uNext;
 
                     // if we are removing the tail then pick a new tail
                     if (pSegment->rgTail[uType] == uBlock)
-                        pSegment->rgTail[uType] = (BYTE)uPrev;
+                        pSegment->rgTail[uType] = (uint8_t)uPrev;
 
                     // if we are removing the hint then pick a new hint
                     if (pSegment->rgHint[uType] == uBlock)
-                        pSegment->rgHint[uType] = (BYTE)uNext;
+                        pSegment->rgHint[uType] = (uint8_t)uNext;
 
                     // we removed the current block - reset uBlock to a valid block
                     uBlock = uPrev;
@@ -1380,7 +1380,7 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
     {
         // yes - link the new blocks into the free list
         pSegment->rgAllocation[uLastFreed] = pSegment->bFreeList;
-        pSegment->bFreeList = (BYTE)uFirstFreed;
+        pSegment->bFreeList = (uint8_t)uFirstFreed;
 
         // update the free count for this chain
         pSegment->rgFreeCount[uType] -= (uRemoved * HANDLE_HANDLES_PER_BLOCK);
@@ -1405,7 +1405,7 @@ void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType, BOOL *pfScaveng
  * This routine is the core implementation for SegmentInsertBlockFromFreeList.
  *
  */
-UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BOOL fUpdateHint)
+uint32_t SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, uint32_t uType, BOOL fUpdateHint)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1417,7 +1417,7 @@ UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BO
     
 
     // fetch the next block from the free list
-    BYTE uBlock = pSegment->bFreeList;
+    uint8_t uBlock = pSegment->bFreeList;
 
     // if we got the terminator then there are no more blocks
     if (uBlock != BLOCK_INVALID)
@@ -1426,7 +1426,7 @@ UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BO
         if (uBlock >= pSegment->bEmptyLine)
         {
             // get the current commit line
-            UINT uCommitLine = pSegment->bCommitLine;
+            uint32_t uCommitLine = pSegment->bCommitLine;
 
             // if this block is uncommitted then commit some memory now
             if (uBlock >= uCommitLine)
@@ -1435,17 +1435,17 @@ UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BO
                 LPVOID pvCommit = pSegment->rgValue + (uCommitLine * HANDLE_HANDLES_PER_BLOCK);
 
                 // we should commit one more page of handles
-                ULONG32 dwCommit = g_SystemInfo.dwPageSize;
+                uint32_t dwCommit = g_SystemInfo.dwPageSize;
 
                 // commit the memory
                 if (!ClrVirtualAlloc(pvCommit, dwCommit, MEM_COMMIT, PAGE_READWRITE))
                     return BLOCK_INVALID;
 
                 // use the previous commit line as the new decommit line
-                pSegment->bDecommitLine = (BYTE)uCommitLine;
+                pSegment->bDecommitLine = (uint8_t)uCommitLine;
 
                 // adjust the commit line by the number of blocks we commited
-                pSegment->bCommitLine = (BYTE)(uCommitLine + (dwCommit / HANDLE_BYTES_PER_BLOCK));
+                pSegment->bCommitLine = (uint8_t)(uCommitLine + (dwCommit / HANDLE_BYTES_PER_BLOCK));
             }
 
             // update our empty line
@@ -1456,11 +1456,11 @@ UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BO
         pSegment->bFreeList = pSegment->rgAllocation[uBlock];
 
         // link our block into the specified chain
-        UINT uOldTail = pSegment->rgTail[uType];
+        uint32_t uOldTail = pSegment->rgTail[uType];
         if (uOldTail == BLOCK_INVALID)
         {
             // first block, set as head and link to itself
-            pSegment->rgAllocation[uBlock] = (BYTE)uBlock;
+            pSegment->rgAllocation[uBlock] = (uint8_t)uBlock;
 
             // there are no other blocks - update the hint anyway
             fUpdateHint = TRUE;
@@ -1469,21 +1469,21 @@ UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BO
         {
             // not first block - link circularly
             pSegment->rgAllocation[uBlock] = pSegment->rgAllocation[uOldTail];
-            pSegment->rgAllocation[uOldTail] = (BYTE)uBlock;
+            pSegment->rgAllocation[uOldTail] = (uint8_t)uBlock;
         
             // chain may need resorting depending on what we added
             pSegment->fResortChains = TRUE;
         }
 
         // mark this block with the type we're using it for
-        pSegment->rgBlockType[uBlock] = (BYTE)uType;
+        pSegment->rgBlockType[uBlock] = (uint8_t)uType;
 
         // update the chain tail
-        pSegment->rgTail[uType] = (BYTE)uBlock;
+        pSegment->rgTail[uType] = (uint8_t)uBlock;
 
         // if we are supposed to update the hint, then point it at the new block
         if (fUpdateHint)
-            pSegment->rgHint[uType] = (BYTE)uBlock;
+            pSegment->rgHint[uType] = (uint8_t)uBlock;
 
         // increment the chain's free count to reflect the additional block
         pSegment->rgFreeCount[uType] += HANDLE_HANDLES_PER_BLOCK;
@@ -1504,7 +1504,7 @@ UINT SegmentInsertBlockFromFreeListWorker(TableSegment *pSegment, UINT uType, BO
  * This routine does the work of securing a parallel user data block if required.
  *
  */
-UINT SegmentInsertBlockFromFreeList(TableSegment *pSegment, UINT uType, BOOL fUpdateHint)
+uint32_t SegmentInsertBlockFromFreeList(TableSegment *pSegment, uint32_t uType, BOOL fUpdateHint)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1514,7 +1514,7 @@ UINT SegmentInsertBlockFromFreeList(TableSegment *pSegment, UINT uType, BOOL fUp
         MODE_ANY;
     */
     
-    UINT uBlock, uData = 0;
+    uint32_t uBlock, uData = 0;
 
     // does this block type require user data?
     BOOL fUserData = TypeHasUserData(pSegment->pHandleTable, uType);
@@ -1541,7 +1541,7 @@ UINT SegmentInsertBlockFromFreeList(TableSegment *pSegment, UINT uType, BOOL fUp
         if ((uBlock != BLOCK_INVALID) && (uData != BLOCK_INVALID))
         {
             // link the data block to the requested block
-            pSegment->rgUserData[uBlock] = (BYTE)uData;
+            pSegment->rgUserData[uBlock] = (uint8_t)uData;
 
             // no handles are ever allocated out of a data block
             // lock the block so it won't be reclaimed accidentally
@@ -1594,27 +1594,27 @@ void SegmentResortChains(TableSegment *pSegment)
         BOOL fCleanupUserData = FALSE;
 
         // fetch the empty line for this segment
-        UINT uLast = pSegment->bEmptyLine;
+        uint32_t uLast = pSegment->bEmptyLine;
 
         // loop over all active blocks, scavenging the empty ones as we go
-        for (UINT uBlock = 0; uBlock < uLast; uBlock++)
+        for (uint32_t uBlock = 0; uBlock < uLast; uBlock++)
         {
             // fetch the block type of this block
-            UINT uType = pSegment->rgBlockType[uBlock];
+            uint32_t uType = pSegment->rgBlockType[uBlock];
 
             // only process public block types - we handle data blocks separately
             if (uType < HANDLE_MAX_PUBLIC_TYPES)
             {
 #ifdef HANDLE_OPTIMIZE_FOR_64_HANDLE_BLOCKS
                 // determine whether this block is empty
-                if (((UINT64*)pSegment->rgFreeMask)[uBlock] == UI64(0xFFFFFFFFFFFFFFFF))
+                if (((uint64_t*)pSegment->rgFreeMask)[uBlock] == UI64(0xFFFFFFFFFFFFFFFF))
 #else
                 // assume this block is empty until we know otherwise
                 BOOL fEmpty = TRUE;
     
                 // get the first mask for this block
-                ULONG32 *pdwMask     = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
-                ULONG32 *pdwMaskLast = pdwMask              + HANDLE_MASKS_PER_BLOCK;
+                uint32_t *pdwMask     = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
+                uint32_t *pdwMaskLast = pdwMask              + HANDLE_MASKS_PER_BLOCK;
 
                 // loop through the masks until we've processed them all or we've found handles
                 do
@@ -1640,7 +1640,7 @@ void SegmentResortChains(TableSegment *pSegment)
                     if (!BlockIsLocked(pSegment, uBlock))
                     {
                         // safe to free - did it have user data associated?
-                        UINT uData = pSegment->rgUserData[uBlock];
+                        uint32_t uData = pSegment->rgUserData[uBlock];
                         if (uData != BLOCK_INVALID)
                         {
                             // data blocks are 'empty' so we keep them locked
@@ -1672,19 +1672,19 @@ void SegmentResortChains(TableSegment *pSegment)
     }
 
     // keep some per-chain data
-    BYTE rgChainCurr[HANDLE_MAX_INTERNAL_TYPES];
-    BYTE rgChainHigh[HANDLE_MAX_INTERNAL_TYPES];
-    BYTE bChainFree = BLOCK_INVALID;
-    UINT uEmptyLine = BLOCK_INVALID;
+    uint8_t rgChainCurr[HANDLE_MAX_INTERNAL_TYPES];
+    uint8_t rgChainHigh[HANDLE_MAX_INTERNAL_TYPES];
+    uint8_t bChainFree = BLOCK_INVALID;
+    uint32_t uEmptyLine = BLOCK_INVALID;
     BOOL fContiguousWithFreeList = TRUE;
 
     // preinit the chain data to no blocks
-	UINT uType;
+	uint32_t uType;
     for (uType = 0; uType < HANDLE_MAX_INTERNAL_TYPES; uType++)
         rgChainHigh[uType] = rgChainCurr[uType] = BLOCK_INVALID;
 
     // scan back through the block types
-    BYTE uBlock = HANDLE_BLOCKS_PER_SEGMENT;
+    uint8_t uBlock = HANDLE_BLOCKS_PER_SEGMENT;
     while (uBlock > 0)
     {
         // decrement the block index
@@ -1710,7 +1710,7 @@ void SegmentResortChains(TableSegment *pSegment)
             pSegment->rgAllocation[uBlock] = rgChainCurr[uType];
 
             // remember this block in type chain
-            rgChainCurr[uType] = (BYTE)uBlock;
+            rgChainCurr[uType] = (uint8_t)uBlock;
         }
         else
         {
@@ -1722,7 +1722,7 @@ void SegmentResortChains(TableSegment *pSegment)
             pSegment->rgAllocation[uBlock] = bChainFree;
 
             // add this block to the free list
-            bChainFree = (BYTE)uBlock;
+            bChainFree = (uint8_t)uBlock;
         }
     }
 
@@ -1730,16 +1730,16 @@ void SegmentResortChains(TableSegment *pSegment)
     for (uType = 0; uType < HANDLE_MAX_INTERNAL_TYPES; uType++)
     {
         // get the first block in the list
-        BYTE bBlock = rgChainCurr[uType];
+        uint8_t bBlock = rgChainCurr[uType];
 
         // if there is a list then make it circular and save it
         if (bBlock != BLOCK_INVALID)
         {
             // highest block we saw becomes tail
-            UINT uTail = rgChainHigh[uType];
+            uint32_t uTail = rgChainHigh[uType];
 
             // store tail in segment
-            pSegment->rgTail[uType] = (BYTE)uTail;
+            pSegment->rgTail[uType] = (uint8_t)uTail;
 
             // link tail to head
             pSegment->rgAllocation[uTail] = bBlock;
@@ -1759,7 +1759,7 @@ void SegmentResortChains(TableSegment *pSegment)
         uEmptyLine = HANDLE_BLOCKS_PER_SEGMENT;
 
     // store the updated empty line
-    pSegment->bEmptyLine = (BYTE)uEmptyLine;
+    pSegment->bEmptyLine = (uint8_t)uEmptyLine;
 }
 
 /*
@@ -1773,8 +1773,8 @@ BOOL DoesSegmentNeedsToTrimExcessPages(TableSegment *pSegment)
     WRAPPER_NO_CONTRACT;
 
     // fetch the empty and decommit lines
-    UINT uEmptyLine    = pSegment->bEmptyLine;
-    UINT uDecommitLine = pSegment->bDecommitLine;
+    uint32_t uEmptyLine    = pSegment->bEmptyLine;
+    uint32_t uDecommitLine = pSegment->bDecommitLine;
 
     // check to see if we can decommit some handles
     // NOTE: we use '<' here to avoid playing ping-pong on page boundaries
@@ -1782,17 +1782,17 @@ BOOL DoesSegmentNeedsToTrimExcessPages(TableSegment *pSegment)
     if (uEmptyLine < uDecommitLine)
     {
         // derive some useful info about the page size
-        UINT_PTR dwPageRound = (UINT_PTR)g_SystemInfo.dwPageSize - 1;
-        UINT_PTR dwPageMask  = ~dwPageRound;
+        uintptr_t dwPageRound = (uintptr_t)g_SystemInfo.dwPageSize - 1;
+        uintptr_t dwPageMask  = ~dwPageRound;
 
         // compute the address corresponding to the empty line
-        UINT_PTR dwLo = (UINT_PTR)pSegment->rgValue + (uEmptyLine  * HANDLE_BYTES_PER_BLOCK);
+        uintptr_t dwLo = (uintptr_t)pSegment->rgValue + (uEmptyLine  * HANDLE_BYTES_PER_BLOCK);
 
         // adjust the empty line address to the start of the nearest whole empty page
         dwLo = (dwLo + dwPageRound) & dwPageMask;
 
         // compute the address corresponding to the old commit line
-        UINT_PTR dwHi = (UINT_PTR)pSegment->rgValue + ((UINT)pSegment->bCommitLine * HANDLE_BYTES_PER_BLOCK);
+        uintptr_t dwHi = (uintptr_t)pSegment->rgValue + ((uint32_t)pSegment->bCommitLine * HANDLE_BYTES_PER_BLOCK);
 
         // is there anything to decommit?
         if (dwHi > dwLo)
@@ -1817,8 +1817,8 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
     WRAPPER_NO_CONTRACT;
 
     // fetch the empty and decommit lines
-    UINT uEmptyLine    = pSegment->bEmptyLine;
-    UINT uDecommitLine = pSegment->bDecommitLine;
+    uint32_t uEmptyLine    = pSegment->bEmptyLine;
+    uint32_t uDecommitLine = pSegment->bDecommitLine;
 
     // check to see if we can decommit some handles
     // NOTE: we use '<' here to avoid playing ping-pong on page boundaries
@@ -1826,17 +1826,17 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
     if (uEmptyLine < uDecommitLine)
     {
         // derive some useful info about the page size
-        UINT_PTR dwPageRound = (UINT_PTR)g_SystemInfo.dwPageSize - 1;
-        UINT_PTR dwPageMask  = ~dwPageRound;
+        uintptr_t dwPageRound = (uintptr_t)g_SystemInfo.dwPageSize - 1;
+        uintptr_t dwPageMask  = ~dwPageRound;
 
         // compute the address corresponding to the empty line
-        UINT_PTR dwLo = (UINT_PTR)pSegment->rgValue + (uEmptyLine  * HANDLE_BYTES_PER_BLOCK);
+        uintptr_t dwLo = (uintptr_t)pSegment->rgValue + (uEmptyLine  * HANDLE_BYTES_PER_BLOCK);
 
         // adjust the empty line address to the start of the nearest whole empty page
         dwLo = (dwLo + dwPageRound) & dwPageMask;
 
         // compute the address corresponding to the old commit line
-        UINT_PTR dwHi = (UINT_PTR)pSegment->rgValue + ((UINT)pSegment->bCommitLine * HANDLE_BYTES_PER_BLOCK);
+        uintptr_t dwHi = (uintptr_t)pSegment->rgValue + ((uint32_t)pSegment->bCommitLine * HANDLE_BYTES_PER_BLOCK);
 
         // is there anything to decommit?
         if (dwHi > dwLo)
@@ -1845,7 +1845,7 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
             ClrVirtualFree((LPVOID)dwLo, dwHi - dwLo, MEM_DECOMMIT);
 
             // update the commit line
-            pSegment->bCommitLine = (BYTE)((dwLo - (size_t)pSegment->rgValue) / HANDLE_BYTES_PER_BLOCK);
+            pSegment->bCommitLine = (uint8_t)((dwLo - (size_t)pSegment->rgValue) / HANDLE_BYTES_PER_BLOCK);
 
             // compute the address for the new decommit line
             size_t dwDecommitAddr = dwLo - g_SystemInfo.dwPageSize;
@@ -1855,10 +1855,10 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
 
             // if the address is within the handle area then compute the line from the address
             if (dwDecommitAddr > (size_t)pSegment->rgValue)
-                uDecommitLine = (UINT)((dwDecommitAddr - (size_t)pSegment->rgValue) / HANDLE_BYTES_PER_BLOCK);
+                uDecommitLine = (uint32_t)((dwDecommitAddr - (size_t)pSegment->rgValue) / HANDLE_BYTES_PER_BLOCK);
 
             // update the decommit line
-            pSegment->bDecommitLine = (BYTE)uDecommitLine;
+            pSegment->bDecommitLine = (uint8_t)uDecommitLine;
         }
     }
 }
@@ -1873,38 +1873,38 @@ void SegmentTrimExcessPages(TableSegment *pSegment)
  * Returns the number of available handles actually allocated.
  *
  */
-UINT BlockAllocHandlesInMask(TableSegment *pSegment, UINT uBlock,
-                             ULONG32 *pdwMask, UINT uHandleMaskDisplacement,
-                             OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t BlockAllocHandlesInMask(TableSegment *pSegment, uint32_t uBlock,
+                             uint32_t *pdwMask, uint32_t uHandleMaskDisplacement,
+                             OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     LIMITED_METHOD_CONTRACT;
 
     // keep track of how many handles we have left to allocate
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // fetch the free mask into a local so we can play with it
-    ULONG32 dwFree = *pdwMask;
+    uint32_t dwFree = *pdwMask;
 
     // keep track of our displacement within the mask
-    UINT uByteDisplacement = 0;
+    uint32_t uByteDisplacement = 0;
 
     // examine the mask byte by byte for free handles
     do
     {
         // grab the low byte of the mask
-        ULONG32 dwLowByte = (dwFree & MASK_LOBYTE);
+        uint32_t dwLowByte = (dwFree & MASK_LOBYTE);
 
         // are there any free handles here?
         if (dwLowByte)
         {
             // remember which handles we've taken
-            ULONG32 dwAlloc = 0;
+            uint32_t dwAlloc = 0;
 
             // loop until we've allocated all the handles we can from here
             do
             {
                 // get the index of the next handle
-                UINT uIndex = c_rgLowBitIndex[dwLowByte];
+                uint32_t uIndex = c_rgLowBitIndex[dwLowByte];
 
                 // compute the mask for the handle we chose
                 dwAlloc |= (1 << uIndex);
@@ -1949,8 +1949,8 @@ UINT BlockAllocHandlesInMask(TableSegment *pSegment, UINT uBlock,
  * Allocates a specified number of handles from a newly committed (empty) block.
  *
  */
-UINT BlockAllocHandlesInitial(TableSegment *pSegment, UINT uType, UINT uBlock,
-                              OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t BlockAllocHandlesInitial(TableSegment *pSegment, uint32_t uType, uint32_t uBlock,
+                              OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1965,10 +1965,10 @@ UINT BlockAllocHandlesInitial(TableSegment *pSegment, UINT uType, UINT uBlock,
     }
 
     // keep track of how many handles we have left to mark in masks
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // get the first mask for this block
-    ULONG32 *pdwMask = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
+    uint32_t *pdwMask = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
 
     // loop through the masks, zeroing the appropriate free bits
     do
@@ -1977,10 +1977,10 @@ UINT BlockAllocHandlesInitial(TableSegment *pSegment, UINT uType, UINT uBlock,
         _ASSERTE(*pdwMask == MASK_EMPTY);
 
         // pick an initial guess at the number to allocate
-        UINT uAlloc = uRemain;
+        uint32_t uAlloc = uRemain;
 
         // compute the default mask based on that count
-        ULONG32 dwNewMask = (MASK_EMPTY << uAlloc);
+        uint32_t dwNewMask = (MASK_EMPTY << uAlloc);
 
         // are we allocating all of them?
         if (uAlloc >= HANDLE_HANDLES_PER_MASK)
@@ -2029,7 +2029,7 @@ UINT BlockAllocHandlesInitial(TableSegment *pSegment, UINT uType, UINT uBlock,
  * Returns the number of available handles actually allocated.
  *
  */
-UINT BlockAllocHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t BlockAllocHandles(TableSegment *pSegment, uint32_t uBlock, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -2040,14 +2040,14 @@ UINT BlockAllocHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandl
     */
     
     // keep track of how many handles we have left to allocate
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // set up our loop and limit mask pointers
-    ULONG32 *pdwMask     = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
-    ULONG32 *pdwMaskLast = pdwMask + HANDLE_MASKS_PER_BLOCK;
+    uint32_t *pdwMask     = pSegment->rgFreeMask + (uBlock * HANDLE_MASKS_PER_BLOCK);
+    uint32_t *pdwMaskLast = pdwMask + HANDLE_MASKS_PER_BLOCK;
 
     // keep track of the handle displacement for the mask we're scanning
-    UINT uDisplacement = uBlock * HANDLE_HANDLES_PER_BLOCK;
+    uint32_t uDisplacement = uBlock * HANDLE_HANDLES_PER_BLOCK;
 
     // loop through all the masks, allocating handles as we go
     do
@@ -2056,7 +2056,7 @@ UINT BlockAllocHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandl
         if (*pdwMask)
         {
             // allocate as many handles as we need from this mask
-            UINT uSatisfied = BlockAllocHandlesInMask(pSegment, uBlock, pdwMask, uDisplacement, pHandleBase, uRemain);
+            uint32_t uSatisfied = BlockAllocHandlesInMask(pSegment, uBlock, pdwMask, uDisplacement, pHandleBase, uRemain);
 
             // adjust our count and array pointer
             uRemain     -= uSatisfied;
@@ -2088,7 +2088,7 @@ UINT BlockAllocHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandl
  * Returns the number of available handles actually allocated.
  *
  */
-UINT SegmentAllocHandlesFromTypeChain(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t SegmentAllocHandlesFromTypeChain(TableSegment *pSegment, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -2099,7 +2099,7 @@ UINT SegmentAllocHandlesFromTypeChain(TableSegment *pSegment, UINT uType, OBJECT
     */
     
     // fetch the number of handles available in this chain
-    UINT uAvail = pSegment->rgFreeCount[uType];
+    uint32_t uAvail = pSegment->rgFreeCount[uType];
 
     // is the available count greater than the requested count?
     if (uAvail > uCount)
@@ -2117,20 +2117,20 @@ UINT SegmentAllocHandlesFromTypeChain(TableSegment *pSegment, UINT uType, OBJECT
     if (uAvail)
     {
         // yes - fetch the head of the block chain and set up a loop limit
-        UINT uBlock = pSegment->rgHint[uType];
-        UINT uLast = uBlock;
+        uint32_t uBlock = pSegment->rgHint[uType];
+        uint32_t uLast = uBlock;
 
         // loop until we have found all handles known to be available
         for (;;)
         {
             // try to allocate handles from the current block
-            UINT uSatisfied = BlockAllocHandles(pSegment, uBlock, pHandleBase, uAvail);
+            uint32_t uSatisfied = BlockAllocHandles(pSegment, uBlock, pHandleBase, uAvail);
 
             // did we get everything we needed?
             if (uSatisfied == uAvail)
             {
                 // yes - update the hint for this type chain and get out
-                pSegment->rgHint[uType] = (BYTE)uBlock;
+                pSegment->rgHint[uType] = (uint8_t)uBlock;
                 break;
             }
 
@@ -2171,7 +2171,7 @@ UINT SegmentAllocHandlesFromTypeChain(TableSegment *pSegment, UINT uType, OBJECT
  * Returns the number of available handles actually allocated.
  *
  */
-UINT SegmentAllocHandlesFromFreeList(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t SegmentAllocHandlesFromFreeList(TableSegment *pSegment, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2182,20 +2182,20 @@ UINT SegmentAllocHandlesFromFreeList(TableSegment *pSegment, UINT uType, OBJECTH
     */
     
     // keep track of how many handles we have left to allocate
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // loop allocating handles until we are done or we run out of free blocks
     do
     {
         // start off assuming we can allocate all the handles
-        UINT uAlloc = uRemain;
+        uint32_t uAlloc = uRemain;
 
         // we can only get a block-full of handles at a time
         if (uAlloc > HANDLE_HANDLES_PER_BLOCK)
             uAlloc = HANDLE_HANDLES_PER_BLOCK;
 
         // try to get a block from the free list
-        UINT uBlock = SegmentInsertBlockFromFreeList(pSegment, uType, (uRemain == uCount));
+        uint32_t uBlock = SegmentInsertBlockFromFreeList(pSegment, uType, (uRemain == uCount));
 
         // if there are no free blocks left then we are done
         if (uBlock == BLOCK_INVALID)
@@ -2230,7 +2230,7 @@ UINT SegmentAllocHandlesFromFreeList(TableSegment *pSegment, UINT uType, OBJECTH
  * Returns the number of available handles actually allocated.
  *
  */
-UINT SegmentAllocHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t SegmentAllocHandles(TableSegment *pSegment, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2241,7 +2241,7 @@ UINT SegmentAllocHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHand
     */
     
     // first try to get some handles from the existing type chain
-    UINT uSatisfied = SegmentAllocHandlesFromTypeChain(pSegment, uType, pHandleBase, uCount);
+    uint32_t uSatisfied = SegmentAllocHandlesFromTypeChain(pSegment, uType, pHandleBase, uCount);
 
     // if there are still slots to be filled then we need to commit more blocks to the type chain
     if (uSatisfied < uCount)
@@ -2269,7 +2269,7 @@ UINT SegmentAllocHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHand
  * in which case it is the number of handles that were successfully allocated.
  *
  */
-UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t TableAllocBulkHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -2280,18 +2280,18 @@ UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandl
     */
     
     // keep track of how many handles we have left to allocate
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // start with the first segment and loop until we are done
     TableSegment *pSegment = pTable->pSegmentList;
 
-    BYTE bLastSequence = 0;
+    uint8_t bLastSequence = 0;
     BOOL fNewSegment = FALSE;
 
     for (;;)
     {
         // get some handles from the current segment
-        UINT uSatisfied = SegmentAllocHandles(pSegment, uType, pHandleBase, uRemain);
+        uint32_t uSatisfied = SegmentAllocHandles(pSegment, uType, pHandleBase, uRemain);
 
         // adjust our count and array pointer
         uRemain     -= uSatisfied;
@@ -2328,7 +2328,7 @@ UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandl
             }
 
             // set up the correct sequence number for the new segment
-            pNextSegment->bSequence = (BYTE)(((UINT)bLastSequence + 1) % 0x100);
+            pNextSegment->bSequence = (uint8_t)(((uint32_t)bLastSequence + 1) % 0x100);
             bLastSequence = pNextSegment->bSequence;
 
             // link the new segment into the list by the order of segment address
@@ -2363,7 +2363,7 @@ UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandl
     }
 
     // compute the number of handles we actually got
-    UINT uAllocated = (uCount - uRemain);
+    uint32_t uAllocated = (uCount - uRemain);
 
     // update the count of handles marked as "used"
     pTable->dwCount += uAllocated;
@@ -2383,13 +2383,13 @@ UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandl
  * Returns the number of handles that were freed from the front of the array.
  *
  */
-UINT BlockFreeHandlesInMask(TableSegment *pSegment, UINT uBlock, UINT uMask, OBJECTHANDLE *pHandleBase, UINT uCount,
-                            LPARAM *pUserData, UINT *puActualFreed, BOOL *pfAllMasksFree)
+uint32_t BlockFreeHandlesInMask(TableSegment *pSegment, uint32_t uBlock, uint32_t uMask, OBJECTHANDLE *pHandleBase, uint32_t uCount,
+                            LPARAM *pUserData, uint32_t *puActualFreed, BOOL *pfAllMasksFree)
 {
     LIMITED_METHOD_CONTRACT;
 
     // keep track of how many handles we have left to free
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
 #ifdef _PREFAST_
 #pragma warning(push)
@@ -2412,10 +2412,10 @@ UINT BlockFreeHandlesInMask(TableSegment *pSegment, UINT uBlock, UINT uMask, OBJ
 #endif
 
     // keep a local copy of the free mask to update as we free handles
-    ULONG32 dwFreeMask = pSegment->rgFreeMask[uMask];
+    uint32_t dwFreeMask = pSegment->rgFreeMask[uMask];
 
     // keep track of how many bogus frees we are asked to do
-    UINT uBogus = 0;
+    uint32_t uBogus = 0;
 
     // loop freeing handles until we encounter one outside our block or there are none left
     do
@@ -2431,14 +2431,14 @@ UINT BlockFreeHandlesInMask(TableSegment *pSegment, UINT uBlock, UINT uMask, OBJ
         _ASSERTE(HndIsNullOrDestroyedHandle(*(_UNCHECKED_OBJECTREF *)handle));
 
         // compute the handle index within the mask
-        UINT uHandle = (UINT)(handle - firstHandle);
+        uint32_t uHandle = (uint32_t)(handle - firstHandle);
 
         // if there is user data then clear the user data for this handle
         if (pUserData)
             pUserData[uHandle] = 0L;
 
         // compute the mask bit for this handle
-        ULONG32 dwFreeBit = (1 << uHandle);
+        uint32_t dwFreeBit = (1 << uHandle);
 
         // the handle should not already be free
         if ((dwFreeMask & dwFreeBit) != 0)
@@ -2465,7 +2465,7 @@ UINT BlockFreeHandlesInMask(TableSegment *pSegment, UINT uBlock, UINT uMask, OBJ
         *pfAllMasksFree = FALSE;
 
     // compute the number of handles we processed from the array
-    UINT uFreed = (uCount - uRemain);
+    uint32_t uFreed = (uCount - uRemain);
 
     // tell the caller how many handles we actually freed
     *puActualFreed += (uFreed - uBogus);
@@ -2485,8 +2485,8 @@ UINT BlockFreeHandlesInMask(TableSegment *pSegment, UINT uBlock, UINT uMask, OBJ
  * Returns the number of handles that were freed from the front of the array.
  *
  */
-UINT BlockFreeHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandleBase, UINT uCount,
-                      UINT *puActualFreed, BOOL *pfScanForFreeBlocks)
+uint32_t BlockFreeHandles(TableSegment *pSegment, uint32_t uBlock, OBJECTHANDLE *pHandleBase, uint32_t uCount,
+                      uint32_t *puActualFreed, BOOL *pfScanForFreeBlocks)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -2497,7 +2497,7 @@ UINT BlockFreeHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandle
     */
     
     // keep track of how many handles we have left to free
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // fetch the user data for this block, if any
     LPARAM *pBlockUserData = BlockFetchUserDataPointer(pSegment, uBlock, FALSE);
@@ -2520,10 +2520,10 @@ UINT BlockFreeHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandle
             break;
 
         // compute the mask that this handle resides in
-        UINT uMask = (UINT)((handle - firstHandle) / HANDLE_HANDLES_PER_MASK);
+        uint32_t uMask = (uint32_t)((handle - firstHandle) / HANDLE_HANDLES_PER_MASK);
 
         // free as many handles as this mask owns from the front of the array
-        UINT uFreed = BlockFreeHandlesInMask(pSegment, uBlock, uMask, pHandleBase, uRemain,
+        uint32_t uFreed = BlockFreeHandlesInMask(pSegment, uBlock, uMask, pHandleBase, uRemain,
                                              pBlockUserData, puActualFreed, &fAllMasksWeTouchedAreFree);
 
         // adjust our count and array pointer
@@ -2558,7 +2558,7 @@ UINT BlockFreeHandles(TableSegment *pSegment, UINT uBlock, OBJECTHANDLE *pHandle
  * Returns the number of handles that were freed from the front of the array.
  *
  */
-UINT SegmentFreeHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount)
+uint32_t SegmentFreeHandles(TableSegment *pSegment, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -2569,7 +2569,7 @@ UINT SegmentFreeHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandl
     */
     
     // keep track of how many handles we have left to free
-    UINT uRemain = uCount;
+    uint32_t uRemain = uCount;
 
     // compute the handle bounds for our segment
     OBJECTHANDLE firstHandle = (OBJECTHANDLE)pSegment->rgValue;
@@ -2579,7 +2579,7 @@ UINT SegmentFreeHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandl
     BOOL fScanForFreeBlocks = FALSE;
 
     // track the number of handles we actually free
-    UINT uActualFreed = 0;
+    uint32_t uActualFreed = 0;
 
     // loop freeing handles until we encounter one outside our segment or there are none left
     do
@@ -2592,13 +2592,13 @@ UINT SegmentFreeHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandl
             break;
 
         // compute the block that this handle resides in
-        UINT uBlock = (UINT)(((UINT_PTR)handle - (UINT_PTR)firstHandle) / (HANDLE_SIZE * HANDLE_HANDLES_PER_BLOCK));
+        uint32_t uBlock = (uint32_t)(((uintptr_t)handle - (uintptr_t)firstHandle) / (HANDLE_SIZE * HANDLE_HANDLES_PER_BLOCK));
 
         // sanity check that this block is the type we expect to be freeing
         _ASSERTE(pSegment->rgBlockType[uBlock] == uType);
 
         // free as many handles as this block owns from the front of the array
-        UINT uFreed = BlockFreeHandles(pSegment, uBlock, pHandleBase, uRemain, &uActualFreed, &fScanForFreeBlocks);
+        uint32_t uFreed = BlockFreeHandles(pSegment, uBlock, pHandleBase, uRemain, &uActualFreed, &fScanForFreeBlocks);
 
         // adjust our count and array pointer
         uRemain     -= uFreed;
@@ -2607,7 +2607,7 @@ UINT SegmentFreeHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandl
     } while (uRemain);
 
     // compute the number of handles we actually freed
-    UINT uFreed = (uCount - uRemain);
+    uint32_t uFreed = (uCount - uRemain);
 
     // update the free count
     pSegment->rgFreeCount[uType] += uActualFreed;
@@ -2643,7 +2643,7 @@ UINT SegmentFreeHandles(TableSegment *pSegment, UINT uType, OBJECTHANDLE *pHandl
  * This routine is optimized for a sorted array of handles but will accept any order.
  *
  */
-void TableFreeBulkPreparedHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount)
+void TableFreeBulkPreparedHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     //Update the count of handles marked as "used"
     pTable->dwCount -= uCount;
@@ -2666,7 +2666,7 @@ void TableFreeBulkPreparedHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE 
         _ASSERTE(pSegment->pHandleTable == pTable);
 
         // free as many handles as this segment owns from the front of the array
-        UINT uFreed = SegmentFreeHandles(pSegment, uType, pHandleBase, uCount);
+        uint32_t uFreed = SegmentFreeHandles(pSegment, uType, pHandleBase, uCount);
 
         // adjust our count and array pointer
         uCount      -= uFreed;
@@ -2683,7 +2683,7 @@ void TableFreeBulkPreparedHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE 
  * Uses the supplied scratch buffer to prepare the handles.
  *
  */
-void TableFreeBulkUnpreparedHandlesWorker(HandleTable *pTable, UINT uType, const OBJECTHANDLE *pHandles, UINT uCount,
+void TableFreeBulkUnpreparedHandlesWorker(HandleTable *pTable, uint32_t uType, const OBJECTHANDLE *pHandles, uint32_t uCount,
                                           OBJECTHANDLE *pScratchBuffer)
 {
     WRAPPER_NO_CONTRACT;
@@ -2692,7 +2692,7 @@ void TableFreeBulkUnpreparedHandlesWorker(HandleTable *pTable, UINT uType, const
     memcpy(pScratchBuffer, pHandles, uCount * sizeof(OBJECTHANDLE));
  
     // sort them for optimal free order
-    QuickSort((UINT_PTR *)pScratchBuffer, 0, uCount - 1, CompareHandlesByFreeOrder);
+    QuickSort((uintptr_t *)pScratchBuffer, 0, uCount - 1, CompareHandlesByFreeOrder);
  
     // make sure the handles are zeroed too
     ZeroHandles(pScratchBuffer, uCount);
@@ -2709,7 +2709,7 @@ void TableFreeBulkUnpreparedHandlesWorker(HandleTable *pTable, UINT uType, const
  * TableFreeBulkPreparedHandlesWorker one or more times.
  *
  */
-void TableFreeBulkUnpreparedHandles(HandleTable *pTable, UINT uType, const OBJECTHANDLE *pHandles, UINT uCount)
+void TableFreeBulkUnpreparedHandles(HandleTable *pTable, uint32_t uType, const OBJECTHANDLE *pHandles, uint32_t uCount)
 {
     CONTRACTL
     {
@@ -2723,7 +2723,7 @@ void TableFreeBulkUnpreparedHandles(HandleTable *pTable, UINT uType, const OBJEC
     OBJECTHANDLE rgStackHandles[HANDLE_HANDLES_PER_BLOCK];
     OBJECTHANDLE *pScratchBuffer  = rgStackHandles;
     OBJECTHANDLE *pLargeScratchBuffer  = NULL;
-    UINT         uFreeGranularity = _countof(rgStackHandles);
+    uint32_t     uFreeGranularity = _countof(rgStackHandles);
  
     // if there are more handles than we can put on the stack then try to allocate a sorting buffer
     if (uCount > uFreeGranularity)

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -1679,7 +1679,7 @@ void SegmentResortChains(TableSegment *pSegment)
     BOOL fContiguousWithFreeList = TRUE;
 
     // preinit the chain data to no blocks
-	uint32_t uType;
+    uint32_t uType;
     for (uType = 0; uType < HANDLE_MAX_INTERNAL_TYPES; uType++)
         rgChainHigh[uType] = rgChainCurr[uType] = BLOCK_INVALID;
 
@@ -1950,7 +1950,7 @@ uint32_t BlockAllocHandlesInMask(TableSegment *pSegment, uint32_t uBlock,
  *
  */
 uint32_t BlockAllocHandlesInitial(TableSegment *pSegment, uint32_t uType, uint32_t uBlock,
-                              OBJECTHANDLE *pHandleBase, uint32_t uCount)
+                                  OBJECTHANDLE *pHandleBase, uint32_t uCount)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2384,7 +2384,7 @@ uint32_t TableAllocBulkHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE
  *
  */
 uint32_t BlockFreeHandlesInMask(TableSegment *pSegment, uint32_t uBlock, uint32_t uMask, OBJECTHANDLE *pHandleBase, uint32_t uCount,
-                            uintptr_t *pUserData, uint32_t *puActualFreed, BOOL *pfAllMasksFree)
+                                uintptr_t *pUserData, uint32_t *puActualFreed, BOOL *pfAllMasksFree)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2486,7 +2486,7 @@ uint32_t BlockFreeHandlesInMask(TableSegment *pSegment, uint32_t uBlock, uint32_
  *
  */
 uint32_t BlockFreeHandles(TableSegment *pSegment, uint32_t uBlock, OBJECTHANDLE *pHandleBase, uint32_t uCount,
-                      uint32_t *puActualFreed, BOOL *pfScanForFreeBlocks)
+                          uint32_t *puActualFreed, BOOL *pfScanForFreeBlocks)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/src/gc/handletablecore.cpp
+++ b/src/gc/handletablecore.cpp
@@ -266,12 +266,12 @@ BOOL TableCanFreeSegmentNow(HandleTable *pTable, TableSegment *pSegment)
  * Gets the user data pointer for the first handle in a block.
  *
  */
-PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t uBlock, BOOL fAssertOnError)
+PTR_uintptr_t BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t uBlock, BOOL fAssertOnError)
 {
     LIMITED_METHOD_DAC_CONTRACT;
 
     // assume NULL until we actually find the data
-    PTR_LPARAM pUserData = NULL;
+    PTR_uintptr_t pUserData = NULL;
     // get the user data index for this block
     uint32_t blockIndex = pSegment->rgUserData[uBlock];
 
@@ -280,7 +280,7 @@ PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t 
     {
         // In DAC builds, we may not have the entire segment table mapped and in any case it will be quite
         // large. Since we only need one element, we'll retrieve just that one element.  
-        pUserData = PTR_LPARAM(PTR_TO_TADDR(pSegment) + offsetof(TableSegment, rgValue) + 
+        pUserData = PTR_uintptr_t(PTR_TO_TADDR(pSegment) + offsetof(TableSegment, rgValue) + 
                                (blockIndex * HANDLE_BYTES_PER_BLOCK));
     }
     else if (fAssertOnError)
@@ -328,7 +328,7 @@ __inline PTR__TableSegmentHeader HandleFetchSegmentPointer(OBJECTHANDLE handle)
  * ASSERTs and returns NULL if handle is not of the expected type.
  *
  */
-LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTypeExpected)
+uintptr_t *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTypeExpected)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -348,7 +348,7 @@ LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTyp
     uint32_t uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
 
     // fetch the user data for this block
-    PTR_LPARAM pUserData = BlockFetchUserDataPointer(pSegment, uBlock, TRUE);
+    PTR_uintptr_t pUserData = BlockFetchUserDataPointer(pSegment, uBlock, TRUE);
 
     // did we get the user data block?
     if (pUserData)
@@ -378,7 +378,7 @@ LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTyp
  * Less validation is performed.
  *
  */
-PTR_LPARAM HandleQuickFetchUserDataPointer(OBJECTHANDLE handle)
+PTR_uintptr_t HandleQuickFetchUserDataPointer(OBJECTHANDLE handle)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -405,7 +405,7 @@ PTR_LPARAM HandleQuickFetchUserDataPointer(OBJECTHANDLE handle)
     uint32_t uBlock = uHandle / HANDLE_HANDLES_PER_BLOCK;
 
     // fetch the user data for this block
-    PTR_LPARAM pUserData = BlockFetchUserDataPointer(pSegment, uBlock, TRUE);
+    PTR_uintptr_t pUserData = BlockFetchUserDataPointer(pSegment, uBlock, TRUE);
 
     // if we got the user data block then adjust the pointer to be handle-specific
     if (pUserData)
@@ -422,7 +422,7 @@ PTR_LPARAM HandleQuickFetchUserDataPointer(OBJECTHANDLE handle)
  * Stores user data with a handle.
  *
  */
-void HandleQuickSetUserData(OBJECTHANDLE handle, LPARAM lUserData)
+void HandleQuickSetUserData(OBJECTHANDLE handle, uintptr_t lUserData)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -433,7 +433,7 @@ void HandleQuickSetUserData(OBJECTHANDLE handle, LPARAM lUserData)
     */
     
     // fetch the user data slot for this handle
-    LPARAM *pUserData = HandleQuickFetchUserDataPointer(handle);
+    uintptr_t *pUserData = HandleQuickFetchUserDataPointer(handle);
 
     // is there a slot?
     if (pUserData)
@@ -2333,7 +2333,7 @@ uint32_t TableAllocBulkHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE
 
             // link the new segment into the list by the order of segment address
             TableSegment* pWalk = pTable->pSegmentList;
-            if ((ULONG_PTR)pNextSegment < (ULONG_PTR)pWalk)
+            if ((uintptr_t)pNextSegment < (uintptr_t)pWalk)
             {
                 pNextSegment->pNextSegment = pWalk;
                 pTable->pSegmentList = pNextSegment;
@@ -2347,7 +2347,7 @@ uint32_t TableAllocBulkHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE
                         pWalk->pNextSegment = pNextSegment;
                         break;
                     }
-                    else if ((ULONG_PTR)pWalk->pNextSegment > (ULONG_PTR)pNextSegment)
+                    else if ((uintptr_t)pWalk->pNextSegment > (uintptr_t)pNextSegment)
                     {
                         pNextSegment->pNextSegment = pWalk->pNextSegment;
                         pWalk->pNextSegment = pNextSegment;
@@ -2384,7 +2384,7 @@ uint32_t TableAllocBulkHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE
  *
  */
 uint32_t BlockFreeHandlesInMask(TableSegment *pSegment, uint32_t uBlock, uint32_t uMask, OBJECTHANDLE *pHandleBase, uint32_t uCount,
-                            LPARAM *pUserData, uint32_t *puActualFreed, BOOL *pfAllMasksFree)
+                            uintptr_t *pUserData, uint32_t *puActualFreed, BOOL *pfAllMasksFree)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -2500,7 +2500,7 @@ uint32_t BlockFreeHandles(TableSegment *pSegment, uint32_t uBlock, OBJECTHANDLE 
     uint32_t uRemain = uCount;
 
     // fetch the user data for this block, if any
-    LPARAM *pBlockUserData = BlockFetchUserDataPointer(pSegment, uBlock, FALSE);
+    uintptr_t *pBlockUserData = BlockFetchUserDataPointer(pSegment, uBlock, FALSE);
 
     // compute the handle bounds for our block
     OBJECTHANDLE firstHandle = (OBJECTHANDLE)(pSegment->rgValue + (uBlock * HANDLE_HANDLES_PER_BLOCK));

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -90,7 +90,7 @@
 #define HANDLE_CLUMPS_PER_SEGMENT       (HANDLE_HANDLES_PER_SEGMENT / HANDLE_HANDLES_PER_CLUMP)
 #define HANDLE_CLUMPS_PER_BLOCK         (HANDLE_HANDLES_PER_BLOCK / HANDLE_HANDLES_PER_CLUMP)
 #define HANDLE_BYTES_PER_BLOCK          (HANDLE_HANDLES_PER_BLOCK * HANDLE_SIZE)
-#define HANDLE_HANDLES_PER_MASK         (sizeof(ULONG32) * BITS_PER_BYTE)
+#define HANDLE_HANDLES_PER_MASK         (sizeof(uint32_t) * BITS_PER_BYTE)
 #define HANDLE_MASKS_PER_SEGMENT        (HANDLE_HANDLES_PER_SEGMENT / HANDLE_HANDLES_PER_MASK)
 #define HANDLE_MASKS_PER_BLOCK          (HANDLE_HANDLES_PER_BLOCK / HANDLE_HANDLES_PER_MASK)
 #define HANDLE_CLUMPS_PER_MASK          (HANDLE_HANDLES_PER_MASK / HANDLE_HANDLES_PER_CLUMP)
@@ -115,8 +115,8 @@ C_ASSERT (HANDLE_HANDLES_PER_MASK * 2 == HANDLE_HANDLES_PER_BLOCK);
 #define MASK_FULL                       (0)
 #define MASK_EMPTY                      (0xFFFFFFFF)
 #define MASK_LOBYTE                     (0x000000FF)
-#define TYPE_INVALID                    ((BYTE)0xFF)
-#define BLOCK_INVALID                   ((BYTE)0xFF)
+#define TYPE_INVALID                    ((uint8_t)0xFF)
+#define BLOCK_INVALID                   ((uint8_t)0xFF)
 
 /*--------------------------------------------------------------------------*/
 
@@ -148,39 +148,39 @@ struct _TableSegmentHeader
      * The value of the byte corresponds to the lowest possible generation that a
      * handle in that clump could point into.
      *
-     * WARNING: Although this array is logically organized as a BYTE[], it is sometimes
-     *  accessed as ULONG32[] when processing bytes in parallel.  Code which treats the
+     * WARNING: Although this array is logically organized as a uint8_t[], it is sometimes
+     *  accessed as uint32_t[] when processing bytes in parallel.  Code which treats the
      *  array as an array of ULONG32s must handle big/little endian issues itself.
      */
-    BYTE rgGeneration[HANDLE_BLOCKS_PER_SEGMENT * sizeof(ULONG32) / sizeof(BYTE)];
+    uint8_t rgGeneration[HANDLE_BLOCKS_PER_SEGMENT * sizeof(uint32_t) / sizeof(uint8_t)];
 
     /*
      * Block Allocation Chains
      *
      * Each slot indexes the next block in an allocation chain.
      */
-    BYTE rgAllocation[HANDLE_BLOCKS_PER_SEGMENT];
+    uint8_t rgAllocation[HANDLE_BLOCKS_PER_SEGMENT];
 
     /*
      * Block Free Masks
      *
      * Masks - 1 bit for every handle in the segment.
      */
-    ULONG32 rgFreeMask[HANDLE_MASKS_PER_SEGMENT];
+    uint32_t rgFreeMask[HANDLE_MASKS_PER_SEGMENT];
 
     /*
      * Block Handle Types
      *
      * Each slot holds the handle type of the associated block.
      */
-    BYTE rgBlockType[HANDLE_BLOCKS_PER_SEGMENT];
+    uint8_t rgBlockType[HANDLE_BLOCKS_PER_SEGMENT];
 
     /*
      * Block User Data Map
      *
      * Each slot holds the index of a user data block (if any) for the associated block.
      */
-    BYTE rgUserData[HANDLE_BLOCKS_PER_SEGMENT];
+    uint8_t rgUserData[HANDLE_BLOCKS_PER_SEGMENT];
 
     /*
      * Block Lock Count
@@ -188,28 +188,28 @@ struct _TableSegmentHeader
      * Each slot holds a lock count for its associated block.
      * Locked blocks are not freed, even when empty.
      */
-    BYTE rgLocks[HANDLE_BLOCKS_PER_SEGMENT];
+    uint8_t rgLocks[HANDLE_BLOCKS_PER_SEGMENT];
 
     /*
      * Allocation Chain Tails
      *
      * Each slot holds the tail block index for an allocation chain.
      */
-    BYTE rgTail[HANDLE_MAX_INTERNAL_TYPES];
+    uint8_t rgTail[HANDLE_MAX_INTERNAL_TYPES];
 
     /*
      * Allocation Chain Hints
      *
      * Each slot holds a hint block index for an allocation chain.
      */
-    BYTE rgHint[HANDLE_MAX_INTERNAL_TYPES];
+    uint8_t rgHint[HANDLE_MAX_INTERNAL_TYPES];
 
     /*
      * Free Count
      *
      * Each slot holds the number of free handles in an allocation chain.
      */
-    UINT rgFreeCount[HANDLE_MAX_INTERNAL_TYPES];
+    uint32_t rgFreeCount[HANDLE_MAX_INTERNAL_TYPES];
 
     /*
      * Next Segment
@@ -232,44 +232,44 @@ struct _TableSegmentHeader
     /*
      * Flags
      */
-    BYTE fResortChains      : 1;    // allocation chains need sorting
-    BYTE fNeedsScavenging   : 1;    // free blocks need scavenging
-    BYTE _fUnused           : 6;    // unused
+    uint8_t fResortChains      : 1;    // allocation chains need sorting
+    uint8_t fNeedsScavenging   : 1;    // free blocks need scavenging
+    uint8_t _fUnused           : 6;    // unused
 
     /*
      * Free List Head
      *
      * Index of the first free block in the segment.
      */
-    BYTE bFreeList;
+    uint8_t bFreeList;
 
     /*
      * Empty Line
      *
      * Index of the first KNOWN block of the last group of unused blocks in the segment.
      */
-    BYTE bEmptyLine;
+    uint8_t bEmptyLine;
 
     /*
      * Commit Line
      *
      * Index of the first uncommited block in the segment.
      */
-    BYTE bCommitLine;
+    uint8_t bCommitLine;
 
     /*
      * Decommit Line
      *
      * Index of the first block in the highest committed page of the segment.
      */
-    BYTE bDecommitLine;
+    uint8_t bDecommitLine;
 
     /*
      * Sequence
      *
      * Indicates the segment sequence number.
      */
-    BYTE bSequence;
+    uint8_t bSequence;
 };
 
 typedef DPTR(struct _TableSegmentHeader) PTR__TableSegmentHeader;
@@ -288,7 +288,7 @@ struct TableSegment : public _TableSegmentHeader
     /*
      * Filler
      */
-    BYTE rgUnused[HANDLE_HEADER_SIZE - sizeof(_TableSegmentHeader)];
+    uint8_t rgUnused[HANDLE_HEADER_SIZE - sizeof(_TableSegmentHeader)];
 
     /*
      * Handles
@@ -296,7 +296,7 @@ struct TableSegment : public _TableSegmentHeader
     _UNCHECKED_OBJECTREF rgValue[HANDLE_HANDLES_PER_SEGMENT];
     
 #ifdef DACCESS_COMPILE
-    static ULONG32 DacSize(TADDR addr);
+    static uint32_t DacSize(TADDR addr);
 #endif
 };
 
@@ -362,18 +362,18 @@ struct HandleTypeCache
 struct ScanCallbackInfo
 {
     PTR_TableSegment pCurrentSegment;   // segment we are presently scanning, if any
-    UINT             uFlags;            // HNDGCF_* flags
+    uint32_t         uFlags;            // HNDGCF_* flags
     BOOL             fEnumUserData;     // whether user data is being enumerated as well
     HANDLESCANPROC   pfnScan;           // per-handle scan callback
     LPARAM           param1;            // callback param 1
     LPARAM           param2;            // callback param 2
-    ULONG32          dwAgeMask;         // generation mask for ephemeral GCs
+    uint32_t         dwAgeMask;         // generation mask for ephemeral GCs
 
 #ifdef _DEBUG
-    UINT DEBUG_BlocksScanned;
-    UINT DEBUG_BlocksScannedNonTrivially;
-    UINT DEBUG_HandleSlotsScanned;
-    UINT DEBUG_HandlesActuallyScanned;
+    uint32_t DEBUG_BlocksScanned;
+    uint32_t DEBUG_BlocksScannedNonTrivially;
+    uint32_t DEBUG_HandleSlotsScanned;
+    uint32_t DEBUG_HandlesActuallyScanned;
 #endif
 };
 
@@ -384,7 +384,7 @@ struct ScanCallbackInfo
  * Prototype for callbacks that implement per-block scanning logic.
  *
  */
-typedef void (CALLBACK *BLOCKSCANPROC)(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+typedef void (CALLBACK *BLOCKSCANPROC)(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -403,7 +403,7 @@ typedef PTR_TableSegment (CALLBACK *SEGMENTITERATOR)(PTR_HandleTable pTable, PTR
  *
  */
 typedef void (CALLBACK *TABLESCANPROC)(PTR_HandleTable pTable,
-                                       const UINT *puType, UINT uTypeCount,
+                                       const uint32_t *puType, uint32_t uTypeCount,
                                        SEGMENTITERATOR pfnSegmentIterator,
                                        BLOCKSCANPROC pfnBlockHandler,
                                        ScanCallbackInfo *pInfo,
@@ -480,7 +480,7 @@ struct HandleTable
      *
      * N.B. this is at offset 0 due to frequent access by cache free codepath
      */
-    UINT rgTypeFlags[HANDLE_MAX_INTERNAL_TYPES];
+    uint32_t rgTypeFlags[HANDLE_MAX_INTERNAL_TYPES];
 
     /*
      * lock for this table
@@ -490,13 +490,13 @@ struct HandleTable
     /*
      * number of types this table supports
      */
-    UINT uTypeCount;
+    uint32_t uTypeCount;
 
     /*
      * number of handles owned by this table that are marked as "used"
      * (this includes the handles residing in rgMainCache and rgQuickCache)
      */
-    DWORD dwCount;
+    uint32_t dwCount;
 
     /*
      * head of segment list for this table
@@ -511,7 +511,7 @@ struct HandleTable
     /*
      * per-table user info
      */
-    UINT uTableIndex;
+    uint32_t uTableIndex;
 
     /*
      * per-table AppDomain info
@@ -528,10 +528,10 @@ struct HandleTable
      */
 #ifdef _DEBUG
     int     _DEBUG_iMaxGen;
-    INT64   _DEBUG_TotalBlocksScanned            [MAXSTATGEN];
-    INT64   _DEBUG_TotalBlocksScannedNonTrivially[MAXSTATGEN];
-    INT64   _DEBUG_TotalHandleSlotsScanned       [MAXSTATGEN];
-    INT64   _DEBUG_TotalHandlesActuallyScanned   [MAXSTATGEN];
+    int64_t _DEBUG_TotalBlocksScanned            [MAXSTATGEN];
+    int64_t _DEBUG_TotalBlocksScannedNonTrivially[MAXSTATGEN];
+    int64_t _DEBUG_TotalHandleSlotsScanned       [MAXSTATGEN];
+    int64_t _DEBUG_TotalHandlesActuallyScanned   [MAXSTATGEN];
 #endif
 
     /*
@@ -560,7 +560,7 @@ struct HandleTable
  * @TODO: move/merge into common util file
  *</TODO>
  */
-typedef int (*PFNCOMPARE)(UINT_PTR p, UINT_PTR q);
+typedef int (*PFNCOMPARE)(uintptr_t p, uintptr_t q);
 
 
 /*
@@ -569,7 +569,7 @@ typedef int (*PFNCOMPARE)(UINT_PTR p, UINT_PTR q);
  * @TODO: move/merge into common util file
  *</TODO>
  */
-void QuickSort(UINT_PTR *pData, int left, int right, PFNCOMPARE pfnCompare);
+void QuickSort(uintptr_t *pData, int left, int right, PFNCOMPARE pfnCompare);
 
 
 /*
@@ -581,7 +581,7 @@ void QuickSort(UINT_PTR *pData, int left, int right, PFNCOMPARE pfnCompare);
  *  >0 - handle Q should be freed before handle P
  *
  */
-int CompareHandlesByFreeOrder(UINT_PTR p, UINT_PTR q);
+int CompareHandlesByFreeOrder(uintptr_t p, uintptr_t q);
 
 /*--------------------------------------------------------------------------*/
 
@@ -599,7 +599,7 @@ int CompareHandlesByFreeOrder(UINT_PTR p, UINT_PTR q);
  * Determines whether a given handle type has user data.
  *
  */
-__inline BOOL TypeHasUserData(HandleTable *pTable, UINT uType)
+__inline BOOL TypeHasUserData(HandleTable *pTable, uint32_t uType)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -626,7 +626,7 @@ BOOL TableCanFreeSegmentNow(HandleTable *pTable, TableSegment *pSegment);
  * Determines if the lock count for the specified block is currently non-zero.
  *
  */
-__inline BOOL BlockIsLocked(TableSegment *pSegment, UINT uBlock)
+__inline BOOL BlockIsLocked(TableSegment *pSegment, uint32_t uBlock)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -644,12 +644,12 @@ __inline BOOL BlockIsLocked(TableSegment *pSegment, UINT uBlock)
  * Increases the lock count for a block.
  *
  */
-__inline void BlockLock(TableSegment *pSegment, UINT uBlock)
+__inline void BlockLock(TableSegment *pSegment, uint32_t uBlock)
 {
     LIMITED_METHOD_CONTRACT;
 
     // fetch the old lock count
-    BYTE bLocks = pSegment->rgLocks[uBlock];
+    uint8_t bLocks = pSegment->rgLocks[uBlock];
 
     // assert if we are about to trash the count
     _ASSERTE(bLocks < 0xFF);
@@ -665,12 +665,12 @@ __inline void BlockLock(TableSegment *pSegment, UINT uBlock)
  * Decreases the lock count for a block.
  *
  */
-__inline void BlockUnlock(TableSegment *pSegment, UINT uBlock)
+__inline void BlockUnlock(TableSegment *pSegment, uint32_t uBlock)
 {
     LIMITED_METHOD_CONTRACT;
 
     // fetch the old lock count
-    BYTE bLocks = pSegment->rgLocks[uBlock];
+    uint8_t bLocks = pSegment->rgLocks[uBlock];
 
     // assert if we are about to trash the count
     _ASSERTE(bLocks > 0);
@@ -686,7 +686,7 @@ __inline void BlockUnlock(TableSegment *pSegment, UINT uBlock)
  * Gets the user data pointer for the first handle in a block.
  *
  */
-PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, UINT uBlock, BOOL fAssertOnError);
+PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t uBlock, BOOL fAssertOnError);
 
 
 /*
@@ -696,7 +696,7 @@ PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, UINT uBlo
  * ASSERTs and returns NULL if handle is not of the expected type.
  *
  */
-LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, UINT uTypeExpected);
+LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTypeExpected);
 
 
 /*
@@ -725,7 +725,7 @@ void HandleQuickSetUserData(OBJECTHANDLE handle, LPARAM lUserData);
  * Computes the type index for a given handle.
  *
  */
-UINT HandleFetchType(OBJECTHANDLE handle);
+uint32_t HandleFetchType(OBJECTHANDLE handle);
 
 
 /*
@@ -782,7 +782,7 @@ BOOL TableContainHandle(HandleTable *pTable, OBJECTHANDLE handle);
  * the segment's free list.
  *
  */
-void SegmentRemoveFreeBlocks(TableSegment *pSegment, UINT uType);
+void SegmentRemoveFreeBlocks(TableSegment *pSegment, uint32_t uType);
 
 
 /*
@@ -823,7 +823,7 @@ void SegmentTrimExcessPages(TableSegment *pSegment);
  * in which case it is the number of handles that were successfully allocated.
  *
  */
-UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount);
+uint32_t TableAllocBulkHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount);
 
 
 /*
@@ -834,7 +834,7 @@ UINT TableAllocBulkHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandl
  * This routine is optimized for a sorted array of handles but will accept any order.
  *
  */
-void TableFreeBulkPreparedHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount);
+void TableFreeBulkPreparedHandles(HandleTable *pTable, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount);
 
 
 /*
@@ -843,7 +843,7 @@ void TableFreeBulkPreparedHandles(HandleTable *pTable, UINT uType, OBJECTHANDLE 
  * Frees an array of handles of the specified type by preparing them and calling TableFreeBulkPreparedHandles.
  *
  */
-void TableFreeBulkUnpreparedHandles(HandleTable *pTable, UINT uType, const OBJECTHANDLE *pHandles, UINT uCount);
+void TableFreeBulkUnpreparedHandles(HandleTable *pTable, uint32_t uType, const OBJECTHANDLE *pHandles, uint32_t uCount);
 
 /*--------------------------------------------------------------------------*/
 
@@ -863,7 +863,7 @@ void TableFreeBulkUnpreparedHandles(HandleTable *pTable, UINT uType, const OBJEC
  * reserve cache is empty, this routine calls TableCacheMissOnAlloc.
  *
  */
-OBJECTHANDLE TableAllocSingleHandleFromCache(HandleTable *pTable, UINT uType);
+OBJECTHANDLE TableAllocSingleHandleFromCache(HandleTable *pTable, uint32_t uType);
 
 
 /*
@@ -874,7 +874,7 @@ OBJECTHANDLE TableAllocSingleHandleFromCache(HandleTable *pTable, UINT uType);
  * free cache is full, this routine calls TableCacheMissOnFree.
  *
  */
-void TableFreeSingleHandleToCache(HandleTable *pTable, UINT uType, OBJECTHANDLE handle);
+void TableFreeSingleHandleToCache(HandleTable *pTable, uint32_t uType, OBJECTHANDLE handle);
 
 
 /*
@@ -884,7 +884,7 @@ void TableFreeSingleHandleToCache(HandleTable *pTable, UINT uType, OBJECTHANDLE 
  * calling TableAllocSingleHandleFromCache.
  *
  */
-UINT TableAllocHandlesFromCache(HandleTable *pTable, UINT uType, OBJECTHANDLE *pHandleBase, UINT uCount);
+uint32_t TableAllocHandlesFromCache(HandleTable *pTable, uint32_t uType, OBJECTHANDLE *pHandleBase, uint32_t uCount);
 
 
 /*
@@ -894,7 +894,7 @@ UINT TableAllocHandlesFromCache(HandleTable *pTable, UINT uType, OBJECTHANDLE *p
  * calling TableFreeSingleHandleToCache.
  *
  */
-void TableFreeHandlesToCache(HandleTable *pTable, UINT uType, const OBJECTHANDLE *pHandleBase, UINT uCount);
+void TableFreeHandlesToCache(HandleTable *pTable, uint32_t uType, const OBJECTHANDLE *pHandleBase, uint32_t uCount);
 
 /*--------------------------------------------------------------------------*/
 
@@ -913,8 +913,8 @@ void TableFreeHandlesToCache(HandleTable *pTable, UINT uType, const OBJECTHANDLE
  *
  */
 void CALLBACK TableScanHandles(PTR_HandleTable pTable,
-                               const UINT *puType,
-                               UINT uTypeCount,
+                               const uint32_t *puType,
+                               uint32_t uTypeCount,
                                SEGMENTITERATOR pfnSegmentIterator,
                                BLOCKSCANPROC pfnBlockHandler,
                                ScanCallbackInfo *pInfo,
@@ -928,8 +928,8 @@ void CALLBACK TableScanHandles(PTR_HandleTable pTable,
  *
  */
 void CALLBACK xxxTableScanHandlesAsync(PTR_HandleTable pTable,
-                                       const UINT *puType,
-                                       UINT uTypeCount,
+                                       const uint32_t *puType,
+                                       uint32_t uTypeCount,
                                        SEGMENTITERATOR pfnSegmentIterator,
                                        BLOCKSCANPROC pfnBlockHandler,
                                        ScanCallbackInfo *pInfo,
@@ -947,7 +947,7 @@ void CALLBACK xxxTableScanHandlesAsync(PTR_HandleTable pTable,
  * IN OTHER WORDS, SCANNING WITH A MIX OF USER-DATA AND NON-USER-DATA TYPES IS NOT SUPPORTED
  *
  */
-BOOL TypesRequireUserDataScanning(HandleTable *pTable, const UINT *types, UINT typeCount);
+BOOL TypesRequireUserDataScanning(HandleTable *pTable, const uint32_t *types, uint32_t typeCount);
 
 
 /*
@@ -956,7 +956,7 @@ BOOL TypesRequireUserDataScanning(HandleTable *pTable, const UINT *types, UINT t
  * Builds an age mask to be used when examining/updating the write barrier.
  *
  */
-ULONG32 BuildAgeMask(UINT uGen, UINT uMaxGen);
+uint32_t BuildAgeMask(uint32_t uGen, uint32_t uMaxGen);
 
 
 /*
@@ -1000,7 +1000,7 @@ PTR_TableSegment CALLBACK FullSegmentIterator(PTR_HandleTable pTable, PTR_TableS
  * NEVER propagates per-handle user data to the callback.
  *
  */
-void CALLBACK BlockScanBlocksWithoutUserData(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockScanBlocksWithoutUserData(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -1010,7 +1010,7 @@ void CALLBACK BlockScanBlocksWithoutUserData(PTR_TableSegment pSegment, UINT uBl
  * ALWAYS propagates per-handle user data to the callback.
  *
  */
-void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -1020,7 +1020,7 @@ void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, UINT uBlock
  * Propagates per-handle user data to the callback if present.
  *
  */
-void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -1029,7 +1029,7 @@ void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, U
  * Ages all clumps in a range of consecutive blocks.
  *
  */
-void CALLBACK BlockAgeBlocks(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockAgeBlocks(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -1038,7 +1038,7 @@ void CALLBACK BlockAgeBlocks(PTR_TableSegment pSegment, UINT uBlock, UINT uCount
  * Ages all clumps within the specified generation.
  *
  */
-void CALLBACK BlockAgeBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockAgeBlocksEphemeral(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -1047,7 +1047,7 @@ void CALLBACK BlockAgeBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, UI
  * Clears the age maps for a range of blocks.
  *
  */
-void CALLBACK BlockResetAgeMapForBlocks(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockResetAgeMapForBlocks(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*
@@ -1056,7 +1056,7 @@ void CALLBACK BlockResetAgeMapForBlocks(PTR_TableSegment pSegment, UINT uBlock, 
  * Verifies the age maps for a range of blocks, and also validates the objects pointed to.
  *
  */
-void CALLBACK BlockVerifyAgeMapForBlocks(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo);
+void CALLBACK BlockVerifyAgeMapForBlocks(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo);
 
 
 /*

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -365,8 +365,8 @@ struct ScanCallbackInfo
     uint32_t         uFlags;            // HNDGCF_* flags
     BOOL             fEnumUserData;     // whether user data is being enumerated as well
     HANDLESCANPROC   pfnScan;           // per-handle scan callback
-    uintptr_t           param1;            // callback param 1
-    uintptr_t           param2;            // callback param 2
+    uintptr_t        param1;            // callback param 1
+    uintptr_t        param2;            // callback param 2
     uint32_t         dwAgeMask;         // generation mask for ephemeral GCs
 
 #ifdef _DEBUG

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -323,7 +323,7 @@ struct HandleTypeCache
     /*
      * index of next available handle slot in the reserve bank
      */
-    LONG lReserveIndex;
+    int32_t lReserveIndex;
     
 
     /*---------------------------------------------------------------------------------
@@ -339,7 +339,7 @@ struct HandleTypeCache
     /*
      * index of next empty slot in the free bank
      */
-    LONG lFreeIndex;
+    int32_t lFreeIndex;
 };
 
 

--- a/src/gc/handletablepriv.h
+++ b/src/gc/handletablepriv.h
@@ -273,7 +273,7 @@ struct _TableSegmentHeader
 };
 
 typedef DPTR(struct _TableSegmentHeader) PTR__TableSegmentHeader;
-typedef DPTR(LPARAM) PTR_LPARAM;
+typedef DPTR(uintptr_t) PTR_uintptr_t;
 
 // The handle table is large and may not be entirely mapped. That's one reason for splitting out the table
 // segment and the header as two separate classes. In DAC builds, we generally need only a single element from
@@ -365,8 +365,8 @@ struct ScanCallbackInfo
     uint32_t         uFlags;            // HNDGCF_* flags
     BOOL             fEnumUserData;     // whether user data is being enumerated as well
     HANDLESCANPROC   pfnScan;           // per-handle scan callback
-    LPARAM           param1;            // callback param 1
-    LPARAM           param2;            // callback param 2
+    uintptr_t           param1;            // callback param 1
+    uintptr_t           param2;            // callback param 2
     uint32_t         dwAgeMask;         // generation mask for ephemeral GCs
 
 #ifdef _DEBUG
@@ -686,7 +686,7 @@ __inline void BlockUnlock(TableSegment *pSegment, uint32_t uBlock)
  * Gets the user data pointer for the first handle in a block.
  *
  */
-PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t uBlock, BOOL fAssertOnError);
+PTR_uintptr_t BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t uBlock, BOOL fAssertOnError);
 
 
 /*
@@ -696,7 +696,7 @@ PTR_LPARAM BlockFetchUserDataPointer(PTR__TableSegmentHeader pSegment, uint32_t 
  * ASSERTs and returns NULL if handle is not of the expected type.
  *
  */
-LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTypeExpected);
+uintptr_t *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTypeExpected);
 
 
 /*
@@ -706,7 +706,7 @@ LPARAM *HandleValidateAndFetchUserDataPointer(OBJECTHANDLE handle, uint32_t uTyp
  * Less validation is performed.
  *
  */
-PTR_LPARAM HandleQuickFetchUserDataPointer(OBJECTHANDLE handle);
+PTR_uintptr_t HandleQuickFetchUserDataPointer(OBJECTHANDLE handle);
 
 
 /*
@@ -716,7 +716,7 @@ PTR_LPARAM HandleQuickFetchUserDataPointer(OBJECTHANDLE handle);
  * Less validation is performed.
  *
  */
-void HandleQuickSetUserData(OBJECTHANDLE handle, LPARAM lUserData);
+void HandleQuickSetUserData(OBJECTHANDLE handle, uintptr_t lUserData);
 
 
 /*

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -406,7 +406,7 @@ uint32_t BuildAgeMask(uint32_t uGen, uint32_t uMaxGen)
  *
  */
 typedef void (CALLBACK *ARRAYSCANPROC)(PTR_UNCHECKED_OBJECTREF pValue, PTR_UNCHECKED_OBJECTREF pLast,
-                                       ScanCallbackInfo *pInfo, LPARAM *pUserData);
+                                       ScanCallbackInfo *pInfo, uintptr_t *pUserData);
 
 
 /*
@@ -420,7 +420,7 @@ typedef void (CALLBACK *ARRAYSCANPROC)(PTR_UNCHECKED_OBJECTREF pValue, PTR_UNCHE
 void CALLBACK ScanConsecutiveHandlesWithoutUserData(PTR_UNCHECKED_OBJECTREF pValue,
                                                     PTR_UNCHECKED_OBJECTREF pLast,
                                                     ScanCallbackInfo *pInfo,
-                                                    LPARAM *)
+                                                    uintptr_t *)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -431,8 +431,8 @@ void CALLBACK ScanConsecutiveHandlesWithoutUserData(PTR_UNCHECKED_OBJECTREF pVal
 
     // get frequently used params into locals
     HANDLESCANPROC pfnScan = pInfo->pfnScan;
-    LPARAM         param1  = pInfo->param1;
-    LPARAM         param2  = pInfo->param2;
+    uintptr_t         param1  = pInfo->param1;
+    uintptr_t         param2  = pInfo->param2;
 
     // scan for non-zero handles
     do
@@ -467,7 +467,7 @@ void CALLBACK ScanConsecutiveHandlesWithoutUserData(PTR_UNCHECKED_OBJECTREF pVal
 void CALLBACK ScanConsecutiveHandlesWithUserData(PTR_UNCHECKED_OBJECTREF pValue,
                                                  PTR_UNCHECKED_OBJECTREF pLast,
                                                  ScanCallbackInfo *pInfo,
-                                                 LPARAM *pUserData)
+                                                 uintptr_t *pUserData)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -481,8 +481,8 @@ void CALLBACK ScanConsecutiveHandlesWithUserData(PTR_UNCHECKED_OBJECTREF pValue,
 
     // get frequently used params into locals
     HANDLESCANPROC pfnScan = pInfo->pfnScan;
-    LPARAM         param1  = pInfo->param1;
-    LPARAM         param2  = pInfo->param2;
+    uintptr_t         param1  = pInfo->param1;
+    uintptr_t         param2  = pInfo->param2;
 
     // scan for non-zero handles
     do
@@ -585,7 +585,7 @@ void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, uint32_t uB
         uint32_t uCur = (u + uBlock);
 
         // fetch the user data for this block
-        LPARAM *pUserData = BlockFetchUserDataPointer(PTR__TableSegmentHeader(pSegment), uCur, TRUE);
+        uintptr_t *pUserData = BlockFetchUserDataPointer(PTR__TableSegmentHeader(pSegment), uCur, TRUE);
 
 #ifndef DACCESS_COMPILE
         // get the first and limit handles for these blocks
@@ -658,7 +658,7 @@ void BlockScanBlocksEphemeralWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Scan
 
     // some scans require us to report per-handle extra info - assume this one doesn't
     ARRAYSCANPROC pfnScanHandles = ScanConsecutiveHandlesWithoutUserData;
-    LPARAM       *pUserData = NULL;
+    uintptr_t       *pUserData = NULL;
 
     // do we need to pass user data to the callback?
     if (pInfo->fEnumUserData)
@@ -1009,7 +1009,7 @@ void BlockVerifyAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, Sc
 
                     if (uType == HNDTYPE_DEPENDENT)
                     {
-                        PTR_LPARAM pUserData = HandleQuickFetchUserDataPointer((OBJECTHANDLE)pValue);
+                        PTR_uintptr_t pUserData = HandleQuickFetchUserDataPointer((OBJECTHANDLE)pValue);
 
                         // if we did then copy the value
                         if (pUserData)
@@ -1207,7 +1207,7 @@ void CALLBACK BlockQueueBlocksForAsyncScan(PTR_TableSegment pSegment, uint32_t u
  * Prototype for callbacks that implement per ScanQNode scanning logic.
  *
  */
-typedef void (CALLBACK *QNODESCANPROC)(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, LPARAM lParam);
+typedef void (CALLBACK *QNODESCANPROC)(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, uintptr_t lParam);
 
 
 /*
@@ -1216,7 +1216,7 @@ typedef void (CALLBACK *QNODESCANPROC)(AsyncScanInfo *pAsyncInfo, ScanQNode *pQN
  * Calls the specified handler once for each node in a scan queue.
  *
  */
-void ProcessScanQueue(AsyncScanInfo *pAsyncInfo, QNODESCANPROC pfnNodeHandler, LPARAM lParam, BOOL fCountEmptyQNodes)
+void ProcessScanQueue(AsyncScanInfo *pAsyncInfo, QNODESCANPROC pfnNodeHandler, uintptr_t lParam, BOOL fCountEmptyQNodes)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1243,7 +1243,7 @@ void ProcessScanQueue(AsyncScanInfo *pAsyncInfo, QNODESCANPROC pfnNodeHandler, L
  * Calls the specified block handler once for each range of blocks in a ScanQNode.
  *
  */
-void CALLBACK ProcessScanQNode(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, LPARAM lParam)
+void CALLBACK ProcessScanQNode(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, uintptr_t lParam)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1276,12 +1276,12 @@ void CALLBACK ProcessScanQNode(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, LPA
  * Unlocks all blocks referenced in the specified node and marks the node as empty.
  *
  */
-void CALLBACK UnlockAndForgetQueuedBlocks(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, LPARAM)
+void CALLBACK UnlockAndForgetQueuedBlocks(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, uintptr_t)
 {
     WRAPPER_NO_CONTRACT;
 
     // unlock the blocks named in this node
-    ProcessScanQNode(pAsyncInfo, pQNode, (LPARAM)BlockUnlockBlocks);
+    ProcessScanQNode(pAsyncInfo, pQNode, (uintptr_t)BlockUnlockBlocks);
 
     // reset the node so it looks empty
     pQNode->uEntries = 0;
@@ -1294,7 +1294,7 @@ void CALLBACK UnlockAndForgetQueuedBlocks(AsyncScanInfo *pAsyncInfo, ScanQNode *
  * Frees the specified ScanQNode
  *
  */
-void CALLBACK FreeScanQNode(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, LPARAM)
+void CALLBACK FreeScanQNode(AsyncScanInfo *pAsyncInfo, ScanQNode *pQNode, uintptr_t)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -1327,7 +1327,7 @@ void xxxTableScanQueuedBlocksAsync(PTR_HandleTable pTable, PTR_TableSegment pSeg
 
 #ifndef DACCESS_COMPILE
     // loop through and lock down all the blocks referenced by the queue
-    ProcessScanQueue(pAsyncInfo, ProcessScanQNode, (LPARAM)BlockLockBlocks, FALSE);
+    ProcessScanQueue(pAsyncInfo, ProcessScanQNode, (uintptr_t)BlockLockBlocks, FALSE);
 #endif
 
     //-------------------------------------------------------------------------------
@@ -1342,7 +1342,7 @@ void xxxTableScanQueuedBlocksAsync(PTR_HandleTable pTable, PTR_TableSegment pSeg
     _ASSERTE(!pTable->Lock.OwnedByCurrentThread());
 
     // perform the actual scanning of the specified blocks
-    ProcessScanQueue(pAsyncInfo, ProcessScanQNode, (LPARAM)pAsyncInfo->pfnBlockHandler, FALSE);
+    ProcessScanQueue(pAsyncInfo, ProcessScanQNode, (uintptr_t)pAsyncInfo->pfnBlockHandler, FALSE);
 
     // re-enter the table lock
     pCrstHolder->Acquire();

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -34,18 +34,18 @@
  /*
 How the macros work:
 Handle table's generation (TableSegmentHeader::rgGeneration) is actually a byte array, each byte is generation of a clump. 
-However it's often used as a DWORD array for perf reasons, 1 DWORD contains 4 bytes for ages of 4 clumps. Operations on such 
-a DWORD include:
+However it's often used as a uint32_t array for perf reasons, 1 uint32_t contains 4 bytes for ages of 4 clumps. Operations on such 
+a uint32_t include:
 
 1. COMPUTE_CLUMP_MASK. For some GC operations, we only want to scan handles in certain generation. To do that, we calculate 
-a Mask DWORD from the original generation DWORD:
+a Mask uint32_t from the original generation uint32_t:
     MaskDWORD = COMPUTE_CLUMP_MASK (GenerationDWORD, BuildAgeMask(generationToScan, MaxGen))
 so that if a byte in GenerationDWORD is smaller than or equals to generationToScan, the corresponding byte in MaskDWORD is non-zero, 
 otherwise it is zero. However, if a byte in GenerationDWORD is between [2, 3E] and generationToScan is 2, the corresponding byte in 
 MaskDWORD is also non-zero.
 
 2. AgeEphemeral. When Ephemeral GC happens, ages for handles which belong to the GC condemned generation should be 
-incremented by 1. The operation is done by calculating a new DWORD using the old DWORD value:
+incremented by 1. The operation is done by calculating a new uint32_t using the old uint32_t value:
     NewGenerationDWORD = COMPUTE_AGED_CLUMPS(OldGenerationDWORD, BuildAgeMask(condemnedGeneration, MaxGen))
 so that if a byte in OldGenerationDWORD is smaller than or equals to condemnedGeneration. the coresponding byte in 
 NewGenerationDWORD is 1 bigger than the old value, otherwise it remains unchanged.
@@ -219,14 +219,14 @@ struct ScanRange
      *
      * Specifies the first block in the range.
      */
-    UINT uIndex;
+    uint32_t uIndex;
 
     /*
      * Count
      *
      * Specifies the number of blocks in the range.
      */
-    UINT uCount;
+    uint32_t uCount;
 };
 
 
@@ -250,7 +250,7 @@ struct ScanQNode
      *
      * Specifies how many entries in this block are valid.
      */
-    UINT              uEntries;
+    uint32_t          uEntries;
 
     /*
      * Range Entries
@@ -285,7 +285,7 @@ struct ScanQNode
  * Creates an inclusion map for the specified type array.
  *
  */
-void BuildInclusionMap(BOOL *rgTypeInclusion, const UINT *puType, UINT uTypeCount)
+void BuildInclusionMap(BOOL *rgTypeInclusion, const uint32_t *puType, uint32_t uTypeCount)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -293,10 +293,10 @@ void BuildInclusionMap(BOOL *rgTypeInclusion, const UINT *puType, UINT uTypeCoun
     ZeroMemory(rgTypeInclusion, INCLUSION_MAP_SIZE * sizeof(BOOL));
 
     // add the specified types to the inclusion map
-    for (UINT u = 0; u < uTypeCount; u++)
+    for (uint32_t u = 0; u < uTypeCount; u++)
     {
         // fetch a type we are supposed to scan
-        UINT uType = puType[u];
+        uint32_t uType = puType[u];
 
         // hope we aren't about to trash the stack :)
         _ASSERTE(uType < HANDLE_MAX_INTERNAL_TYPES);
@@ -313,12 +313,12 @@ void BuildInclusionMap(BOOL *rgTypeInclusion, const UINT *puType, UINT uTypeCoun
  * Checks a type inclusion map for the inclusion of a particular block.
  *
  */
-__inline BOOL IsBlockIncluded(TableSegment *pSegment, UINT uBlock, const BOOL *rgTypeInclusion)
+__inline BOOL IsBlockIncluded(TableSegment *pSegment, uint32_t uBlock, const BOOL *rgTypeInclusion)
 {
     LIMITED_METHOD_CONTRACT;
 
     // fetch the adjusted type for this block
-    UINT uType = (UINT)(((int)(signed char)pSegment->rgBlockType[uBlock]) + 1);
+    uint32_t uType = (uint32_t)(((int)(signed char)pSegment->rgBlockType[uBlock]) + 1);
 
     // hope the adjusted type was valid
     _ASSERTE(uType <= HANDLE_MAX_INTERNAL_TYPES);
@@ -339,13 +339,13 @@ __inline BOOL IsBlockIncluded(TableSegment *pSegment, UINT uBlock, const BOOL *r
  * IN OTHER WORDS, SCANNING WITH A MIX OF USER-DATA AND NON-USER-DATA TYPES IS NOT SUPPORTED
  *
  */
-BOOL TypesRequireUserDataScanning(HandleTable *pTable, const UINT *types, UINT typeCount)
+BOOL TypesRequireUserDataScanning(HandleTable *pTable, const uint32_t *types, uint32_t typeCount)
 {
     WRAPPER_NO_CONTRACT;
 
     // count up the number of types passed that have user data associated
-    UINT userDataCount = 0;
-    for (UINT u = 0; u < typeCount; u++)
+    uint32_t userDataCount = 0;
+    for (uint32_t u = 0; u < typeCount; u++)
     {
         if (TypeHasUserData(pTable, types[u]))
             userDataCount++;
@@ -370,7 +370,7 @@ BOOL TypesRequireUserDataScanning(HandleTable *pTable, const UINT *types, UINT t
  * Builds an age mask to be used when examining/updating the write barrier.
  *
  */
-ULONG32 BuildAgeMask(UINT uGen, UINT uMaxGen)
+uint32_t BuildAgeMask(uint32_t uGen, uint32_t uMaxGen)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -512,14 +512,14 @@ void CALLBACK ScanConsecutiveHandlesWithUserData(PTR_UNCHECKED_OBJECTREF pValue,
  * Ages all clumps in a range of consecutive blocks.
  *
  */
-void CALLBACK BlockAgeBlocks(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockAgeBlocks(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
 
 #ifndef DACCESS_COMPILE
     // set up to update the specified blocks
-    ULONG32 *pdwGen     = (ULONG32 *)pSegment->rgGeneration + uBlock;
-    ULONG32 *pdwGenLast =            pdwGen                 + uCount;
+    uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uBlock;
+    uint32_t *pdwGenLast =             pdwGen                 + uCount;
 
     // loop over all the blocks, aging their clumps as we go
     do
@@ -538,7 +538,7 @@ void CALLBACK BlockAgeBlocks(PTR_TableSegment pSegment, UINT uBlock, UINT uCount
  * optionally aging the corresponding generation clumps.
  *
  */
-void CALLBACK BlockScanBlocksWithoutUserData(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockScanBlocksWithoutUserData(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
     
@@ -574,15 +574,15 @@ void CALLBACK BlockScanBlocksWithoutUserData(PTR_TableSegment pSegment, UINT uBl
  * optionally aging the corresponding generation clumps.
  *
  */
-void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
 
     // iterate individual blocks scanning with user data
-    for (UINT u = 0; u < uCount; u++)
+    for (uint32_t u = 0; u < uCount; u++)
     {
         // compute the current block
-        UINT uCur = (u + uBlock);
+        uint32_t uCur = (u + uBlock);
 
         // fetch the user data for this block
         LPARAM *pUserData = BlockFetchUserDataPointer(PTR__TableSegmentHeader(pSegment), uCur, TRUE);
@@ -620,7 +620,7 @@ void CALLBACK BlockScanBlocksWithUserData(PTR_TableSegment pSegment, UINT uBlock
  * identified by the clump mask in the specified block.
  *
  */
-void BlockScanBlocksEphemeralWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanCallbackInfo *pInfo)
+void BlockScanBlocksEphemeralWorker(uint32_t *pdwGen, uint32_t dwClumpMask, ScanCallbackInfo *pInfo)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -646,7 +646,7 @@ void BlockScanBlocksEphemeralWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanCa
         *pdwGen = APPLY_CLUMP_ADDENDS(*pdwGen, MAKE_CLUMP_MASK_ADDENDS(dwClumpMask));
 
     // compute the index of the first clump in the block
-    UINT uClump = (UINT)((BYTE *)pdwGen - pSegment->rgGeneration);
+    uint32_t uClump = (uint32_t)((uint8_t *)pdwGen - pSegment->rgGeneration);
 
 #ifndef DACCESS_COMPILE
     // compute the first handle in the first clump of this block
@@ -701,22 +701,22 @@ void BlockScanBlocksEphemeralWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanCa
  * generation in a block.
  *
  */
-void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     WRAPPER_NO_CONTRACT;
 
     // get frequently used params into locals
-    ULONG32 dwAgeMask = pInfo->dwAgeMask;
+    uint32_t dwAgeMask = pInfo->dwAgeMask;
 
     // set up to update the specified blocks
-    ULONG32 *pdwGen     = (ULONG32 *)pSegment->rgGeneration + uBlock;
-    ULONG32 *pdwGenLast =            pdwGen                 + uCount;
+    uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uBlock;
+    uint32_t *pdwGenLast =            pdwGen                 + uCount;
 
     // loop over all the blocks, checking for elligible clumps as we go
     do
     {
         // determine if any clumps in this block are elligible
-        ULONG32 dwClumpMask = COMPUTE_CLUMP_MASK(*pdwGen, dwAgeMask);
+        uint32_t dwClumpMask = COMPUTE_CLUMP_MASK(*pdwGen, dwAgeMask);
 
         // if there are any clumps to scan then scan them now
         if (dwClumpMask)
@@ -756,16 +756,16 @@ void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, U
  * Ages all clumps within the specified generation.
  *
  */
-void CALLBACK BlockAgeBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockAgeBlocksEphemeral(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     LIMITED_METHOD_CONTRACT;
 
     // get frequently used params into locals
-    ULONG32 dwAgeMask = pInfo->dwAgeMask;
+    uint32_t dwAgeMask = pInfo->dwAgeMask;
 
     // set up to update the specified blocks
-    ULONG32 *pdwGen     = (ULONG32 *)pSegment->rgGeneration + uBlock;
-    ULONG32 *pdwGenLast =            pdwGen                 + uCount;
+    uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uBlock;
+    uint32_t *pdwGenLast =             pdwGen                 + uCount;
 
     // loop over all the blocks, aging their clumps as we go
     do
@@ -783,7 +783,7 @@ void CALLBACK BlockAgeBlocksEphemeral(PTR_TableSegment pSegment, UINT uBlock, UI
  * identified by the clump mask in the specified block.
  *
  */
-void BlockResetAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanCallbackInfo *pInfo)
+void BlockResetAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, ScanCallbackInfo *pInfo)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -794,7 +794,7 @@ void BlockResetAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanC
     TableSegment *pSegment = pInfo->pCurrentSegment;
 
     // compute the index of the first clump in the block
-    UINT uClump = (UINT)((BYTE *)pdwGen - pSegment->rgGeneration);
+    uint32_t uClump = (uint32_t)((uint8_t *)pdwGen - pSegment->rgGeneration);
 
     // compute the first handle in the first clump of this block
     _UNCHECKED_OBJECTREF *pValue = pSegment->rgValue + (uClump * HANDLE_HANDLES_PER_CLUMP);
@@ -833,8 +833,8 @@ void BlockResetAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanC
                             {
                                 ArrayBase* pUserArrayObject = (ArrayBase*)pUserObject;
                                 Object **pObj = (Object**)pUserArrayObject->GetDataPtr(TRUE);
-                                SIZE_T num = pUserArrayObject->GetNumComponents();
-                                for (SIZE_T i = 0; i < num; i ++)
+                                size_t num = pUserArrayObject->GetNumComponents();
+                                for (size_t i = 0; i < num; i ++)
                                 {
                                      thisAge = GCHeap::GetGCHeap()->WhichGeneration(pObj[i]);
                                      if (minAge > thisAge)
@@ -847,7 +847,7 @@ void BlockResetAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanC
                 }
             }
             _ASSERTE(FitsInU1(minAge));
-            ((BYTE *)pSegment->rgGeneration)[uClump] = static_cast<BYTE>(minAge);
+            ((uint8_t *)pSegment->rgGeneration)[uClump] = static_cast<uint8_t>(minAge);
         }
         // skip to the next clump
         dwClumpMask = NEXT_CLUMP_IN_MASK(dwClumpMask);
@@ -864,30 +864,30 @@ void BlockResetAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanC
  * though, most handles refer to objects that don't get demoted and that need to be aged therefore.
  *
  */
-void CALLBACK BlockResetAgeMapForBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockResetAgeMapForBlocks(TableSegment *pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     WRAPPER_NO_CONTRACT;
 
 #if 0
     // zero the age map for the specified range of blocks
-    ZeroMemory((ULONG32 *)pSegment->rgGeneration + uBlock, uCount * sizeof(ULONG32));
+    ZeroMemory((uint32_t *)pSegment->rgGeneration + uBlock, uCount * sizeof(uint32_t));
 #else
     // Actually, we need to be more sophisticated than the above code - there are scenarios
     // where there is demotion in almost every gc cycle, so none of handles get
     // aged appropriately.
 
     // get frequently used params into locals
-    ULONG32 dwAgeMask = pInfo->dwAgeMask;
+    uint32_t dwAgeMask = pInfo->dwAgeMask;
 
     // set up to update the specified blocks
-    ULONG32 *pdwGen     = (ULONG32 *)pSegment->rgGeneration + uBlock;
-    ULONG32 *pdwGenLast =            pdwGen                 + uCount;
+    uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uBlock;
+    uint32_t *pdwGenLast =            pdwGen                 + uCount;
 
     // loop over all the blocks, checking for eligible clumps as we go
     do
     {
         // determine if any clumps in this block are eligible
-        ULONG32 dwClumpMask = COMPUTE_CLUMP_MASK(*pdwGen, dwAgeMask);
+        uint32_t dwClumpMask = COMPUTE_CLUMP_MASK(*pdwGen, dwAgeMask);
 
         // if there are any clumps to scan then scan them now
         if (dwClumpMask)
@@ -915,7 +915,7 @@ static void VerifyObject(_UNCHECKED_OBJECTREF from, _UNCHECKED_OBJECTREF obj)
 #endif // FEATURE_REDHAWK
 }
 
-static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTREF from, _UNCHECKED_OBJECTREF obj, BYTE minAge)
+static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTREF from, _UNCHECKED_OBJECTREF obj, uint8_t minAge)
 {
     VerifyObject(from, obj);
 
@@ -955,7 +955,7 @@ static void VerifyObjectAndAge(_UNCHECKED_OBJECTREF *pValue, _UNCHECKED_OBJECTRE
  * Also validates the objects themselves.
  *
  */
-void BlockVerifyAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, ScanCallbackInfo *pInfo, UINT uType)
+void BlockVerifyAgeMapForBlocksWorker(uint32_t *pdwGen, uint32_t dwClumpMask, ScanCallbackInfo *pInfo, uint32_t uType)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -963,7 +963,7 @@ void BlockVerifyAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, Scan
     TableSegment *pSegment = pInfo->pCurrentSegment;
 
     // compute the index of the first clump in the block
-    UINT uClump = (UINT)((BYTE *)pdwGen - pSegment->rgGeneration);
+    uint32_t uClump = (uint32_t)((uint8_t *)pdwGen - pSegment->rgGeneration);
 
     // compute the first handle in the first clump of this block
     _UNCHECKED_OBJECTREF *pValue = pSegment->rgValue + (uClump * HANDLE_HANDLES_PER_CLUMP);
@@ -978,7 +978,7 @@ void BlockVerifyAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, Scan
         if (dwClumpMask & GEN_CLUMP_0_MASK)
         {
             // for each clump, check whether any object is younger than the age indicated by the clump
-            BYTE minAge = ((BYTE *)pSegment->rgGeneration)[uClump];
+            uint8_t minAge = ((uint8_t *)pSegment->rgGeneration)[uClump];
             for ( ; pValue < pLast; pValue++)
             {
                 if (!HndIsNullOrDestroyedHandle(*pValue))
@@ -997,8 +997,8 @@ void BlockVerifyAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, Scan
                             {
                                 ArrayBase* pUserArrayObject = (ArrayBase*)pUserObject;
                                 Object **pObj = (Object**)pUserArrayObject->GetDataPtr(TRUE);
-                                SIZE_T num = pUserArrayObject->GetNumComponents();
-                                for (SIZE_T i = 0; i < num; i ++)
+                                size_t num = pUserArrayObject->GetNumComponents();
+                                for (size_t i = 0; i < num; i ++)
                                 {
                                      VerifyObjectAndAge(pValue, pUserObject, pObj[i], minAge);
                                 }                                    
@@ -1025,7 +1025,7 @@ void BlockVerifyAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, Scan
             }
         }
 //        else
-//            printf("skipping clump with age %x\n", ((BYTE *)pSegment->rgGeneration)[uClump]);
+//            printf("skipping clump with age %x\n", ((uint8_t *)pSegment->rgGeneration)[uClump]);
 
         // skip to the next clump
         dwClumpMask = NEXT_CLUMP_IN_MASK(dwClumpMask);
@@ -1041,17 +1041,17 @@ void BlockVerifyAgeMapForBlocksWorker(ULONG32 *pdwGen, ULONG32 dwClumpMask, Scan
  * though, most handles refer to objects that don't get demoted and that need to be aged therefore.
  *
  */
-void CALLBACK BlockVerifyAgeMapForBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *pInfo)
+void CALLBACK BlockVerifyAgeMapForBlocks(TableSegment *pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *pInfo)
 {
     WRAPPER_NO_CONTRACT;
 
-    for (UINT u = 0; u < uCount; u++)
+    for (uint32_t u = 0; u < uCount; u++)
     {
-        UINT uCur = (u + uBlock);
+        uint32_t uCur = (u + uBlock);
 
-        ULONG32 *pdwGen     = (ULONG32 *)pSegment->rgGeneration + uCur;
+        uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uCur;
 
-        UINT uType = pSegment->rgBlockType[uCur];
+        uint32_t uType = pSegment->rgBlockType[uCur];
 
         BlockVerifyAgeMapForBlocksWorker(pdwGen, 0xFFFFFFFF, pInfo, uType);
     }
@@ -1063,7 +1063,7 @@ void CALLBACK BlockVerifyAgeMapForBlocks(TableSegment *pSegment, UINT uBlock, UI
  * Locks all blocks in the specified range.
  *
  */
-void CALLBACK BlockLockBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *)
+void CALLBACK BlockLockBlocks(TableSegment *pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1079,7 +1079,7 @@ void CALLBACK BlockLockBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount, 
  * Unlocks all blocks in the specified range.
  *
  */
-void CALLBACK BlockUnlockBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *)
+void CALLBACK BlockUnlockBlocks(TableSegment *pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1095,7 +1095,7 @@ void CALLBACK BlockUnlockBlocks(TableSegment *pSegment, UINT uBlock, UINT uCount
  * Queues the specified blocks to be scanned asynchronously.
  *
  */
-void CALLBACK BlockQueueBlocksForAsyncScan(PTR_TableSegment pSegment, UINT uBlock, UINT uCount, ScanCallbackInfo *)
+void CALLBACK BlockQueueBlocksForAsyncScan(PTR_TableSegment pSegment, uint32_t uBlock, uint32_t uCount, ScanCallbackInfo *)
 {
     CONTRACTL
     {
@@ -1175,7 +1175,7 @@ void CALLBACK BlockQueueBlocksForAsyncScan(PTR_TableSegment pSegment, UINT uBloc
     }
 
     // we will be using the last slot after the existing entries
-    UINT uSlot = pQNode->uEntries;
+    uint32_t uSlot = pQNode->uEntries;
 
     // fetch the slot where we will be storing the new block range
     ScanRange *pNewRange = pQNode->rgRange + uSlot;
@@ -1459,11 +1459,11 @@ PTR_TableSegment CALLBACK FullSegmentIterator(PTR_HandleTable pTable, PTR_TableS
     CONTRACTL_END;
 
     // we will be resetting the next segment's sequence number
-    UINT uSequence = 0;
+    uint32_t uSequence = 0;
 
     // if we have a previous segment then compute the next sequence number from it
     if (pPrevSegment)
-        uSequence = (UINT)pPrevSegment->bSequence + 1;
+        uSequence = (uint32_t)pPrevSegment->bSequence + 1;
 
     // loop until we find an appropriate segment to return
     PTR_TableSegment pNextSegment;
@@ -1489,7 +1489,7 @@ PTR_TableSegment CALLBACK FullSegmentIterator(PTR_HandleTable pTable, PTR_TableS
         if (pNextSegment->bEmptyLine > 0)
         {
             // update this segment's sequence number
-            pNextSegment->bSequence = (BYTE)(uSequence % 0x100);
+            pNextSegment->bSequence = (uint8_t)(uSequence % 0x100);
 
             // break out and return the segment
             break;
@@ -1592,7 +1592,7 @@ PTR_TableSegment CALLBACK xxxAsyncSegmentIterator(PTR_HandleTable pTable, PTR_Ta
  * Implements the single-type block scanning loop for a single segment.
  *
  */
-void SegmentScanByTypeChain(PTR_TableSegment pSegment, UINT uType, BLOCKSCANPROC pfnBlockHandler, ScanCallbackInfo *pInfo)
+void SegmentScanByTypeChain(PTR_TableSegment pSegment, uint32_t uType, BLOCKSCANPROC pfnBlockHandler, ScanCallbackInfo *pInfo)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1600,7 +1600,7 @@ void SegmentScanByTypeChain(PTR_TableSegment pSegment, UINT uType, BLOCKSCANPROC
     _ASSERTE(uType < HANDLE_MAX_INTERNAL_TYPES);
 
     // fetch the tail
-    UINT uBlock = pSegment->rgTail[uType];
+    uint32_t uBlock = pSegment->rgTail[uType];
     
     // if we didn't find a terminator then there's blocks to enumerate
     if (uBlock != BLOCK_INVALID)
@@ -1609,11 +1609,11 @@ void SegmentScanByTypeChain(PTR_TableSegment pSegment, UINT uType, BLOCKSCANPROC
         uBlock = pSegment->rgAllocation[uBlock];
 
         // scan until we loop back to the first block
-        UINT uHead = uBlock;
+        uint32_t uHead = uBlock;
         do
         {
             // search forward trying to batch up sequential runs of blocks
-            UINT uLast, uNext = uBlock;
+            uint32_t uLast, uNext = uBlock;
             do
             {
                 // compute the next sequential block for comparison
@@ -1647,10 +1647,10 @@ void SegmentScanByTypeMap(PTR_TableSegment pSegment, const BOOL *rgTypeInclusion
     WRAPPER_NO_CONTRACT;
 
     // start scanning with the first block in the segment
-    UINT uBlock = 0;
+    uint32_t uBlock = 0;
 
     // we don't need to scan the whole segment, just up to the empty line
-    UINT uLimit = pSegment->bEmptyLine;
+    uint32_t uLimit = pSegment->bEmptyLine;
 
     // loop across the segment looking for blocks to scan
     for (;;)
@@ -1671,7 +1671,7 @@ void SegmentScanByTypeMap(PTR_TableSegment pSegment, const BOOL *rgTypeInclusion
         }
 
         // remember this block as the first that needs scanning
-        UINT uFirst = uBlock;
+        uint32_t uFirst = uBlock;
 
         // find the next block not included in the type map
         for (;;)
@@ -1704,8 +1704,8 @@ void SegmentScanByTypeMap(PTR_TableSegment pSegment, const BOOL *rgTypeInclusion
  *
  */
 void CALLBACK TableScanHandles(PTR_HandleTable pTable,
-                               const UINT *puType,
-                               UINT uTypeCount,
+                               const uint32_t *puType,
+                               uint32_t uTypeCount,
                                SEGMENTITERATOR pfnSegmentIterator,
                                BLOCKSCANPROC pfnBlockHandler,
                                ScanCallbackInfo *pInfo,
@@ -1766,8 +1766,8 @@ void CALLBACK TableScanHandles(PTR_HandleTable pTable,
  *
  */
 void CALLBACK xxxTableScanHandlesAsync(PTR_HandleTable pTable,
-                                       const UINT *puType,
-                                       UINT uTypeCount,
+                                       const uint32_t *puType,
+                                       uint32_t uTypeCount,
                                        SEGMENTITERATOR pfnSegmentIterator,
                                        BLOCKSCANPROC pfnBlockHandler,
                                        ScanCallbackInfo *pInfo,
@@ -1841,14 +1841,14 @@ void CALLBACK xxxTableScanHandlesAsync(PTR_HandleTable pTable,
 // TableSegment is variable size, where the data up to "rgValue" is static,
 // then more is committed as TableSegment::bCommitLine * HANDLE_BYTES_PER_BLOCK.
 // See SegmentInitialize in HandleTableCore.cpp.
-ULONG32 TableSegment::DacSize(TADDR addr)
+uint32_t TableSegment::DacSize(TADDR addr)
 {
     WRAPPER_NO_CONTRACT;
     
-    BYTE commitLine = 0;
+    uint8_t commitLine = 0;
     DacReadAll(addr + offsetof(TableSegment, bCommitLine), &commitLine, sizeof(commitLine), true);
     
-    return offsetof(TableSegment, rgValue) + (ULONG32)commitLine * HANDLE_BYTES_PER_BLOCK;
+    return offsetof(TableSegment, rgValue) + (uint32_t)commitLine * HANDLE_BYTES_PER_BLOCK;
 }
 #endif
 /*--------------------------------------------------------------------------*/

--- a/src/gc/handletablescan.cpp
+++ b/src/gc/handletablescan.cpp
@@ -431,8 +431,8 @@ void CALLBACK ScanConsecutiveHandlesWithoutUserData(PTR_UNCHECKED_OBJECTREF pVal
 
     // get frequently used params into locals
     HANDLESCANPROC pfnScan = pInfo->pfnScan;
-    uintptr_t         param1  = pInfo->param1;
-    uintptr_t         param2  = pInfo->param2;
+    uintptr_t      param1  = pInfo->param1;
+    uintptr_t      param2  = pInfo->param2;
 
     // scan for non-zero handles
     do
@@ -481,8 +481,8 @@ void CALLBACK ScanConsecutiveHandlesWithUserData(PTR_UNCHECKED_OBJECTREF pValue,
 
     // get frequently used params into locals
     HANDLESCANPROC pfnScan = pInfo->pfnScan;
-    uintptr_t         param1  = pInfo->param1;
-    uintptr_t         param2  = pInfo->param2;
+    uintptr_t      param1  = pInfo->param1;
+    uintptr_t      param2  = pInfo->param2;
 
     // scan for non-zero handles
     do
@@ -710,7 +710,7 @@ void CALLBACK BlockScanBlocksEphemeral(PTR_TableSegment pSegment, uint32_t uBloc
 
     // set up to update the specified blocks
     uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uBlock;
-    uint32_t *pdwGenLast =            pdwGen                 + uCount;
+    uint32_t *pdwGenLast =             pdwGen                 + uCount;
 
     // loop over all the blocks, checking for elligible clumps as we go
     do
@@ -881,7 +881,7 @@ void CALLBACK BlockResetAgeMapForBlocks(TableSegment *pSegment, uint32_t uBlock,
 
     // set up to update the specified blocks
     uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uBlock;
-    uint32_t *pdwGenLast =            pdwGen                 + uCount;
+    uint32_t *pdwGenLast =             pdwGen                 + uCount;
 
     // loop over all the blocks, checking for eligible clumps as we go
     do
@@ -1049,7 +1049,7 @@ void CALLBACK BlockVerifyAgeMapForBlocks(TableSegment *pSegment, uint32_t uBlock
     {
         uint32_t uCur = (u + uBlock);
 
-        uint32_t *pdwGen     = (uint32_t *)pSegment->rgGeneration + uCur;
+        uint32_t *pdwGen = (uint32_t *)pSegment->rgGeneration + uCur;
 
         uint32_t uType = pSegment->rgBlockType[uCur];
 

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -44,9 +44,9 @@ DhContext *g_pDependentHandleContexts;
  */
 struct VARSCANINFO
 {
-    LPARAM         lEnableMask; // mask of types to trace
+    uintptr_t         lEnableMask; // mask of types to trace
     HANDLESCANPROC pfnTrace;    // tracing function to use
-    LPARAM         lp2;         // second parameter
+    uintptr_t         lp2;         // second parameter
 };
 
 
@@ -58,7 +58,7 @@ struct VARSCANINFO
  * This callback is called to trace individual objects referred to by handles
  * in the variable-strength table.
  */
-void CALLBACK VariableTraceDispatcher(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK VariableTraceDispatcher(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -80,7 +80,7 @@ void CALLBACK VariableTraceDispatcher(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pEx
  * This callback is called to trace individual objects referred to by handles
  * in the refcounted table.
  */
-void CALLBACK PromoteRefCounted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK PromoteRefCounted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -110,7 +110,7 @@ void CALLBACK PromoteRefCounted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInf
 }
 #endif // FEATURE_COMINTEROP || FEATURE_REDHAWK
 
-void CALLBACK TraceDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK TraceDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -133,7 +133,7 @@ void CALLBACK TraceDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtra
     }
 }
 
-void CALLBACK UpdateDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK UpdateDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(pExtraInfo);
@@ -172,7 +172,7 @@ void CALLBACK UpdateDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtr
 #endif
 }
 
-void CALLBACK PromoteDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK PromoteDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(pExtraInfo);
@@ -210,7 +210,7 @@ void CALLBACK PromoteDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExt
     }
 }
     
-void CALLBACK ClearDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK ClearDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
     _ASSERTE(pExtraInfo);
@@ -242,7 +242,7 @@ void CALLBACK ClearDependentHandle(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtra
  * This callback is called to pin individual objects referred to by handles in
  * the pinning table.
  */
-void CALLBACK PinObject(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK PinObject(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     STATIC_CONTRACT_NOTHROW;
     STATIC_CONTRACT_GC_NOTRIGGER;
@@ -299,7 +299,7 @@ void CALLBACK PinObject(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARA
  * This callback is called to trace individual objects referred to by handles
  * in the strong table.
  */
-void CALLBACK PromoteObject(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK PromoteObject(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -318,7 +318,7 @@ void CALLBACK PromoteObject(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, L
  * This callback is called to check promotion of individual objects referred to by
  * handles in the weak tables.
  */
-void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -337,7 +337,7 @@ void CALLBACK CheckPromoted(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, L
     }
 }
 
-void CALLBACK CalculateSizedRefSize(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK CalculateSizedRefSize(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -362,7 +362,7 @@ void CALLBACK CalculateSizedRefSize(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtr
  * This callback is called to update pointers for individual objects referred to by
  * handles in the weak and strong tables.
  */
-void CALLBACK UpdatePointer(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK UpdatePointer(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -396,7 +396,7 @@ void CALLBACK UpdatePointer(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, L
  * This callback is called to update pointers for individual objects referred to by
  * handles in the weak and strong tables.
  */
-void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     CONTRACTL
     {
@@ -535,7 +535,7 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, LPARAM
  * This callback is called to update pointers for individual objects referred to by
  * handles in the pinned table.
  */
-void CALLBACK UpdatePointerPinned(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARAM lp1, LPARAM lp2)
+void CALLBACK UpdatePointerPinned(_UNCHECKED_OBJECTREF *pObjRef, uintptr_t *pExtraInfo, uintptr_t lp1, uintptr_t lp2)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -927,7 +927,7 @@ void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF objref)
         HndWriteBarrier(handle, objref);
 
     // store the pointer
-    HndSetHandleExtraInfo(handle, HNDTYPE_DEPENDENT, (LPARAM)value);
+    HndSetHandleExtraInfo(handle, HNDTYPE_DEPENDENT, (uintptr_t)value);
 }
 
 
@@ -954,7 +954,7 @@ OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_
     }
 
     // create the handle
-    return HndCreateHandle(hTable, HNDTYPE_VARIABLE, object, (LPARAM)type);
+    return HndCreateHandle(hTable, HNDTYPE_VARIABLE, object, (uintptr_t)type);
 }
 
 /*
@@ -998,7 +998,7 @@ void UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type)
     //
 
     // store the type in the handle's extra info
-    HndSetHandleExtraInfo(handle, HNDTYPE_VARIABLE, (LPARAM)type);
+    HndSetHandleExtraInfo(handle, HNDTYPE_VARIABLE, (uintptr_t)type);
 }
 
 /*
@@ -1015,7 +1015,7 @@ uint32_t CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType
     _ASSERTE(IS_VALID_VHT_VALUE(oldType) && IS_VALID_VHT_VALUE(newType));
 
     // attempt to store the type in the handle's extra info
-    return (uint32_t)HndCompareExchangeHandleExtraInfo(handle, HNDTYPE_VARIABLE, (LPARAM)oldType, (LPARAM)newType);
+    return (uint32_t)HndCompareExchangeHandleExtraInfo(handle, HNDTYPE_VARIABLE, (uintptr_t)oldType, (uintptr_t)newType);
 }
 
 
@@ -1025,13 +1025,13 @@ uint32_t CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType
  * Convenience function for tracing variable-strength handles.
  * Wraps HndScanHandlesForGC.
  */
-void TraceVariableHandles(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, uint32_t uEnableMask, uint32_t condemned, uint32_t maxgen, uint32_t flags)
+void TraceVariableHandles(HANDLESCANPROC pfnTrace, uintptr_t lp1, uintptr_t lp2, uint32_t uEnableMask, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
     // set up to scan variable handles with the specified mask and trace function
     uint32_t               type = HNDTYPE_VARIABLE;
-    struct VARSCANINFO info = { (LPARAM)uEnableMask, pfnTrace, lp2 };
+    struct VARSCANINFO info = { (uintptr_t)uEnableMask, pfnTrace, lp2 };
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
@@ -1049,7 +1049,7 @@ void TraceVariableHandles(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, uint3
                     }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
                     HndScanHandlesForGC(hTable, VariableTraceDispatcher,
-                                        lp1, (LPARAM)&info, &type, 1, condemned, maxgen, HNDGCF_EXTRAINFO | flags);
+                                        lp1, (uintptr_t)&info, &type, 1, condemned, maxgen, HNDGCF_EXTRAINFO | flags);
                 }
             }
         walk = walk->pNext;
@@ -1060,13 +1060,13 @@ void TraceVariableHandles(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, uint3
   loop scan version of TraceVariableHandles for single-thread-managed Ref_* functions
   should be kept in sync with the code above
 */
-void TraceVariableHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, uint32_t uEnableMask, uint32_t condemned, uint32_t maxgen, uint32_t flags)
+void TraceVariableHandlesBySingleThread(HANDLESCANPROC pfnTrace, uintptr_t lp1, uintptr_t lp2, uint32_t uEnableMask, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
     // set up to scan variable handles with the specified mask and trace function
     uint32_t type = HNDTYPE_VARIABLE;
-    struct VARSCANINFO info = { (LPARAM)uEnableMask, pfnTrace, lp2 };
+    struct VARSCANINFO info = { (uintptr_t)uEnableMask, pfnTrace, lp2 };
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
@@ -1079,7 +1079,7 @@ void TraceVariableHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, LPA
                    HHANDLETABLE hTable = walk->pBuckets[i]->pTable[uCPUindex];
                     if (hTable)
                         HndScanHandlesForGC(hTable, VariableTraceDispatcher,
-                                        lp1, (LPARAM)&info, &type, 1, condemned, maxgen, HNDGCF_EXTRAINFO | flags);
+                                        lp1, (uintptr_t)&info, &type, 1, condemned, maxgen, HNDGCF_EXTRAINFO | flags);
                 }
             }
         walk = walk->pNext;
@@ -1112,14 +1112,14 @@ void Ref_TracePinningRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc,
                         sc->pCurrentDomain = SystemDomain::GetAppDomainAtIndex(HndGetHandleTableADIndex(hTable));
                     }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
-                    HndScanHandlesForGC(hTable, PinObject, LPARAM(sc), LPARAM(fn), types, _countof(types), condemned, maxgen, flags);
+                    HndScanHandlesForGC(hTable, PinObject, uintptr_t(sc), uintptr_t(fn), types, _countof(types), condemned, maxgen, flags);
                 }
             }
         walk = walk->pNext;
     }
 
     // pin objects pointed to by variable handles whose dynamic type is VHT_PINNED
-    TraceVariableHandles(PinObject, LPARAM(sc), LPARAM(fn), VHT_PINNED, condemned, maxgen, flags);
+    TraceVariableHandles(PinObject, uintptr_t(sc), uintptr_t(fn), VHT_PINNED, condemned, maxgen, flags);
 }
 
 
@@ -1150,14 +1150,14 @@ void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, 
                     }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
 
-                    HndScanHandlesForGC(hTable, PromoteObject, LPARAM(sc), LPARAM(fn), types, uTypeCount, condemned, maxgen, flags);
+                    HndScanHandlesForGC(hTable, PromoteObject, uintptr_t(sc), uintptr_t(fn), types, uTypeCount, condemned, maxgen, flags);
                 }
             }
         walk = walk->pNext;
     }
 
     // promote objects pointed to by variable handles whose dynamic type is VHT_STRONG
-    TraceVariableHandles(PromoteObject, LPARAM(sc), LPARAM(fn), VHT_STRONG, condemned, maxgen, flags);
+    TraceVariableHandles(PromoteObject, uintptr_t(sc), uintptr_t(fn), VHT_STRONG, condemned, maxgen, flags);
 
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_REDHAWK)
     // don't scan ref-counted handles during concurrent phase as the clean-up of CCWs can race with AD unload and cause AV's
@@ -1173,7 +1173,7 @@ void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, 
                 {
                     HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
                     if (hTable)
-                        HndScanHandlesForGC(hTable, PromoteRefCounted, LPARAM(sc), LPARAM(fn), &type, 1, condemned, maxgen, flags );
+                        HndScanHandlesForGC(hTable, PromoteRefCounted, uintptr_t(sc), uintptr_t(fn), &type, 1, condemned, maxgen, flags );
                 }
             walk = walk->pNext;
         }
@@ -1183,7 +1183,7 @@ void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, 
 
 #ifdef FEATURE_COMINTEROP
 
-void Ref_TraceRefCountHandles(HANDLESCANPROC callback, LPARAM lParam1, LPARAM lParam2)
+void Ref_TraceRefCountHandles(HANDLESCANPROC callback, uintptr_t lParam1, uintptr_t lParam2)
 {
     int max_slots = getNumberOfSlots();
     uint32_t handleType = HNDTYPE_REFCOUNTED;
@@ -1211,7 +1211,7 @@ void Ref_TraceRefCountHandles(HANDLESCANPROC callback, LPARAM lParam1, LPARAM lP
 
 
 
-void Ref_CheckReachable(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
+void Ref_CheckReachable(uint32_t condemned, uint32_t maxgen, uintptr_t lp1)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1321,8 +1321,8 @@ bool Ref_ScanDependentHandlesForPromotion(DhContext *pDhContext)
                     {
                         HndScanHandlesForGC(hTable,
                                             PromoteDependentHandle,
-                                            LPARAM(pDhContext->m_pScanContext),
-                                            LPARAM(pDhContext->m_pfnPromoteFunction),
+                                            uintptr_t(pDhContext->m_pScanContext),
+                                            uintptr_t(pDhContext->m_pfnPromoteFunction),
                                             &type, 1,
                                             pDhContext->m_iCondemned,
                                             pDhContext->m_iMaxGen,
@@ -1360,7 +1360,7 @@ void Ref_ScanDependentHandlesForClearing(uint32_t condemned, uint32_t maxgen, Sc
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
                 if (hTable)
                 {
-                    HndScanHandlesForGC(hTable, ClearDependentHandle, LPARAM(sc), LPARAM(fn), &type, 1, condemned, maxgen, flags );
+                    HndScanHandlesForGC(hTable, ClearDependentHandle, uintptr_t(sc), uintptr_t(fn), &type, 1, condemned, maxgen, flags );
                 }
             }
         }
@@ -1386,7 +1386,7 @@ void Ref_ScanDependentHandlesForRelocation(uint32_t condemned, uint32_t maxgen, 
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
                 if (hTable)
                 {
-                    HndScanHandlesForGC(hTable, UpdateDependentHandle, LPARAM(sc), LPARAM(fn), &type, 1, condemned, maxgen, flags );
+                    HndScanHandlesForGC(hTable, UpdateDependentHandle, uintptr_t(sc), uintptr_t(fn), &type, 1, condemned, maxgen, flags );
                 }
             }
         }
@@ -1398,7 +1398,7 @@ void Ref_ScanDependentHandlesForRelocation(uint32_t condemned, uint32_t maxgen, 
   loop scan version of TraceVariableHandles for single-thread-managed Ref_* functions
   should be kept in sync with the code above
 */
-void TraceDependentHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, uint32_t condemned, uint32_t maxgen, uint32_t flags)
+void TraceDependentHandlesBySingleThread(HANDLESCANPROC pfnTrace, uintptr_t lp1, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1416,7 +1416,7 @@ void TraceDependentHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, ui
                     HHANDLETABLE hTable = walk->pBuckets[i]->pTable[uCPUindex];
                     if (hTable)
                         HndScanHandlesForGC(hTable, TraceDependentHandle,
-                                    lp1, (LPARAM)pfnTrace, &type, 1, condemned, maxgen, HNDGCF_EXTRAINFO | flags);
+                                    lp1, (uintptr_t)pfnTrace, &type, 1, condemned, maxgen, HNDGCF_EXTRAINFO | flags);
                 }
             }
         walk = walk->pNext;
@@ -1456,7 +1456,7 @@ void ScanSizedRefByAD(uint32_t maxgen, HANDLESCANPROC scanProc, ScanContext* sc,
                                 sc->pCurrentDomain = SystemDomain::GetAppDomainAtIndex(adIndex);
                             }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
-                            HndScanHandlesForGC(hTable, scanProc, LPARAM(sc), LPARAM(fn), &type, 1, maxgen, maxgen, flags);
+                            HndScanHandlesForGC(hTable, scanProc, uintptr_t(sc), uintptr_t(fn), &type, 1, maxgen, maxgen, flags);
                         }
                     }
                 }
@@ -1488,7 +1488,7 @@ void ScanSizedRefByCPU(uint32_t maxgen, HANDLESCANPROC scanProc, ScanContext* sc
                     }
 #endif //FEATURE_APPDOMAIN_RESOURCE_MONITORING
 
-                    HndScanHandlesForGC(hTable, scanProc, LPARAM(sc), LPARAM(fn), &type, 1, maxgen, maxgen, flags);
+                    HndScanHandlesForGC(hTable, scanProc, uintptr_t(sc), uintptr_t(fn), &type, 1, maxgen, maxgen, flags);
                 }
             }
         }
@@ -1505,7 +1505,7 @@ void Ref_ScanSizedRefHandles(uint32_t condemned, uint32_t maxgen, ScanContext* s
     ScanSizedRefByCPU(maxgen, CalculateSizedRefSize, sc, fn, flags);
 }
 
-void Ref_CheckAlive(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
+void Ref_CheckAlive(uint32_t condemned, uint32_t maxgen, uintptr_t lp1)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1561,7 +1561,7 @@ void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Re
     }
 
     if (bDo)   
-        GCToEEInterface::SyncBlockCacheWeakPtrScan(&UpdatePointer, LPARAM(sc), LPARAM(fn));
+        GCToEEInterface::SyncBlockCacheWeakPtrScan(&UpdatePointer, uintptr_t(sc), uintptr_t(fn));
 
     LOG((LF_GC, LL_INFO10000, "Updating pointers to referents of non-pinning handles in generation %u\n", condemned));
 
@@ -1590,19 +1590,19 @@ void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Re
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
                 if (hTable)
-                    HndScanHandlesForGC(hTable, UpdatePointer, LPARAM(sc), LPARAM(fn), types, _countof(types), condemned, maxgen, flags);
+                    HndScanHandlesForGC(hTable, UpdatePointer, uintptr_t(sc), uintptr_t(fn), types, _countof(types), condemned, maxgen, flags);
             }
         walk = walk->pNext;
     }
 
     // update pointers in variable handles whose dynamic type is VHT_WEAK_SHORT, VHT_WEAK_LONG or VHT_STRONG
-    TraceVariableHandles(UpdatePointer, LPARAM(sc), LPARAM(fn), VHT_WEAK_SHORT | VHT_WEAK_LONG | VHT_STRONG, condemned, maxgen, flags);
+    TraceVariableHandles(UpdatePointer, uintptr_t(sc), uintptr_t(fn), VHT_WEAK_SHORT | VHT_WEAK_LONG | VHT_STRONG, condemned, maxgen, flags);
 }
 
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
 // Please update this if you change the Ref_UpdatePointers function above.
-void Ref_ScanPointersForProfilerAndETW(uint32_t maxgen, LPARAM lp1)
+void Ref_ScanPointersForProfilerAndETW(uint32_t maxgen, uintptr_t lp1)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1658,7 +1658,7 @@ void Ref_ScanDependentHandlesForProfilerAndETW(uint32_t maxgen, ProfilingScanCon
 
     uint32_t flags = HNDGCF_NORMAL;
 
-    LPARAM lp1 = (LPARAM)SC;
+    uintptr_t lp1 = (uintptr_t)SC;
     // we'll re-use pHeapId (which was either unused (0) or freed by EndRootReferences2
     // (-1)), so reset it to NULL
     _ASSERTE((*((size_t *)(&SC->pHeapId)) == (size_t)(-1)) ||
@@ -1686,17 +1686,17 @@ void Ref_UpdatePinnedPointers(uint32_t condemned, uint32_t maxgen, ScanContext* 
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
                 if (hTable)
-                    HndScanHandlesForGC(hTable, UpdatePointerPinned, LPARAM(sc), LPARAM(fn), types, _countof(types), condemned, maxgen, flags); 
+                    HndScanHandlesForGC(hTable, UpdatePointerPinned, uintptr_t(sc), uintptr_t(fn), types, _countof(types), condemned, maxgen, flags); 
             }
         walk = walk->pNext;
     }
 
     // update pointers in variable handles whose dynamic type is VHT_PINNED
-    TraceVariableHandles(UpdatePointerPinned, LPARAM(sc), LPARAM(fn), VHT_PINNED, condemned, maxgen, flags);
+    TraceVariableHandles(UpdatePointerPinned, uintptr_t(sc), uintptr_t(fn), VHT_PINNED, condemned, maxgen, flags);
 }
 
 
-void Ref_AgeHandles(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
+void Ref_AgeHandles(uint32_t condemned, uint32_t maxgen, uintptr_t lp1)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1738,7 +1738,7 @@ void Ref_AgeHandles(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
 }
 
 
-void Ref_RejuvenateHandles(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
+void Ref_RejuvenateHandles(uint32_t condemned, uint32_t maxgen, uintptr_t lp1)
 {
     WRAPPER_NO_CONTRACT;
 

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -44,9 +44,9 @@ DhContext *g_pDependentHandleContexts;
  */
 struct VARSCANINFO
 {
-    uintptr_t         lEnableMask; // mask of types to trace
+    uintptr_t      lEnableMask; // mask of types to trace
     HANDLESCANPROC pfnTrace;    // tracing function to use
-    uintptr_t         lp2;         // second parameter
+    uintptr_t      lp2;         // second parameter
 };
 
 

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -1555,8 +1555,8 @@ void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Re
 
     if (GCHeap::IsServerHeap()) 
     {
-        bDo = (FastInterlockIncrement(&uCount) == 1);
-        FastInterlockCompareExchange (&uCount, 0, GCHeap::GetGCHeap()->GetNumberOfHeaps());        
+        bDo = (FastInterlockIncrement((LONG*)&uCount) == 1);
+        FastInterlockCompareExchange ((LONG*)&uCount, 0, GCHeap::GetGCHeap()->GetNumberOfHeaps());
         _ASSERTE (uCount <= GCHeap::GetGCHeap()->GetNumberOfHeaps());
     }
 

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -1540,7 +1540,7 @@ void Ref_CheckAlive(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
     TraceVariableHandles(CheckPromoted, lp1, 0, VHT_WEAK_SHORT, condemned, maxgen, flags);
 }
 
-static VOLATILE(LONG) uCount = 0;
+static VOLATILE(int32_t) uCount = 0;
 
 // NOTE: Please: if you update this function, update the very similar profiling function immediately below!!!
 void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -272,8 +272,8 @@ void CALLBACK PinObject(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraInfo, LPARA
                 pOverlapped->m_userObjectInternal = static_cast<void*>(OBJECTREFToObject(pOverlapped->m_userObject));
                 ArrayBase* pUserObject = (ArrayBase*)OBJECTREFToObject(pOverlapped->m_userObject);
                 Object **ppObj = (Object**)pUserObject->GetDataPtr(TRUE);
-                SIZE_T num = pUserObject->GetNumComponents();
-                for (SIZE_T i = 0; i < num; i ++)
+                size_t num = pUserObject->GetNumComponents();
+                for (size_t i = 0; i < num; i ++)
                 {
                     callback(ppObj + i, (ScanContext *)lp1, GC_CALL_PINNED);
                 }
@@ -414,7 +414,7 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, LPARAM
     // Get a hold of the heap ID that's tacked onto the end of the scancontext struct.
     ProfilingScanContext *pSC = (ProfilingScanContext *)lp1;
 
-    DWORD rootFlags = 0;
+    uint32_t rootFlags = 0;
     BOOL isDependent = FALSE;
 
     OBJECTHANDLE handle = (OBJECTHANDLE)(pRef);
@@ -444,7 +444,7 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, LPARAM
 #ifdef FEATURE_REDHAWK
     {
         // Set the appropriate ETW flags for the current strength of this variable handle
-        UINT nVarHandleType = GetVariableHandleType(handle);
+        uint32_t nVarHandleType = GetVariableHandleType(handle);
         if (((nVarHandleType & VHT_WEAK_SHORT) != 0) ||
             ((nVarHandleType & VHT_WEAK_LONG) != 0))
         {
@@ -485,7 +485,7 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, LPARAM
         {
             BEGIN_PIN_PROFILER(CORProfilerTrackGC());
             g_profControlBlock.pProfInterface->RootReference2(
-                (BYTE *)*pRef, 
+                (uint8_t *)*pRef,
                 kEtwGCRootKindHandle,
                 (EtwGCRootFlags)rootFlags,
                 pRef, 
@@ -497,8 +497,8 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, LPARAM
             BEGIN_PIN_PROFILER(CORProfilerTrackConditionalWeakTableElements());
             pSec = (_UNCHECKED_OBJECTREF)HndGetHandleExtraInfo(handle);
             g_profControlBlock.pProfInterface->ConditionalWeakTableElementReference(
-                (BYTE*)*pRef,
-                (BYTE*)pSec,
+                (uint8_t*)*pRef,
+                (uint8_t*)pSec,
                 pRef,
                 &pSC->pHeapId);
             END_PIN_PROFILER();
@@ -552,7 +552,7 @@ void CALLBACK UpdatePointerPinned(_UNCHECKED_OBJECTREF *pObjRef, LPARAM *pExtraI
 //----------------------------------------------------------------------------
 
 // flags describing the handle types
-static const UINT s_rgTypeFlags[] =
+static const uint32_t s_rgTypeFlags[] =
 {
     HNDF_NORMAL,    // HNDTYPE_WEAK_SHORT
     HNDF_NORMAL,    // HNDTYPE_WEAK_LONG
@@ -742,7 +742,7 @@ HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex)
     
     walk = &g_HandleTableMap;
     HandleTableMap *last = NULL;
-    UINT offset = 0;
+    uint32_t offset = 0;
 
     result = new HandleTableBucket;
     result->pTable = NULL;
@@ -764,7 +764,7 @@ HandleTableBucket *Ref_CreateHandleTableBucket(ADIndex uADIndex)
     for (;;) {
         // Do we have free slot
         while (walk) {
-            for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++) {
+            for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++) {
                 if (walk->pBuckets[i] == 0) {
                     for (int uCPUindex=0; uCPUindex < n_slots; uCPUindex++)
                         HndSetHandleTableIndex(result->pTable[uCPUindex], i+offset);
@@ -860,7 +860,7 @@ int getSlotNumber(ScanContext* sc)
 }
 
 // <TODO> - reexpress as complete only like hndtable does now!!! -fmh</REVISIT_TODO>
-void Ref_EndSynchronousGC(UINT condemned, UINT maxgen)
+void Ref_EndSynchronousGC(uint32_t condemned, uint32_t maxgen)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -870,7 +870,7 @@ void Ref_EndSynchronousGC(UINT condemned, UINT maxgen)
     // tell the table we finished a GC
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++) {
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++) {
             HHANDLETABLE hTable = walk->pTable[i];
             if (hTable)
                 HndNotifyGcCycleComplete(hTable, condemned, maxgen);
@@ -941,7 +941,7 @@ void SetDependentHandleSecondary(OBJECTHANDLE handle, OBJECTREF objref)
  * N.B. This routine is not a macro since we do validation in RETAIL.
  * We always validate the type here because it can come from external callers.
  */
-OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, UINT type)
+OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -962,11 +962,11 @@ OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, UINT ty
 *
 * Retrieves the dynamic type of a variable-strength handle.
 */
-UINT GetVariableHandleType(OBJECTHANDLE handle)
+uint32_t GetVariableHandleType(OBJECTHANDLE handle)
 {
     WRAPPER_NO_CONTRACT;
 
-    return (UINT)HndGetHandleExtraInfo(handle);
+    return (uint32_t)HndGetHandleExtraInfo(handle);
 }
 
 /*
@@ -977,7 +977,7 @@ UINT GetVariableHandleType(OBJECTHANDLE handle)
  * N.B. This routine is not a macro since we do validation in RETAIL.
  * We always validate the type here because it can come from external callers.
  */
-void UpdateVariableHandleType(OBJECTHANDLE handle, UINT type)
+void UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1007,7 +1007,7 @@ void UpdateVariableHandleType(OBJECTHANDLE handle, UINT type)
 * Changes the dynamic type of a variable-strength handle. Unlike UpdateVariableHandleType we assume that the
 * types have already been validated.
 */
-UINT CompareExchangeVariableHandleType(OBJECTHANDLE handle, UINT oldType, UINT newType)
+uint32_t CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1015,7 +1015,7 @@ UINT CompareExchangeVariableHandleType(OBJECTHANDLE handle, UINT oldType, UINT n
     _ASSERTE(IS_VALID_VHT_VALUE(oldType) && IS_VALID_VHT_VALUE(newType));
 
     // attempt to store the type in the handle's extra info
-    return (UINT)HndCompareExchangeHandleExtraInfo(handle, HNDTYPE_VARIABLE, (LPARAM)oldType, (LPARAM)newType);
+    return (uint32_t)HndCompareExchangeHandleExtraInfo(handle, HNDTYPE_VARIABLE, (LPARAM)oldType, (LPARAM)newType);
 }
 
 
@@ -1025,17 +1025,17 @@ UINT CompareExchangeVariableHandleType(OBJECTHANDLE handle, UINT oldType, UINT n
  * Convenience function for tracing variable-strength handles.
  * Wraps HndScanHandlesForGC.
  */
-void TraceVariableHandles(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, UINT uEnableMask, UINT condemned, UINT maxgen, UINT flags)
+void TraceVariableHandles(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, uint32_t uEnableMask, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
     // set up to scan variable handles with the specified mask and trace function
-    UINT               type = HNDTYPE_VARIABLE;
+    uint32_t               type = HNDTYPE_VARIABLE;
     struct VARSCANINFO info = { (LPARAM)uEnableMask, pfnTrace, lp2 };
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber((ScanContext*) lp1)];
@@ -1060,17 +1060,17 @@ void TraceVariableHandles(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, UINT 
   loop scan version of TraceVariableHandles for single-thread-managed Ref_* functions
   should be kept in sync with the code above
 */
-void TraceVariableHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, UINT uEnableMask, UINT condemned, UINT maxgen, UINT flags)
+void TraceVariableHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, LPARAM lp2, uint32_t uEnableMask, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
     // set up to scan variable handles with the specified mask and trace function
-    UINT type = HNDTYPE_VARIABLE;
+    uint32_t type = HNDTYPE_VARIABLE;
     struct VARSCANINFO info = { (LPARAM)uEnableMask, pfnTrace, lp2 };
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                   // this is the one of Ref_* function performed by single thread in MULTI_HEAPS case, so we need to loop through all HT of the bucket
@@ -1088,19 +1088,19 @@ void TraceVariableHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, LPA
 
 //----------------------------------------------------------------------------
 
-void Ref_TracePinningRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_TracePinningRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Pinning referents of pinned handles in generation %u\n", condemned));
 
     // pin objects pointed to by pinning handles
-    UINT types[2] = {HNDTYPE_PINNED, HNDTYPE_ASYNCPINNED};
-    UINT flags = sc->concurrent ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t types[2] = {HNDTYPE_PINNED, HNDTYPE_ASYNCPINNED};
+    uint32_t flags = sc->concurrent ? HNDGCF_ASYNC : HNDGCF_NORMAL;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber((ScanContext*) sc)];
@@ -1123,7 +1123,7 @@ void Ref_TracePinningRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_pro
 }
 
 
-void Ref_TraceNormalRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1131,13 +1131,13 @@ void Ref_TraceNormalRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_prom
 
     // promote objects pointed to by strong handles
     // during ephemeral GCs we also want to promote the ones pointed to by sizedref handles.
-    UINT types[2] = {HNDTYPE_STRONG, HNDTYPE_SIZEDREF};
-    UINT uTypeCount = (((condemned >= maxgen) && !GCHeap::GetGCHeap()->IsConcurrentGCInProgress()) ? 1 : _countof(types));
-    UINT flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t types[2] = {HNDTYPE_STRONG, HNDTYPE_SIZEDREF};
+    uint32_t uTypeCount = (((condemned >= maxgen) && !GCHeap::GetGCHeap()->IsConcurrentGCInProgress()) ? 1 : _countof(types));
+    uint32_t flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
@@ -1164,11 +1164,11 @@ void Ref_TraceNormalRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_prom
     if (!sc->concurrent)
     {
         // promote ref-counted handles
-        UINT type = HNDTYPE_REFCOUNTED;
+        uint32_t type = HNDTYPE_REFCOUNTED;
 
         walk = &g_HandleTableMap;
         while (walk) {
-            for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+            for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
                 if (walk->pBuckets[i] != NULL)
                 {
                     HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
@@ -1186,12 +1186,12 @@ void Ref_TraceNormalRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_prom
 void Ref_TraceRefCountHandles(HANDLESCANPROC callback, LPARAM lParam1, LPARAM lParam2)
 {
     int max_slots = getNumberOfSlots();
-    UINT handleType = HNDTYPE_REFCOUNTED;
+    uint32_t handleType = HNDTYPE_REFCOUNTED;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk)
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i++)
         {
             if (walk->pBuckets[i] != NULL)
             {
@@ -1211,14 +1211,14 @@ void Ref_TraceRefCountHandles(HANDLESCANPROC callback, LPARAM lParam1, LPARAM lP
 
 
 
-void Ref_CheckReachable(UINT condemned, UINT maxgen, LPARAM lp1)
+void Ref_CheckReachable(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Checking reachability of referents of long-weak handles in generation %u\n", condemned));
 
     // these are the handle types that need to be checked
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_LONG,
 #if defined(FEATURE_COMINTEROP) || defined(FEATURE_REDHAWK)
@@ -1227,12 +1227,12 @@ void Ref_CheckReachable(UINT condemned, UINT maxgen, LPARAM lp1)
     };
 
     // check objects pointed to by short weak handles
-    UINT flags = (((ScanContext*) lp1)->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t flags = (((ScanContext*) lp1)->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
     int uCPUindex = getSlotNumber((ScanContext*) lp1);
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
             if (walk->pBuckets[i] != NULL)
            {
@@ -1285,8 +1285,8 @@ DhContext *Ref_GetDependentHandleContext(ScanContext* sc)
 bool Ref_ScanDependentHandlesForPromotion(DhContext *pDhContext)
 {
     LOG((LF_GC, LL_INFO10000, "Checking liveness of referents of dependent handles in generation %u\n", pDhContext->m_iCondemned));
-    UINT type = HNDTYPE_DEPENDENT;
-    UINT flags = (pDhContext->m_pScanContext->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t type = HNDTYPE_DEPENDENT;
+    uint32_t flags = (pDhContext->m_pScanContext->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
     flags |= HNDGCF_EXTRAINFO;
 
     // Keep a note of whether we promoted anything over the entire scan (not just the last iteration). We need
@@ -1312,7 +1312,7 @@ bool Ref_ScanDependentHandlesForPromotion(DhContext *pDhContext)
         HandleTableMap *walk = &g_HandleTableMap;
         while (walk) 
         {
-            for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+            for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             {
                 if (walk->pBuckets[i] != NULL)
                 {
@@ -1343,17 +1343,17 @@ bool Ref_ScanDependentHandlesForPromotion(DhContext *pDhContext)
 
 // Perform a scan of dependent handles for the purpose of clearing any that haven't had their primary
 // promoted.
-void Ref_ScanDependentHandlesForClearing(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_ScanDependentHandlesForClearing(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     LOG((LF_GC, LL_INFO10000, "Clearing dead dependent handles in generation %u\n", condemned));
-    UINT type = HNDTYPE_DEPENDENT;
-    UINT flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t type = HNDTYPE_DEPENDENT;
+    uint32_t flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
     flags |= HNDGCF_EXTRAINFO;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) 
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
             if (walk->pBuckets[i] != NULL)
             {
@@ -1369,17 +1369,17 @@ void Ref_ScanDependentHandlesForClearing(UINT condemned, UINT maxgen, ScanContex
 }
 
 // Perform a scan of dependent handles for the purpose of updating handles to track relocated objects.
-void Ref_ScanDependentHandlesForRelocation(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_ScanDependentHandlesForRelocation(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     LOG((LF_GC, LL_INFO10000, "Relocating moved dependent handles in generation %u\n", condemned));
-    UINT type = HNDTYPE_DEPENDENT;
-    UINT flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t type = HNDTYPE_DEPENDENT;
+    uint32_t flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
     flags |= HNDGCF_EXTRAINFO;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) 
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
             if (walk->pBuckets[i] != NULL)
             {
@@ -1398,16 +1398,16 @@ void Ref_ScanDependentHandlesForRelocation(UINT condemned, UINT maxgen, ScanCont
   loop scan version of TraceVariableHandles for single-thread-managed Ref_* functions
   should be kept in sync with the code above
 */
-void TraceDependentHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, UINT condemned, UINT maxgen, UINT flags)
+void TraceDependentHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, uint32_t condemned, uint32_t maxgen, uint32_t flags)
 {
     WRAPPER_NO_CONTRACT;
 
     // set up to scan variable handles with the specified mask and trace function
-    UINT type = HNDTYPE_DEPENDENT;
+    uint32_t type = HNDTYPE_DEPENDENT;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 // this is the one of Ref_* function performed by single thread in MULTI_HEAPS case, so we need to loop through all HT of the bucket
@@ -1429,21 +1429,21 @@ void TraceDependentHandlesBySingleThread(HANDLESCANPROC pfnTrace, LPARAM lp1, UI
 // indices haven't been reused yet) and we could be scanning them in an unbalanced fashion. 
 // Consider using an array to represent the compacted form of all AD indices exist for the 
 // sized ref handles. 
-void ScanSizedRefByAD(UINT maxgen, HANDLESCANPROC scanProc, ScanContext* sc, Ref_promote_func* fn, UINT flags)
+void ScanSizedRefByAD(uint32_t maxgen, HANDLESCANPROC scanProc, ScanContext* sc, Ref_promote_func* fn, uint32_t flags)
 {
     HandleTableMap *walk = &g_HandleTableMap;
-    UINT type = HNDTYPE_SIZEDREF;
+    uint32_t type = HNDTYPE_SIZEDREF;
     int uCPUindex = getSlotNumber(sc);
     int n_slots = GCHeap::GetGCHeap()->GetNumberOfHeaps();
 
     while (walk)
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
             if (walk->pBuckets[i] != NULL)
             {
                 ADIndex adIndex = HndGetHandleTableADIndex(walk->pBuckets[i]->pTable[0]);
-                if ((adIndex.m_dwIndex % n_slots) == (DWORD)uCPUindex)
+                if ((adIndex.m_dwIndex % n_slots) == (uint32_t)uCPUindex)
                 {
                     for (int index = 0; index < n_slots; index++)
                     {
@@ -1466,15 +1466,15 @@ void ScanSizedRefByAD(UINT maxgen, HANDLESCANPROC scanProc, ScanContext* sc, Ref
     }
 }
 
-void ScanSizedRefByCPU(UINT maxgen, HANDLESCANPROC scanProc, ScanContext* sc, Ref_promote_func* fn, UINT flags)
+void ScanSizedRefByCPU(uint32_t maxgen, HANDLESCANPROC scanProc, ScanContext* sc, Ref_promote_func* fn, uint32_t flags)
 {
     HandleTableMap *walk = &g_HandleTableMap;
-    UINT type = HNDTYPE_SIZEDREF;
+    uint32_t type = HNDTYPE_SIZEDREF;
     int uCPUindex = getSlotNumber(sc);
 
     while (walk) 
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
         	if (walk->pBuckets[i] != NULL)
 	        {
@@ -1496,36 +1496,36 @@ void ScanSizedRefByCPU(UINT maxgen, HANDLESCANPROC scanProc, ScanContext* sc, Re
     }
 }
 
-void Ref_ScanSizedRefHandles(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_ScanSizedRefHandles(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     LOG((LF_GC, LL_INFO10000, "Scanning SizedRef handles to in generation %u\n", condemned));
     _ASSERTE (condemned == maxgen);
-    UINT flags = (sc->concurrent ? HNDGCF_ASYNC : HNDGCF_NORMAL) | HNDGCF_EXTRAINFO;
+    uint32_t flags = (sc->concurrent ? HNDGCF_ASYNC : HNDGCF_NORMAL) | HNDGCF_EXTRAINFO;
 
     ScanSizedRefByCPU(maxgen, CalculateSizedRefSize, sc, fn, flags);
 }
 
-void Ref_CheckAlive(UINT condemned, UINT maxgen, LPARAM lp1)
+void Ref_CheckAlive(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Checking liveness of referents of short-weak handles in generation %u\n", condemned));
 
     // perform a multi-type scan that checks for unreachable objects
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_SHORT
 #ifdef FEATURE_COMINTEROP
         , HNDTYPE_WEAK_WINRT
 #endif // FEATURE_COMINTEROP
     };
-    UINT flags = (((ScanContext*) lp1)->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t flags = (((ScanContext*) lp1)->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
 
     int uCPUindex = getSlotNumber((ScanContext*) lp1);
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk)
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
             if (walk->pBuckets[i] != NULL)
             {
@@ -1543,7 +1543,7 @@ void Ref_CheckAlive(UINT condemned, UINT maxgen, LPARAM lp1)
 static VOLATILE(LONG) uCount = 0;
 
 // NOTE: Please: if you update this function, update the very similar profiling function immediately below!!!
-void Ref_UpdatePointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1566,7 +1566,7 @@ void Ref_UpdatePointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promot
     LOG((LF_GC, LL_INFO10000, "Updating pointers to referents of non-pinning handles in generation %u\n", condemned));
 
     // these are the handle types that need their pointers updated
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_SHORT,
         HNDTYPE_WEAK_LONG,
@@ -1581,11 +1581,11 @@ void Ref_UpdatePointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promot
     };
 
     // perform a multi-type scan that updates pointers
-    UINT flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
@@ -1602,7 +1602,7 @@ void Ref_UpdatePointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promot
 #if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
 // Please update this if you change the Ref_UpdatePointers function above.
-void Ref_ScanPointersForProfilerAndETW(UINT maxgen, LPARAM lp1)
+void Ref_ScanPointersForProfilerAndETW(uint32_t maxgen, LPARAM lp1)
 {
     WRAPPER_NO_CONTRACT;
 
@@ -1612,7 +1612,7 @@ void Ref_ScanPointersForProfilerAndETW(UINT maxgen, LPARAM lp1)
 
     // <REVISIT_TODO>We should change the following to not report weak either
     // these are the handle types that need their pointers updated</REVISIT_TODO>
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_SHORT,
         HNDTYPE_WEAK_LONG,
@@ -1629,12 +1629,12 @@ void Ref_ScanPointersForProfilerAndETW(UINT maxgen, LPARAM lp1)
         HNDTYPE_SIZEDREF,
     };
 
-    UINT flags = HNDGCF_NORMAL;
+    uint32_t flags = HNDGCF_NORMAL;
 
     // perform a multi-type scan that updates pointers
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
                 // this is the one of Ref_* function performed by single thread in MULTI_HEAPS case, so we need to loop through all HT of the bucket
                 for (int uCPUindex=0; uCPUindex < getNumberOfSlots(); uCPUindex++)
@@ -1650,13 +1650,13 @@ void Ref_ScanPointersForProfilerAndETW(UINT maxgen, LPARAM lp1)
     TraceVariableHandlesBySingleThread(&ScanPointerForProfilerAndETW, lp1, 0, VHT_WEAK_SHORT | VHT_WEAK_LONG | VHT_STRONG, maxgen, maxgen, flags);
 }
 
-void Ref_ScanDependentHandlesForProfilerAndETW(UINT maxgen, ProfilingScanContext * SC)
+void Ref_ScanDependentHandlesForProfilerAndETW(uint32_t maxgen, ProfilingScanContext * SC)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC | LF_CORPROF, LL_INFO10000, "Scanning dependent handles for profiler.\n"));
 
-    UINT flags = HNDGCF_NORMAL;
+    uint32_t flags = HNDGCF_NORMAL;
 
     LPARAM lp1 = (LPARAM)SC;
     // we'll re-use pHeapId (which was either unused (0) or freed by EndRootReferences2
@@ -1669,19 +1669,19 @@ void Ref_ScanDependentHandlesForProfilerAndETW(UINT maxgen, ProfilingScanContext
 
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 
-void Ref_UpdatePinnedPointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn)
+void Ref_UpdatePinnedPointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Updating pointers to referents of pinning handles in generation %u\n", condemned));
 
     // these are the handle types that need their pointers updated
-    UINT types[2] = {HNDTYPE_PINNED, HNDTYPE_ASYNCPINNED};
-    UINT flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
+    uint32_t types[2] = {HNDTYPE_PINNED, HNDTYPE_ASYNCPINNED};
+    uint32_t flags = (sc->concurrent) ? HNDGCF_ASYNC : HNDGCF_NORMAL;
 
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[getSlotNumber(sc)];
@@ -1696,14 +1696,14 @@ void Ref_UpdatePinnedPointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_
 }
 
 
-void Ref_AgeHandles(UINT condemned, UINT maxgen, LPARAM lp1)
+void Ref_AgeHandles(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Aging handles in generation %u\n", condemned));
 
     // these are the handle types that need their ages updated
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_SHORT,
         HNDTYPE_WEAK_LONG,
@@ -1726,7 +1726,7 @@ void Ref_AgeHandles(UINT condemned, UINT maxgen, LPARAM lp1)
     // perform a multi-type scan that ages the handles
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[uCPUindex];
@@ -1738,14 +1738,14 @@ void Ref_AgeHandles(UINT condemned, UINT maxgen, LPARAM lp1)
 }
 
 
-void Ref_RejuvenateHandles(UINT condemned, UINT maxgen, LPARAM lp1)
+void Ref_RejuvenateHandles(uint32_t condemned, uint32_t maxgen, LPARAM lp1)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Rejuvenating handles.\n"));
 
     // these are the handle types that need their ages updated
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_SHORT,
         HNDTYPE_WEAK_LONG,
@@ -1769,7 +1769,7 @@ void Ref_RejuvenateHandles(UINT condemned, UINT maxgen, LPARAM lp1)
     // reset the ages of these handles
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk) {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
             if (walk->pBuckets[i] != NULL)
             {
                 HHANDLETABLE hTable = walk->pBuckets[i]->pTable[uCPUindex];
@@ -1780,14 +1780,14 @@ void Ref_RejuvenateHandles(UINT condemned, UINT maxgen, LPARAM lp1)
     }
 }
 
-void Ref_VerifyHandleTable(UINT condemned, UINT maxgen, ScanContext* sc)
+void Ref_VerifyHandleTable(uint32_t condemned, uint32_t maxgen, ScanContext* sc)
 {
     WRAPPER_NO_CONTRACT;
 
     LOG((LF_GC, LL_INFO10000, "Verifying handles.\n"));
 
     // these are the handle types that need to be verified
-    UINT types[] =
+    uint32_t types[] =
     {
         HNDTYPE_WEAK_SHORT,
         HNDTYPE_WEAK_LONG,
@@ -1812,7 +1812,7 @@ void Ref_VerifyHandleTable(UINT condemned, UINT maxgen, ScanContext* sc)
     HandleTableMap *walk = &g_HandleTableMap;
     while (walk)
     {
-        for (UINT i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
+        for (uint32_t i = 0; i < INITIAL_HANDLE_TABLE_ARRAY_SIZE; i ++)
         {
             if (walk->pBuckets[i] != NULL)
             {

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -203,7 +203,7 @@ struct HandleTableMap
 {
     PTR_PTR_HandleTableBucket   pBuckets;
     PTR_HandleTableMap          pNext;
-    DWORD                       dwMaxIndex;
+    uint32_t                    dwMaxIndex;
 };
 
 GVAL_DECL(HandleTableMap, g_HandleTableMap);
@@ -216,7 +216,7 @@ GVAL_DECL(HandleTableMap, g_HandleTableMap);
 struct HandleTableBucket
 {
     PTR_HHANDLETABLE pTable;
-    UINT             HandleTableIndex;
+    uint32_t         HandleTableIndex;
 
     bool Contains(OBJECTHANDLE handle);
 };
@@ -438,10 +438,10 @@ inline void DestroyDependentHandle(OBJECTHANDLE handle)
 
 #ifndef DACCESS_COMPILE
 
-OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, UINT type);
-UINT         GetVariableHandleType(OBJECTHANDLE handle);
-void         UpdateVariableHandleType(OBJECTHANDLE handle, UINT type);
-UINT         CompareExchangeVariableHandleType(OBJECTHANDLE handle, UINT oldType, UINT newType);
+OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type);
+uint32_t         GetVariableHandleType(OBJECTHANDLE handle);
+void         UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type);
+uint32_t         CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);
 
 inline void  DestroyVariableHandle(OBJECTHANDLE handle)
 {
@@ -654,30 +654,30 @@ BOOL Ref_ContainHandle(HandleTableBucket *pBucket, OBJECTHANDLE handle);
 struct ScanContext;
 struct DhContext;
 struct ProfilingScanContext;
-void Ref_BeginSynchronousGC   (UINT uCondemnedGeneration, UINT uMaxGeneration);
-void Ref_EndSynchronousGC     (UINT uCondemnedGeneration, UINT uMaxGeneration);
+void Ref_BeginSynchronousGC   (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration);
+void Ref_EndSynchronousGC     (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration);
 
-typedef void Ref_promote_func(class Object**, ScanContext*, DWORD);
+typedef void Ref_promote_func(class Object**, ScanContext*, uint32_t);
 
 void Ref_TraceRefCountHandles(HANDLESCANPROC callback, LPARAM lParam1, LPARAM lParam2);
-void Ref_TracePinningRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
-void Ref_TraceNormalRoots(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
-void Ref_UpdatePointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
-void Ref_UpdatePinnedPointers(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_TracePinningRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_UpdatePinnedPointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 DhContext *Ref_GetDependentHandleContext(ScanContext* sc);
 bool Ref_ScanDependentHandlesForPromotion(DhContext *pDhContext);
-void Ref_ScanDependentHandlesForClearing(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
-void Ref_ScanDependentHandlesForRelocation(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
-void Ref_ScanSizedRefHandles(UINT condemned, UINT maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_ScanDependentHandlesForClearing(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_ScanDependentHandlesForRelocation(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
+void Ref_ScanSizedRefHandles(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 
-void Ref_CheckReachable       (UINT uCondemnedGeneration, UINT uMaxGeneration, LPARAM lp1);
-void Ref_CheckAlive           (UINT uCondemnedGeneration, UINT uMaxGeneration, LPARAM lp1);
-void Ref_ScanPointersForProfilerAndETW(UINT uMaxGeneration, LPARAM lp1);
-void Ref_ScanDependentHandlesForProfilerAndETW(UINT uMaxGeneration, ProfilingScanContext * SC);
-void Ref_AgeHandles           (UINT uCondemnedGeneration, UINT uMaxGeneration, LPARAM lp1);
-void Ref_RejuvenateHandles(UINT uCondemnedGeneration, UINT uMaxGeneration, LPARAM lp1);
+void Ref_CheckReachable       (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
+void Ref_CheckAlive           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
+void Ref_ScanPointersForProfilerAndETW(uint32_t uMaxGeneration, LPARAM lp1);
+void Ref_ScanDependentHandlesForProfilerAndETW(uint32_t uMaxGeneration, ProfilingScanContext * SC);
+void Ref_AgeHandles           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
+void Ref_RejuvenateHandles(uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
 
-void Ref_VerifyHandleTable(UINT condemned, UINT maxgen, ScanContext* sc);
+void Ref_VerifyHandleTable(uint32_t condemned, uint32_t maxgen, ScanContext* sc);
 
 #endif // DACCESS_COMPILE
 

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -439,9 +439,9 @@ inline void DestroyDependentHandle(OBJECTHANDLE handle)
 #ifndef DACCESS_COMPILE
 
 OBJECTHANDLE CreateVariableHandle(HHANDLETABLE hTable, OBJECTREF object, uint32_t type);
-uint32_t         GetVariableHandleType(OBJECTHANDLE handle);
+uint32_t     GetVariableHandleType(OBJECTHANDLE handle);
 void         UpdateVariableHandleType(OBJECTHANDLE handle, uint32_t type);
-uint32_t         CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);
+uint32_t     CompareExchangeVariableHandleType(OBJECTHANDLE handle, uint32_t oldType, uint32_t newType);
 
 inline void  DestroyVariableHandle(OBJECTHANDLE handle)
 {

--- a/src/gc/objecthandle.h
+++ b/src/gc/objecthandle.h
@@ -385,7 +385,7 @@ inline OBJECTHANDLE CreateSizedRefHandle(HHANDLETABLE table, OBJECTREF object)
 { 
     WRAPPER_NO_CONTRACT;
 
-    return HndCreateHandle(table, HNDTYPE_SIZEDREF, object, (LPARAM)0);
+    return HndCreateHandle(table, HNDTYPE_SIZEDREF, object, (uintptr_t)0);
 }
 
 void DestroySizedRefHandle(OBJECTHANDLE handle);
@@ -413,7 +413,7 @@ inline OBJECTHANDLE CreateWinRTWeakHandle(HHANDLETABLE table, OBJECTREF object, 
 {
     WRAPPER_NO_CONTRACT;
     _ASSERTE(pWinRTWeakReference != NULL);
-    return HndCreateHandle(table, HNDTYPE_WEAK_WINRT, object, reinterpret_cast<LPARAM>(pWinRTWeakReference));
+    return HndCreateHandle(table, HNDTYPE_WEAK_WINRT, object, reinterpret_cast<uintptr_t>(pWinRTWeakReference));
 }
 
 void DestroyWinRTWeakHandle(OBJECTHANDLE handle);
@@ -659,7 +659,7 @@ void Ref_EndSynchronousGC     (uint32_t uCondemnedGeneration, uint32_t uMaxGener
 
 typedef void Ref_promote_func(class Object**, ScanContext*, uint32_t);
 
-void Ref_TraceRefCountHandles(HANDLESCANPROC callback, LPARAM lParam1, LPARAM lParam2);
+void Ref_TraceRefCountHandles(HANDLESCANPROC callback, uintptr_t lParam1, uintptr_t lParam2);
 void Ref_TracePinningRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 void Ref_TraceNormalRoots(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 void Ref_UpdatePointers(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
@@ -670,12 +670,12 @@ void Ref_ScanDependentHandlesForClearing(uint32_t condemned, uint32_t maxgen, Sc
 void Ref_ScanDependentHandlesForRelocation(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 void Ref_ScanSizedRefHandles(uint32_t condemned, uint32_t maxgen, ScanContext* sc, Ref_promote_func* fn);
 
-void Ref_CheckReachable       (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
-void Ref_CheckAlive           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
-void Ref_ScanPointersForProfilerAndETW(uint32_t uMaxGeneration, LPARAM lp1);
+void Ref_CheckReachable       (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
+void Ref_CheckAlive           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
+void Ref_ScanPointersForProfilerAndETW(uint32_t uMaxGeneration, uintptr_t lp1);
 void Ref_ScanDependentHandlesForProfilerAndETW(uint32_t uMaxGeneration, ProfilingScanContext * SC);
-void Ref_AgeHandles           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
-void Ref_RejuvenateHandles(uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, LPARAM lp1);
+void Ref_AgeHandles           (uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
+void Ref_RejuvenateHandles(uint32_t uCondemnedGeneration, uint32_t uMaxGeneration, uintptr_t lp1);
 
 void Ref_VerifyHandleTable(uint32_t condemned, uint32_t maxgen, ScanContext* sc);
 

--- a/src/gc/sample/GCSample.cpp
+++ b/src/gc/sample/GCSample.cpp
@@ -60,8 +60,8 @@ Object * AllocateObject(MethodTable * pMT)
 
     size_t size = pMT->GetBaseSize();
 
-    BYTE* result = acontext->alloc_ptr;
-    BYTE* advance = result + size;
+    uint8_t* result = acontext->alloc_ptr;
+    uint8_t* advance = result + size;
     if (advance <= acontext->alloc_limit)
     {
         acontext->alloc_ptr = advance;
@@ -92,14 +92,14 @@ inline void ErectWriteBarrier(Object ** dst, Object * ref)
 {
     // if the dst is outside of the heap (unboxed value classes) then we
     //      simply exit
-    if (((BYTE*)dst < g_lowest_address) || ((BYTE*)dst >= g_highest_address))
+    if (((uint8_t*)dst < g_lowest_address) || ((uint8_t*)dst >= g_highest_address))
         return;
         
-    if((BYTE*)ref >= g_ephemeral_low && (BYTE*)ref < g_ephemeral_high)
+    if((uint8_t*)ref >= g_ephemeral_low && (uint8_t*)ref < g_ephemeral_high)
     {
         // volatile is used here to prevent fetch of g_card_table from being reordered 
         // with g_lowest/highest_address check above. See comment in code:gc_heap::grow_brick_card_tables.
-        BYTE* pCardByte = (BYTE *)*(volatile BYTE **)(&g_card_table) + card_byte((BYTE *)dst);
+        uint8_t* pCardByte = (uint8_t *)*(volatile uint8_t **)(&g_card_table) + card_byte((uint8_t *)dst);
         if(*pCardByte != 0xFF)
             *pCardByte = 0xFF;
     }

--- a/src/gcinfo/gcinfodumper.cpp
+++ b/src/gcinfo/gcinfodumper.cpp
@@ -44,7 +44,7 @@ size_t GcInfoDumper::GetGCInfoSize()
 void GcInfoDumper::LivePointerCallback (
         LPVOID          hCallback,      // callback data
         OBJECTREF*      pObject,        // address of obect-reference we are reporting
-        DWORD           flags           // is this a pinned and/or interior pointer
+        uint32_t        flags           // is this a pinned and/or interior pointer
         DAC_ARG(DacSlotLocation loc))   // the location of the slot
 {
     GcInfoDumper *pDumper = (GcInfoDumper*)hCallback;

--- a/src/inc/crtwrap.h
+++ b/src/inc/crtwrap.h
@@ -29,6 +29,7 @@
 #include <tchar.h>
 #include "debugmacros.h"
 #include <stdlib.h>
+#include <stdint.h>
 #include <malloc.h>
 #include <wchar.h>
 #include <stdio.h>

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -2336,7 +2336,9 @@ inline type* DacUnsafeMarshalSingleElement( ArrayDPTR(type) arrayPtr )
 //----------------------------------------------------------------------------
 
 typedef ArrayDPTR(BYTE)    PTR_BYTE;
+typedef ArrayDPTR(uint8_t) PTR_uint8_t;
 typedef DPTR(PTR_BYTE) PTR_PTR_BYTE;
+typedef DPTR(PTR_uint8_t) PTR_PTR_uint8_t;
 typedef DPTR(PTR_PTR_BYTE) PTR_PTR_PTR_BYTE;
 typedef ArrayDPTR(signed char) PTR_SBYTE;
 typedef ArrayDPTR(const BYTE) PTR_CBYTE;
@@ -2345,6 +2347,7 @@ typedef DPTR(INT16)   PTR_INT16;
 typedef DPTR(WORD)    PTR_WORD;
 typedef DPTR(USHORT)  PTR_USHORT;
 typedef DPTR(DWORD)   PTR_DWORD;
+typedef DPTR(uint32_t) PTR_uint32_t;
 typedef DPTR(LONG)    PTR_LONG;
 typedef DPTR(ULONG)   PTR_ULONG;
 typedef DPTR(INT32)   PTR_INT32;

--- a/src/inc/dbggcinfodecoder.h
+++ b/src/inc/dbggcinfodecoder.h
@@ -58,7 +58,7 @@ typedef SIZE_T TADDR;
 typedef void (*GCEnumCallback)(
     LPVOID          hCallback,      // callback data
     OBJECTREF*      pObject,        // address of obect-reference we are reporting
-    DWORD           flags           // is this a pinned and/or interior pointer
+    uint32_t        flags           // is this a pinned and/or interior pointer
 );
 
 

--- a/src/inc/eetwain.h
+++ b/src/inc/eetwain.h
@@ -64,7 +64,7 @@ typedef struct _DAC_SLOT_LOCATION
 typedef void (*GCEnumCallback)(
     LPVOID          hCallback,      // callback data
     OBJECTREF*      pObject,        // address of obect-reference we are reporting
-    DWORD           flags           // is this a pinned and/or interior pointer
+    uint32_t        flags           // is this a pinned and/or interior pointer
     DAC_ARG(DacSlotLocation loc)    // where the reference came from
 );
 

--- a/src/inc/gcinfodecoder.h
+++ b/src/inc/gcinfodecoder.h
@@ -112,7 +112,7 @@ inline BOOL IS_ALIGNED( void* val, size_t alignment )
 typedef void (*GCEnumCallback)(
     LPVOID          hCallback,      // callback data
     OBJECTREF*      pObject,        // address of obect-reference we are reporting
-    DWORD           flags           // is this a pinned and/or interior pointer
+    uint32_t        flags           // is this a pinned and/or interior pointer
 );
 
 #ifndef _strike_h

--- a/src/inc/gcinfodumper.h
+++ b/src/inc/gcinfodumper.h
@@ -94,7 +94,7 @@ private:
     static void LivePointerCallback (
             LPVOID          hCallback,      // callback data
             OBJECTREF*      pObject,        // address of obect-reference we are reporting
-            DWORD           flags           // is this a pinned and/or interior pointer
+            uint32_t        flags           // is this a pinned and/or interior pointer
             DAC_ARG(DacSlotLocation loc));  // the location the pointer came from
 
     static void FreePointerRecords (LivePointerRecord *pRecords);

--- a/src/inc/profilepriv.h
+++ b/src/inc/profilepriv.h
@@ -150,7 +150,7 @@ GVAL_DECL(ProfControlBlock, g_profControlBlock);
 
 // This is the helper callback that the gc uses when walking the heap.
 BOOL HeapWalkHelper(Object* pBO, void* pv);
-void ScanRootsHelper(Object** ppObj, ScanContext *pSC, DWORD dwUnused);
+void ScanRootsHelper(Object** ppObj, ScanContext *pSC, uint32_t dwUnused);
 BOOL AllocByClassHelper(Object* pBO, void* pv);
 
 #endif  // _ProfilePriv_h_

--- a/src/tools/InjectResource/InjectResource.cpp
+++ b/src/tools/InjectResource/InjectResource.cpp
@@ -5,6 +5,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <windows.h>
 #include <daccess.h>
 

--- a/src/vm/amd64/JitHelpers_Slow.asm
+++ b/src/vm/amd64/JitHelpers_Slow.asm
@@ -454,7 +454,7 @@ NESTED_END JIT_NewArr1OBJ_MP, _TEXT
 ;        Unfortunately, the compiler intrinsic for InterlockedExchangePointer seems to be broken and we
 ;        get bad code gen in gc.cpp on IA64. </TODO>
 
-M_GCLOCK equ ?m_GCLock@@3JC
+M_GCLOCK equ ?m_GCLock@@3HC
 extern M_GCLOCK:dword
 extern generation_table:qword
 

--- a/src/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/vm/amd64/jitinterfaceamd64.cpp
@@ -18,9 +18,9 @@
 #include "excep.h"
 #include "threadsuspend.h"
 
-extern BYTE* g_ephemeral_low; 
-extern BYTE* g_ephemeral_high;
-extern DWORD*  g_card_table;
+extern uint8_t* g_ephemeral_low;
+extern uint8_t* g_ephemeral_high;
+extern uint32_t*  g_card_table;
 
 // Patch Labels for the various write barriers
 EXTERN_C void JIT_WriteBarrier_End();

--- a/src/vm/amd64/jitinterfaceamd64.cpp
+++ b/src/vm/amd64/jitinterfaceamd64.cpp
@@ -20,7 +20,7 @@
 
 extern uint8_t* g_ephemeral_low;
 extern uint8_t* g_ephemeral_high;
-extern uint32_t*  g_card_table;
+extern uint32_t* g_card_table;
 
 // Patch Labels for the various write barriers
 EXTERN_C void JIT_WriteBarrier_End();

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -1428,7 +1428,7 @@ void CEECompileInfo::GetAssemblyCodeBase(CORINFO_ASSEMBLY_HANDLE hAssembly, SStr
 
 //=================================================================================
 
-void FakePromote(PTR_PTR_Object ppObj, ScanContext *pSC, DWORD dwFlags)
+void FakePromote(PTR_PTR_Object ppObj, ScanContext *pSC, uint32_t dwFlags)
 {
     CONTRACTL {
         NOTHROW;
@@ -1442,7 +1442,7 @@ void FakePromote(PTR_PTR_Object ppObj, ScanContext *pSC, DWORD dwFlags)
 
 //=================================================================================
 
-void FakePromoteCarefully(promote_func *fn, Object **ppObj, ScanContext *pSC, DWORD dwFlags)
+void FakePromoteCarefully(promote_func *fn, Object **ppObj, ScanContext *pSC, uint32_t dwFlags)
 {
     (*fn)(ppObj, pSC, dwFlags);
 }

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -134,7 +134,7 @@ BOOL g_fEEComActivatedStartup=FALSE;
 GVAL_IMPL_INIT(DWORD, g_fHostConfig, 0);
 
 #ifdef FEATURE_SVR_GC
-SVAL_IMPL_INIT(DWORD,GCHeap,gcHeapType,GCHeap::GC_HEAP_WKS);
+SVAL_IMPL_INIT(uint32_t,GCHeap,gcHeapType,GCHeap::GC_HEAP_WKS);
 #endif
 
 void UpdateGCSettingFromHost()

--- a/src/vm/eetwain.cpp
+++ b/src/vm/eetwain.cpp
@@ -4708,7 +4708,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pContext,
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
         // Note that I really want to say hCallBack is a GCCONTEXT, but this is pretty close
-        extern void GcEnumObject(LPVOID pData, OBJECTREF *pObj, DWORD flags);
+        extern void GcEnumObject(LPVOID pData, OBJECTREF *pObj, uint32_t flags);
         _ASSERTE((void*) GcEnumObject == pCallBack);
 #endif
         GCCONTEXT   *pCtx = (GCCONTEXT *) hCallBack;
@@ -4961,7 +4961,7 @@ bool EECodeManager::EnumGcRefs( PREGDISPLAY     pRD,
 
 #if defined(_DEBUG) && !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
         // Note that I really want to say hCallBack is a GCCONTEXT, but this is pretty close
-        extern void GcEnumObject(LPVOID pData, OBJECTREF *pObj, DWORD flags);
+        extern void GcEnumObject(LPVOID pData, OBJECTREF *pObj, uint32_t flags);
         _ASSERTE((void*) GcEnumObject == pCallBack);
 #endif
         GCCONTEXT   *pCtx = (GCCONTEXT *) hCallBack;

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1340,8 +1340,8 @@ void BulkComLogger::LogAllComObjects()
     // We need to do work in HandleWalkCallback which may trigger a GC.  We cannot do this while
     // enumerating the handle table.  Instead, we will build a list of RefCount handles we found
     // during the handle table enumeration first (m_enumResult) during this enumeration:
-    Ref_TraceRefCountHandles(BulkComLogger::HandleWalkCallback, LPARAM(this), 0);
-
+    Ref_TraceRefCountHandles(BulkComLogger::HandleWalkCallback, uintptr_t(this), 0);
+    
     // Now that we have all of the object handles, we will walk all of the handles and write the
     // etw events.
     for (CCWEnumerationEntry *curr = m_enumResult; curr; curr = curr->Next)
@@ -1381,7 +1381,7 @@ void BulkComLogger::LogAllComObjects()
 
 }
 
-void BulkComLogger::HandleWalkCallback(Object **handle, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2)
+void BulkComLogger::HandleWalkCallback(Object **handle, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2)
 {
     CONTRACTL 
     {

--- a/src/vm/eventtrace.cpp
+++ b/src/vm/eventtrace.cpp
@@ -1341,7 +1341,7 @@ void BulkComLogger::LogAllComObjects()
     // enumerating the handle table.  Instead, we will build a list of RefCount handles we found
     // during the handle table enumeration first (m_enumResult) during this enumeration:
     Ref_TraceRefCountHandles(BulkComLogger::HandleWalkCallback, uintptr_t(this), 0);
-    
+
     // Now that we have all of the object handles, we will walk all of the handles and write the
     // etw events.
     for (CCWEnumerationEntry *curr = m_enumResult; curr; curr = curr->Next)

--- a/src/vm/eventtracepriv.h
+++ b/src/vm/eventtracepriv.h
@@ -342,7 +342,7 @@ private:
     void FlushCcw();
 
     // Callback used during handle table enumeration.
-    static void HandleWalkCallback(PTR_UNCHECKED_OBJECTREF pref, LPARAM *pExtraInfo, LPARAM param1, LPARAM param2);
+    static void HandleWalkCallback(PTR_UNCHECKED_OBJECTREF pref, uintptr_t *pExtraInfo, uintptr_t param1, uintptr_t param2);
 
     // Used during CCW enumeration to keep track of all object handles which point to a CCW.
     void AddCcwHandle(Object **handle);

--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1454,7 +1454,7 @@ struct IsObjRefProtectedScanContext : public ScanContext
     }
 };
 
-void IsObjRefProtected (Object** ppObj, ScanContext* sc, DWORD)
+void IsObjRefProtected (Object** ppObj, ScanContext* sc, uint32_t)
 {
     LIMITED_METHOD_CONTRACT;
     IsObjRefProtectedScanContext * orefProtectedSc = (IsObjRefProtectedScanContext *)sc;

--- a/src/vm/gcenv.cpp
+++ b/src/vm/gcenv.cpp
@@ -50,7 +50,7 @@ void GCToEEInterface::RestartEE(BOOL bFinishedGC)
  * GC enumeration callback
  */
 
-void GcEnumObject(LPVOID pData, OBJECTREF *pObj, DWORD flags)
+void GcEnumObject(LPVOID pData, OBJECTREF *pObj, uint32_t flags)
 {
     Object ** ppObj = (Object **)pObj;
     GCCONTEXT   * pCtx  = (GCCONTEXT *) pData;

--- a/src/vm/gcenv.h
+++ b/src/vm/gcenv.h
@@ -49,7 +49,7 @@
 struct ScanContext;
 class CrawlFrame;
 
-typedef void promote_func(PTR_PTR_Object, ScanContext*, DWORD);
+typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
 
 typedef struct
 {

--- a/src/vm/perfdefaults.cpp
+++ b/src/vm/perfdefaults.cpp
@@ -27,7 +27,7 @@
 PerformanceDefaults::PerformanceScenario PerformanceDefaults::s_Scenario = Uninitialized;
 
 // See use in code:PerformanceDefaults:InitializeForScenario
-extern LONG g_bLowMemoryFromHost;
+extern int32_t g_bLowMemoryFromHost;
 
 
 //

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -1250,7 +1250,7 @@ BOOL AllocByClassHelper(Object * pBO, void * pv)
 //                to COR_PRF_GC_ROOT_FLAGS.
 //
 
-void ScanRootsHelper(Object** ppObject, ScanContext *pSC, DWORD dwFlags)
+void ScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
 {
     CONTRACTL
     {

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -4922,7 +4922,7 @@ BOOL MetaSig::CompareMethodConstraints(const Substitution *pSubst1,
 void PromoteCarefully(promote_func   fn, 
                       PTR_PTR_Object ppObj, 
                       ScanContext*   sc, 
-                      DWORD          flags /* = GC_CALL_INTERIOR*/ )
+                      uint32_t       flags /* = GC_CALL_INTERIOR*/ )
 {
     LIMITED_METHOD_CONTRACT;
 

--- a/src/vm/siginfo.hpp
+++ b/src/vm/siginfo.hpp
@@ -70,13 +70,13 @@ enum VarKind
 //---------------------------------------------------------------------------------------
 
 struct ScanContext;
-typedef void promote_func(PTR_PTR_Object, ScanContext*, DWORD);
-typedef void promote_carefully_func(promote_func*, PTR_PTR_Object, ScanContext*, DWORD);
+typedef void promote_func(PTR_PTR_Object, ScanContext*, uint32_t);
+typedef void promote_carefully_func(promote_func*, PTR_PTR_Object, ScanContext*, uint32_t);
 
 void PromoteCarefully(promote_func   fn,
                       PTR_PTR_Object obj, 
                       ScanContext*   sc, 
-                      DWORD          flags = GC_CALL_INTERIOR);
+                      uint32_t       flags = GC_CALL_INTERIOR);
 
 class LoaderAllocator;
 void GcReportLoaderAllocator(promote_func* fn, ScanContext* sc, LoaderAllocator *pLoaderAllocator);


### PR DESCRIPTION
This change replaces windows specific types like DWORD, LONG, ULONG, LPARAM, BYTE etc, in the GC code by size explicit types.
The only things that weren't changed are:
- BOOL which is of a different size than bool and there were concerns that it could be destabilizing. I still think that we should try to change that later and use deep stress /perf testing to make sure it doesn't cause some unexpected regressions.
- Windows specific types in Windows API signatures. That required adding casting to DWORD / LONG at the invocation of windows apis that have pointers to these types as parameters. This will go away later on as part of a planned refactoring that will replace direct calls of Windows OS APIs from the GC (or their Unix implementations) by OS agnostic methods on a well defined static interface class.