### PR TITLE
Remove unnecessary null checks from KeyedCollection<TKey,TItem>

### DIFF
--- a/src/mscorlib/src/System/Collections/ObjectModel/KeyedCollection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/KeyedCollection.cs
@@ -79,10 +79,8 @@ namespace System.Collections.ObjectModel
                 return dict.ContainsKey(key);
             }
 
-            if (key != null) {
-                foreach (TItem item in Items) {
-                    if (comparer.Equals(GetKeyForItem(item), key)) return true;
-                }
+            foreach (TItem item in Items) {
+                if (comparer.Equals(GetKeyForItem(item), key)) return true;
             }
             return false;
         }
@@ -114,12 +112,10 @@ namespace System.Collections.ObjectModel
                 return false;
             }
 
-            if (key != null) {
-                for (int i = 0; i < Items.Count; i++) {
-                    if (comparer.Equals(GetKeyForItem(Items[i]), key)) {
-                        RemoveItem(i);
-                        return true;
-                    }
+            for (int i = 0; i < Items.Count; i++) {
+                if (comparer.Equals(GetKeyForItem(Items[i]), key)) {
+                    RemoveItem(i);
+                    return true;
                 }
             }
             return false;


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/4701 to CoreCLR

---

`Contains` and `Remove` already throw if the key parameter is null, so there's no need for additional null checks later in these methods.

Fixes https://github.com/dotnet/corefx/issues/4691