### PR TITLE
Enable ILDASM for Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,7 @@ add_subdirectory(dlls)
 add_subdirectory(ToolBox)
 add_subdirectory(tools)
 add_subdirectory(unwinder)
+add_subdirectory(ildasm)
 
 if(WIN32)
   add_subdirectory(ipcman)

--- a/src/dlls/mscoree/mscorwks_ntdef.src
+++ b/src/dlls/mscoree/mscorwks_ntdef.src
@@ -24,12 +24,11 @@ EXPORTS
         coreclr_initialize
         coreclr_shutdown
 
-#ifdef FEATURE_PREJIT
-        ; MetaDataGetDispenser is needed for nidump. We want nidump to work on non-debug
-        ; builds, but we don't want the API to be public, so export it by ordinal.
-        ; This ordinal is hard-coded in tools\nidump\nidump.cpp.
-        MetaDataGetDispenser                                @3 noname private
-#endif // FEATURE_PREJIT
+        ; il{d}asm
+        MetaDataGetDispenser
+        GetMetaDataInternalInterface
+        GetMetaDataInternalInterfaceFromPublic
+        GetMetaDataPublicInterfaceFromInternal
 
 #else //FEATURE_CORECLR 
 

--- a/src/ildasm/CMakeLists.txt
+++ b/src/ildasm/CMakeLists.txt
@@ -1,0 +1,4 @@
+if (WIN32)
+    add_subdirectory(exe)
+    add_subdirectory(rcdll)
+endif()

--- a/src/ildasm/dasm.rc
+++ b/src/ildasm/dasm.rc
@@ -11,7 +11,9 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
+#ifndef FEATURE_CORECLR
 #include "afxres.h"
+#endif
 #include <winresrc.h>
 
 /////////////////////////////////////////////////////////////////////////////
@@ -22,8 +24,6 @@
 
 #include <fxver.h>
 #include <fxver.rc>
-
-#include <copyrightstring.rc>
 
 /////////////////////////////////////////////////////////////////////////////
 // English (U.S.) resources
@@ -59,7 +59,7 @@ END
 #endif    // APSTUDIO_INVOKED
 
 
-#ifndef FEATURE_PAL
+#if !defined(FEATURE_PAL) && !defined(FEATURE_CORECLR)
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -281,7 +281,7 @@ BEGIN
 END
 
 #endif // FX_VFT == VFT_DLL
-#endif // !FEATURE_PAL
+#endif // !defined(FEATURE_PAL) && !defined(FEATURE_CORECLR)
 
 #if FX_VFT == VFT_DLL
 STRINGTABLE DISCARDABLE 

--- a/src/ildasm/dasm_pr.cpp
+++ b/src/ildasm/dasm_pr.cpp
@@ -5,6 +5,7 @@
 
 #include "ildasmpch.h"
 
+#ifndef FEATURE_CORECLR
 #include "resource.h"
 #include "formattype.h"
 
@@ -272,3 +273,4 @@ void DestroyProgressBar()
     g_hwndCancel = NULL;
     g_ulCount = 0;
 }
+#endif

