### PR TITLE
Separate CancellationTokenSource linking into a derived class

### DIFF
--- a/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
+++ b/src/mscorlib/src/System/Threading/CancellationTokenSource.cs
@@ -69,23 +69,12 @@ namespace System.Threading
         private volatile int m_threadIDExecutingCallbacks = -1;
 
         private bool m_disposed;
-
-        private CancellationTokenRegistration [] m_linkingRegistrations; //lazily initialized if required.
-        
-        private static readonly Action<object> s_LinkedTokenCancelDelegate = new Action<object>(LinkedTokenCancelDelegate);
         
         // we track the running callback to assist ctr.Dispose() to wait for the target callback to complete.
         private volatile CancellationCallbackInfo m_executingCallback;
 
         // provided for CancelAfter and timer-related constructors
         private volatile Timer m_timer;
-
-        private static void LinkedTokenCancelDelegate(object source)
-        {
-            CancellationTokenSource cts = source as CancellationTokenSource;
-            Contract.Assert(source != null);
-            cts.Cancel();
-        }
         
         // ---------------------- 
         // ** public properties
@@ -550,7 +539,7 @@ namespace System.Threading
         {
             // There is nothing to do if disposing=false because the CancellationTokenSource holds no unmanaged resources.
 
-            if (disposing)
+            if (disposing && !m_disposed)
             {
                 //NOTE: We specifically tolerate that a callback can be deregistered
                 //      after the CTS has been disposed and/or concurrently with cts.Dispose().
@@ -567,20 +556,7 @@ namespace System.Threading
                 //      than if Dispose wasn't safe to use concurrently, as Dispose would never be called,
                 //      and thus no handlers would be dropped.
 
-                if (m_disposed)
-                    return;
-
                 if (m_timer != null) m_timer.Dispose();
-
-                var linkingRegistrations = m_linkingRegistrations;
-                if (linkingRegistrations != null)
-                {
-                    m_linkingRegistrations = null; // free for GC once we're done enumerating
-                    for (int i = 0; i < linkingRegistrations.Length; i++)
-                    {
-                        linkingRegistrations[i].Dispose();
-                    }
-                }
 
                 // registered callbacks are now either complete or will never run, due to guarantees made by ctr.Dispose()
                 // so we can now perform main disposal work without risk of linking callbacks trying to use this CTS.
@@ -870,28 +846,9 @@ namespace System.Threading
         /// to the source tokens.</returns>
         public static CancellationTokenSource CreateLinkedTokenSource(CancellationToken token1, CancellationToken token2)
         {
-            CancellationTokenSource linkedTokenSource = new CancellationTokenSource();
-
-            bool token2CanBeCanceled = token2.CanBeCanceled;
-
-            if( token1.CanBeCanceled )
-            {
-                linkedTokenSource.m_linkingRegistrations = new CancellationTokenRegistration[token2CanBeCanceled ? 2 : 1]; // there will be at least 1 and at most 2 linkings
-                linkedTokenSource.m_linkingRegistrations[0] = token1.InternalRegisterWithoutEC(s_LinkedTokenCancelDelegate, linkedTokenSource);
-            }
-            
-            if( token2CanBeCanceled )
-            {
-                int index = 1;
-                if( linkedTokenSource.m_linkingRegistrations == null )
-                {
-                    linkedTokenSource.m_linkingRegistrations = new CancellationTokenRegistration[1]; // this will be the only linking
-                    index = 0;
-                }
-                linkedTokenSource.m_linkingRegistrations[index] = token2.InternalRegisterWithoutEC(s_LinkedTokenCancelDelegate, linkedTokenSource);
-            }
-            
-            return linkedTokenSource;
+            return token1.CanBeCanceled || token2.CanBeCanceled ?
+                new LinkedCancellationTokenSource(token1, token2) :
+                new CancellationTokenSource();
         }
 
         /// <summary>
@@ -914,21 +871,7 @@ namespace System.Threading
             // hence each item cannot be null itself, and reads of the payloads cannot be torn.
             Contract.EndContractBlock();
 
-            CancellationTokenSource linkedTokenSource = new CancellationTokenSource();
-            linkedTokenSource.m_linkingRegistrations = new CancellationTokenRegistration[tokens.Length];
-
-            for (int i = 0; i < tokens.Length; i++)
-            {
-                if (tokens[i].CanBeCanceled)
-                {
-                    linkedTokenSource.m_linkingRegistrations[i] = tokens[i].InternalRegisterWithoutEC(s_LinkedTokenCancelDelegate, linkedTokenSource);
-                }
-                // Empty slots in the array will be default(CancellationTokenRegistration), which are nops to Dispose.
-                // Based on usage patterns, such occurrences should also be rare, such that it's not worth resizing
-                // the array and incurring the related costs.
-            }
-
-            return linkedTokenSource;
+            return new LinkedCancellationTokenSource(tokens);
         }
 
 
@@ -942,6 +885,69 @@ namespace System.Threading
             {
                 sw.SpinOnce();  //spin as we assume callback execution is fast and that this situation is rare.
             }
+        }
+
+        private sealed class LinkedCancellationTokenSource : CancellationTokenSource
+        {
+            private static readonly Action<object> s_linkedTokenCancelDelegate = s => ((CancellationTokenSource)s).Cancel();
+            private CancellationTokenRegistration[] m_linkingRegistrations;
+
+            internal LinkedCancellationTokenSource(CancellationToken token1, CancellationToken token2)
+            {
+                bool token2CanBeCanceled = token2.CanBeCanceled;
+
+                if (token1.CanBeCanceled)
+                {
+                    m_linkingRegistrations = new CancellationTokenRegistration[token2CanBeCanceled ? 2 : 1]; // there will be at least 1 and at most 2 linkings
+                    m_linkingRegistrations[0] = token1.InternalRegisterWithoutEC(s_linkedTokenCancelDelegate, this);
+                }
+
+                if (token2CanBeCanceled)
+                {
+                    int index = 1;
+                    if (m_linkingRegistrations == null)
+                    {
+                        m_linkingRegistrations = new CancellationTokenRegistration[1]; // this will be the only linking
+                        index = 0;
+                    }
+                    m_linkingRegistrations[index] = token2.InternalRegisterWithoutEC(s_linkedTokenCancelDelegate, this);
+                }
+            }
+
+            internal LinkedCancellationTokenSource(params CancellationToken[] tokens)
+            {
+                m_linkingRegistrations = new CancellationTokenRegistration[tokens.Length];
+
+                for (int i = 0; i < tokens.Length; i++)
+                {
+                    if (tokens[i].CanBeCanceled)
+                    {
+                        m_linkingRegistrations[i] = tokens[i].InternalRegisterWithoutEC(s_linkedTokenCancelDelegate, this);
+                    }
+                    // Empty slots in the array will be default(CancellationTokenRegistration), which are nops to Dispose.
+                    // Based on usage patterns, such occurrences should also be rare, such that it's not worth resizing
+                    // the array and incurring the related costs.
+                }
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                if (!disposing || m_disposed)
+                    return;
+
+                CancellationTokenRegistration[] linkingRegistrations = m_linkingRegistrations;
+                if (linkingRegistrations != null)
+                {
+                    m_linkingRegistrations = null; // release for GC once we're done enumerating
+                    for (int i = 0; i < linkingRegistrations.Length; i++)
+                    {
+                        linkingRegistrations[i].Dispose();
+                    }
+                }
+
+                base.Dispose(disposing);
+            }
+
         }
     }
 


### PR DESCRIPTION
This change reduces the size of a normal CancellationTokenSource by ~11%.

The CancellationTokenSource.m_linkingRegistrations field is only used on CancellationTokenSource instances created by the static CreateLinkedTokenSource factory.  This commit creates a private LinkedCancellationTokenSource derived type to contain that field and related logic, so that the field is pay for play.  

(There are some other potential memory improvements I'm exploring, but they all come with tradeoffs, e.g. removing a field in exchange for another interlocked operation, moving several fields into a lazily-allocated object, etc.)

cc: @ericeil, @AlfredoM
Related to https://github.com/dotnet/coreclr/issues/2113