### PR TITLE
Add new IPC message for out of context unwinding

### DIFF
--- a/src/debug/di/shimdatatarget.cpp
+++ b/src/debug/di/shimdatatarget.cpp
@@ -80,21 +80,6 @@ DWORD ShimDataTarget::GetPid()
 }
 
 //---------------------------------------------------------------------------------------
-//
-// Unwind the stack to the next frame.
-//
-// Return Value: 
-//     context and contextPointers filled in with the next frame
-//
-HRESULT STDMETHODCALLTYPE ShimDataTarget::VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context)
-{
-#ifndef FEATURE_PAL
-    _ASSERTE(!"ShimDataTarget::VirtualUnwind NOT IMPLEMENTED");
-#endif 
-    return E_NOTIMPL;
-}
-
-//---------------------------------------------------------------------------------------
 // Hook a custom function to handle ICorDebugMutableDataTarget::ContinueStatusChanged
 //
 // Arguments:

--- a/src/debug/di/shimdatatarget.h
+++ b/src/debug/di/shimdatatarget.h
@@ -90,7 +90,8 @@ public:
     //    
 
     // Unwind to the next stack frame
-    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context);
+    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(
+        DWORD threadId, ULONG32 contextSize, PBYTE context) = 0;
 
 protected:
     // Pid of the target process.

--- a/src/debug/di/shimlocaldatatarget.cpp
+++ b/src/debug/di/shimlocaldatatarget.cpp
@@ -67,6 +67,9 @@ public:
         DWORD dwThreadId,
         CORDB_CONTINUE_STATUS dwContinueStatus);
 
+    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(
+        DWORD threadId, ULONG32 contextSize, PBYTE context);
+
 private:
     // Handle to the process. We own this.
     HANDLE m_hProcess;
@@ -450,3 +453,20 @@ ShimLocalDataTarget::ContinueStatusChanged(
     }
     return E_NOTIMPL;
 }
+
+//---------------------------------------------------------------------------------------
+//
+// Unwind the stack to the next frame.
+//
+// Return Value: 
+//     context filled in with the next frame
+//
+HRESULT STDMETHODCALLTYPE 
+ShimLocalDataTarget::VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context)
+{
+#ifndef FEATURE_PAL
+    _ASSERTE(!"ShimLocalDataTarget::VirtualUnwind NOT IMPLEMENTED");
+#endif 
+    return E_NOTIMPL;
+}
+

--- a/src/debug/di/shimremotedatatarget.cpp
+++ b/src/debug/di/shimremotedatatarget.cpp
@@ -64,6 +64,9 @@ public:
         DWORD dwThreadId,
         CORDB_CONTINUE_STATUS dwContinueStatus);
 
+    virtual HRESULT STDMETHODCALLTYPE VirtualUnwind(
+        DWORD threadId, ULONG32 contextSize, PBYTE context);
+
 private:
     DbgTransportTarget  * m_pProxy;
     DbgTransportSession * m_pTransport;
@@ -331,4 +334,17 @@ ShimRemoteDataTarget::ContinueStatusChanged(
         return m_fpContinueStatusChanged(m_pContinueStatusChangedUserData, dwThreadId, dwContinueStatus);
     }
     return E_NOTIMPL;
+}
+
+//---------------------------------------------------------------------------------------
+//
+// Unwind the stack to the next frame.
+//
+// Return Value: 
+//     context filled in with the next frame
+//
+HRESULT STDMETHODCALLTYPE 
+ShimRemoteDataTarget::VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context)
+{
+    return m_pTransport->VirtualUnwind(threadId, contextSize, context);
 }

--- a/src/debug/inc/dbgtransportsession.h
+++ b/src/debug/inc/dbgtransportsession.h
@@ -371,6 +371,7 @@ public:
     // Read and write memory on the LS from the RS.
     HRESULT ReadMemory(PBYTE pbRemoteAddress, PBYTE pbBuffer, SIZE_T cbBuffer);
     HRESULT WriteMemory(PBYTE pbRemoteAddress, PBYTE pbBuffer, SIZE_T cbBuffer);
+    HRESULT VirtualUnwind(DWORD threadId, ULONG32 contextSize, PBYTE context);
 
     // Read and write the debugger control block on the LS from the RS.
     HRESULT GetDCB(DebuggerIPCControlBlock *pDCB);
@@ -417,6 +418,7 @@ private:
         // Misc management operations.
         MT_ReadMemory,      // RS <-> LS : RS wants to read LS memory block (or LS is replying to such a request)
         MT_WriteMemory,     // RS <-> LS : RS wants to write LS memory block (or LS is replying to such a request)
+        MT_VirtualUnwind,   // RS <-> LS : RS wants to LS unwind a stack frame (or LS is replying to such a request)
         MT_GetDCB,          // RS <-> LS : RS wants to read LS DCB (or LS is replying to such a request)
         MT_SetDCB,          // RS <-> LS : RS wants to write LS DCB (or LS is replying to such a request)
         MT_GetAppDomainCB,  // RS <-> LS : RS wants to read LS AppDomainCB (or LS is replying to such a request)
@@ -557,6 +559,7 @@ private:
         LONG        m_cSentEvent;
         LONG        m_cSentReadMemory;
         LONG        m_cSentWriteMemory;
+        LONG        m_cSentVirtualUnwind;
         LONG        m_cSentGetDCB;
         LONG        m_cSentSetDCB;
         LONG        m_cSentGetAppDomainCB;
@@ -571,6 +574,7 @@ private:
         LONG        m_cReceivedEvent;
         LONG        m_cReceivedReadMemory;
         LONG        m_cReceivedWriteMemory;
+        LONG        m_cReceivedVirtualUnwind;
         LONG        m_cReceivedGetDCB;
         LONG        m_cReceivedSetDCB;
         LONG        m_cReceivedGetAppDomainCB;


### PR DESCRIPTION
 Used to get the full context for HelperMethodFrames.