--- a/src/ildasm/dis.cpp
+++ b/src/ildasm/dis.cpp
@@ -134,9 +134,11 @@ char* AnsiToUtf(__in __nullterminated const char* sz) { return UnicodeToUtf(Ansi
     
 static void UnicodeToConsoleOrMsgBox(__in __nullterminated const WCHAR* wz)
 {
+#ifndef FEATURE_CORECLR
     if (g_Mode & MODE_GUI)
             WszMessageBox(NULL,wz,RstrW(IDS_ERRORCAPTION),MB_OK|MB_ICONERROR|GetDasmMBRTLStyle());
     else
+#endif
     {
         //DWORD dw;
         //char* sz = UnicodeToAnsi(wz);
@@ -154,9 +156,11 @@ static void UnicodeToFile(__in __nullterminated const WCHAR* wz, FILE* pF)
 }
 static void ToGUIOrFile(__in __nullterminated const char* sz, void* GUICookie)
 {
+#ifndef FEATURE_CORECLR
     if (g_Mode & MODE_GUI)
         GUIAddOpcode(sz, GUICookie);
     else
+#endif
     {
         if(g_fDumpRTF) fprintf((FILE*)GUICookie,"%s\\line\n",sz);
         else fprintf((FILE*)GUICookie,"%s\n",sz);
@@ -872,7 +876,7 @@ BOOL SourceLinesHelper(void *GUICookie, LineCodeDescr* pLCD, __out_ecount(nSize)
         sprintf_s(szString,SZSTRING_SIZE,RstrUTF(IDS_ERRORREOPENINGFILE),pLCD->FileToken);
         printError(GUICookie, szString);
     }
-    WIN_PAL_ENDTRY
+    PAL_ENDTRY
 
     return param.fRet;
 }

--- a/src/ildasm/exe/CMakeLists.txt
+++ b/src/ildasm/exe/CMakeLists.txt
@@ -1,0 +1,58 @@
+project(ildasm)
+
+add_definitions(-DUNICODE)
+add_definitions(-D_UNICODE)
+add_definitions(-D_FEATURE_NO_HOST)
+add_definitions(-D__ILDASM__)
+
+add_definitions(-DFEATURE_CORECLR)
+
+set(ILDASM_SOURCES
+    ../ceeload.cpp
+    ../dasm.cpp
+    ../dasm_formattype.cpp
+    ../dasm_mi.cpp
+    ../dasm_pr.cpp
+    ../dasm_sz.cpp
+    ../dis.cpp
+    ../dman.cpp
+    ../dres.cpp
+    ../gui.cpp
+    ../ildasmpch.cpp
+    ../windasm.cpp
+)
+
+add_executable(ildasm
+    ${ILDASM_SOURCES}
+    ${ILDASM_RESOURCES}
+)
+
+set(ILDASM_LINK_LIBRARIES
+    utilcodestaticnohost
+    mdhotdata_full
+    corguids
+    coreclr
+)
+
+if(CLR_CMAKE_PLATFORM_UNIX)
+    # TODO
+    target_link_libraries(ildasm
+        mscorrc_debug
+        coreclrpal
+        palrt
+    )
+else()
+    target_link_libraries(ildasm
+        ${ILDASM_LINK_LIBRARIES}
+         msvcrt
+         ole32
+         oleaut32
+         shell32
+    )
+
+    # We will generate PDB only for the debug configuration
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ildasm.pdb DESTINATION PDB)
+
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
+install (TARGETS ildasm DESTINATION .)

--- a/src/ildasm/gui.cpp
+++ b/src/ildasm/gui.cpp
@@ -5,6 +5,7 @@
 
 #include "ildasmpch.h"
 
+#ifndef FEATURE_CORECLR
 #include "debugmacros.h"
 #include "corpriv.h"
 #include "ceeload.h"
@@ -41,7 +42,7 @@ ULONG InGlobalBuffer;
 // Global HINSTANCE
 //
 extern HINSTANCE   g_hInstance;
-HINSTANCE   g_hResources;
+extern HINSTANCE   g_hResources;
 
 //
 // Main window
@@ -4010,4 +4011,4 @@ void DumpTreeItem(HTREEITEM hSelf, FILE* pFile, __inout __nullterminated WCHAR* 
         printLineW(pFile,szIndent);
     }
 }
-
+#endif

--- a/src/ildasm/rcdll/CMakeLists.txt
+++ b/src/ildasm/rcdll/CMakeLists.txt
@@ -1,0 +1,27 @@
+project(ildasmrc)
+
+add_definitions(-DUNICODE)
+add_definitions(-D_UNICODE)
+add_definitions(-D_FEATURE_NO_HOST)
+add_definitions(-D__ILDASM__)
+
+add_definitions(-DFEATURE_CORECLR)
+add_definitions(-DFX_VFT=VFT_DLL)
+
+set(ILDASM_RESOURCES
+    ../dasm.rc
+)
+
+add_library(ildasmrc
+    SHARED
+    ${ILDASM_RESOURCES}
+)
+
+target_link_libraries(ildasmrc
+     msvcrt
+)
+
+# We will generate PDB only for the debug configuration
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ildasmrc.pdb DESTINATION PDB)
+
+install (TARGETS ildasmrc DESTINATION .)

--- a/src/ildasm/resource.h
+++ b/src/ildasm/resource.h
@@ -1,14 +1,12 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information. 
+//
+
 //{{NO_DEPENDENCIES}}
 // Microsoft Developer Studio generated include file.
 // Used by dasm.rc
 //
-
-#include <copyrightstring.h>
 
 #define IDS_FILE                        1
 #define IDS_VIEW                        2

--- a/src/inc/palclr_win.h
+++ b/src/inc/palclr_win.h
@@ -144,15 +144,6 @@
         }                                                                       \
     }
 
-#define WIN_PAL_CPP_TRY try
-#define WIN_PAL_CPP_ENDTRY
-#define WIN_PAL_CPP_THROW(type, obj) throw obj;
-#define WIN_PAL_CPP_RETHROW throw;
-#define WIN_PAL_CPP_CATCH_EXCEPTION(obj) catch (Exception * obj)
-#define WIN_PAL_CPP_CATCH_DERIVED(type, obj) catch (type * obj)
-#define WIN_PAL_CPP_CATCH_ALL catch (...)
-#define WIN_PAL_CPP_CATCH_EXCEPTION_NOARG catch (Exception *)
-
 #endif // !PAL_WIN_SEH
 
 

--- a/src/tools/metainfo/mdinfo.cpp
+++ b/src/tools/metainfo/mdinfo.cpp
@@ -23,7 +23,9 @@
 
 #define LEGACY_ACTIVATION_SHIM_LOAD_LIBRARY WszLoadLibrary
 #define LEGACY_ACTIVATION_SHIM_DEFINE_CoInitializeEE
+#ifndef FEATURE_CORECLR
 #include "LegacyActivationShim.h"
+#endif
 
 #define ENUM_BUFFER_SIZE 10
 #define TAB_SIZE 8
@@ -754,9 +756,11 @@ void MDInfo::Error(const char* szError, HRESULT hr)
             pIErr->Release();
 
     }
+#ifndef FEATURE_CORECLR
     LegacyActivationShim::CoUninitializeCor();
 #ifndef FEATURE_PAL
     CoUninitialize();
+#endif
 #endif
     exit(hr);
 } // void MDInfo::Error()


### PR DESCRIPTION
This enables building ILDASM with Cmake for Windows.
This ILDASM now depends on CoreCLR targeting cross-platform and thus I dropped some features like GUI/PDB -- default output is console.
Metadata related APIs in CoreCLR are directly exported, and used in ILDASM:
 MetaDataGetDispenser
 GetMetaDataInternalInterface
 GetMetaDataInternalInterfaceFromPublic
 GetMetaDataPublicInterfaceFromInternal
The code path is diverged by a definition FEATURE_CORECLR.
There are still Window specific components. Among others, resource file/dll generation is the one that should be ported.