### PR TITLE
Fix unicode input on the command line

### DIFF
--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -62,7 +62,7 @@ static LPCWSTR StringToUnicode(LPCSTR str)
     LPWSTR result = new (nothrow) WCHAR[length];
     ASSERTE_ALL_BUILDS(result != NULL);
     
-    length = MultiByteToWideChar(CP_ACP, 0, str, length, result, length);
+    length = MultiByteToWideChar(CP_ACP, 0, str, -1, result, length);
     ASSERTE_ALL_BUILDS(length != 0);
 
     return result;


### PR DESCRIPTION
For issue #2080 

The length of the wide char string in characters was incorrectly being passed in for the cbMultiByte parameter of the multibyte string, causing the code to not read to the end of the multibyte text thus leaving trailing random memory values and\or not adding a null. This could also cause an exception and core dump under certain cases.

See API at https://msdn.microsoft.com/en-us/library/windows/desktop/dd319072(v=vs.85).aspx

