### PR TITLE
Fix generated test script to properly check for debugger

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -132,7 +132,7 @@ fi
         <ParamText>=*</ParamText> <!-- Bash specific -->
         <ParamName>debuggerFullPath</ParamName>
         <Command><![CDATA[        _DebuggerFullPath="${i#*=}"
-        if [ ! -f DebuggerFullPath ]
+        if [ ! -f "$_DebuggerFullPath" ]
         then
             echo The Debugger FullPath \"$_DebuggerFullPath\" doesn\'t exist
             usage
@@ -196,10 +196,10 @@ usage()
     echo "Usage: $0  $(_CLRTestParamList)"
     echo 
     echo "Arguments:"
-@(BatchCLRTestExecutionScriptArgument -> '    echo "-%(Identity) %(ParamName)"
+@(BatchCLRTestExecutionScriptArgument -> '    echo "-%(Identity)=%(ParamName)"
     echo      "%(Description)"', '
 ')
-    echo "    -?,-h,--help    show this message"
+    echo "-?,-h,--help    show this message"
     exit 1
 }
 


### PR DESCRIPTION
Also tried fixing the generated help to show that you need `=`. This should be conditional based on `HasParam` but since there is only one switch it works for now.