### PR TITLE
Use dbi's path to load dac and add RPATH to make files.

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -1,3 +1,11 @@
+# Set the RPATH of sos so that it can find dependencies without needing to set LD_LIBRARY_PATH
+# For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
+if(CLR_CMAKE_PLATFORM_DARWIN)
+    set(CMAKE_INSTALL_RPATH "@loader_path")
+else()
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+endif(CLR_CMAKE_PLATFORM_DARWIN)
+
 if(CLR_CMAKE_PLATFORM_ARCH_AMD64)
   add_definitions(-DSOS_TARGET_AMD64=1)
   add_definitions(-D_TARGET_WIN64_=1)

--- a/src/ToolBox/SOS/lldbplugin/soscommand.cpp
+++ b/src/ToolBox/SOS/lldbplugin/soscommand.cpp
@@ -90,11 +90,6 @@ exit:
 
             if (g_coreclrDirectory != NULL)
             {
-
-                // Load the DAC module first explicitly because SOS and DBI
-                // have implicit references to the DAC's PAL.
-                LoadModule(client, MAKEDLLNAME_A("mscordaccore"));
-
                 m_sosHandle = LoadModule(client, MAKEDLLNAME_A("sos"));
             }
         }

--- a/src/debug/di/cordb.cpp
+++ b/src/debug/di/cordb.cpp
@@ -21,11 +21,10 @@
 #include "dbgtransportmanager.h"
 #endif // FEATURE_DBGIPC_TRANSPORT_DI
 
-// Helper function returns the instance handle of this module.
-HINSTANCE GetModuleInst();
-
 //********** Globals. *********************************************************
+#ifndef FEATURE_PAL
 HINSTANCE       g_hInst;                // Instance handle to this piece of code.
+#endif
 
 //-----------------------------------------------------------------------------
 // SxS Versioning story for Mscordbi (ICorDebug + friends)
@@ -180,9 +179,9 @@ BOOL WINAPI DbgDllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID lpReserved)
 
         case DLL_PROCESS_ATTACH:
         {
+#ifndef FEATURE_PAL
             g_hInst = hInstance;
-
-#ifdef FEATURE_PAL
+#else
             int err = PAL_InitializeDLL();
             if(err != 0)
             {
@@ -429,16 +428,15 @@ HRESULT STDMETHODCALLTYPE CClassFactory::LockServer(
 }
 
 
-
-
-
 //*****************************************************************************
 // This helper provides access to the instance handle of the loaded image.
 //*****************************************************************************
+#ifndef FEATURE_PAL
 HINSTANCE GetModuleInst()
 {
     return g_hInst;
 }
+#endif
 
 
 //-----------------------------------------------------------------------------

--- a/src/debug/di/rsmain.cpp
+++ b/src/debug/di/rsmain.cpp
@@ -486,7 +486,11 @@ void CordbCommonBase::InitializeCommon()
             unsigned level = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::EXTERNAL_LogLevel, LL_INFO1000);
             unsigned bytesPerThread = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_StressLogSize, STRESSLOG_CHUNK_SIZE * 2);
             unsigned totalBytes = REGUTIL::GetConfigDWORD_DontUse_(CLRConfig::UNSUPPORTED_TotalStressLogSize, STRESSLOG_CHUNK_SIZE * 1024);
+#ifndef FEATURE_PAL
             StressLog::Initialize(facilities, level, bytesPerThread, totalBytes, GetModuleInst());
+#else
+            StressLog::Initialize(facilities, level, bytesPerThread, totalBytes, NULL);
+#endif
         }
     }
 

--- a/src/debug/di/rspriv.h
+++ b/src/debug/di/rspriv.h
@@ -138,7 +138,9 @@ class DbgTransportSession;
 class ShimProcess;
 
 
+#ifndef FEATURE_PAL
 extern HINSTANCE GetModuleInst();
+#endif
 
 
 template <class T>

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -1,3 +1,12 @@
+
+# Set the RPATH of mscordbi so that it can find dependencies without needing to set LD_LIBRARY_PATH
+# For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
+if(CLR_CMAKE_PLATFORM_DARWIN)
+    set(CMAKE_INSTALL_RPATH "@loader_path")
+else()
+    set(CMAKE_INSTALL_RPATH "\$ORIGIN")
+endif(CLR_CMAKE_PLATFORM_DARWIN)
+
 set(MSCORDBI_SOURCES
   mscordbi.cpp
 )  

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3642,13 +3642,13 @@ PALIMPORT
 HMODULE
 PALAPI
 LoadLibraryA(
-         IN LPCSTR lpLibFileName);
+        IN LPCSTR lpLibFileName);
 
 PALIMPORT
 HMODULE
 PALAPI
 LoadLibraryW(
-         IN LPCWSTR lpLibFileName);
+        IN LPCWSTR lpLibFileName);
 
 PALIMPORT
 HMODULE
@@ -3667,17 +3667,17 @@ LoadLibraryExW(
         IN DWORD dwFlags);
 
 PALIMPORT
-HMODULE
+void *
 PALAPI
 PAL_LoadLibraryDirect(
-         IN LPCWSTR lpLibFileName);
+        IN LPCWSTR lpLibFileName);
 
 PALIMPORT
 HMODULE
 PALAPI
 PAL_RegisterLibraryDirect(
-         IN HMODULE dl_handle,
-         IN LPCWSTR lpLibFileName);
+        IN void *dl_handle,
+        IN LPCWSTR lpLibFileName);
 
 /*++
 Function:


### PR DESCRIPTION
Fixes VS's problems with debugging and running different versions of coreclr.