### PR TITLE
Only track alive TaskSchedulers when Task.s_asyncDebuggingEnabled is set

### DIFF
--- a/src/mscorlib/src/System/Threading/Tasks/TaskScheduler.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskScheduler.cs
@@ -301,10 +301,13 @@ namespace System.Threading.Tasks
         /// </summary>
         protected TaskScheduler()
         {
-            // Protected constructor. It's here to ensure all user implemented TaskSchedulers will be 
-            // registered in the active schedulers list.
-            Contract.Assert(s_activeTaskSchedulers != null, "Expected non-null s_activeTaskSchedulers");
-            s_activeTaskSchedulers.Add(this, null);
+			if (Task.s_asyncDebuggingEnabled)
+			{
+				// Protected constructor. It's here to ensure all user implemented TaskSchedulers will be 
+				// registered in the active schedulers list.
+				Contract.Assert(s_activeTaskSchedulers != null, "Expected non-null s_activeTaskSchedulers");
+				s_activeTaskSchedulers.Add(this, null);
+			}
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #2189 

Added a check in TaskScheduler constructor to track alive TaskSchedulers only when `Task.s_asyncDebuggingEnabled` is set.