### PR TITLE
Memory growth improvement in coreconsole

### DIFF
--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -45,7 +45,7 @@ public:
             m_capacity = m_defaultSize;
         }
         while (m_length + strLen + 1 > m_capacity) {
-            size_t newCapacity = m_capacity * 1.5f;
+            size_t newCapacity = m_capacity * 3 / 2;
             wchar_t* newBuffer = new wchar_t[newCapacity];
             wcsncpy_s(newBuffer, newCapacity, m_buffer, m_length);
             delete[] m_buffer;

--- a/src/coreclr/hosts/coreconsole/coreconsole.cpp
+++ b/src/coreclr/hosts/coreconsole/coreconsole.cpp
@@ -44,8 +44,8 @@ public:
             m_buffer = new wchar_t[m_defaultSize];
             m_capacity = m_defaultSize;
         }
-        if (m_length + strLen + 1 > m_capacity) {
-            size_t newCapacity = m_capacity * 2;
+        while (m_length + strLen + 1 > m_capacity) {
+            size_t newCapacity = m_capacity * 1.5f;
             wchar_t* newBuffer = new wchar_t[newCapacity];
             wcsncpy_s(newBuffer, newCapacity, m_buffer, m_length);
             delete[] m_buffer;


### PR DESCRIPTION
Now Append will work properly if strLen is big (for example 3*m_capacity). And value 1.5 is better for memory growth.