### PR TITLE
Avoid enumerator allocations inside KeyedCollection<TKey, TItem>

### DIFF
--- a/src/mscorlib/src/System/Collections/ObjectModel/KeyedCollection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/KeyedCollection.cs
@@ -28,7 +28,9 @@ namespace System.Collections.ObjectModel
         protected KeyedCollection(IEqualityComparer<TKey> comparer): this(comparer, defaultThreshold) {}
 
 
-        protected KeyedCollection(IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold) {
+        protected KeyedCollection(IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
+            : base(new List<TItem>()) { // Be explicit about the use of List<T> so we can foreach over
+                                        // Items internally without enumerator allocations.
             if (comparer == null) { 
                 comparer = EqualityComparer<TKey>.Default;
             }
@@ -43,6 +45,17 @@ namespace System.Collections.ObjectModel
 
             this.comparer = comparer;
             this.threshold = dictionaryCreationThreshold;
+        }
+
+        /// <summary>
+        /// Enables the use of foreach internally without allocations using <see cref="List{T}"/>'s struct enumerator.
+        /// </summary>
+        new private List<TItem> Items {
+            get {
+                Contract.Assert(base.Items is List<TItem>);
+
+                return (List<TItem>)base.Items;
+            }
         }
 
         public IEqualityComparer<TKey> Comparer {


### PR DESCRIPTION
Port https://github.com/dotnet/corefx/pull/4703 to CoreCLR

---

Methods on `KeyedCollection<TKey, TItem>` will internally loop over `Items` using foreach before the dictionary threshold is reached. `Items` is a protected (non-virtual) property defined on the base `Collection<T>` class and typed as `IList<T>`. This means `KeyedCollection<TKey, TValue>` members like `Contains` and `Item[TKey]` allocate an enumerator when looping over `Items`.

We can avoid the enumerator allocations inside `KeyedCollection<TKey, TValue>` by providing a new private `Items` property that is typed as `List<T>` instead of `IList<T>`, so that `List<T>`'s struct enumerator is used, which avoids the enumerator heap allocation and also avoids interface dispatch.

`KeyedCollection<TKey, TItem>`'s constructors call the default `Collection<T>` constructor which already initializes `Items` to an instance of `List<T>`, so this change is just being explicit about the use of `List<T>` for `Items` inside `KeyedCollection<TKey, TItem>`.

---

I put together a quick (roughly equivalent example) 1,000,000 iteration [microbenchmark](https://gist.github.com/justinvp/a09a27fb4560c8638d35) to demonstrate the improvement, calling `Contains(TKey)` against before & after collections of size 100, run on the full framework 4.6 (x64 ryujit).

| Run | Before (ms) | After (ms) | Faster |
|----------|-------------|------------|--------|
| 1        | 4.9430322   | 3.0111028  | 64.16% |
| 2        | 4.9251824   | 3.0526213  | 61.34% |
| 3        | 4.9867314   | 3.0471864  | 63.65% |
| 4        | 4.9749371   | 3.0516947  | 63.02% |