### PR TITLE
Fixes for Issues #s 2105 and 2106.

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -750,7 +750,12 @@ protected :
             struct
             {
                 regNumberSmall  scRegNum;
-                regNumberSmall  scOtherReg; // used for "other half" of long var
+                
+                // Used for:
+                //  - "other half" of long var on architectures with 32 bit size registers - x86.
+                //  - for System V structs it stores the second register 
+                //    used to pass a register passed struct.
+                regNumberSmall  scOtherReg;
             } u1;
 
             struct
@@ -776,6 +781,7 @@ protected :
 
     void                psiEndPrologScope(psiScope *        scope);
 
+    void                psSetScopeOffset(psiScope* newScope, LclVarDsc * lclVarDsc1);
 
 /*****************************************************************************
  *                        TrnslLocalVarInfo

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -4243,13 +4243,7 @@ void            CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg,
         if (doingFloat)
         {
 #if defined(_TARGET_ARM_) || defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-#if defined(_TARGET_ARM_)
-            insCopy = INS_vmov;
-#elif defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-            insCopy = INS_mov;
-#else
-#error Error. Wrong architecture.
-#endif
+            insCopy = ins_Copy(TYP_FLOAT);
             // Compute xtraReg here when we have a float argument
             assert(xtraReg == REG_NA);
 
@@ -4258,23 +4252,22 @@ void            CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg,
             fpAvailMask = RBM_FLT_CALLEE_TRASH & ~regArgMaskLive;
 #if defined(_TARGET_ARM_)
             fpAvailMask &= RBM_DBL_REGS;
-#elif defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-            fpAvailMask &= RBM_ALLFLOAT;
 #else
+#if !defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 #error Error. Wrong architecture.
-#endif
-            
+#endif // !defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
+#endif // defined(_TARGET_ARM_)
 
             if (fpAvailMask == RBM_NONE)
             {
                 fpAvailMask = RBM_ALLFLOAT & ~regArgMaskLive;
 #if defined(_TARGET_ARM_)
                 fpAvailMask &= RBM_DBL_REGS;
-#elif defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-                fpAvailMask &= RBM_ALLFLOAT;
 #else
+#if !defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 #error Error. Wrong architecture.
-#endif
+#endif // !defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
+#endif // defined(_TARGET_ARM_)
             }
 
             assert(fpAvailMask != RBM_NONE);


### PR DESCRIPTION
For issue 2105 after more analysis there might be a very rare situation
(since this is not hit by the tests we have in coreclr and corefx) where
(even though there are not XMM callee saved register on System V) a
circular dependency might occur when homing params passed in XMM
registers. Used the right instruction for doing copying of XMM reg to XMM
reg

For issue # 2106 make sure for 2 register passed struct to use the
already available scOtherReg in struct psiScope.