### PR TITLE
Port System.Threading.Semaphore from corefx to mscorlib

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -12217,6 +12217,15 @@
       <Member Name="get_IsSet"/>
       <Member Name="get_WaitHandle"/>
     </Type>
+    <Type Name="System.Threading.Semaphore">
+      <Member Name="#ctor(System.Int32,System.Int32)" />
+      <Member Name="#ctor(System.Int32,System.Int32,System.String)" />
+      <Member Name="#ctor(System.Int32,System.Int32,System.String,System.Boolean@)" />
+      <Member Name="OpenExisting(System.String)" />
+      <Member Name="Release" />
+      <Member Name="Release(System.Int32)" />
+      <Member Name="TryOpenExisting(System.String,System.Threading.Semaphore@)" />
+    </Type>
     <Type Name="System.Threading.SemaphoreSlim">
       <Member Name="#ctor(System.Int32)"/>
       <Member Name="#ctor(System.Int32,System.Int32)"/>

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -817,6 +817,7 @@
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\Overlapped.cs" />
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\ParameterizedThreadStart.cs" />
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\ReaderWriterLock.cs" />
+    <ThreadingSources Condition="'$(FeatureCoreClr)'=='true'" Include="$(BclSourcesRoot)\System\Threading\Semaphore.cs" />
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\SemaphoreFullException.cs" />
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\SynchronizationLockException.cs" />
     <ThreadingSources Include="$(BclSourcesRoot)\System\Threading\Thread.cs" />

