### PR TITLE
Import additional JIT tests.

### DIFF
--- a/tests/src/JIT/Directed/UnrollLoop/loop6.cs
+++ b/tests/src/JIT/Directed/UnrollLoop/loop6.cs
@@ -1,0 +1,194 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+internal struct VT
+{
+    public float one;
+    public double delta;
+    public double temp;
+}
+internal class loop6
+{
+    public static int cnt;
+
+    public static float sone;
+    public static double sdelta;
+    public static double stemp;
+
+    public static void f1()
+    {
+        float one = 1.0F;
+        double delta = 1.0D;
+        double temp = 0.0D;
+        while (temp != one)
+        {
+            temp = one + delta;
+            delta = delta / 2.0F;
+        }
+        if ((delta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f1 passed");
+        }
+        else
+            System.Console.WriteLine("f1 failed");
+    }
+
+    public static void f2()
+    {
+        float one = 1.0F;
+        double delta = 1.0D;
+        double temp = 0.0D;
+        while (temp != one)
+        {
+            temp = one + delta;
+            delta = delta / 2.0F;
+        }
+        if ((delta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f2 passed");
+        }
+        else
+            System.Console.WriteLine("f2 failed");
+    }
+
+    public static void f3()
+    {
+        double temp = 0.0D;
+        float one = 1.0F;
+        double delta = 1.0D;
+        while (temp != one)
+        {
+            temp = one + delta;
+            delta = delta / 2.0F;
+        }
+        if ((delta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f3 passed");
+        }
+        else
+            System.Console.WriteLine("f3 failed");
+    }
+
+    public static void f4()
+    {
+        float one = 1.0F;
+        double delta = 1.0D;
+        double temp = 0.0D;
+        temp = one + delta;
+        while (temp > one)
+        {
+            temp = one + delta;
+            delta = delta / 2.0F;
+        }
+        if ((delta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f4 passed");
+        }
+        else
+            System.Console.WriteLine("f4 failed");
+    }
+
+    public static void f5()
+    {
+        sone = 1.0F;
+        sdelta = 1.0D;
+        stemp = 0.0D;
+        while (stemp != sone)
+        {
+            stemp = sone + sdelta;
+            sdelta = sdelta / 2.0F;
+        }
+        if ((sdelta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f5 passed");
+        }
+        else
+            System.Console.WriteLine("f5 failed");
+    }
+    public static void f6()
+    {
+        VT vt;
+        vt.one = 1.0F;
+        vt.delta = 1.0D;
+        vt.temp = 0.0D;
+        while (vt.temp != vt.one)
+        {
+            vt.temp = vt.one + vt.delta;
+            vt.delta = vt.delta / 2.0F;
+        }
+        if ((vt.delta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f6 passed");
+        }
+        else
+            System.Console.WriteLine("f6 failed");
+    }
+
+    public static void f7()
+    {
+        float one = 1.0F;
+        double delta = 1.0D;
+        double temp = 0.0D;
+        temp = one + delta;
+        while (-temp < -one)
+        {
+            temp = one + delta;
+            delta = delta * 0.5F;
+        }
+        if ((delta - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f7 passed");
+        }
+        else
+            System.Console.WriteLine("f7 failed");
+    }
+
+    public static void f8()
+    {
+        float one = 1.0F;
+        double delta = 1.0D;
+        double temp = 0.0D;
+
+        TypedReference one_ref = __makeref(one);
+        TypedReference delta_ref = __makeref(delta);
+        TypedReference temp_ref = __makeref(temp);
+
+        while (__refvalue(temp_ref, double) != __refvalue(one_ref, float))
+        {
+            __refvalue(temp_ref, double) = __refvalue(one_ref, float) + __refvalue(delta_ref, double);
+            __refvalue(delta_ref, double) = __refvalue(delta_ref, double) / 2.0F;
+        }
+        if ((__refvalue(delta_ref, double) - 5.551115E-17) < 1.2E-10)
+        {
+            cnt++;
+            System.Console.WriteLine("f8 passed");
+        }
+        else
+            System.Console.WriteLine("f8 failed");
+    }
+
+    public static int Main()
+    {
+        cnt = 0;
+        f1();
+        f2();
+        f3();
+        f4();
+        f5();
+        f6();
+        f7();
+        f8();
+        if (cnt == 8)
+            return 100;
+        else
+            return 1;
+    }
+}

--- a/tests/src/JIT/Directed/UnrollLoop/loop6_cs_d.csproj
+++ b/tests/src/JIT/Directed/UnrollLoop/loop6_cs_d.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="loop6.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Directed/UnrollLoop/loop6_cs_do.csproj
+++ b/tests/src/JIT/Directed/UnrollLoop/loop6_cs_do.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="loop6.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Directed/UnrollLoop/loop6_cs_r.csproj
+++ b/tests/src/JIT/Directed/UnrollLoop/loop6_cs_r.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="loop6.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Directed/UnrollLoop/loop6_cs_ro.csproj
+++ b/tests/src/JIT/Directed/UnrollLoop/loop6_cs_ro.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="loop6.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_dbggc_nested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_dbggc_nested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="gc_nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_dbgnested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_dbgnested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_relgc_nested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_relgc_nested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="gc_nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_relnested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_relnested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_speed_dbggc_nested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_speed_dbggc_nested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="gc_nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_speed_dbgnested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_speed_dbgnested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_speed_relgc_nested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_speed_relgc_nested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="gc_nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/VT/etc/_speed_relnested.csproj
+++ b/tests/src/JIT/Methodical/VT/etc/_speed_relnested.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="nested.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/doublearray/app.config
+++ b/tests/src/JIT/Methodical/doublearray/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Methodical/doublearray/dblarray1.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1.cs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Goal: Test arrays of doubles are allocated on large object heap and therefore 8 byte aligned
+// Assumptions:
+// 1) large object heap is always 8 byte aligned
+// 2) double array greater than 1000 elements is on large object heap
+// 3) non-double array greater than 1000 elements but less than 85K is NOT on large object heap
+// 4) new arrays allocated in large object heap is of generation 2
+// 5) new arrays NOT allocated in large object heap is of generation 0 
+// 6) the threshold can be set by registry key DoubleArrayToLargeObjectHeap
+
+// Variation on array length
+
+using System;
+internal class DblArray1
+{
+    private static int s_LOH_GEN = 0;
+    public static void f0()
+    {
+        double[] arr = new double[1];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f1()
+    {
+        double[] arr = new double[99];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f2()
+    {
+        double[] arr = new double[100];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f3()
+    {
+        double[] arr = new double[999];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f4()
+    {
+        double[] arr = new double[1000];
+        if (GC.GetGeneration(arr) != s_LOH_GEN)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f5()
+    {
+        double[] arr = new double[1001];
+        if (GC.GetGeneration(arr) != s_LOH_GEN)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static int Main()
+    {
+        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        {
+            s_LOH_GEN = 2;
+        }
+        try
+        {
+            f0();
+            f1();
+            f2();
+            f3();
+            f4();
+            f5();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            Console.WriteLine(e.StackTrace);
+            Console.WriteLine("FAILED");
+            Console.WriteLine();
+            Console.WriteLine(@"// Goal: Test arrays of doubles are allocated on large object heap and therefore 8 byte aligned
+// Assumptions:
+// 1) large object heap is always 8 byte aligned
+// 2) double array greater than 1000 elements is on large object heap
+// 3) non-double array greater than 1000 elements but less than 85K is NOT on large object heap
+// 4) new arrays allocated in large object heap is of generation 2
+// 5) new arrays NOT allocated in large object heap is of generation 0 ");
+
+            return -1;
+        }
+        Console.WriteLine("PASSED");
+        return 100;
+    }
+}

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_d.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_do.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_r.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_ro.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray1.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray2.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2.cs
@@ -1,0 +1,321 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Goal: Test arrays of doubles are allocated on large object heap and therefore 8 byte aligned
+// Assumptions:
+// 1) large object heap is always 8 byte aligned
+// 2) double array greater than 1000 elements is on large object heap
+// 3) non-double array greater than 1000 elements but less than 85K is NOT on large object heap
+// 4) new arrays allocated in large object heap is of generation 2
+// 5) new arrays NOT allocated in large object heap is of generation 0 
+// 6) the threshold can be set by registry key DoubleArrayToLargeObjectHeap
+
+
+using System;
+internal class DblArray
+{
+    private static int s_LOH_GEN = 0;
+    public static void f0()
+    {
+        double[] arr = new double[1000];
+        if (GC.GetGeneration(arr) != s_LOH_GEN)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f1a()
+    {
+        float[] arr = new float[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f1b()
+    {
+        float[] arr = new float[3000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f2a()
+    {
+        decimal[] arr = new decimal[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f2b()
+    {
+        decimal[] arr = new decimal[3000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f3a()
+    {
+        long[] arr = new long[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f3b()
+    {
+        long[] arr = new long[3000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f4a()
+    {
+        ulong[] arr = new ulong[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f4b()
+    {
+        ulong[] arr = new ulong[3000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f5a()
+    {
+        int[] arr = new int[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f5b()
+    {
+        int[] arr = new int[3000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f6a()
+    {
+        uint[] arr = new uint[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f6b()
+    {
+        uint[] arr = new uint[3000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f7a()
+    {
+        short[] arr = new short[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f7b()
+    {
+        short[] arr = new short[5000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f8a()
+    {
+        ushort[] arr = new ushort[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f8b()
+    {
+        ushort[] arr = new ushort[5000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f9a()
+    {
+        byte[] arr = new byte[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f9b()
+    {
+        byte[] arr = new byte[10000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f10a()
+    {
+        sbyte[] arr = new sbyte[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f10b()
+    {
+        sbyte[] arr = new sbyte[10000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f11a()
+    {
+        char[] arr = new char[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f11b()
+    {
+        char[] arr = new char[10000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f12a()
+    {
+        bool[] arr = new bool[1000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static void f12b()
+    {
+        bool[] arr = new bool[10000];
+        if (GC.GetGeneration(arr) != 0)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            throw new Exception();
+        }
+    }
+
+    public static int Main()
+    {
+        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        {
+            s_LOH_GEN = 2;
+        }
+        try
+        {
+            f0();
+            f1a();
+            f2a();
+            f3a();
+            f4a();
+            f5a();
+            f6a();
+            f7a();
+            f8a();
+            f9a();
+            f10a();
+            f11a();
+            f12a();
+            f1b();
+            f2b();
+            f3b();
+            f4b();
+            f5b();
+            f6b();
+            f7b();
+            f8b();
+            f9b();
+            f10b();
+            f11b();
+            f12b();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(e.Message);
+            Console.WriteLine(e.StackTrace);
+            Console.WriteLine("FAILED");
+            Console.WriteLine();
+            Console.WriteLine(@"// Goal: Test arrays of doubles are allocated on large object heap and therefore 8 byte aligned
+// Assumptions:
+// 1) large object heap is always 8 byte aligned
+// 2) double array greater than 1000 elements is on large object heap
+// 3) non-double array greater than 1000 elements but less than 85K is NOT on large object heap
+// 4) new arrays allocated in large object heap is of generation 2
+// 5) new arrays NOT allocated in large object heap is of generation 0 ");
+
+            return -1;
+        }
+        Console.WriteLine("PASSED");
+        return 100;
+    }
+}

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_d.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_do.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_r.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_ro.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray2.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray4.cs
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// Goal: Test arrays of doubles are allocated on large object heap and therefore 8 byte aligned
+// Assumptions:
+// 1) large object heap is always 8 byte aligned
+// 2) double array greater than 1000 elements is on large object heap
+// 3) non-double array greater than 1000 elements but less than 85K is NOT on large object heap
+// 4) new arrays allocated in large object heap is of generation 2
+// 5) new arrays NOT allocated in large object heap is of generation 0
+// 6) the threshold can be set by registry key DoubleArrayToLargeObjectHeap
+
+// Test DoubleArrayToLargeObjectHeap - need to set the key to <= 100
+
+using System;
+
+internal class DblArray4
+{
+    private static int s_LOH_GEN = 0;
+    public static int Main()
+    {
+        if (Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE") == "x86")
+        {
+            s_LOH_GEN = 2;
+        }
+
+        Console.WriteLine("DoubleArrayToLargeObjectHeap is {0}", Environment.GetEnvironmentVariable("complus_DoubleArrayToLargeObjectHeap"));
+
+        double[] arr = new double[101];
+        if (GC.GetGeneration(arr) != s_LOH_GEN)
+        {
+            Console.WriteLine("Generation {0}", GC.GetGeneration(arr));
+            Console.WriteLine("FAILED");
+            return 1;
+        }
+        Console.WriteLine("PASSED");
+        return 100;
+    }
+}

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="dblarray4.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/dynamic_methods/app.config
+++ b/tests/src/JIT/Methodical/dynamic_methods/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Methodical/dynamic_methods/bug_445388.cs
+++ b/tests/src/JIT/Methodical/dynamic_methods/bug_445388.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+
+internal class Host
+{
+    private static string s_field = "somefield";
+}
+
+internal class Program
+{
+    private delegate string Getter();
+
+    private static int Main()
+    {
+        DynamicMethod method = new DynamicMethod("GetField",
+            typeof(string), new Type[0], typeof(Host));
+
+        ILGenerator il = method.GetILGenerator();
+        il.Emit(OpCodes.Ldsfld, typeof(Host).GetField(
+            "s_field", BindingFlags.Static | BindingFlags.NonPublic));
+        il.Emit(OpCodes.Ret);
+
+        Getter g = (Getter)method.CreateDelegate(typeof(Getter));
+
+        string res = g();
+
+        return Assert(res == "somefield", "Host has not been properly initialized");
+    }
+
+    private static int Assert(bool condition, string message)
+    {
+        if (condition)
+        {
+            Console.WriteLine("[assert passed]");
+            return 100;
+        }
+
+        Console.WriteLine("[assert failed] {0}", message);
+        return 101;
+    }
+}

--- a/tests/src/JIT/Methodical/dynamic_methods/bug_445388.csproj
+++ b/tests/src/JIT/Methodical/dynamic_methods/bug_445388.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,21 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="bug_445388.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>project.json</ProjectJson>
+    <ProjectLockJson>project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Methodical/dynamic_methods/project.json
+++ b/tests/src/JIT/Methodical/dynamic_methods/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Console": "4.0.0-beta-*",
+    "System.Reflection.Emit.Lightweight": "4.0.0-beta-*",
+    "System.Runtime": "4.0.20-beta-*",
+    "System.Runtime.Extensions": "4.0.10-beta-*",
+    "System.Reflection.TypeExtensions": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/tests/src/JIT/Methodical/dynamic_methods/project.lock.json
+++ b/tests/src/JIT/Methodical/dynamic_methods/project.lock.json
@@ -1,0 +1,1419 @@
+{
+  "locked": true,
+  "version": 2,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Console.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23127": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
+    "DNXCore,Version=v5.0/win7-x86": {
+      "runtime.win7.System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Console.dll": {}
+        }
+      },
+      "System.Globalization/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23127": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
+    "DNXCore,Version=v5.0/win7-x64": {
+      "runtime.win7.System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Console.dll": {}
+        }
+      },
+      "System.Globalization/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23127": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0-beta-23127",
+          "System.Reflection.Emit.ILGeneration": "4.0.0-beta-23127",
+          "System.Reflection.Primitives": "4.0.0-beta-23127",
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "runtime.win7.System.Console/4.0.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "TJZhrw44Bf7sYqne+CX5II/PaNf5L7oKVfl0FLkr4pj76KS8hSsJzsKL0IvxC+bi4d51+wTbv91kF1kgPyHMVw==",
+      "files": [
+        "ref/dotnet/_._",
+        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg",
+        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg.sha512",
+        "runtime.win7.System.Console.nuspec",
+        "runtimes/win7/lib/dotnet5.4/System.Console.dll",
+        "runtimes/win7/lib/net/_._"
+      ]
+    },
+    "System.Console/4.0.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "tzF4Dbbv+5bcbQ7GHuuKafkaDZThiUiwxqCc1ngewnMWZ5YmIgjQZjs+E1DNhoMVAvkH0tSmLJvsDlx9dFg+Aw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.1/de/System.Console.xml",
+        "ref/dotnet5.1/es/System.Console.xml",
+        "ref/dotnet5.1/fr/System.Console.xml",
+        "ref/dotnet5.1/it/System.Console.xml",
+        "ref/dotnet5.1/ja/System.Console.xml",
+        "ref/dotnet5.1/ko/System.Console.xml",
+        "ref/dotnet5.1/ru/System.Console.xml",
+        "ref/dotnet5.1/System.Console.dll",
+        "ref/dotnet5.1/System.Console.xml",
+        "ref/dotnet5.1/zh-hans/System.Console.xml",
+        "ref/dotnet5.1/zh-hant/System.Console.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Console.4.0.0-beta-23516.nupkg",
+        "System.Console.4.0.0-beta-23516.nupkg.sha512",
+        "System.Console.nuspec"
+      ]
+    },
+    "System.Globalization/4.0.0": {
+      "type": "package",
+      "sha512": "IBJyTo1y7ZtzzoJUA60T1XPvNTyw/wfFmjFoBFtlYfkekIOtD/AzDDIg0YdUa7eNtFEfliED2R7HdppTdU4t5A==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Globalization.xml",
+        "ref/netcore50/es/System.Globalization.xml",
+        "ref/netcore50/fr/System.Globalization.xml",
+        "ref/netcore50/it/System.Globalization.xml",
+        "ref/netcore50/ja/System.Globalization.xml",
+        "ref/netcore50/ko/System.Globalization.xml",
+        "ref/netcore50/ru/System.Globalization.xml",
+        "ref/netcore50/System.Globalization.dll",
+        "ref/netcore50/System.Globalization.xml",
+        "ref/netcore50/zh-hans/System.Globalization.xml",
+        "ref/netcore50/zh-hant/System.Globalization.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Globalization.4.0.0.nupkg",
+        "System.Globalization.4.0.0.nupkg.sha512",
+        "System.Globalization.nuspec"
+      ]
+    },
+    "System.IO/4.0.0": {
+      "type": "package",
+      "sha512": "MoCHQ0u5n0OMwUS8OX4Gl48qKiQziSW5cXvt82d+MmAcsLq9OL90+ihnu/aJ1h6OOYcBswrZAEuApfZha9w2lg==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.IO.xml",
+        "ref/netcore50/es/System.IO.xml",
+        "ref/netcore50/fr/System.IO.xml",
+        "ref/netcore50/it/System.IO.xml",
+        "ref/netcore50/ja/System.IO.xml",
+        "ref/netcore50/ko/System.IO.xml",
+        "ref/netcore50/ru/System.IO.xml",
+        "ref/netcore50/System.IO.dll",
+        "ref/netcore50/System.IO.xml",
+        "ref/netcore50/zh-hans/System.IO.xml",
+        "ref/netcore50/zh-hant/System.IO.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.4.0.0.nupkg",
+        "System.IO.4.0.0.nupkg.sha512",
+        "System.IO.nuspec"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
+      "files": [
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.Primitives.4.0.0.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0-beta-23127": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "KT9JGnTYRf51pwPluZtpewmdBPiROzemamLmpzgzl3Pu3Y0vmH2CBLZktngD4I4YPNFO6ieCupeM0X3R1u26kA==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0-beta-23127.nupkg",
+        "System.Private.Uri.4.0.0-beta-23127.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.0": {
+      "type": "package",
+      "sha512": "g96Rn8XuG7y4VfxPj/jnXroRJdQ8L3iN3k3zqsuzk4k3Nq4KMXARYiIO4BLW4GwX06uQpuYwRMcAC/aF117knQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Reflection.xml",
+        "ref/netcore50/es/System.Reflection.xml",
+        "ref/netcore50/fr/System.Reflection.xml",
+        "ref/netcore50/it/System.Reflection.xml",
+        "ref/netcore50/ja/System.Reflection.xml",
+        "ref/netcore50/ko/System.Reflection.xml",
+        "ref/netcore50/ru/System.Reflection.xml",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.xml",
+        "ref/netcore50/zh-hans/System.Reflection.xml",
+        "ref/netcore50/zh-hant/System.Reflection.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Reflection.4.0.0.nupkg",
+        "System.Reflection.4.0.0.nupkg.sha512",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.0-beta-23127": {
+      "type": "package",
+      "sha512": "Z953hng7bseRmyedsWYyRMXm6VlKYaAizg/h1bN3Yol+dKcdU1PPNgtyM5lFf1poMQQWedqFrB6wP+PrV9MNFQ==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23127.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.0-beta-23127.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.Lightweight/4.0.0-beta-23127": {
+      "type": "package",
+      "sha512": "gEy6W3AxCqidpmFNSCn6CdfQ+oUMjVdMWl7sFLFU79dJVraSAV6XvTpBR8ZAyckDv2BXFPPuxTaerqkyUjgP4A==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.Lightweight.4.0.0-beta-23127.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.0-beta-23127.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.4.0.0.nupkg",
+        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "System.Reflection.TypeExtensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.4.0.0.nupkg",
+        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-23127": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "naLsXkry4PBYCdXLOGx2r9TRuFWJpdZvV7W9rk4QRTPTS7H9911J09o8KXrhX+NW28YVsCgvcw8Wr0JsFEQdLQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20-beta-23127.nupkg",
+        "System.Runtime.4.0.20-beta-23127.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YwtpybYxpRqjF+TnBzmNdgGq2jNtEO9MkxYSIMW36lV7F6qEph+nCcKDLsCslgSz7dn44eSCnnsgBQQsF85eQQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.4.0.0.nupkg",
+        "System.Runtime.Handles.4.0.0.nupkg.sha512",
+        "System.Runtime.Handles.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.4.0.20.nupkg",
+        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.0": {
+      "type": "package",
+      "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Text.Encoding.xml",
+        "ref/netcore50/es/System.Text.Encoding.xml",
+        "ref/netcore50/fr/System.Text.Encoding.xml",
+        "ref/netcore50/it/System.Text.Encoding.xml",
+        "ref/netcore50/ja/System.Text.Encoding.xml",
+        "ref/netcore50/ko/System.Text.Encoding.xml",
+        "ref/netcore50/ru/System.Text.Encoding.xml",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.Encoding.4.0.0.nupkg",
+        "System.Text.Encoding.4.0.0.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "type": "package",
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.10": {
+      "type": "package",
+      "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.4.0.10.nupkg",
+        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec"
+      ]
+    },
+    "System.Threading/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.4.0.10.nupkg",
+        "System.Threading.4.0.10.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0": {
+      "type": "package",
+      "sha512": "dA3y1B6Pc8mNt9obhEWWGGpvEakS51+nafXpmM/Z8IF847GErLXGTjdfA+AYEKszfFbH7SVLWUklXhYeeSQ1lw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.Tasks.xml",
+        "ref/netcore50/es/System.Threading.Tasks.xml",
+        "ref/netcore50/fr/System.Threading.Tasks.xml",
+        "ref/netcore50/it/System.Threading.Tasks.xml",
+        "ref/netcore50/ja/System.Threading.Tasks.xml",
+        "ref/netcore50/ko/System.Threading.Tasks.xml",
+        "ref/netcore50/ru/System.Threading.Tasks.xml",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Tasks.4.0.0.nupkg",
+        "System.Threading.Tasks.4.0.0.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.4.0.10.nupkg",
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Console >= 4.0.0-beta-*",
+      "System.Reflection.Emit.Lightweight >= 4.0.0-beta-*",
+      "System.Runtime >= 4.0.20-beta-*",
+      "System.Runtime.Extensions >= 4.0.10-beta-*",
+      "System.Reflection.TypeExtensions >= 4.0.0"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/tests/src/JIT/Methodical/refany/_dbggcreport.csproj
+++ b/tests/src/JIT/Methodical/refany/_dbggcreport.csproj
@@ -27,8 +27,8 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcreport.cs" />

--- a/tests/src/JIT/Methodical/refany/_dbgnative.csproj
+++ b/tests/src/JIT/Methodical/refany/_dbgnative.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="native.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_dbgstress1.csproj
+++ b/tests/src/JIT/Methodical/refany/_dbgstress1.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress1.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_dbgstress3.csproj
+++ b/tests/src/JIT/Methodical/refany/_dbgstress3.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress3-64bit.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_dbgvirtcall.csproj
+++ b/tests/src/JIT/Methodical/refany/_dbgvirtcall.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="virtcall.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_relgcreport.csproj
+++ b/tests/src/JIT/Methodical/refany/_relgcreport.csproj
@@ -27,8 +27,8 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcreport.cs" />

--- a/tests/src/JIT/Methodical/refany/_relnative.csproj
+++ b/tests/src/JIT/Methodical/refany/_relnative.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="native.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_relstress1.csproj
+++ b/tests/src/JIT/Methodical/refany/_relstress1.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress1.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_relstress3.csproj
+++ b/tests/src/JIT/Methodical/refany/_relstress3.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress3-64bit.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_relvirtcall.csproj
+++ b/tests/src/JIT/Methodical/refany/_relvirtcall.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="virtcall.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_dbggcreport.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_dbggcreport.csproj
@@ -27,8 +27,8 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcreport.cs" />

--- a/tests/src/JIT/Methodical/refany/_speed_dbgnative.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_dbgnative.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="native.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_dbgstress1.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_dbgstress1.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress1.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_dbgstress3.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_dbgstress3.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress3-64bit.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_dbgvirtcall.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_dbgvirtcall.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="virtcall.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_relgcreport.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_relgcreport.csproj
@@ -27,8 +27,8 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcreport.cs" />

--- a/tests/src/JIT/Methodical/refany/_speed_relnative.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_relnative.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="native.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_relstress1.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_relstress1.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress1.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_relstress3.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_relstress3.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="stress3-64bit.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/_speed_relvirtcall.csproj
+++ b/tests/src/JIT/Methodical/refany/_speed_relvirtcall.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="virtcall.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/refany/array2.csproj
+++ b/tests/src/JIT/Methodical/refany/array2.csproj
@@ -13,7 +13,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>

--- a/tests/src/JIT/Methodical/refany/format.csproj
+++ b/tests/src/JIT/Methodical/refany/format.csproj
@@ -13,7 +13,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>

--- a/tests/src/JIT/Methodical/refany/lcs.csproj
+++ b/tests/src/JIT/Methodical/refany/lcs.csproj
@@ -13,7 +13,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>

--- a/tests/src/JIT/Methodical/refany/native.csproj
+++ b/tests/src/JIT/Methodical/refany/native.csproj
@@ -13,7 +13,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>

--- a/tests/src/JIT/Methodical/refany/stress1.cs
+++ b/tests/src/JIT/Methodical/refany/stress1.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace JitTest
+{
+    using System;
+
+    internal class StressTest
+    {
+        private const int ITERATIONS = 2000;
+        private const ulong MAGIC = 0x7700001492000077;
+
+        private static ulong UnpackRef(TypedReference _ref, int iterCount)
+        {
+            if (iterCount++ == ITERATIONS)
+            {
+                Console.WriteLine(ITERATIONS.ToString() + " refs unpacked.");
+                if (__refvalue(_ref, ulong) == MAGIC)
+                {
+                    Console.WriteLine("Passed.");
+                    throw new ArgumentException();  //cleanup in an unusual way
+                }
+                else
+                {
+                    Console.WriteLine("failed.");
+                    throw new Exception();
+                }
+            }
+            else
+                return __refvalue(_ref, ulong);
+        }
+
+        private static void PackRef(TypedReference _ref, int iterCount)
+        {
+            if (++iterCount == ITERATIONS)
+            {
+                Console.WriteLine(ITERATIONS.ToString() + " refs packed.");
+                UnpackRef(_ref, iterCount);
+            }
+            else
+            {
+                ulong N = UnpackRef(_ref, 0);
+                PackRef(__makeref(N), iterCount);
+            }
+        }
+
+        private static int Main()
+        {
+            try
+            {
+                ulong N = MAGIC;
+                PackRef(__makeref(N), 0);
+                return 2;
+            }
+            catch (ArgumentException)
+            {
+                return 100;
+            }
+            catch (Exception)
+            {
+                return 1;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Methodical/refany/stress3-64bit.cs
+++ b/tests/src/JIT/Methodical/refany/stress3-64bit.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace JitTest
+{
+    using System;
+
+    internal class StressTest
+    {
+        private const int ITERATIONS = 4500;
+
+        private static void PackRef(ref String refee, int iterCount)
+        {
+            if (++iterCount == ITERATIONS)
+            {
+                Console.WriteLine(ITERATIONS.ToString() + " refs created.");
+            }
+            else
+            {
+                TypedReference _ref = __makeref(refee);
+                PackRef(ref refee, iterCount);
+                if (__reftype(_ref) != typeof(String) ||
+                    __refvalue(_ref, String) != "Hello")
+                    throw new Exception();
+            }
+        }
+
+        private static int Main()
+        {
+            try
+            {
+                String N = "Hello";
+                PackRef(ref N, 0);
+                return 100;
+            }
+            catch (Exception)
+            {
+                return 1;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Methodical/refany/virtcall.csproj
+++ b/tests/src/JIT/Methodical/refany/virtcall.csproj
@@ -13,7 +13,6 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>

--- a/tests/src/JIT/Methodical/xxobj/operand/_dbgrefanyval.csproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_dbgrefanyval.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="refanyval.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_relrefanyval.csproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_relrefanyval.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="refanyval.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_speed_dbgrefanyval.csproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_speed_dbgrefanyval.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="refanyval.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_speed_relrefanyval.csproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_speed_relrefanyval.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="refanyval.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51817/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51817/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51817/b51817.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51817/b51817.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace QQ
+{
+    using System;
+
+    internal class AA
+    {
+        private static void Test(TypedReference arg, String result) { }
+        private static int Main()
+        {
+            DateTime[] t = new DateTime[200];
+            t[1] = new DateTime(100, 10, 1);
+            Test(__makeref(t[1]), t[1].ToString());
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51817/b51817.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51817/b51817.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b51817.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52593/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52593/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52593/b52593.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52593/b52593.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test
+{
+    using System;
+    internal class App
+    {
+        private static void Method1(TypedReference param1, object obj) { }
+        private static int Main()
+        {
+            int[] an = { 0 };
+            Method1(__makeref(an[0]), 1);
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52593/b52593.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52593/b52593.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b52593.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52733/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52733/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52733/b52733.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52733/b52733.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test
+{
+    using System;
+
+    internal struct AA
+    {
+        private static float[] s_af;
+        private static bool s_b;
+
+        private static float[] Method1() { return s_af = new float[5]; }
+
+        private static int Main()
+        {
+            bool b = false;
+            if (b)
+                b = __refvalue(__makeref(s_b), bool);
+            else
+                Method1();
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52733/b52733.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52733/b52733.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b52733.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52840/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52840/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52840/b52840.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52840/b52840.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test
+{
+    using System;
+
+    internal class App
+    {
+        private static byte s_b;
+        private static void Func(ref String s) { }
+        private static void Main1()
+        {
+            Func(ref __refvalue(__makeref(s_b), String[])[0]);
+        }
+        private static int Main()
+        {
+            try
+            {
+                Main1();
+                return 1;
+            }
+            catch (InvalidCastException)
+            {
+                return 100;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52840/b52840.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b52840/b52840.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b52840.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226a.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226a.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test
+{
+    using System;
+
+    internal class App
+    {
+        private static void Func(TypedReference tr) { }
+
+        private static int Main()
+        {
+            bool b = false;
+            TypedReference tr = __makeref(b);
+            Func(b ? tr : __makeref(b));
+            return 100;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226a.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226a.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b53226a.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226b.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226b.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test
+{
+    using System;
+
+    internal class App
+    {
+        private static int Main1()
+        {
+            bool b = false;
+            TypedReference tr = __makeref(b);
+            byte bb = __refvalue((b ? __makeref(b) : tr), byte);
+            return 0;
+        }
+        private static int Main()
+        {
+            try
+            {
+                return Main1();
+            }
+            catch (InvalidCastException)
+            {
+                return 100;
+            }
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226b.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53226/b53226b.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b53226b.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/b66533.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/b66533.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Test
+{
+    using System;
+    using System.Collections;
+
+    public enum TestEnum
+    {
+        red = 1,
+        green = 2,
+        blue = 4,
+    }
+
+    public struct AA
+    {
+        public Array m_xField1;
+        public object m_xField2;
+        public long[] m_alField3;
+        public sbyte[] m_asbField4;
+        public int m_iField5;
+        public static TestEnum[] m_axStatic1;
+
+        public void Break() { throw new Exception(); }
+        public ulong Method1()
+        {
+            String[] local1 = new String[] { };
+            byte[] local2 = new byte[] { };
+            bool local3 = true;
+            TypedReference local4 = __makeref(App.m_xFwd1);
+            String[] local5 = new String[] { "120", "70", "105" };
+            if (local3)
+                while (local3)
+                {
+                    TestEnum[] local6 = new TestEnum[] { TestEnum.red };
+                    do
+                    {
+                        sbyte[] local7 = (new sbyte[117]);
+                        sbyte local8 = App.m_suFwd2;
+                        double[] local9 = new double[] { 72.0 };
+                        char[] local10 = (new char[118]);
+                        int[] local11 = new int[] { 98, 126, 35 };
+                        for (new TestEnum(); local3; new sbyte())
+                        {
+                            int[] local12 = new int[] { };
+                            String[] local13 = (new String[9]);
+                            ulong[] local14 = (new ulong[56]);
+                            App.m_asuFwd3 = (new sbyte[116]);
+                            Break();
+                        }
+                        try
+                        {
+                            double local12 = 48.0;
+                            TestEnum[] local13 = AA.m_axStatic1;
+                            char[] local14 = (new char[83]);
+                            sbyte local15 = App.m_suFwd2;
+                            Array[] local16 = (new Array[73]);
+                            throw new IndexOutOfRangeException();
+                        }
+                        catch (IndexOutOfRangeException)
+                        {
+                            byte[] local12 = (new byte[19]);
+                            sbyte[] local13 = App.m_asbFwd4;
+                            TestEnum local14 = TestEnum.red;
+                            return App.m_ulFwd5;
+                        }
+                    }
+                    while (local3);
+                }
+            else
+                goto label1;
+            while (local3)
+            {
+                ulong local6 = App.m_ulFwd5;
+                object local7 = null;
+                double[] local8 = (new double[71]);
+                byte local9 = App.m_bFwd6;
+                AA[] local10 = (new AA[47]);
+                do
+                {
+                    object local11 = null;
+                    float local12 = 72.0f;
+                    int[] local13 = new int[] { 76 };
+                    int local14 = 23;
+                    for (local14 = local14; local3; new double())
+                    {
+                        int[] local15 = new int[] { 91, 54 };
+                        byte[] local16 = (new byte[14]);
+                        double local17 = 94.0;
+                        TestEnum local18 = 0;
+                        local10 = local10;
+                    }
+                }
+                while (local3);
+            }
+            if (local3)
+                try
+                {
+                    float[] local6 = new float[] { 113.0f, 23.0f };
+                    sbyte local7 = App.m_suFwd2;
+                    TestEnum[] local8 = AA.m_axStatic1;
+                    uint local9 = 1u;
+                    throw new InvalidOperationException();
+                }
+                finally
+                {
+                    double local6 = 61.0;
+                    object local7 = null;
+                    uint[] local8 = new uint[] { 38u };
+                    char[] local9 = (new char[17]);
+                    for (App.m_iFwd7 = App.m_iFwd7; local3; local7 = local7)
+                    {
+                        char[] local10 = new char[] { };
+                        sbyte[] local11 = (new sbyte[39]);
+                        object[] local12 = (new object[50]);
+                        Array[] local13 = App.m_axFwd8;
+                        local11 = local11;
+                    }
+                }
+            label1:
+            return App.m_ulFwd5;
+        }
+    }
+
+    internal class App
+    {
+        private static int Main()
+        {
+            try
+            {
+                new AA().Method1();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Passed.");
+                return 100;
+            }
+            return 101;
+        }
+        public static AA m_xFwd1;
+        public static sbyte m_suFwd2;
+        public static sbyte[] m_asuFwd3;
+        public static sbyte[] m_asbFwd4;
+        public static ulong m_ulFwd5;
+        public static byte m_bFwd6;
+        public static int m_iFwd7;
+        public static Array[] m_axFwd8;
+        public static char m_cFwd9;
+        public static bool m_bFwd10;
+        public static byte m_siFwd11;
+        public static long m_lFwd12;
+        public static ulong[] m_aulFwd13;
+        public static byte[] m_asiFwd14;
+        public static object m_xFwd15;
+        public static String m_xFwd16;
+        public static double m_dFwd17;
+        public static Array m_xFwd18;
+        public static float[] m_afFwd19;
+        public static long[] m_alFwd20;
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/b66533.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/b66533.csproj
@@ -27,11 +27,10 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b66533.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b67414/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b67414/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b67414/b67414.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b67414/b67414.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.IO;
+
+internal class bug
+{
+    public static int Main()
+    {
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b67414/b67414.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b67414/b67414.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,21 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b67414.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.cs
@@ -1,0 +1,964 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security;
+using System.Reflection;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Collections;
+
+#if false
+Here is the bug text from the bugs that motivated this regression case.  I've annotated
+the text to hopefully make it clearer where the type safety violations were occurring.
+
+Note:
+
+    Both of the bugs deal with JIT trees that were invalid because they loaded the same
+    expression (e.g., this.m_a) multiple times and implicitly assumed that the same value
+    would be loaded each time.
+
+    It is crucial to compile this code using /debug to ensure that these multiple loads
+    aren't collapsed into one by the optimizer.
+
+Text from the first bug report:
+
+    Unboxing an object generates code to check if the type of the object is as expected, and
+    then to generate the byref by adding to the object pointer.
+
+    These two non-atomic operations expose a race if the object is not a local variable, and
+    can be mutated by another thread.
+
+    This is the tree generated for unboxing an int.  Note the two occurences of "field ref m_obj".
+
+
+    [[
+        If mutation happens, the this.m_obj reload at 0x001A4EC8 will load a different object
+        than the one that was validated in the QMARK (loads at 0x001A4D00 and 0x001A4DC8).
+
+        This means 0x001A5160 dereferences a pointer into an unknown object that may not be a
+        boxed int.  This is a type safety violation.
+    ]]
+
+
+    // Recover the boxed int by dereferencing the computed pointer to the embedded valuetype
+    // content in the boxed object.
+    //
+
+    [001A5160] 0x0027 --CXG-----W-               indir     int
+
+            // Load a pointer to the content embedded in this boxed object (at offset 0x4).
+            //
+
+             [001A50B8] 0x0024 ------------               const     int    4
+          [001A50F0] 0x0025 ---XG-------               +         byref
+             [001A4EC8] 0x001C ---XG-------               field     ref    m_obj <--------------------------------------
+                [001A4E90] 0x001B ------------               lclVar    ref    V00 (this)
+
+       [001A5128] 0x0026 --CXG-------               comma     byref
+
+                [001A5010] 0x0021 ------------ then          nop       void
+
+             [001A5048] 0x0022 --CXG-------               colon     void
+
+                // This tree runs if the fastpath check fails.  Invoke the unbox helper.
+                //
+
+                [001A4FC8] 0x0020 --CXG------- else         call help  void   HELPER.CORINFO_HELP_UNBOX
+                   [001A4F10] 0x001D ------------ arg0 on STK   const(h)  int    0x5BA855A0 class
+                   [001A4DC8] 0x0018 ---XG------- arg1 on STK   field     ref    m_obj
+                      [001A4D90] 0x0017 ------------               lclVar    ref    V00 (this)
+
+          [001A5080] 0x0023 --CXG-------               qmark     void
+
+                // Fastpath check to see if the object's MethodTable is exactly equal to 0x5BA855A0.
+                //
+
+                [001A4D48] 0x0016 ------------               const(h)  int    0x5BA855A0 class
+             [001A4E58] 0x001A ---XG-------    if         ==        int
+                [001A4E10] 0x0019 ---XG-------               indir     int
+                   [001A4D00] 0x0015 ---XG-------               field     ref    m_obj <--------------------------------------
+                      [001A4CC8] 0x0014 ------------               lclVar    ref    V00 (this)
+
+
+    This happens because of the use of Compiler::impCloneExpr() to clone the object. The fix
+    is to assign the object to a local variable, and to unbox the local variable.
+
+    The second bug exposes a similar race with code generated for calling a generic virtual method.
+
+
+Text from the second bug report:
+
+    Calling a generic method generates code to look up the function pointer based on the
+    "this" argument, and then to call the resulting function pointer and passing it the
+    "this" argument.
+
+    However, the value for "this" could be mutated from another thread if it is not a local
+    variable.
+
+    These are the 2 trees generated.
+
+    Note that "this.m_a" is the "this" argument for the call, and it can be mutated by
+    another thread.
+
+    Hence we will end up calling the resulting function pointer on a mutated value.
+
+
+    [[
+        With this tree, type safety can be violated if this.m_a changes between 0x001A416C and
+        0x001A425C.
+
+        Say there is a change and the former loads X while the latter loads Y.
+
+        The call will go to the virtual function implementation F that was found on object X.
+        The `this' argument to F will be Y.
+
+        The codegen for F will make all sorts of `this'-relative accesses that are only valid if
+        the runtime type of `this' is X or one or X's subclasses.  If the runtime type of Y is
+        not equal to (or a subclass of) the runtime type of X, then running F is very likely to
+        violate type safety.
+    ]]
+
+
+     [001A4494] 0x000F ------------               stmtExpr  void  (IL 001h...010h)
+
+           [001A43DC] 0x000C --CXG-------              call help  int    HELPER.CORINFO_HELP_VIRTUAL_FUNC_PTR
+
+                // HelperArg1 - this.m_a
+                //
+              [001A416C] 0x0002 ---XG------- arg0 on STK   field     ref    m_a
+                 [001A4134] 0x0001 ------------               lclVar    ref    V00 (this)
+
+                // HelperArg2 - class handle 0x2c111f8
+                //
+              [001A42A4] 0x0007 ------------ arg1 on STK   const(h)  int    0x2C111F8 class
+
+                // HelperArg3 - token handle 0x2c112e8
+                //
+              [001A42EC] 0x0008 ----------W- arg2 on STK   const(h)  int    0x2C112E8 token
+
+        [001A445C] 0x000E -ACXG-------               =         int
+
+                // V02 receives the result of the CORINFO_HELP_VIRTUAL_FUNC_PTR call.
+                //
+           [001A4424] 0x000D D------N----               lclVar    int    V02 (tmp0)
+
+
+
+     [001A463C] 0x0016 ------------               stmtExpr  void  (IL FFFh...FFFh)
+
+              [001A455C] 0x0012 ------------               const     int    5
+
+           [001A4594] 0x0013 --CX--------               ==        int
+
+                // Call through the virtual function pointer looked up above.
+                //
+              [001A4514] 0x0011 --CX--------              call ind   int
+
+                    // `this' ptr passed to looked up target - this.m_a.
+                    //
+                 [001A425C] 0x0006 ---XG------- this in ECX   field     ref    m_a
+                    [001A4224] 0x0005 ------------               lclVar    ref    V00 (this)
+
+                    // Arg1 to looked up target - 0.
+                    //
+                 [001A41B4] 0x0003 ------------ arg1 on STK   const     int    0
+
+                    // V02 supplies the special "calli tgt" arg that indicates how to find the target address
+                    // to use for the call.
+                    //
+                 [001A44DC] 0x0010 ------------ calli tgt     lclVar    int    V02 (tmp0)
+
+        [001A4604] 0x0015 -ACX--------               =         int
+
+           [001A45CC] 0x0014 D------N----               lclVar    int    V01 (loc0)
+#endif
+
+public static class Util
+{
+    public static Timer MakeOneShotTimer(TimerCallback callback, int dueTimeInMilliseconds)
+    {
+        return new Timer(callback, null, dueTimeInMilliseconds, Timeout.Infinite);
+    }
+
+    public static void PrintFailureAndAddToTestResults(string format, params object[] args)
+    {
+        Console.WriteLine(format, args);
+        Mutate.RecordFailure(new Exception(String.Format(format, args)));
+        return;
+    }
+}
+
+public enum ScenarioKind
+{
+    Invalid = 0,
+    WithThrowingChecks = 1,
+    WithNonThrowingChecks = 2,
+}
+
+public class ScenarioMonitor
+{
+    //
+    // These thresholds were chosen more or less arbitrarily.  In rough terms, the idea was to
+    // pick thresholds that can be reached in less than 1 billion CPU cycles, meaning they can
+    // be reached fairly quickly (within a handful of seconds) even on relatively slow hardware
+    // (e.g., CPUs that run at 1GHz or slower) or relatively busy systems.
+    //
+    // In cases with throwing checks (i.e., scenarios where ~50% of the checks will generate an
+    // exception), the cost of throwing and catching these exceptions is very high and drives
+    // down the number of iterations that are possible in 1 billion CPU cycles.
+    //
+
+    private const long MinimumCheckIterationCount_ForThrowingChecks = 2000L;
+    private const long MinimumCheckIterationCount_ForNonThrowingChecks = 50000L;
+    private const long MinimumFlipIterationCount = 100000L;
+
+
+    //
+    // Force each scenario to run for at least 3 seconds.  If the scenario doesn't make the
+    // required amount of progress within 3 minutes, signal a test failure.
+    //
+    // The maximum is set very high to try and minimize the chance of seeing a spurious test
+    // failure when the test and the CLR are operating fine, just very slowly.  This can
+    // happen, e.g., if a test machine is otherwise very busy when this test runs (busy with
+    // antivirus activity, busy with other tests in a multiworker run, etc).
+    //
+
+    private const int MinimumExecutionTimeInMilliseconds = (3 * 1000);
+    private const int MaximumExecutionTimeInMilliseconds = (180 * 1000);
+
+
+    //
+    // Define the volatile fields that will be used (generally using cross-thread accesses) to
+    // track whether or not the scenario has hit the different relevant thresholds.
+    //
+
+    private volatile bool _fMinimumTimeHasElapsed = false;
+    private volatile bool _fMaximumTimeHasElapsed = false;
+    private volatile bool _fAllRequiredCheckIterationsHaveOccurred = false;
+    private volatile bool _fAllRequiredFlipIterationsHaveOccurred = false;
+    private volatile bool _fScenarioHasEnded = false;
+    private volatile bool _fScenarioExceededTheMaximumTime = false;
+
+
+    private void MinimumTimeHasElapsed(object state) { _fMinimumTimeHasElapsed = true; }
+    private void MaximumTimeHasElapsed(object state) { _fMaximumTimeHasElapsed = true; }
+
+
+    private string _caption;
+    private long _minimumCheckIterationCount;
+
+
+    public ScenarioMonitor(string caption, ScenarioKind kind)
+    {
+        _caption = caption;
+
+        if (kind == ScenarioKind.WithThrowingChecks)
+        {
+            _minimumCheckIterationCount = ScenarioMonitor.MinimumCheckIterationCount_ForThrowingChecks;
+        }
+        else
+        {
+            _minimumCheckIterationCount = ScenarioMonitor.MinimumCheckIterationCount_ForNonThrowingChecks;
+        }
+
+        return;
+    }
+
+
+    public void RunScenario(ThreadStart runCheckThread, Action runFlipThread)
+    {
+        Thread checkThread;
+        TimeSpan elapsedTime;
+        DateTime endTime;
+        DateTime startTime;
+        Timer timerForMaximumTime;
+        Timer timerForMinimumTime;
+
+
+        //
+        // Start the "check" thread for this scenario.
+        //
+
+        startTime = DateTime.Now;
+        checkThread = new Thread(runCheckThread);
+        checkThread.Start();
+        Thread.Sleep(0);
+
+
+        //
+        // Start one-shot timers that will fire after the minimum and maximum execution times
+        // elapse, respectively.
+        //
+
+        using (timerForMinimumTime = Util.MakeOneShotTimer(this.MinimumTimeHasElapsed, ScenarioMonitor.MinimumExecutionTimeInMilliseconds))
+        using (timerForMaximumTime = Util.MakeOneShotTimer(this.MaximumTimeHasElapsed, ScenarioMonitor.MaximumExecutionTimeInMilliseconds))
+        {
+            // Use this thread to run the "flip" thread (hopefully in parallel with the "check" thread)
+            // until the scenario ends (either due to timeout or due to completing the required amount
+            // of work).
+            //
+            runFlipThread();
+
+            // The "flip" thread has exited, meaning the scenario is complete.  Block until the "check"
+            // thread terminates.
+            //
+            checkThread.Join();
+        }
+
+
+        if (_fScenarioHasEnded)
+        {
+            if (_fScenarioExceededTheMaximumTime)
+            {
+                Util.PrintFailureAndAddToTestResults(
+                    "Timeout: The `{0}' scenario exceeded the time limit ({1}s) without reaching the basic work thresholds.",
+                    _caption,
+                    (ScenarioMonitor.MaximumExecutionTimeInMilliseconds / 1000)
+                );
+            }
+            else
+            {
+                endTime = DateTime.Now;
+                elapsedTime = (endTime - startTime);
+
+                Console.WriteLine(
+                    "{0}: Checks={1}, Flips={2}, Elapsed={3}",
+                    _caption,
+                    _checkIterations,
+                    _flipIterations,
+                    elapsedTime.ToString()
+                );
+            }
+        }
+        else
+        {
+            Util.PrintFailureAndAddToTestResults("Internal error: The `{0}' scenario did not end as expected.", _caption);
+        }
+
+        return;
+    }
+
+
+    // This non-volatile data and data accessor can only be used on the check thread.
+    private long _checkIterations;
+    public void RecordCheckIteration()
+    {
+        _checkIterations += 1;
+
+        if (_checkIterations >= _minimumCheckIterationCount)
+        {
+            _fAllRequiredCheckIterationsHaveOccurred = true;
+        }
+
+        return;
+    }
+
+
+    // This non-volatile data and data accessor can only be used on the flip thread.
+    private long _flipIterations;
+    public void RecordFlipIteration()
+    {
+        _flipIterations += 1;
+
+        if (_flipIterations >= ScenarioMonitor.MinimumFlipIterationCount)
+        {
+            _fAllRequiredFlipIterationsHaveOccurred = true;
+        }
+
+        return;
+    }
+
+
+    public bool ScenarioShouldContinueRunning()
+    {
+        if (_fScenarioHasEnded)
+        {
+            // Once any call to this function determines that the scenario has ended, all future calls
+            // return false and take no other action.  This invariant makes it possible to record
+            // better information about the exact reason (timeout or threshold satisfaction) that first
+            // moves the scenario from "running" to "ended".
+            //
+            return false;
+        }
+        else
+        {
+            if (_fMaximumTimeHasElapsed)
+            {
+                // The maximum execution time has elapsed, meaning the scenario needs to end
+                // immediately.
+                //
+                _fScenarioExceededTheMaximumTime = true;
+                _fScenarioHasEnded = true;
+                return false;
+            }
+            else
+            {
+                if (_fMinimumTimeHasElapsed &&
+                    _fAllRequiredCheckIterationsHaveOccurred &&
+                    _fAllRequiredFlipIterationsHaveOccurred)
+                {
+                    // Basic requirements have been met for execution time and iteration counts, so the
+                    // scenario does not need to continue.
+                    //
+                    _fScenarioExceededTheMaximumTime = false;
+                    _fScenarioHasEnded = true;
+                    return false;
+                }
+                else
+                {
+                    // Some basic requirement for execution time or iteration count has not been met and
+                    // more time is available before hitting the maximum time limit.  Continue running the
+                    // scenario until it fulfills the basic requirements or hits the maximum time limit.
+                    //
+                    return true;
+                }
+            }
+        }
+    }
+}
+
+
+//************************************************************************
+
+public class CastClass
+{
+    private static ScenarioMonitor s_monitor = null;
+
+    private object _obj;
+    private volatile object _objVolatile;
+    private static object s_obj;
+    private volatile static object s_objVolatile;
+
+    private static object[] s_objs;
+
+    static CastClass()
+    {
+        s_objs = new object[2];
+        s_objs[0] = new object();
+        s_objs[1] = "Hello";
+    }
+
+    public CastClass()
+    {
+        _obj = s_objs[0];
+        _objVolatile = s_objs[1];
+        s_obj = s_objs[0];
+        s_objVolatile = s_objs[1];
+    }
+
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static public object GetObject()
+    {
+        return s_obj;
+    }
+
+
+    public static void CheckVal(string str)
+    {
+        if (str[0] != 'H')
+        {
+            throw new Exception("Bad string " + str);
+        }
+    }
+
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public void CheckObjects()
+    {
+        string str = null;
+        ulong i;
+
+        try
+        {
+            for (i = 0; CastClass.s_monitor.ScenarioShouldContinueRunning(); i++)
+            {
+                CastClass.s_monitor.RecordCheckIteration();
+
+                switch (i % 5)
+                {
+                    case 0:
+                        try { str = (string)_obj; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 1:
+                        try { str = (string)_objVolatile; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 2:
+                        try { str = (string)s_obj; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 3:
+                        try { str = (string)s_objVolatile; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 4:
+                        try { str = (string)CastClass.GetObject(); } catch (InvalidCastException) { continue; }
+                        break;
+
+                    default:
+                        throw new Exception("We should never get here");
+                }
+
+
+                //
+                // No exception occurred during this iteration of the loop, meaning the cast successfully
+                // yielded a string object.  Check the computed string value.
+                //
+                // The race condition cases involve System.Object instances being returned from seemingly
+                // successful casts.  In this case, the fields checked by CheckVal will actually be part of
+                // a System.Object instance, meaning they are unlikely to match the text pattern that
+                // CheckVal expects.
+                //
+                // In this case, CheckVal throws an exception to signal the fact that a type safety
+                // violation has occurred.
+                //
+
+                CastClass.CheckVal(str);
+            }
+        }
+        catch (Exception ex)
+        {
+            Mutate.RecordFailure(ex);
+        }
+
+        return;
+    }
+
+
+    private void Flip()
+    {
+        for (uint i = 0; CastClass.s_monitor.ScenarioShouldContinueRunning(); i++)
+        {
+            CastClass.s_monitor.RecordFlipIteration();
+
+            // Rotate the current (i % 2) object into the instance member and static member variable
+            // sets.
+
+            _objVolatile = _obj;
+            _obj = s_objs[i % 2];
+
+            s_objVolatile = s_obj;
+            s_obj = s_objs[i % 2];
+        }
+
+        return;
+    }
+
+
+    public static void Test()
+    {
+        CastClass o = new CastClass();
+        CastClass.s_monitor = new ScenarioMonitor("CastClass", ScenarioKind.WithThrowingChecks);
+        CastClass.s_monitor.RunScenario(o.CheckObjects, o.Flip);
+        return;
+    }
+}
+
+
+//************************************************************************
+
+public class Unbox
+{
+    private const int VAL = 0x50005000;
+
+    private static ScenarioMonitor s_monitor = null;
+
+    private object _obj;
+    private volatile object _objVolatile;
+    private static object s_obj;
+    private volatile static object s_objVolatile;
+
+    private static object[] s_objs;
+
+    static Unbox()
+    {
+        s_objs = new object[2];
+        s_objs[0] = (object)VAL;
+        s_objs[1] = "Hello";
+    }
+
+    public Unbox()
+    {
+        _obj = s_objs[0];
+        _objVolatile = s_objs[1];
+        s_obj = s_objs[0];
+        s_objVolatile = s_objs[1];
+    }
+
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static public object GetObject()
+    {
+        return s_obj;
+    }
+
+
+    public static void CheckVal(int val)
+    {
+        if (val != VAL)
+        {
+            throw new Exception("Bad value " + val);
+        }
+    }
+
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public void CheckObjects()
+    {
+        int val = 0;
+        ulong i;
+
+        try
+        {
+            for (i = 0; Unbox.s_monitor.ScenarioShouldContinueRunning(); i++)
+            {
+                Unbox.s_monitor.RecordCheckIteration();
+
+                switch (i % 5)
+                {
+                    case 0:
+                        try { val = (int)_obj; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 1:
+                        try { val = (int)_objVolatile; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 2:
+                        try { val = (int)s_obj; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 3:
+                        try { val = (int)s_objVolatile; } catch (InvalidCastException) { continue; }
+                        break;
+
+                    case 4:
+                        try { val = (int)Unbox.GetObject(); } catch (InvalidCastException) { continue; }
+                        break;
+
+                    default:
+                        throw new Exception("We should never get here");
+                }
+
+
+                //
+                // No exception occurred during this iteration of the loop, meaning the cast successfully
+                // extracted an int32 value from a boxed int32 object.  Check the computed unboxed value.
+                //
+                // The race condition cases involve the unboxed data being extracted from a System.String
+                // object instead of a boxed System.Int32 object.  In this case, the fields checked by
+                // CheckVal will actually be part of a System.String instance, meaning they are unlikely to
+                // match the precise VAL that CheckVal expects to see.
+                //
+                // In this case, CheckVal throws an exception to signal the fact that a type safety
+                // violation has occurred.
+                //
+
+                Unbox.CheckVal(val);
+            }
+        }
+        catch (Exception ex)
+        {
+            Mutate.RecordFailure(ex);
+        }
+
+        return;
+    }
+
+
+    private void Flip()
+    {
+        for (uint i = 0; Unbox.s_monitor.ScenarioShouldContinueRunning(); i++)
+        {
+            Unbox.s_monitor.RecordFlipIteration();
+
+            // Rotate the current (i % 2) object into the instance member and static member variable
+            // sets.
+
+            _objVolatile = _obj;
+            _obj = s_objs[i % 2];
+
+            s_objVolatile = s_obj;
+            s_obj = s_objs[i % 2];
+        }
+    }
+
+
+    public static void Test()
+    {
+        Unbox o = new Unbox();
+        Unbox.s_monitor = new ScenarioMonitor("Unbox", ScenarioKind.WithThrowingChecks);
+        Unbox.s_monitor.RunScenario(o.CheckObjects, o.Flip);
+        return;
+    }
+}
+
+
+//************************************************************************
+
+public class GenericMethod1
+{
+    public const int VAL1 = 0x50005000;
+
+    private int _i1;
+
+    public GenericMethod1(int val)
+    {
+        // If this GenericMethod1 instance is part of a derived GenericMethod2 object, then `val'
+        // will be zero.
+        //
+        // Otherwise, the `val' argument will always be VAL1.
+        _i1 = val;
+    }
+
+    public virtual int GetVal<T>()
+    {
+        // If reached, this function returns either 0 or VAL1 as described above.
+        return _i1;
+    }
+}
+
+
+public class GenericMethod2 : GenericMethod1
+{
+    public const int VAL2 = 0x60006000;
+
+    private static ScenarioMonitor s_monitor = null;
+
+    private int _i2;
+
+    public override int GetVal<T>()
+    {
+        // This is the GetVal<T> implementation for objects of type GenericMethod2.  If this code
+        // runs, it will always return VAL2.
+        return _i2;
+    }
+
+
+    private GenericMethod1 _obj;
+    private volatile GenericMethod1 _objVolatile;
+    private static GenericMethod1 s_obj;
+    private volatile static GenericMethod1 s_objVolatile;
+
+    private static GenericMethod1[] s_objs;
+
+    static GenericMethod2()
+    {
+        // Build the s_objs array during class construction.  Bind the GenericMethod1 instance to
+        // VAL1 and the GenericMethod2 instance to VAL2.
+        s_objs = new GenericMethod1[2];
+        s_objs[0] = new GenericMethod1(VAL1);
+        s_objs[1] = new GenericMethod2(VAL2);
+    }
+
+
+    public GenericMethod2(int val) : base(0)
+    {
+        // The `val' argument will always be VAL2.
+        _i2 = val;
+
+        _obj = s_objs[0];
+        _objVolatile = s_objs[1];
+        s_obj = s_objs[0];
+        s_objVolatile = s_objs[1];
+    }
+
+
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static public GenericMethod1 GetObject()
+    {
+        return s_obj;
+    }
+
+
+    public static void CheckVal(int val)
+    {
+        if (val != VAL1 && val != VAL2)
+        {
+            throw new Exception("Bad value " + val);
+        }
+    }
+
+
+    /// <summary>
+    ///
+    /// The idea is to catch cases where the `this' value Y passed to GetVal<string> is different
+    /// from the object X that was used when resolving the GetVal<string> function pointer.  There
+    /// are four possibilities:
+    ///
+    ///     (X is GenericMethod1), (Y is GenericMethod1)
+    ///
+    ///         GenericMethod1.GetVal<string> runs.  The function call returns VAL1.
+    ///
+    ///     (X is GenericMethod2), (Y is GenericMethod2)
+    ///
+    ///         GenericMethod2.GetVal<string> runs.  The function call returns VAL2.
+    ///
+    ///     (X is GenericMethod1), (Y is GenericMethod2)
+    ///
+    ///         GenericMethod1.GetVal<string> runs.  It assumes that `this' is a GenericMethod1 instance
+    ///         and loads this.m_i1.  In reality, `this' is a GenericMethod2 instance.
+    ///
+    ///         Since GenericMethod2 is a subclass of GenericMethod1, this loads the m_i1 field from the
+    ///         GenericMethod1 subobject.  Since GenericMethod2 always passes 0 to the base class
+    ///         constructor, m_i1 is set to 0 in this case.
+    ///
+    ///         As a result, the function call returns 0.
+    ///
+    ///     (X is GenericMethod2), (Y is GenericMethod1)
+    ///
+    ///         GenericMethod2.GetVal<string> runs.  It assumes that `this' is a GenericMethod2 instance
+    ///         and loads this.m_i2.  In reality, `this' is a GenericMethod1 instance.
+    ///
+    ///         The m_i2 field in GenericMethod2 lies beyond all of the fields in the GenericMethod1
+    ///         subobject.  Therefore, loading m_i2 will almost certainly load a field that lies off the
+    ///         end of the object.
+    ///
+    ///         As a result, the function call might AV but will usually return an unpredictable chunk
+    ///         of data loaded from off the end of the GenericMethod1 instance.
+    ///
+    /// </summary>
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    public void CheckObjects()
+    {
+        int val = 0;
+        ulong i;
+
+        try
+        {
+            for (i = 0; GenericMethod2.s_monitor.ScenarioShouldContinueRunning(); i++)
+            {
+                GenericMethod2.s_monitor.RecordCheckIteration();
+
+                // Based on the current iteration number, choose one of the instance or static member
+                // objects and call into that object's implementation of the virtual GetVal<string> method.
+
+                switch (i % 5)
+                {
+                    case 0:
+                        val = _obj.GetVal<string>();
+                        break;
+
+                    case 1:
+                        val = _objVolatile.GetVal<string>();
+                        break;
+
+                    case 2:
+                        val = s_obj.GetVal<string>();
+                        break;
+
+                    case 3:
+                        val = s_objVolatile.GetVal<string>();
+                        break;
+
+                    case 4:
+                        val = GenericMethod2.GetObject().GetVal<string>();
+                        break;
+
+                    default:
+                        throw new Exception("We should never get here");
+                }
+
+
+                //
+                // Check the basic consistency of the int value observed during this iteration.
+                //
+                // As described above, if either of the race condition cases occur the observed value will
+                // be neither VAL1 nor VAL2.  Therefore, races will be detected and promoted to exceptions
+                // at this point.
+                //
+
+                GenericMethod2.CheckVal(val);
+            }
+        }
+        catch (Exception ex)
+        {
+            Mutate.RecordFailure(ex);
+        }
+
+        return;
+    }
+
+
+    private void Flip()
+    {
+        for (uint i = 0; GenericMethod2.s_monitor.ScenarioShouldContinueRunning(); i++)
+        {
+            GenericMethod2.s_monitor.RecordFlipIteration();
+
+            // Rotate the current (i % 2) object into the instance member and static member variable
+            // sets.
+
+            _objVolatile = _obj;
+            _obj = s_objs[i % 2];
+
+            s_objVolatile = s_obj;
+            s_obj = s_objs[i % 2];
+        }
+    }
+
+
+    public static void Test()
+    {
+        GenericMethod2 o = new GenericMethod2(VAL2);
+        GenericMethod2.s_monitor = new ScenarioMonitor("GenericMethod", ScenarioKind.WithNonThrowingChecks);
+        GenericMethod2.s_monitor.RunScenario(o.CheckObjects, o.Flip);
+        return;
+    }
+}
+
+
+//************************************************************************
+
+public class Mutate
+{
+    private static object s_syncRoot = new object();
+    private static volatile List<Exception> s_exceptions = new List<Exception>();
+
+    public static void RecordFailure(Exception ex)
+    {
+        lock (Mutate.s_syncRoot)
+        {
+            s_exceptions.Add(ex);
+        }
+    }
+
+    public static int Main(String[] args)
+    {
+        try
+        {
+            CastClass.Test();
+            Unbox.Test();
+            GenericMethod2.Test();
+
+            if (s_exceptions.Count > 0)
+            {
+                Console.WriteLine("{0} exceptions were thrown", s_exceptions.Count);
+
+                foreach (Exception ex in s_exceptions)
+                {
+                    Console.WriteLine(ex);
+                    Console.WriteLine();
+                    Console.WriteLine();
+                }
+
+                throw new Exception("Failure");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(ex);
+            Console.WriteLine("Test FAILED");
+            return 101;
+        }
+
+        Console.WriteLine("Test SUCCESS");
+        return 100;
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/b425314.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,21 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b425314.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>project.json</ProjectJson>
+    <ProjectLockJson>project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/project.json
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/project.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0-beta-*",
+    "System.Console": "4.0.0-beta-*",
+    "System.Runtime": "4.0.20-beta-*",
+    "System.Runtime.Extensions": "4.0.10-beta-*",
+    "System.Threading": "4.0.0-beta-*",
+    "System.Threading.Thread": "4.0.0-beta-*",
+    "System.Threading.Timer": "4.0.0-beta-*",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/project.lock.json
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b425314/project.lock.json
@@ -1,0 +1,1414 @@
+{
+  "locked": true,
+  "version": 2,
+  "targets": {
+    "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Console.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23127": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Threading/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Threading.Tasks": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      }
+    },
+    "DNXCore,Version=v5.0/win7-x86": {
+      "runtime.win7.System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+        }
+      },
+      "System.Collections/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Console.dll": {}
+        }
+      },
+      "System.Globalization/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23127": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Threading.Tasks": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      }
+    },
+    "DNXCore,Version=v5.0/win7-x64": {
+      "runtime.win7.System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+        }
+      },
+      "System.Collections/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Console.dll": {}
+        }
+      },
+      "System.Globalization/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0-beta-23127": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127",
+          "System.Threading.Tasks": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-beta-23516": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.Timer/4.0.0-beta-23127": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0-beta-23127"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Timer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Timer.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "runtime.win7.System.Console/4.0.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "TJZhrw44Bf7sYqne+CX5II/PaNf5L7oKVfl0FLkr4pj76KS8hSsJzsKL0IvxC+bi4d51+wTbv91kF1kgPyHMVw==",
+      "files": [
+        "ref/dotnet/_._",
+        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg",
+        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg.sha512",
+        "runtime.win7.System.Console.nuspec",
+        "runtimes/win7/lib/dotnet5.4/System.Console.dll",
+        "runtimes/win7/lib/net/_._"
+      ]
+    },
+    "System.Collections/4.0.0-beta-23127": {
+      "type": "package",
+      "sha512": "vQ0QO0WoYy64J3hGOf164kuf+q89If+KUcABPI0X5MJfYnxLbn/iKyeIgiMie8xgJ6qdsAjAgu5O2Ar8rkMOvQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Collections.xml",
+        "ref/netcore50/es/System.Collections.xml",
+        "ref/netcore50/fr/System.Collections.xml",
+        "ref/netcore50/it/System.Collections.xml",
+        "ref/netcore50/ja/System.Collections.xml",
+        "ref/netcore50/ko/System.Collections.xml",
+        "ref/netcore50/ru/System.Collections.xml",
+        "ref/netcore50/System.Collections.dll",
+        "ref/netcore50/System.Collections.xml",
+        "ref/netcore50/zh-hans/System.Collections.xml",
+        "ref/netcore50/zh-hant/System.Collections.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.4.0.0-beta-23127.nupkg",
+        "System.Collections.4.0.0-beta-23127.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
+    "System.Console/4.0.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "tzF4Dbbv+5bcbQ7GHuuKafkaDZThiUiwxqCc1ngewnMWZ5YmIgjQZjs+E1DNhoMVAvkH0tSmLJvsDlx9dFg+Aw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Console.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.1/de/System.Console.xml",
+        "ref/dotnet5.1/es/System.Console.xml",
+        "ref/dotnet5.1/fr/System.Console.xml",
+        "ref/dotnet5.1/it/System.Console.xml",
+        "ref/dotnet5.1/ja/System.Console.xml",
+        "ref/dotnet5.1/ko/System.Console.xml",
+        "ref/dotnet5.1/ru/System.Console.xml",
+        "ref/dotnet5.1/System.Console.dll",
+        "ref/dotnet5.1/System.Console.xml",
+        "ref/dotnet5.1/zh-hans/System.Console.xml",
+        "ref/dotnet5.1/zh-hant/System.Console.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Console.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.Console.4.0.0-beta-23516.nupkg",
+        "System.Console.4.0.0-beta-23516.nupkg.sha512",
+        "System.Console.nuspec"
+      ]
+    },
+    "System.Globalization/4.0.0": {
+      "type": "package",
+      "sha512": "IBJyTo1y7ZtzzoJUA60T1XPvNTyw/wfFmjFoBFtlYfkekIOtD/AzDDIg0YdUa7eNtFEfliED2R7HdppTdU4t5A==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Globalization.xml",
+        "ref/netcore50/es/System.Globalization.xml",
+        "ref/netcore50/fr/System.Globalization.xml",
+        "ref/netcore50/it/System.Globalization.xml",
+        "ref/netcore50/ja/System.Globalization.xml",
+        "ref/netcore50/ko/System.Globalization.xml",
+        "ref/netcore50/ru/System.Globalization.xml",
+        "ref/netcore50/System.Globalization.dll",
+        "ref/netcore50/System.Globalization.xml",
+        "ref/netcore50/zh-hans/System.Globalization.xml",
+        "ref/netcore50/zh-hant/System.Globalization.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Globalization.4.0.0.nupkg",
+        "System.Globalization.4.0.0.nupkg.sha512",
+        "System.Globalization.nuspec"
+      ]
+    },
+    "System.IO/4.0.0": {
+      "type": "package",
+      "sha512": "MoCHQ0u5n0OMwUS8OX4Gl48qKiQziSW5cXvt82d+MmAcsLq9OL90+ihnu/aJ1h6OOYcBswrZAEuApfZha9w2lg==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.IO.xml",
+        "ref/netcore50/es/System.IO.xml",
+        "ref/netcore50/fr/System.IO.xml",
+        "ref/netcore50/it/System.IO.xml",
+        "ref/netcore50/ja/System.IO.xml",
+        "ref/netcore50/ko/System.IO.xml",
+        "ref/netcore50/ru/System.IO.xml",
+        "ref/netcore50/System.IO.dll",
+        "ref/netcore50/System.IO.xml",
+        "ref/netcore50/zh-hans/System.IO.xml",
+        "ref/netcore50/zh-hant/System.IO.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.4.0.0.nupkg",
+        "System.IO.4.0.0.nupkg.sha512",
+        "System.IO.nuspec"
+      ]
+    },
+    "System.IO.FileSystem.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "7pJUvYi/Yq3A5nagqCCiOw3+aJp3xXc/Cjr8dnJDnER3/6kX3LEencfqmXUcPl9+7OvRNyPMNhqsLAcMK6K/KA==",
+      "files": [
+        "lib/dotnet/System.IO.FileSystem.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/es/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/fr/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/it/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ja/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ko/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hans/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.IO.FileSystem.Primitives.4.0.0.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0-beta-23127": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "KT9JGnTYRf51pwPluZtpewmdBPiROzemamLmpzgzl3Pu3Y0vmH2CBLZktngD4I4YPNFO6ieCupeM0X3R1u26kA==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0-beta-23127.nupkg",
+        "System.Private.Uri.4.0.0-beta-23127.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.0": {
+      "type": "package",
+      "sha512": "g96Rn8XuG7y4VfxPj/jnXroRJdQ8L3iN3k3zqsuzk4k3Nq4KMXARYiIO4BLW4GwX06uQpuYwRMcAC/aF117knQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Reflection.xml",
+        "ref/netcore50/es/System.Reflection.xml",
+        "ref/netcore50/fr/System.Reflection.xml",
+        "ref/netcore50/it/System.Reflection.xml",
+        "ref/netcore50/ja/System.Reflection.xml",
+        "ref/netcore50/ko/System.Reflection.xml",
+        "ref/netcore50/ru/System.Reflection.xml",
+        "ref/netcore50/System.Reflection.dll",
+        "ref/netcore50/System.Reflection.xml",
+        "ref/netcore50/zh-hans/System.Reflection.xml",
+        "ref/netcore50/zh-hant/System.Reflection.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Reflection.4.0.0.nupkg",
+        "System.Reflection.4.0.0.nupkg.sha512",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.4.0.0.nupkg",
+        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.4.0.0.nupkg",
+        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20-beta-23127": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "naLsXkry4PBYCdXLOGx2r9TRuFWJpdZvV7W9rk4QRTPTS7H9911J09o8KXrhX+NW28YVsCgvcw8Wr0JsFEQdLQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20-beta-23127.nupkg",
+        "System.Runtime.4.0.20-beta-23127.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YwtpybYxpRqjF+TnBzmNdgGq2jNtEO9MkxYSIMW36lV7F6qEph+nCcKDLsCslgSz7dn44eSCnnsgBQQsF85eQQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg",
+        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Runtime.Handles/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Handles.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Handles.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Handles.xml",
+        "ref/dotnet/es/System.Runtime.Handles.xml",
+        "ref/dotnet/fr/System.Runtime.Handles.xml",
+        "ref/dotnet/it/System.Runtime.Handles.xml",
+        "ref/dotnet/ja/System.Runtime.Handles.xml",
+        "ref/dotnet/ko/System.Runtime.Handles.xml",
+        "ref/dotnet/ru/System.Runtime.Handles.xml",
+        "ref/dotnet/System.Runtime.Handles.dll",
+        "ref/dotnet/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Handles.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Handles.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
+        "System.Runtime.Handles.4.0.0.nupkg",
+        "System.Runtime.Handles.4.0.0.nupkg.sha512",
+        "System.Runtime.Handles.nuspec"
+      ]
+    },
+    "System.Runtime.InteropServices/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.InteropServices.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.InteropServices.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.InteropServices.xml",
+        "ref/dotnet/es/System.Runtime.InteropServices.xml",
+        "ref/dotnet/fr/System.Runtime.InteropServices.xml",
+        "ref/dotnet/it/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ja/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ko/System.Runtime.InteropServices.xml",
+        "ref/dotnet/ru/System.Runtime.InteropServices.xml",
+        "ref/dotnet/System.Runtime.InteropServices.dll",
+        "ref/dotnet/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hans/System.Runtime.InteropServices.xml",
+        "ref/dotnet/zh-hant/System.Runtime.InteropServices.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
+        "System.Runtime.InteropServices.4.0.20.nupkg",
+        "System.Runtime.InteropServices.4.0.20.nupkg.sha512",
+        "System.Runtime.InteropServices.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.0": {
+      "type": "package",
+      "sha512": "AMxFNOXpA6Ab8swULbXuJmoT2K5w6TnV3ObF5wsmEcIHQUJghoZtDVfVHb08O2wW15mOSI1i9Wg0Dx0pY13o8g==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Text.Encoding.xml",
+        "ref/netcore50/es/System.Text.Encoding.xml",
+        "ref/netcore50/fr/System.Text.Encoding.xml",
+        "ref/netcore50/it/System.Text.Encoding.xml",
+        "ref/netcore50/ja/System.Text.Encoding.xml",
+        "ref/netcore50/ko/System.Text.Encoding.xml",
+        "ref/netcore50/ru/System.Text.Encoding.xml",
+        "ref/netcore50/System.Text.Encoding.dll",
+        "ref/netcore50/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.Encoding.4.0.0.nupkg",
+        "System.Text.Encoding.4.0.0.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "type": "package",
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.10": {
+      "type": "package",
+      "sha512": "TZvlwXMxKo3bSRIcsWZLCIzIhLbvlz+mGeKYRZv/zUiSoQzGOwkYeBu6hOw2XPQgKqT0F4Rv8zqKdvmp2fWKYg==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
+        "System.Text.Encoding.Extensions.4.0.10.nupkg",
+        "System.Text.Encoding.Extensions.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec"
+      ]
+    },
+    "System.Threading/4.0.0-beta-23127": {
+      "type": "package",
+      "sha512": "SSZaF3U+EjcgXqifrYus6mcx2GYkIplUBngnNHqR9tISvhGTbd04j5VF+I7dAwmoRKtaKEHWKEvc+uT+PxK00A==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.xml",
+        "ref/netcore50/es/System.Threading.xml",
+        "ref/netcore50/fr/System.Threading.xml",
+        "ref/netcore50/it/System.Threading.xml",
+        "ref/netcore50/ja/System.Threading.xml",
+        "ref/netcore50/ko/System.Threading.xml",
+        "ref/netcore50/ru/System.Threading.xml",
+        "ref/netcore50/System.Threading.dll",
+        "ref/netcore50/System.Threading.xml",
+        "ref/netcore50/zh-hans/System.Threading.xml",
+        "ref/netcore50/zh-hant/System.Threading.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.4.0.0-beta-23127.nupkg",
+        "System.Threading.4.0.0-beta-23127.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.0": {
+      "type": "package",
+      "sha512": "dA3y1B6Pc8mNt9obhEWWGGpvEakS51+nafXpmM/Z8IF847GErLXGTjdfA+AYEKszfFbH7SVLWUklXhYeeSQ1lw==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Threading.Tasks.xml",
+        "ref/netcore50/es/System.Threading.Tasks.xml",
+        "ref/netcore50/fr/System.Threading.Tasks.xml",
+        "ref/netcore50/it/System.Threading.Tasks.xml",
+        "ref/netcore50/ja/System.Threading.Tasks.xml",
+        "ref/netcore50/ko/System.Threading.Tasks.xml",
+        "ref/netcore50/ru/System.Threading.Tasks.xml",
+        "ref/netcore50/System.Threading.Tasks.dll",
+        "ref/netcore50/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hans/System.Threading.Tasks.xml",
+        "ref/netcore50/zh-hant/System.Threading.Tasks.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Tasks.4.0.0.nupkg",
+        "System.Threading.Tasks.4.0.0.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.4.0.10.nupkg",
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    },
+    "System.Threading.Thread/4.0.0-beta-23516": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "/yo7KuZ9zLrB3hdWARrvus3YTAdvvuqHWf2oMNpyG1mpoVlmhRwkZ9JqYRC+TL3hSFHa7mvHa8EItA+BBahlsA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Thread.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.1/de/System.Threading.Thread.xml",
+        "ref/dotnet5.1/es/System.Threading.Thread.xml",
+        "ref/dotnet5.1/fr/System.Threading.Thread.xml",
+        "ref/dotnet5.1/it/System.Threading.Thread.xml",
+        "ref/dotnet5.1/ja/System.Threading.Thread.xml",
+        "ref/dotnet5.1/ko/System.Threading.Thread.xml",
+        "ref/dotnet5.1/ru/System.Threading.Thread.xml",
+        "ref/dotnet5.1/System.Threading.Thread.dll",
+        "ref/dotnet5.1/System.Threading.Thread.xml",
+        "ref/dotnet5.1/zh-hans/System.Threading.Thread.xml",
+        "ref/dotnet5.1/zh-hant/System.Threading.Thread.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Thread.4.0.0-beta-23516.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23516.nupkg.sha512",
+        "System.Threading.Thread.nuspec"
+      ]
+    },
+    "System.Threading.Timer/4.0.0-beta-23127": {
+      "type": "package",
+      "sha512": "KiGhjDuGS3yGb4OMznFlC5vYmOQxEpj4PleDRnwrxrxyFY6yPs/9R9/X7HRDhgG6Ulp08MvSaPpxD17dDeC4ZQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Timer.dll",
+        "lib/net451/_._",
+        "lib/netcore50/System.Threading.Timer.dll",
+        "lib/win81/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Threading.Timer.xml",
+        "ref/dotnet/es/System.Threading.Timer.xml",
+        "ref/dotnet/fr/System.Threading.Timer.xml",
+        "ref/dotnet/it/System.Threading.Timer.xml",
+        "ref/dotnet/ja/System.Threading.Timer.xml",
+        "ref/dotnet/ko/System.Threading.Timer.xml",
+        "ref/dotnet/ru/System.Threading.Timer.xml",
+        "ref/dotnet/System.Threading.Timer.dll",
+        "ref/dotnet/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hans/System.Threading.Timer.xml",
+        "ref/dotnet/zh-hant/System.Threading.Timer.xml",
+        "ref/net451/_._",
+        "ref/netcore50/System.Threading.Timer.dll",
+        "ref/netcore50/System.Threading.Timer.xml",
+        "ref/win81/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
+        "System.Threading.Timer.4.0.0-beta-23127.nupkg",
+        "System.Threading.Timer.4.0.0-beta-23127.nupkg.sha512",
+        "System.Threading.Timer.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "System.Collections >= 4.0.0-beta-*",
+      "System.Console >= 4.0.0-beta-*",
+      "System.Runtime >= 4.0.20-beta-*",
+      "System.Runtime.Extensions >= 4.0.10-beta-*",
+      "System.Threading >= 4.0.0-beta-*",
+      "System.Threading.Thread >= 4.0.0-beta-*",
+      "System.Threading.Timer >= 4.0.0-beta-*"
+    ],
+    "DNXCore,Version=v5.0": []
+  }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b604247/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b604247/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b604247/b604247.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b604247/b604247.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+
+public class Test
+{
+    public static int Main(String[] arguments)
+    {
+        bool testCaseSucceeded = false;
+        string[] theArray = { "Wrong =0", "Correct =1", "Wrong =2", "Wrong =3" };
+
+        for (int i = 0; i < 1; i++)
+        {
+            if (theArray[i * 3 + 1] != "-")
+            {
+                testCaseSucceeded = (theArray[(i * 3) + 1] == theArray[1]);
+                Console.WriteLine("First Result: " + theArray[(i * 3) + 1]);
+                int temp = (i * 3) + 1;
+                Console.WriteLine("Second Result: " + theArray[temp]);
+            }
+        }
+
+        if (testCaseSucceeded)
+        {
+            Console.WriteLine("PASSED");
+            return 100;
+        }
+        else
+        {
+            Console.WriteLine("FAILED");
+            return 666;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b604247/b604247.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-RTM/b604247/b604247.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,22 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize></Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="b604247.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Regression/Dev11/dev11_76013/Dev11_76013.cs
+++ b/tests/src/JIT/Regression/Dev11/dev11_76013/Dev11_76013.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net;
+
+namespace Test
+{
+    class MyException : Exception
+    {
+        int _code;
+
+        public MyException(int code)
+        {
+            _code = code;
+        }
+    }
+
+    internal class Program
+    {
+        private static int Main(string[] args)
+        {
+            bool flag = false;
+            try
+            {
+                flag = true;
+                Console.WriteLine("flag={0} (should be True)", flag);
+                ThrowMyException(); // throws exception
+            }
+            catch (MyException)
+            {
+                Console.WriteLine("MyException Handled");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Unknown Exception: We should never reach this line");
+                flag = false;
+            }
+            Console.WriteLine("flag={0} (should be True)", flag);
+            if (flag)
+            {
+                Console.WriteLine("PASSED");
+                return 100;
+            }
+            else
+            {
+                Console.WriteLine("FAILED");
+                return -1;
+            }
+        }
+
+        private static void ThrowMyException()
+        {
+            throw new MyException(42);
+        }
+    }
+}

--- a/tests/src/JIT/Regression/Dev11/dev11_76013/Dev11_76013.csproj
+++ b/tests/src/JIT/Regression/Dev11/dev11_76013/Dev11_76013.csproj
@@ -13,8 +13,8 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <ReferenceLocalMscorlib>true</ReferenceLocalMscorlib>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,22 +27,21 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="Dev11_76013.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <PropertyGroup>
-    <ProjectJson>$(JitPackagesConfigFileDirectory)empty\project.json</ProjectJson>
-    <ProjectLockJson>$(JitPackagesConfigFileDirectory)empty\project.lock.json</ProjectLockJson>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">

--- a/tests/src/JIT/Regression/Dev11/dev11_76013/app.config
+++ b/tests/src/JIT/Regression/Dev11/dev11_76013/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/_5mvazhg.cs
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/_5mvazhg.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+
+public struct AA
+{
+    public static byte Static2()
+    {
+        do
+        {
+            TypedReference local19 = __makeref(App.m_xFwd6);
+            do
+            {
+            }
+            while (App.m_bFwd5);
+        }
+        while (App.m_bFwd5);
+        return App.m_byFwd9;
+    }
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public class App
+{
+    private static int Main()
+    {
+        try
+        {
+            Console.WriteLine("Testing AA::Static2");
+            AA.Static2();
+        }
+        catch (Exception x)
+        {
+            Console.WriteLine("Exception handled: " + x.ToString());
+        }
+        Console.WriteLine("Passed.");
+        return 100;
+    }
+    public static bool m_bFwd5;
+    public static AA m_xFwd6;
+    public static byte m_byFwd9;
+}

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/app.config
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/b302509.csproj
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/b302509.csproj
@@ -27,11 +27,11 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    <DebugType>Full</DebugType>
-    <Optimize>False</Optimize>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="gcreport.cs" />
+    <Compile Include="_5mvazhg.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)empty\project.json" />

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -13,6 +13,10 @@ JIT/Directed/PREFIX/unaligned/4/arglist/arglist.sh
 JIT/Directed/PREFIX/volatile/1/arglist/arglist.sh
 JIT/Directed/StructABI/StructABI/StructABI.sh
 JIT/Directed/TypedReference/TypedReference/TypedReference.sh
+JIT/Directed/UnrollLoop/loop6_cs_d/loop6_cs_d.sh
+JIT/Directed/UnrollLoop/loop6_cs_do/loop6_cs_do.sh
+JIT/Directed/UnrollLoop/loop6_cs_r/loop6_cs_r.sh
+JIT/Directed/UnrollLoop/loop6_cs_ro/loop6_cs_ro.sh
 JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_ref/_il_dbgi_ref.sh
 JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_ref/_il_dbgu_ref.sh
 JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_ref/_il_reli_ref.sh
@@ -21,6 +25,8 @@ JIT/Methodical/refany/array1/array1.sh
 JIT/Methodical/refany/array2/array2.sh
 JIT/Methodical/refany/format/format.sh
 JIT/Methodical/refany/gcreport/gcreport.sh
+JIT/Methodical/refany/_dbgstress1/_dbgstress1.sh
+JIT/Methodical/refany/_dbgstress3/_dbgstress3.sh
 JIT/Methodical/refany/_il_dbgarray1/_il_dbgarray1.sh
 JIT/Methodical/refany/_il_dbgarray2/_il_dbgarray2.sh
 JIT/Methodical/refany/_il_dbgarray3/_il_dbgarray3.sh
@@ -33,6 +39,12 @@ JIT/Methodical/refany/_il_relarray3/_il_relarray3.sh
 JIT/Methodical/refany/_il_relnative/_il_relnative.sh
 JIT/Methodical/refany/_il_relseq/_il_relseq.sh
 JIT/Methodical/refany/_il_relu_native/_il_relu_native.sh
+JIT/Methodical/refany/_relstress1/_relstress1.sh
+JIT/Methodical/refany/_relstress3/_relstress3.sh
+JIT/Methodical/refany/_speed_dbgstress1/_speed_dbgstress1.sh
+JIT/Methodical/refany/_speed_dbgstress3/_speed_dbgstress3.sh
+JIT/Methodical/refany/_speed_relstress1/_speed_relstress1.sh
+JIT/Methodical/refany/_speed_relstress3/_speed_relstress3.sh
 JIT/Methodical/refany/lcs/lcs.sh
 JIT/Methodical/refany/native/native.sh
 JIT/Methodical/refany/virtcall/virtcall.sh
@@ -76,7 +88,9 @@ JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b31746/b31746/b31746.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b37646/b37646/b37646.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b41852/b41852/b41852.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51575/b51575/b51575.sh
+JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b66533/b66533/b66533.sh
 JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b88793/b88793/b88793.sh
 JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b91248/b91248/b91248.sh
 JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b409748/b409748/b409748.sh
+JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b302509/b302509/b302509.sh
 Loader/NativeLibs/FromNativePaths/FromNativePaths.sh


### PR DESCRIPTION
Most of these tests were missed in the first round because they rely on
TypedReference.