### PR TITLE
Fix mismatched use of new and delete

### DIFF
--- a/src/tools/util/consoleargs.cpp
+++ b/src/tools/util/consoleargs.cpp
@@ -665,7 +665,7 @@ LEADINGWHITE:
         argLast = &listArgNew->next;
     }
 
-    delete szTemp;
+    delete[] szTemp;
 
 }
 


### PR DESCRIPTION
Clang > 2.7.0 emits warnings for mismatched uses of new and
delete (-Wmismatched-new-delete).

Refs #2135