### PR TITLE
Don't enable Concurrent GC on Unix by default

### DIFF
--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -107,8 +107,7 @@ static void ExtractStartupFlagsAndConvertToUnicode(
     STARTUP_FLAGS startupFlags =
         static_cast<STARTUP_FLAGS>(
             STARTUP_FLAGS::STARTUP_LOADER_OPTIMIZATION_SINGLE_DOMAIN |
-            STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN |
-            STARTUP_FLAGS::STARTUP_CONCURRENT_GC);
+            STARTUP_FLAGS::STARTUP_SINGLE_APPDOMAIN);
     int propertyCountW = 0;
     for (int propertyIndex = 0; propertyIndex < propertyCount; ++propertyIndex)
     {


### PR DESCRIPTION
This change temporary disables the code in Unix hosting APIs that switches Concurrent GC on by default on Unix because this feature is not supported yet and having this flag set causes a performance regression (this problem is tracked by issue https://github.com/dotnet/coreclr/issues/2155).
