### PR TITLE
pal,cmake: Check presence of builtin function

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -16,6 +16,7 @@
 #cmakedefine01 HAVE_LIBUNWIND_H
 #cmakedefine01 HAVE_RUNETYPE_H
 
+#cmakedefine01 HAVE___BUILTIN___CLEAR_CACHE
 #cmakedefine01 HAVE_KQUEUE
 #cmakedefine01 HAVE_GETPWUID_R
 #cmakedefine01 HAVE_PTHREAD_SUSPEND

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -842,6 +842,12 @@ int main()
 }" FILE_OPS_CHECK_FERROR_OF_PREVIOUS_CALL)
 set(CMAKE_REQUIRED_DEFINITIONS)
 
+check_c_source_compiles("
+int main(int argc, char **argv)
+{
+        __builtin___clear_cache(0, 0);
+}" HAVE___BUILTIN___CLEAR_CACHE)
+
 set(SYNCHMGR_SUSPENSION_SAFE_CONDITION_SIGNALING 1)
 set(ERROR_FUNC_FOR_GLOB_HAS_FIXED_PARAMS 1)
 

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -35,6 +35,14 @@ SET_DEFAULT_DEBUG_CHANNEL(DEBUG);
 // in context2.S
 extern void CONTEXT_CaptureContext(LPCONTEXT lpContext);
 
+#if HAVE___BUILTIN___CLEAR_CACHE
+#define flush_cache(ADDR, LEN) \
+    __builtin___clear_cache((ADDR), (ADDR) + (LEN))
+#else
+#include <stddef.h>
+extern void flush_cache (void *addr, size_t len);
+#endif
+
 #ifdef _X86_
 #define CONTEXT_ALL_FLOATING (CONTEXT_FLOATING_POINT | CONTEXT_EXTENDED_REGISTERS)
 #elif defined(_AMD64_)
@@ -1303,8 +1311,7 @@ DBG_FlushInstructionCache(
                           IN LPCVOID lpBaseAddress,
                           IN SIZE_T dwSize)
 {
-    // Intrinsic should do the right thing across all platforms
-    __builtin___clear_cache((char *)lpBaseAddress, (char *)((INT_PTR)lpBaseAddress + dwSize));
+    flush_cache((char *)lpBaseAddress, dwSize);
 
     return TRUE;
 }


### PR DESCRIPTION
If `__builtin___clear_cache` is not available, use `flush_cache` in
`stddef.h`.

Fixes #2124.