### PR TITLE
Add Exclude2 option for runtest.cmd for additive exclusion.

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -9,7 +9,7 @@ if defined VS120COMNTOOLS set __VSVersion=vs2013
 if defined VS140COMNTOOLS set __VSVersion=vs2015
 
 :: Default __Exclude to issues.targets
-set __Exclude=%~dp0\issues.targets
+set __Exclude0=%~dp0\issues.targets
 
 :Arg_Loop
 if "%1" == "" goto ArgsDone
@@ -20,6 +20,7 @@ if /i "%1" == "debug"    (set __BuildType=debug&shift&goto Arg_Loop)
 if /i "%1" == "release"   (set __BuildType=release&shift&goto Arg_Loop)
 if /i "%1" == "SkipWrapperGeneration" (set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 if /i "%1" == "Exclude" (set __Exclude=%2&shift&shift&goto Arg_Loop)
+if /i "%1" == "Exclude0" (set __Exclude0=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "TestEnv" (set __TestEnv=%2&shift&shift&goto Arg_Loop)
 
 if /i "%1" == "vs2013" (set __VSVersion=%1&shift&goto Arg_Loop)
@@ -154,7 +155,9 @@ echo.
 echo BuildArch is x64, x86
 echo BuildType can be: Debug, Release
 echo SkipWrapperGeneration- Optional parameter - this will run the same set of tests as the last time it was run
-echo Exclude- Optional parameter - this will exclude individual tests from running, specified by ExcludeList ItemGroup in an .targets file.
+echo Exclude0- Optional parameter - specify location of default exclusion file (defaults to issues.targets if not specified)
+echo                                Set to "" to disable default exclusion file.
+echo Exclude-  Optional parameter - this will exclude individual tests from running, specified by ExcludeList ItemGroup in an .targets file.
 echo TestEnv- Optional parameter - this will run a custom script to set custom test environment settings.
 echo VSVersion- optional argument to use VS2013 or VS2015  (default VS2015)
 echo CORE_ROOT The path to the runtime  

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -42,7 +42,12 @@
   </Target>
 
 
+  <Import Project="$(__Exclude0)" Condition="'$(__Exclude0)' != '' AND '$(XunitTestBinBase)' != ''" /> 
   <Import Project="$(__Exclude)" Condition="'$(__Exclude)' != '' AND '$(XunitTestBinBase)' != ''" /> 
+  <PropertyGroup>
+    <HaveExcludes>False</HaveExcludes>
+    <HaveExcludes Condition="('$(__Exclude0)' != '') Or ('$(__Exclude)' != '')">True</HaveExcludes>
+  </PropertyGroup>
 
   <Target Name="CreateXunitWrapper" DependsOnTargets="CreateXunitFacts">
 
@@ -191,12 +196,12 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
     </PropertyGroup>
 
     <ItemGroup>
-      <CanonicalExcludeList Include="%(ExcludeList.FullPath)" Condition="'$(__Exclude)' != ''"/>
+      <CanonicalExcludeList Include="%(ExcludeList.FullPath)" Condition="$(HaveExcludes)"/>
     </ItemGroup>
 
     <ItemGroup>
       <AllCMDsPresent Include="$(_CMDDIR)\**\*.cmd" />
-      <AllCMDExcludeFilter Include="@(CanonicalExcludeList)" Condition="'$(__Exclude)' != ''"/>
+      <AllCMDExcludeFilter Include="@(CanonicalExcludeList)" Condition="$(HaveExcludes)"/>
       <AllCMDs Include="@(AllCMDsPresent)" Exclude="@(AllCMDExcludeFilter)"/>
 
       <AllCommands Include="@(AllCMDs)" >


### PR DESCRIPTION
Currently when the Exclude parameter is passed to the coreclr
tests/runtest.cmd, the specified file replaces the default coreclr
exclusion file.

But an independent project, e.g. LLILC, may want to exclude the tests
in the coreclr issues.targets file as well as additional tests. In
that case it would be useful if runtest.cmd supported adding an
additional exclusion file that does not replace the default.

Closes #2238.