### PR TITLE
Build the legacy jit for x86.

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -88,6 +88,8 @@ elseif(CLR_CMAKE_PLATFORM_ARCH_I386)
     targetx86.cpp
     lowerxarch.cpp
     codegenxarch.cpp
+    codegenlegacy.cpp
+    stackfp.cpp
   )
 elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
   set( ARCH_SOURCES
@@ -137,3 +139,7 @@ set(CLR_EXPORTED_SYMBOL_FILE ${CLRJIT_EXPORTS_DEF})
 add_subdirectory(dll)
 add_subdirectory(crossgen)
 add_subdirectory(standalone)
+
+if (CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)
+    add_subdirectory(protojit)
+endif (CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)

--- a/src/jit/crossgen/CMakeLists.txt
+++ b/src/jit/crossgen/CMakeLists.txt
@@ -1,3 +1,7 @@
 include(${CLR_DIR}/crossgen.cmake)
 
+if(CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)
+  add_definitions(-DLEGACY_BACKEND)
+endif(CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)
+
 add_library(jit_crossgen ${SOURCES})

--- a/src/jit/dll/CMakeLists.txt
+++ b/src/jit/dll/CMakeLists.txt
@@ -1,5 +1,9 @@
 project(ClrJit)
 
+if(CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)
+    add_definitions(-DLEGACY_BACKEND)
+endif(CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)
+
 # Disable the following for UNIX altjit on Windows
 if(CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-fPIC)

--- a/src/jit/protojit/CMakeLists.txt
+++ b/src/jit/protojit/CMakeLists.txt
@@ -1,0 +1,46 @@
+project(protojit)
+
+remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
+
+add_library(protojit
+   SHARED
+   ${SHARED_LIB_SOURCES}
+)
+
+set(RYUJIT_LINK_LIBRARIES
+   utilcodestaticnohost
+   gcinfo
+)
+
+if(CLR_CMAKE_PLATFORM_UNIX)
+    list(APPEND RYUJIT_LINK_LIBRARIES
+       mscorrc_debug
+       coreclrpal
+       palrt
+    )
+else()
+    list(APPEND RYUJIT_LINK_LIBRARIES
+       msvcrt.lib
+       kernel32.lib
+       advapi32.lib
+       ole32.lib
+       oleaut32.lib
+       uuid.lib
+       user32.lib
+       version.lib
+       shlwapi.lib
+       bcrypt.lib
+       crypt32.lib
+       RuntimeObject.lib
+    )
+endif(CLR_CMAKE_PLATFORM_UNIX)
+
+target_link_libraries(protojit
+   ${RYUJIT_LINK_LIBRARIES}
+)
+
+# add the install targets
+install (TARGETS protojit DESTINATION .)
+if(WIN32)
+    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/protojit.pdb DESTINATION PDB)
+endif(WIN32)


### PR DESCRIPTION
Small changes to cmake, which allows us to build the legacy jit as the fallback jit for x86.

**** NOTE ****

This change will break the x86 build. It is not ready to merge until the legacy jit link errors are fixed. However, I would like to put it out for review.

@BruceForstall PTAL

Update: created a new cmakelists file to build a seperate ryujit x86 which can be used as the alt jit with the legacy jit linked statically into coreclr.