### PR TITLE
Fix ArgumentOutOfRangeException in XplatEventLogger

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/XplatEventLogger.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/XplatEventLogger.cs
@@ -79,6 +79,10 @@ namespace System.Diagnostics.Tracing
                 return String.Empty;
 
             Contract.Assert(payloadName.Count == payload.Count);
+            if(payloadName.Count != payload.Count)
+            {
+                return string.Empty;
+            }
             
             var sb = StringBuilderCache.Acquire();
 


### PR DESCRIPTION
Ensure that the XplatEventLogger doesn't run off the end of any of the payload arrays.