### PR TITLE
Replace double quotes around test arguments with single quotes.

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -106,7 +106,7 @@ echo BEGIN EXECUTION]]>
       </BashCLRTestExitCodePrep>
     
       <BashCLRTestArgPrep Condition=" '$(CLRTestExecutionArguments)'!='' ">
-<![CDATA[CLRTestExecutionArguments="$(CLRTestExecutionArguments)"]]>
+<![CDATA[CLRTestExecutionArguments='$(CLRTestExecutionArguments)']]>
       </BashCLRTestArgPrep>
     
       <!-- By default, be prepared to do a full check -->


### PR DESCRIPTION
When test args are things like `"foo bar"`, the current way quotes are being added around them makes it `""foo bar""` which is read as `foo`.

Now, it will be `'"foo bar"'` which will be `"foo bar"` as expected.

Please don't merge until everything passes in CI.
