### PR TITLE
Make app shutdown wait for secondary threads

### DIFF
--- a/src/vm/appdomain.cpp
+++ b/src/vm/appdomain.cpp
@@ -3693,7 +3693,7 @@ void SystemDomain::ExecuteMainMethod(HMODULE hMod, __in_opt LPWSTR path /*=NULL*
         pDomain->GetMulticoreJitManager().AutoStartProfile(pDomain);
 #endif
 
-        pDomain->m_pRootAssembly->ExecuteMainMethod(NULL);
+        pDomain->m_pRootAssembly->ExecuteMainMethod(NULL, FALSE /* waitForOtherThreads */);
     }
 
     pThread->ReturnToContext(&frame);

--- a/src/vm/appdomainnative.cpp
+++ b/src/vm/appdomainnative.cpp
@@ -538,7 +538,7 @@ INT32 AppDomainNative::ExecuteAssemblyHelper(Assembly* pAssembly,
 
     EE_TRY_FOR_FINALLY(Param *, pParam, &param)
     {
-        pParam->iRetVal = pParam->pAssembly->ExecuteMainMethod(pParam->pStringArgs);
+        pParam->iRetVal = pParam->pAssembly->ExecuteMainMethod(pParam->pStringArgs, TRUE /* waitForOtherThreads */);
     }
     EE_FINALLY 
     {

--- a/src/vm/assembly.cpp
+++ b/src/vm/assembly.cpp
@@ -2649,7 +2649,7 @@ static void RunMainPost()
     }
 }
 
-INT32 Assembly::ExecuteMainMethod(PTRARRAYREF *stringArgs)
+INT32 Assembly::ExecuteMainMethod(PTRARRAYREF *stringArgs, BOOL waitForOtherThreads)
 {
     CONTRACTL
     {
@@ -2722,7 +2722,7 @@ INT32 Assembly::ExecuteMainMethod(PTRARRAYREF *stringArgs)
     //to decide when the process should get torn down.  So, don't call it from
     // AppDomain.ExecuteAssembly()
     if (pMeth) {
-        if (stringArgs == NULL)
+        if (waitForOtherThreads)
             RunMainPost();
     }
     else {

--- a/src/vm/assembly.hpp
+++ b/src/vm/assembly.hpp
@@ -500,7 +500,7 @@ public:
 
     //****************************************************************************************
     //
-    INT32 ExecuteMainMethod(PTRARRAYREF *stringArgs);
+    INT32 ExecuteMainMethod(PTRARRAYREF *stringArgs, BOOL waitForOtherThreads);
 
     //****************************************************************************************
 

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -1345,7 +1345,7 @@ HRESULT CorHost2::ExecuteAssembly(DWORD dwAppDomainId,
             arguments->SetAt(i, argument);
         }
 
-        DWORD retval = pAssembly->ExecuteMainMethod(&arguments);
+        DWORD retval = pAssembly->ExecuteMainMethod(&arguments, TRUE /* waitForOtherThreads */);
         if (pReturnValue)
         {
             *pReturnValue = retval;
@@ -2555,7 +2555,7 @@ VOID CorHost2::ExecuteMainInner(Assembly* pRootAssembly)
 		// since this is the thread 0 entry point for AppX apps we use
 		// the EntryPointFilter so that an unhandled exception here will
 		// trigger the same behavior as in classic apps.
-        pParam->pRootAssembly->ExecuteMainMethod(NULL);
+        pParam->pRootAssembly->ExecuteMainMethod(NULL, FALSE /* waitForOtherThreads */);
     }
     PAL_EXCEPT_FILTER(EntryPointFilter)
     {


### PR DESCRIPTION
This change makes the CoreCLR behavior the same as the desktop CLR
w.r.t. the app shutdown and secondary threads. Now the application
waits for secondary threads to exit before exiting.