--- a/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
+++ b/src/mscorlib/src/Microsoft/Win32/Win32Native.cs
@@ -1045,6 +1045,9 @@ namespace Microsoft.Win32 {
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool ReleaseSemaphore(SafeWaitHandle handle, int releaseCount, out int previousCount);
 
+        [DllImport(KERNEL32, SetLastError = true, CharSet = CharSet.Auto, BestFitMapping = false)]
+        internal static extern SafeWaitHandle OpenSemaphore(/* DWORD */ int desiredAccess, bool inheritHandle, String name);
+
         // Will be in winnls.h
         internal const int FIND_STARTSWITH  = 0x00100000; // see if value is at the beginning of source
         internal const int FIND_ENDSWITH    = 0x00200000; // see if value is at the end of source

--- a/src/mscorlib/src/System/Threading/Semaphore.cs
+++ b/src/mscorlib/src/System/Threading/Semaphore.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32;
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics.Contracts;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace System.Threading
+{
+    public sealed partial class Semaphore : WaitHandle
+    {
+        [SecuritySafeCritical]
+        public Semaphore(int initialCount, int maximumCount) : this(initialCount, maximumCount, null) { }
+
+        [SecurityCritical]
+        public Semaphore(int initialCount, int maximumCount, string name)
+        {
+            if (initialCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("initialCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+
+            if (maximumCount < 1)
+            {
+                throw new ArgumentOutOfRangeException("maximumCount", Environment.GetResourceString("ArgumentOutOfRange_NeedPosNum"));
+            }
+
+            if (initialCount > maximumCount)
+            {
+                throw new ArgumentException(Environment.GetResourceString("Argument_SemaphoreInitialMaximum"));
+            }
+
+            SafeWaitHandle myHandle = CreateSemaphone(initialCount, maximumCount, name);
+
+            if (myHandle.IsInvalid)
+            {
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (null != name && 0 != name.Length && Win32Native.ERROR_INVALID_HANDLE == errorCode)
+                    throw new WaitHandleCannotBeOpenedException(
+                        Environment.GetResourceString("Threading.WaitHandleCannotBeOpenedException_InvalidHandle", name));
+
+                __Error.WinIOError();
+            }
+            this.SafeWaitHandle = myHandle;
+        }
+
+        [SecurityCritical]
+        public Semaphore(int initialCount, int maximumCount, string name, out bool createdNew)
+        {
+            if (initialCount < 0)
+            {
+                throw new ArgumentOutOfRangeException("initialCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+
+            if (maximumCount < 1)
+            {
+                throw new ArgumentOutOfRangeException("maximumCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+
+            if (initialCount > maximumCount)
+            {
+                throw new ArgumentException(Environment.GetResourceString("Argument_SemaphoreInitialMaximum"));
+            }
+
+            SafeWaitHandle myHandle = CreateSemaphone(initialCount, maximumCount, name);
+
+            int errorCode = Marshal.GetLastWin32Error();
+            if (myHandle.IsInvalid)
+            {
+                if (null != name && 0 != name.Length && Win32Native.ERROR_INVALID_HANDLE == errorCode)
+                    throw new WaitHandleCannotBeOpenedException(
+                        Environment.GetResourceString("Threading.WaitHandleCannotBeOpenedException_InvalidHandle", name));
+                __Error.WinIOError();
+            }
+            createdNew = errorCode != Win32Native.ERROR_ALREADY_EXISTS;
+            this.SafeWaitHandle = myHandle;
+        }
+
+        [SecurityCritical]
+        private Semaphore(SafeWaitHandle handle)
+        {
+            this.SafeWaitHandle = handle;
+        }
+
+        [SecurityCritical]
+        private static SafeWaitHandle CreateSemaphone(int initialCount, int maximumCount, string name)
+        {
+            if (name != null)
+            {
+#if PLATFORM_UNIX
+                throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
+                if (name.Length > Path.MAX_PATH)
+                    throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+#endif
+            }
+
+            Contract.Assert(initialCount >= 0);
+            Contract.Assert(maximumCount >= 1);
+            Contract.Assert(initialCount <= maximumCount);
+
+            return Win32Native.CreateSemaphore(null, initialCount, maximumCount, name);
+        }
+
+        [SecurityCritical]
+
+        public static Semaphore OpenExisting(string name)
+        {
+            Semaphore result;
+            switch (OpenExistingWorker(name, out result))
+            {
+                case OpenExistingResult.NameNotFound:
+                    throw new WaitHandleCannotBeOpenedException();
+                case OpenExistingResult.NameInvalid:
+                    throw new WaitHandleCannotBeOpenedException(Environment.GetResourceString("Threading.WaitHandleCannotBeOpenedException_InvalidHandle", name));
+                case OpenExistingResult.PathNotFound:
+                    throw new IOException(Win32Native.GetMessage(Win32Native.ERROR_PATH_NOT_FOUND));
+                default:
+                    return result;
+            }
+        }
+
+        [SecurityCritical]
+        public static bool TryOpenExisting(string name, out Semaphore result)
+        {
+            return OpenExistingWorker(name, out result) == OpenExistingResult.Success;
+        }
+
+        [SecurityCritical]
+        private static OpenExistingResult OpenExistingWorker(string name, out Semaphore result)
+        {
+#if PLATFORM_UNIX
+            throw new PlatformNotSupportedException(Environment.GetResourceString("PlatformNotSupported_NamedSynchronizationPrimitives"));
+#else
+            if (name == null)
+                throw new ArgumentNullException("name", Environment.GetResourceString("ArgumentNull_WithParamName"));
+            if (name.Length == 0)
+                throw new ArgumentException(Environment.GetResourceString("Argument_EmptyName"), "name");
+            if (name.Length > Path.MAX_PATH)
+                throw new ArgumentException(Environment.GetResourceString("Argument_WaitHandleNameTooLong", name));
+                     
+            const int SYNCHRONIZE = 0x00100000;
+            const int SEMAPHORE_MODIFY_STATE = 0x00000002;
+
+            //Pass false to OpenSemaphore to prevent inheritedHandles
+            SafeWaitHandle myHandle = Win32Native.OpenSemaphore(SEMAPHORE_MODIFY_STATE | SYNCHRONIZE, false, name);
+
+            if (myHandle.IsInvalid)
+            {
+                result = null;
+
+                int errorCode = Marshal.GetLastWin32Error();
+
+                if (Win32Native.ERROR_FILE_NOT_FOUND == errorCode || Win32Native.ERROR_INVALID_NAME == errorCode)
+                    return OpenExistingResult.NameNotFound;
+                if (Win32Native.ERROR_PATH_NOT_FOUND == errorCode)
+                    return OpenExistingResult.PathNotFound;
+                if (null != name && 0 != name.Length && Win32Native.ERROR_INVALID_HANDLE == errorCode)
+                    return OpenExistingResult.NameInvalid;
+                //this is for passed through NativeMethods Errors
+                __Error.WinIOError();
+            }
+
+            result = new Semaphore(myHandle);
+            return OpenExistingResult.Success;
+#endif   
+        }
+
+        public int Release()
+        {
+            return Release(1);
+        }
+
+        // increase the count on a semaphore, returns previous count
+        [SecuritySafeCritical]
+        public int Release(int releaseCount)
+        {
+            if (releaseCount < 1)
+            {
+                throw new ArgumentOutOfRangeException("releaseCount", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
+            }
+
+            //If ReleaseSempahore returns false when the specified value would cause
+            //   the semaphore's count to exceed the maximum count set when Semaphore was created
+            //Non-Zero return 
+
+            int previousCount;
+            if (!Win32Native.ReleaseSemaphore(SafeWaitHandle, releaseCount, out previousCount))
+            {
+                throw new SemaphoreFullException();
+            }
+
+            return previousCount;
+        }
+    }
+}

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -2085,7 +2085,10 @@ Parallel_ForEach_PartitionerNotDynamic=The Partitioner used here must support dy
 Parallel_ForEach_PartitionerReturnedNull=The Partitioner used here returned a null partitioner source.
 Parallel_ForEach_NullEnumerator=The Partitioner source returned a null enumerator.
 
-; SemaphyoreFullException
+; Semaphore
+Argument_SemaphoreInitialMaximum=The initial count for the semaphore must be greater than or equal to zero and less than the maximum count.
+
+; SemaphoreFullException
 Threading_SemaphoreFullException=Adding the specified count to the semaphore would cause it to exceed its maximum count.
 
 ; Lazy


### PR DESCRIPTION
In the full framework, System.Threading.Semaphore is defined in System.dll, which no longer exists in coreclr/corefx.  Thus Semaphore needs to be defined in either mscorlib in coreclr or in System.Threading.dll in corefx (either way it's exposed from the System.Threading contract).  Today it's implemented in System.Threading.dll in corefx, but this results in a very unnatural dependency on Unix from System.Threading.dll to libcoreclr's PAL layer.  This is because on Unix libcoreclr needs to emulate wait handles, and thus all of the implementation for a Win32 semaphore (for which Semaphore is a thin wrapper) is in libcoreclr.

To eliminate that unnatural dependency, this commit ports System.Threading.Semaphore to mscorlib (I've not done much code cleanup, with changes being things to make the code fit into mscorlib, such as resource string handling, using #ifdefs for platform-specific stuff, etc.).  It'll be type-forwarded as part of the System.Threading.dll partial facade.  A corresponding commit https://github.com/dotnet/corefx/pull/4783 in corefx will remove all of the implementation from there after this goes in.

cc: @jkotas, @mellinoe, @AlexGhiondea, @ellismg 