### PR TITLE
Initial bringup of GC performance tests

### DIFF
--- a/tests/src/GC/Performance/Framework/GCPerfTestFramework.xproj
+++ b/tests/src/GC/Performance/Framework/GCPerfTestFramework.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>f1913803-be3c-47c7-ad4e-8289bd7b665a</ProjectGuid>
+    <RootNamespace>GCPerfTestFramework</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/CircularBuffer.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/CircularBuffer.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    internal class CircularBuffer<T> : IEnumerable<T>
+        where T : class
+    {
+        private int StartIndex, AfterEndIndex, Size;
+        private T[] Items;
+        public CircularBuffer(int size)
+        {
+            if (size < 1)
+                throw new ArgumentException("size");
+
+            StartIndex = 0;
+            AfterEndIndex = 0;
+            Size = size + 1;
+            Items = new T[Size];
+        }
+
+        public void Add(T item)
+        {
+            if (Next(AfterEndIndex) == StartIndex)
+            {
+                Items[StartIndex] = null;
+                StartIndex = Next(StartIndex);
+            }
+            Items[AfterEndIndex] = item;
+            AfterEndIndex = Next(AfterEndIndex);
+        }
+
+        private int Next(int i)
+        {
+            return (i == Size - 1) ? 0 : i + 1;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            for (int i = StartIndex; i != AfterEndIndex; i = Next(i))
+            {
+                yield return Items[i];
+            }
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/CondemnedReasonGroup.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/CondemnedReasonGroup.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    // Condemned reasons are organized into the following groups.
+    // Each group corresponds to one or more reasons. 
+    // Groups are organized in the way that they mean something to users. 
+    internal enum CondemnedReasonGroup
+    {
+        // The first 4 will have values of a number which is the generation.
+        // Note that right now these 4 have the exact same value as what's in
+        // Condemned_Reason_Generation.
+        CRG_Initial_Generation = 0,
+        CRG_Final_Generation = 1,
+        CRG_Alloc_Exceeded = 2,
+        CRG_Time_Tuning = 3,
+
+        // The following are either true(1) or false(0). They are not 
+        // a 1:1 mapping from 
+        CRG_Induced = 4,
+        CRG_Low_Ephemeral = 5,
+        CRG_Expand_Heap = 6,
+        CRG_Fragmented_Ephemeral = 7,
+        CRG_Fragmented_Gen1_To_Gen2 = 8,
+        CRG_Fragmented_Gen2 = 9,
+        CRG_Fragmented_Gen2_High_Mem = 10,
+        CRG_GC_Before_OOM = 11,
+        CRG_Too_Small_For_BGC = 12,
+        CRG_Ephemeral_Before_BGC = 13,
+        CRG_Internal_Tuning = 14,
+        CRG_Max = 15,
+    }
+
+}

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/DictionaryExtensions.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/DictionaryExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    internal static class DictionaryExtensions
+    {
+        public static V GetOrCreate<K, V>(this IDictionary<K, V> dict, K key) where V : new()
+        {
+            V value;
+            if (dict.TryGetValue(key, out value))
+            {
+                return value;
+            }
+
+            value = new V();
+            dict[key] = value;
+            return value;
+        }
+    }
+}

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/GCEvent.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/GCEvent.cs
@@ -1,0 +1,1445 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS
+
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    internal class GCEvent
+    {
+        #region Public Fields
+        //  Time it takes to do the suspension. Before 4.0 we didn't have a SuspendEnd event so we calculate it by just 
+        // substracting GC duration from pause duration. For concurrent GC this would be inaccurate so we just return 0.
+        public double _SuspendDurationMSec;
+
+        public double[] AllocedSinceLastGCBasedOnAllocTickMB = { 0.0, 0.0 };
+        public long duplicatedPinningReports;
+        public double DurationSinceLastRestartMSec;
+        // The amount of CPU time this GC consumed.
+        public float GCCpuMSec;
+
+        public float[] GCCpuServerGCThreads = null;
+        public double GCDurationMSec;
+        public int GCGeneration;
+        // Primary fields (set in the callbacks)
+        public int GCNumber;
+
+        public double GCStartRelativeMSec;
+        public GCGlobalHeapHistoryTraceData GlobalHeapHistory;
+        public bool HasAllocTickEvents = false;
+        public GCHeapStatsTraceData HeapStats;
+        public int Index;
+        // In 2.0 we didn't have all the events. I try to keep the code not version specific and this is really
+        // for debugging/verification purpose.
+        public bool is20Event;
+
+        // Did we get the complete event sequence for this GC?
+        // For BGC this is the HeapStats event; for other GCs this means you have both the HeapStats and RestartEEEnd event.
+        public bool isComplete;
+
+        //  Set in Start, does not include suspension.  
+        //  Set in Stop This is JUST the GC time (not including suspension) That is Stop-Start.  
+        // This only applies to 2.0. I could just set the type to Background GC but I'd rather not disturb
+        // the code that handles background GC.
+        public bool isConcurrentGC;
+
+        public GCProcess Parent;                //process that did that GC
+        public double PauseDurationMSec;
+
+        public double PauseStartRelativeMSec;
+
+        public List<GCPerHeapHistoryTraceData> PerHeapHistories;
+
+        // The dictionary of heap number and info on time it takes to mark various roots.
+        public Dictionary<int, MarkInfo> PerHeapMarkTimes;
+
+        public Dictionary<ulong, long> PinnedObjects = new Dictionary<ulong, long>();
+
+        public List<PinnedPlug> PinnedPlugs = new List<PinnedPlug>();
+
+        // For background GC we need to remember when the GC before it ended because
+        // when we get the GCStop event some foreground GCs may have happened.
+        public float ProcessCpuAtLastGC;
+
+        //  Total time EE is suspended (can be less than GC time for background)
+        // The amount of CPU time the process consumed since the last GC.
+        public float ProcessCpuMSec;
+
+        public GCReason Reason;
+
+        public long totalPinnedPlugSize;
+
+        public long totalUserPinnedPlugSize;
+
+        //  Set in GCStop(Generation 0, 1 or 2)
+        public GCType Type;
+
+        private GCCondemnedReasons[] _PerHeapCondemnedReasons;
+
+        private GCPerHeapHistoryGenData[][] _PerHeapGenData;
+
+        #endregion
+
+        #region Private Fields
+        //  Set in GCStart
+        private double _TotalGCTimeMSec = -1;
+
+        //  Set in GCStart
+        // When we are using Server GC we store the CPU spent on each thread
+        // so we can see if there's an imbalance. We concurrently don't do this
+        // for server background GC as the imbalance there is much less important.
+        int heapCount = -1;
+
+        private long pinnedObjectSizes;
+
+        //  Set in GCStart
+        //  Set in GCStart
+        //list of workload histories per server GC heap
+        private List<ServerGcHistory> ServerGcHeapHistories = new List<ServerGcHistory>();
+
+        private PerHeapEventVersion Version = PerHeapEventVersion.V0;
+        #endregion
+
+        #region Constructors
+        public GCEvent(GCProcess owningProcess)
+        {
+            Parent = owningProcess;
+            heapCount = owningProcess.heapCount;
+
+            if (heapCount > 1)
+            {
+                GCCpuServerGCThreads = new float[heapCount];
+            }
+
+            pinnedObjectSizes = -1;
+            totalPinnedPlugSize = -1;
+            totalUserPinnedPlugSize = -1;
+            duplicatedPinningReports = 0;
+        }
+
+        #endregion
+
+        #region Private Enums
+        private enum InducedType
+        {
+            Blocking = 1,
+            NotForced = 2,
+        }
+
+        // TODO: get rid of the remaining version checking here - convert the leftover checks with using the Has* methods 
+        // to determine whether that particular data is available.
+        private enum PerHeapEventVersion
+        {
+            V0, // Not set
+            V4_0,
+            V4_5,
+            V4_6,
+        }
+
+        #endregion
+
+        #region Public Properties
+        public double AllocedSinceLastGCMB
+        {
+            get
+            {
+                return GetUserAllocated(Gens.Gen0) + GetUserAllocated(Gens.GenLargeObj);
+            }
+        }
+
+        public double AllocRateMBSec { get { return AllocedSinceLastGCMB * 1000.0 / DurationSinceLastRestartMSec; } }
+
+        public double CondemnedMB
+        {
+            get
+            {
+                double ret = GenSizeBeforeMB(0);
+                if (1 <= GCGeneration)
+                    ret += GenSizeBeforeMB(Gens.Gen1);
+                if (2 <= GCGeneration)
+                    ret += GenSizeBeforeMB(Gens.Gen2) + GenSizeBeforeMB(Gens.GenLargeObj);
+                return ret;
+            }
+        }
+
+        // Index into the list of GC events
+        // The list that contains this event
+        private List<GCEvent> Events
+        {
+            get
+            {
+                return Parent.Events.OfType<GCEvent>().ToList();
+            }
+        }
+
+        public double FragmentationMB
+        {
+            get
+            {
+                double ret = 0;
+                for (Gens gen = Gens.Gen0; gen <= Gens.GenLargeObj; gen++)
+                    ret += GenFragmentationMB(gen);
+                return ret;
+            }
+        }
+
+        public int Generation => GCNumber;
+
+        public bool HasServerGcThreadingInfo
+        {
+            get
+            {
+                foreach (var heap in ServerGcHeapHistories)
+                {
+                    if (heap.SampleSpans.Count > 0 || heap.SwitchSpans.Count > 0)
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// This include fragmentation
+        /// </summary>
+        public double HeapSizeAfterMB
+        {
+            get
+            {
+                if (null != HeapStats)
+                {
+                    return (HeapStats.GenerationSize0 + HeapStats.GenerationSize1 + HeapStats.GenerationSize2 + HeapStats.GenerationSize3) / 1000000.0;
+                }
+                else
+                {
+                    return -1.0;
+                }
+            }
+        }
+
+        public double HeapSizeBeforeMB
+        {
+            get
+            {
+                double ret = 0;
+                for (Gens gen = Gens.Gen0; gen <= Gens.GenLargeObj; gen++)
+                    ret += GenSizeBeforeMB(gen);
+                return ret;
+            }
+        }
+
+        public double HeapSizePeakMB
+        {
+            get
+            {
+                var ret = HeapSizeBeforeMB;
+                if (Type == GCType.BackgroundGC)
+                {
+                    var BgGcEndedRelativeMSec = PauseStartRelativeMSec + GCDurationMSec;
+                    for (int i = Index + 1; i < Events.Count; i++)
+                    {
+                        var _event = Events[i];
+                        if (BgGcEndedRelativeMSec < _event.PauseStartRelativeMSec)
+                            break;
+                        ret = Math.Max(ret, _event.HeapSizeBeforeMB);
+                    }
+                }
+                return ret;
+            }
+        }
+
+        //  Set in GCStart (starts at 1, unique for process)
+        // Of all the CPU, how much as a percentage is spent in the GC since end of last GC.
+        public double PercentTimeInGC { get { return (GetTotalGCTime() * 100 / ProcessCpuMSec); } }
+        public double PromotedMB
+        {
+            get
+            {
+                return (HeapStats.TotalPromotedSize0 + HeapStats.TotalPromotedSize1 +
+                       HeapStats.TotalPromotedSize2 + HeapStats.TotalPromotedSize3) / 1000000.0;
+            }
+        }
+
+        public double RatioPeakAfter { get { if (HeapSizeAfterMB == 0) return 0; return HeapSizePeakMB / HeapSizeAfterMB; } }
+
+        private GCCondemnedReasons[] PerHeapCondemnedReasons
+        {
+            get
+            {
+                if ((PerHeapHistories != null) && (_PerHeapCondemnedReasons == null))
+                {
+                    GetVersion();
+
+                    int NumHeaps = PerHeapHistories.Count;
+                    _PerHeapCondemnedReasons = new GCCondemnedReasons[NumHeaps];
+
+                    for (int HeapIndex = 0; HeapIndex < NumHeaps; HeapIndex++)
+                    {
+                        _PerHeapCondemnedReasons[HeapIndex] = new GCCondemnedReasons();
+                        _PerHeapCondemnedReasons[HeapIndex].EncodedReasons.Reasons = PerHeapHistories[HeapIndex].CondemnReasons0;
+                        if (Version != PerHeapEventVersion.V4_0)
+                        {
+                            _PerHeapCondemnedReasons[HeapIndex].EncodedReasons.ReasonsEx = PerHeapHistories[HeapIndex].CondemnReasons1;
+                        }
+                        _PerHeapCondemnedReasons[HeapIndex].CondemnedReasonGroups = new byte[(int)CondemnedReasonGroup.CRG_Max];
+                        _PerHeapCondemnedReasons[HeapIndex].Decode(Version);
+                    }
+                }
+
+                return _PerHeapCondemnedReasons;
+            }
+        }
+
+        // There's a list of things we need to get from the events we collected. 
+        // To increase the efficiency so we don't need to go back to TraceEvent
+        // too often we construct the generation data all at once here.
+        private GCPerHeapHistoryGenData[][] PerHeapGenData
+        {
+            get
+            {
+                if ((PerHeapHistories != null) && (_PerHeapGenData == null))
+                {
+                    GetVersion();
+
+                    int NumHeaps = PerHeapHistories.Count;
+                    _PerHeapGenData = new GCPerHeapHistoryGenData[NumHeaps][];
+                    for (int HeapIndex = 0; HeapIndex < NumHeaps; HeapIndex++)
+                    {
+                        _PerHeapGenData[HeapIndex] = new GCPerHeapHistoryGenData[(int)Gens.GenLargeObj + 1];
+                        for (Gens GenIndex = Gens.Gen0; GenIndex <= Gens.GenLargeObj; GenIndex++)
+                        {
+                            _PerHeapGenData[HeapIndex][(int)GenIndex] = PerHeapHistories[HeapIndex].GenData(GenIndex);
+                        }
+                    }
+                }
+
+                return _PerHeapGenData;
+            }
+        }
+
+        #endregion
+
+        #region Public Methods
+        public void AddLOHWaitThreadInfo(int TID, double time, int reason, bool IsStart)
+        {
+#if HAS_PRIVATE_GC_EVENTS
+            BGCAllocWaitReason ReasonLOHAlloc = (BGCAllocWaitReason)reason;
+
+            if ((ReasonLOHAlloc == BGCAllocWaitReason.GetLOHSeg) ||
+                (ReasonLOHAlloc == BGCAllocWaitReason.AllocDuringSweep))
+            {
+                if (LOHWaitThreads == null)
+                {
+                    LOHWaitThreads = new Dictionary<int, BGCAllocWaitInfo>();
+                }
+
+                BGCAllocWaitInfo info;
+
+                if (LOHWaitThreads.TryGetValue(TID, out info))
+                {
+                    if (IsStart)
+                    {
+                        // If we are finding the value it means we are hitting the small
+                        // window where BGC sweep finished and BGC itself finished, discard
+                        // this.
+                    }
+                    else
+                    {
+                        Debug.Assert(info.Reason == ReasonLOHAlloc);
+                        info.WaitStopRelativeMSec = time;
+                    }
+                }
+                else
+                {
+                    info = new BGCAllocWaitInfo();
+                    if (IsStart)
+                    {
+                        info.Reason = ReasonLOHAlloc;
+                        info.WaitStartRelativeMSec = time;
+                    }
+                    else
+                    {
+                        // We are currently not displaying this because it's incomplete but I am still adding 
+                        // it so we could display if we want to.
+                        info.WaitStopRelativeMSec = time;
+                    }
+
+                    LOHWaitThreads.Add(TID, info);
+                }
+            }
+#endif
+        }
+
+        public void AddServerGcSample(ThreadWorkSpan sample)
+        {
+            if (sample.ProcessorNumber >= 0 && sample.ProcessorNumber < ServerGcHeapHistories.Count)
+                ServerGcHeapHistories[sample.ProcessorNumber].AddSampleEvent(sample);
+        }
+
+        public void AddServerGcThreadSwitch(ThreadWorkSpan cswitch)
+        {
+            if (cswitch.ProcessorNumber >= 0 && cswitch.ProcessorNumber < ServerGcHeapHistories.Count)
+                ServerGcHeapHistories[cswitch.ProcessorNumber].AddSwitchEvent(cswitch);
+        }
+
+        public void AddServerGCThreadTime(int heapIndex, float cpuMSec)
+        {
+            if (GCCpuServerGCThreads != null)
+                GCCpuServerGCThreads[heapIndex] += cpuMSec;
+        }
+
+        // Unfortunately sometimes we just don't get mark events from all heaps, even for GCs that we have seen GCStart for.
+        // So accommodating this scenario.
+        public bool AllHeapsSeenMark()
+        {
+            if (PerHeapMarkTimes != null)
+                return (heapCount == PerHeapMarkTimes.Count);
+            else
+                return false;
+        }
+
+        public bool DetailedGenDataAvailable()
+        {
+            return (PerHeapHistories != null);
+        }
+
+        public void GCEnd()
+        {
+            ConvertMarkTimes();
+
+            if (ServerGcHeapHistories != null)
+            {
+                foreach (var serverHeap in ServerGcHeapHistories)
+                {
+                    serverHeap.GCEnd();
+                }
+            }
+        }
+
+        public double GenBudgetMB(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double budget = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                budget += PerHeapGenData[HeapIndex][(int)gen].Budget / 1000000.0;
+            return budget;
+        }
+
+        public double GenFragmentationMB(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].Fragmentation / 1000000.0;
+            return ret;
+        }
+
+        public double GenFragmentationPercent(Gens gen)
+        {
+            return (GenFragmentationMB(gen) * 100.0 / GenSizeAfterMB(gen));
+        }
+
+        public double GenFreeListAfter(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].FreeListSpaceAfter;
+            return ret;
+        }
+
+        public double GenFreeListBefore(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].FreeListSpaceBefore;
+            return ret;
+        }
+
+        public double GenInMB(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].In / 1000000.0;
+            return ret;
+        }
+
+        public double GenNonePinnedSurv(Gens gen)
+        {
+            if ((PerHeapHistories == null) || !(PerHeapGenData[0][0].HasNonePinnedSurv()))
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].NonePinnedSurv;
+            return ret;
+        }
+
+        public double GenOut(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].Out;
+            return ret;
+        }
+
+        public double GenOutMB(Gens gen)
+        {
+            if (PerHeapHistories == null)
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].Out / 1000000.0;
+            return ret;
+        }
+
+        public double GenPinnedSurv(Gens gen)
+        {
+            if ((PerHeapHistories == null) || !(PerHeapGenData[0][0].HasPinnedSurv()))
+                return double.NaN;
+            double ret = 0.0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                ret += PerHeapGenData[HeapIndex][(int)gen].PinnedSurv;
+            return ret;
+        }
+
+        // Note that in 4.0 TotalPromotedSize is not entirely accurate (since it doesn't
+        // count the pins that got demoted. We could consider using the PerHeap event data
+        // to compute the accurate promoted size. 
+        // In 4.5 this is accurate.
+        public double GenPromotedMB(Gens gen)
+        {
+            if (gen == Gens.GenLargeObj)
+                return HeapStats.TotalPromotedSize3 / 1000000.0;
+            if (gen == Gens.Gen2)
+                return HeapStats.TotalPromotedSize2 / 1000000.0;
+            if (gen == Gens.Gen1)
+                return HeapStats.TotalPromotedSize1 / 1000000.0;
+            if (gen == Gens.Gen0)
+                return HeapStats.TotalPromotedSize0 / 1000000.0;
+            Debug.Assert(false);
+            return double.NaN;
+        }
+
+        public double GenSizeAfterMB(Gens gen)
+        {
+            if (gen == Gens.GenLargeObj)
+                return HeapStats.GenerationSize3 / 1000000.0;
+            if (gen == Gens.Gen2)
+                return HeapStats.GenerationSize2 / 1000000.0;
+            if (gen == Gens.Gen1)
+                return HeapStats.GenerationSize1 / 1000000.0;
+            if (gen == Gens.Gen0)
+                return HeapStats.GenerationSize0 / 1000000.0;
+            Debug.Assert(false);
+            return double.NaN;
+        }
+
+        // Per generation stats.  
+        public double GenSizeBeforeMB(Gens gen)
+        {
+            if (PerHeapHistories != null)
+            {
+                double ret = 0.0;
+                for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                    ret += PerHeapGenData[HeapIndex][(int)gen].SizeBefore / 1000000.0;
+                return ret;
+            }
+
+            // When we don't have perheap history we can only estimate for gen0 and gen3.
+            double Gen0SizeBeforeMB = 0;
+            if (gen == Gens.Gen0)
+                Gen0SizeBeforeMB = AllocedSinceLastGCBasedOnAllocTickMB[0];
+            if (Index == 0)
+            {
+                return ((gen == Gens.Gen0) ? Gen0SizeBeforeMB : 0);
+            }
+
+            // Find a previous HeapStats.  
+            GCHeapStatsTraceData heapStats = null;
+            for (int j = Index - 1; ; --j)
+            {
+                if (j == 0)
+                    return 0;
+                heapStats = Events[j].HeapStats;
+                if (heapStats != null)
+                    break;
+            }
+            if (gen == Gens.Gen0)
+                return Math.Max((heapStats.GenerationSize0 / 1000000.0), Gen0SizeBeforeMB);
+            if (gen == Gens.Gen1)
+                return heapStats.GenerationSize1 / 1000000.0;
+            if (gen == Gens.Gen2)
+                return heapStats.GenerationSize2 / 1000000.0;
+
+            Debug.Assert(gen == Gens.GenLargeObj);
+
+            if (HeapStats != null)
+                return Math.Max(heapStats.GenerationSize3, HeapStats.GenerationSize3) / 1000000.0;
+            else
+                return heapStats.GenerationSize3 / 1000000.0;
+        }
+
+        public void GetCondemnedReasons(Dictionary<CondemnedReasonGroup, int> ReasonsInfo)
+        {
+            // Older versions of the runtime does not have this event. So even for a complete GC, we may not have this
+            // info.
+            if (PerHeapCondemnedReasons == null)
+                return;
+
+            int HeapIndexHighestGen = 0;
+            if (PerHeapCondemnedReasons.Length != 1)
+            {
+                HeapIndexHighestGen = FindFirstHighestCondemnedHeap();
+            }
+
+            byte[] ReasonGroups = PerHeapCondemnedReasons[HeapIndexHighestGen].CondemnedReasonGroups;
+
+            // These 2 reasons indicate a gen number. If the number is the same as the condemned gen, we 
+            // include this reason.
+            for (int i = (int)CondemnedReasonGroup.CRG_Alloc_Exceeded; i <= (int)CondemnedReasonGroup.CRG_Time_Tuning; i++)
+            {
+                if (ReasonGroups[i] == GCGeneration)
+                    AddCondemnedReason(ReasonsInfo, (CondemnedReasonGroup)i);
+            }
+
+            if (ReasonGroups[(int)CondemnedReasonGroup.CRG_Induced] != 0)
+            {
+                if (ReasonGroups[(int)CondemnedReasonGroup.CRG_Initial_Generation] == GCGeneration)
+                {
+                    AddCondemnedReason(ReasonsInfo, CondemnedReasonGroup.CRG_Induced);
+                }
+            }
+
+            // The rest of the reasons are conditions so include the ones that are set.
+            for (int i = (int)CondemnedReasonGroup.CRG_Low_Ephemeral; i < (int)CondemnedReasonGroup.CRG_Max; i++)
+            {
+                if (ReasonGroups[i] != 0)
+                    AddCondemnedReason(ReasonsInfo, (CondemnedReasonGroup)i);
+            }
+        }
+
+        //
+        // Approximations we do in this function for V4_5 and prior:
+        // On 4.0 we didn't seperate free list from free obj, so we just use fragmentation (which is the sum)
+        // as an approximation. This makes the efficiency value a bit larger than it actually is.
+        // We don't actually update in for the older gen - this means we only know the out for the younger 
+        // gen which isn't necessarily all allocated into the older gen. So we could see cases where the 
+        // out is > 0, yet the older gen's free list doesn't change. Using the younger gen's out as an 
+        // approximation makes the efficiency value larger than it actually is.
+        //
+        // For V4_6 this requires no approximation.
+        //
+        public bool GetFreeListEfficiency(Gens gen, ref double Allocated, ref double FreeListConsumed)
+        {
+            // I am not worried about gen0 or LOH's free list efficiency right now - it's 
+            // calculated differently.
+            if ((PerHeapHistories == null) ||
+                (gen == Gens.Gen0) ||
+                (gen == Gens.GenLargeObj) ||
+                (Index <= 0) ||
+                !(PerHeapHistories[0].VersionRecognized))
+            {
+                return false;
+            }
+
+            int YoungerGen = (int)gen - 1;
+
+            if (GCGeneration != YoungerGen)
+                return false;
+
+            if (PerHeapHistories[0].V4_6)
+            {
+                Allocated = 0;
+                FreeListConsumed = 0;
+                for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+                {
+                    GCPerHeapHistoryTraceData3 hist = (GCPerHeapHistoryTraceData3)PerHeapHistories[HeapIndex];
+                    Allocated += hist.FreeListAllocated;
+                    FreeListConsumed += hist.FreeListAllocated + hist.FreeListRejected;
+                }
+                return true;
+            }
+
+            // I am not using MB here because what's promoted from gen1 can easily be less than a MB.
+            double YoungerGenOut = 0;
+            double FreeListBefore = 0;
+            double FreeListAfter = 0;
+            // Includes fragmentation. This lets us know if we had to expand the size.
+            double GenSizeBefore = 0;
+            double GenSizeAfter = 0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+            {
+                YoungerGenOut += PerHeapGenData[HeapIndex][YoungerGen].Out;
+                GenSizeBefore += PerHeapGenData[HeapIndex][(int)gen].SizeBefore;
+                GenSizeAfter += PerHeapGenData[HeapIndex][(int)gen].SizeAfter;
+                if (Version == PerHeapEventVersion.V4_0)
+                {
+                    // Occasionally I've seen a GC in the middle that simply missed some events,
+                    // some of which are PerHeap hist events so we don't have data.
+                    if (Events[Index - 1].PerHeapGenData == null)
+                        return false;
+                    FreeListBefore += Events[Index - 1].PerHeapGenData[HeapIndex][(int)gen].Fragmentation;
+                    FreeListAfter += PerHeapGenData[HeapIndex][(int)gen].Fragmentation;
+                }
+                else
+                {
+                    FreeListBefore += PerHeapGenData[HeapIndex][(int)gen].FreeListSpaceBefore;
+                    FreeListAfter += PerHeapGenData[HeapIndex][(int)gen].FreeListSpaceAfter;
+                }
+            }
+
+            double GenSizeGrown = GenSizeAfter - GenSizeBefore;
+
+            // This is the most accurate situation we can calculuate (if it's not accurate it means
+            // we are over estimating which is ok.
+            if ((GenSizeGrown == 0) && ((FreeListBefore > 0) && (FreeListAfter >= 0)))
+            {
+                Allocated = YoungerGenOut;
+                FreeListConsumed = FreeListBefore - FreeListAfter;
+                // We don't know how much of the survived is pinned so we are overestimating here.
+                if (Allocated < FreeListConsumed)
+                    return true;
+            }
+
+            return false;
+        }
+
+        public void GetGenDataObjSizeAfterMB(ref double[] GenData)
+        {
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+            {
+                for (int GenIndex = 0; GenIndex <= (int)Gens.GenLargeObj; GenIndex++)
+                    GenData[GenIndex] += PerHeapGenData[HeapIndex][GenIndex].ObjSizeAfter / 1000000.0;
+            }
+        }
+
+        public void GetGenDataSizeAfterMB(ref double[] GenData)
+        {
+            for (int GenIndex = 0; GenIndex <= (int)Gens.GenLargeObj; GenIndex++)
+                GenData[GenIndex] = GenSizeAfterMB((Gens)GenIndex);
+        }
+
+        public double GetMaxGen0ObjSizeMB()
+        {
+            double MaxGen0ObjSize = 0;
+            for (int HeapIndex = 0; HeapIndex < PerHeapHistories.Count; HeapIndex++)
+            {
+                MaxGen0ObjSize = Math.Max(MaxGen0ObjSize, PerHeapGenData[HeapIndex][(int)Gens.Gen0].ObjSizeAfter / 1000000.0);
+            }
+            return MaxGen0ObjSize;
+        }
+
+        // This represents the percentage time spent paused for this GC since the last GC completed.
+        public double GetPauseTimePercentageSinceLastGC()
+        {
+            double pauseTimePercentage;
+
+            if (Type == GCType.BackgroundGC)
+            {
+                // Find all GCs that occurred during the current background GC.
+                double startTimeRelativeMSec = this.GCStartRelativeMSec;
+                double endTimeRelativeMSec = this.GCStartRelativeMSec + this.GCDurationMSec;
+
+                // Calculate the pause time for this BGC.
+                // Pause time is defined as pause time for the BGC + pause time for all FGCs that ran during the BGC.
+                double totalPauseTime = this.PauseDurationMSec;
+
+                if (Index + 1 < Events.Count)
+                {
+                    GCEvent gcEvent;
+                    for (int i = Index + 1; i < Events.Count; ++i)
+                    {
+                        gcEvent = Events[i];
+                        if ((gcEvent.GCStartRelativeMSec >= startTimeRelativeMSec) && (gcEvent.GCStartRelativeMSec < endTimeRelativeMSec))
+                        {
+                            totalPauseTime += gcEvent.PauseDurationMSec;
+                        }
+                        else
+                        {
+                            // We've finished processing all FGCs that occurred during this BGC.
+                            break;
+                        }
+                    }
+                }
+
+                // Get the elapsed time since the previous GC finished.
+                int previousGCIndex = Index - 1;
+                double previousGCStopTimeRelativeMSec;
+                if (previousGCIndex >= 0)
+                {
+                    GCEvent previousGCEvent = Events[previousGCIndex];
+                    previousGCStopTimeRelativeMSec = previousGCEvent.GCStartRelativeMSec + previousGCEvent.GCDurationMSec;
+                }
+                else
+                {
+                    // Backstop in case this is the first GC.
+                    previousGCStopTimeRelativeMSec = Events[0].GCStartRelativeMSec;
+                }
+
+                double totalTime = (GCStartRelativeMSec + GCDurationMSec) - previousGCStopTimeRelativeMSec;
+                pauseTimePercentage = (totalPauseTime * 100) / (totalTime);
+            }
+            else
+            {
+                double totalTime = PauseDurationMSec + DurationSinceLastRestartMSec;
+                pauseTimePercentage = (PauseDurationMSec * 100) / (totalTime);
+            }
+
+            Debug.Assert(pauseTimePercentage <= 100);
+            return pauseTimePercentage;
+        }
+
+        public int GetPinnedObjectPercentage()
+        {
+            if (totalPinnedPlugSize == -1)
+            {
+                totalPinnedPlugSize = 0;
+                totalUserPinnedPlugSize = 0;
+
+                foreach (KeyValuePair<ulong, long> item in PinnedObjects)
+                {
+                    ulong Address = item.Key;
+
+                    for (int i = 0; i < PinnedPlugs.Count; i++)
+                    {
+                        if ((Address >= PinnedPlugs[i].Start) && (Address < PinnedPlugs[i].End))
+                        {
+                            PinnedPlugs[i].PinnedByUser = true;
+                            break;
+                        }
+                    }
+                }
+
+                for (int i = 0; i < PinnedPlugs.Count; i++)
+                {
+                    long Size = (long)(PinnedPlugs[i].End - PinnedPlugs[i].Start);
+                    totalPinnedPlugSize += Size;
+                    if (PinnedPlugs[i].PinnedByUser)
+                    {
+                        totalUserPinnedPlugSize += Size;
+                    }
+                }
+            }
+
+            return ((totalPinnedPlugSize == 0) ? -1 : (int)((double)pinnedObjectSizes * 100 / (double)totalPinnedPlugSize));
+        }
+
+        public long GetPinnedObjectSizes()
+        {
+            if (pinnedObjectSizes == -1)
+            {
+                pinnedObjectSizes = 0;
+                foreach (KeyValuePair<ulong, long> item in PinnedObjects)
+                {
+                    pinnedObjectSizes += item.Value;
+                }
+            }
+            return pinnedObjectSizes;
+        }
+
+        public double GetTotalGCTime()
+        {
+            if (_TotalGCTimeMSec < 0)
+            {
+                _TotalGCTimeMSec = 0;
+                if (GCCpuServerGCThreads != null)
+                {
+                    for (int i = 0; i < GCCpuServerGCThreads.Length; i++)
+                    {
+                        _TotalGCTimeMSec += GCCpuServerGCThreads[i];
+                    }
+                }
+                _TotalGCTimeMSec += GCCpuMSec;
+            }
+
+            Debug.Assert(_TotalGCTimeMSec >= 0);
+            return _TotalGCTimeMSec;
+        }
+
+        /// <summary>
+        /// Get what's allocated into gen0 or gen3. For server GC this gets the total for 
+        /// all heaps.
+        /// </summary>
+        public double GetUserAllocated(Gens gen)
+        {
+            Debug.Assert((gen == Gens.Gen0) || (gen == Gens.GenLargeObj));
+
+            if ((Type == GCType.BackgroundGC) && (gen == Gens.Gen0))
+            {
+                return AllocedSinceLastGCBasedOnAllocTickMB[(int)gen];
+            }
+
+            if (PerHeapHistories != null && Index > 0 && Events[Index - 1].PerHeapHistories != null)
+            {
+                double TotalAllocated = 0;
+                if (Index > 0)
+                {
+                    for (int i = 0; i < PerHeapHistories.Count; i++)
+                    {
+                        double Allocated = GetUserAllocatedPerHeap(i, gen);
+
+                        TotalAllocated += Allocated / 1000000.0;
+                    }
+
+                    return TotalAllocated;
+                }
+                else
+                {
+                    return GenSizeBeforeMB(gen);
+                }
+            }
+
+            return AllocedSinceLastGCBasedOnAllocTickMB[(gen == Gens.Gen0) ? 0 : 1];
+        }
+
+        public bool IsLowEphemeral()
+        {
+            return CondemnedReasonGroupSet(CondemnedReasonGroup.CRG_Low_Ephemeral);
+        }
+
+        public bool IsNotCompacting()
+        {
+            return ((GlobalHeapHistory.GlobalMechanisms & (GCGlobalMechanisms.Compaction)) != 0);
+        }
+
+        public double ObjSizeAfter(Gens gen)
+        {
+            double TotalObjSizeAfter = 0;
+
+            if (PerHeapHistories != null)
+            {
+                for (int i = 0; i < PerHeapHistories.Count; i++)
+                {
+                    TotalObjSizeAfter += PerHeapGenData[i][(int)gen].ObjSizeAfter;
+                }
+            }
+
+            return TotalObjSizeAfter;
+        }
+
+        // Set in HeapStats
+        public void SetHeapCount(int count)
+        {
+            if (heapCount == -1)
+            {
+                heapCount = count;
+            }
+        }
+        public void SetUpServerGcHistory()
+        {
+            for (int i = 0; i < heapCount; i++)
+            {
+                int gcThreadId = 0;
+                int gcThreadPriority = 0;
+                Parent.ServerGcHeap2ThreadId.TryGetValue(i, out gcThreadId);
+                Parent.ThreadId2Priority.TryGetValue(gcThreadId, out gcThreadPriority);
+                ServerGcHeapHistories.Add(new ServerGcHistory
+                {
+                    Parent = this,
+                    ProcessId = Parent.ProcessID,
+                    HeapId = i,
+                    GcWorkingThreadId = gcThreadId,
+                    GcWorkingThreadPriority = gcThreadPriority
+                });
+            }
+        }
+
+        public double SurvivalPercent(Gens gen)
+        {
+            double retSurvRate = double.NaN;
+
+            long SurvRate = 0;
+
+            if (gen == Gens.GenLargeObj)
+            {
+                if (GCGeneration < 2)
+                {
+                    return retSurvRate;
+                }
+            }
+            else if ((int)gen > GCGeneration)
+            {
+                return retSurvRate;
+            }
+
+            if (PerHeapHistories != null)
+            {
+                for (int i = 0; i < PerHeapHistories.Count; i++)
+                {
+                    SurvRate += PerHeapGenData[i][(int)gen].SurvRate;
+                }
+
+                SurvRate /= PerHeapHistories.Count;
+            }
+
+            retSurvRate = SurvRate;
+
+            return retSurvRate;
+        }
+
+#endregion
+
+        #region Internal Methods
+        internal void AddGcJoin(GCJoinTraceData data)
+        {
+            if (data.Heap >= 0 && data.Heap < ServerGcHeapHistories.Count)
+                ServerGcHeapHistories[data.Heap].AddJoin(data);
+            else
+            {
+                foreach (var heap in ServerGcHeapHistories)
+                    heap.AddJoin(data);
+            }
+
+        }
+        #endregion
+
+        #region Private Methods
+        private void AddCondemnedReason(Dictionary<CondemnedReasonGroup, int> ReasonsInfo, CondemnedReasonGroup Reason)
+        {
+            if (!ReasonsInfo.ContainsKey(Reason))
+                ReasonsInfo.Add(Reason, 1);
+            else
+                (ReasonsInfo[Reason])++;
+        }
+
+        // For true/false groups, return whether that group is set.
+        private bool CondemnedReasonGroupSet(CondemnedReasonGroup Group)
+        {
+            if (PerHeapCondemnedReasons == null)
+            {
+                return false;
+            }
+
+            int HeapIndexHighestGen = 0;
+            if (PerHeapCondemnedReasons.Length != 1)
+            {
+                HeapIndexHighestGen = FindFirstHighestCondemnedHeap();
+            }
+
+            return (PerHeapCondemnedReasons[HeapIndexHighestGen].CondemnedReasonGroups[(int)Group] != 0);
+        }
+
+        // We recorded these as the timestamps when we saw the mark events, now convert them 
+        // to the actual time that it took for each mark.
+        private void ConvertMarkTimes()
+        {
+            if (PerHeapMarkTimes != null)
+            {
+                foreach (KeyValuePair<int, MarkInfo> item in PerHeapMarkTimes)
+                {
+                    if (item.Value.MarkTimes[(int)MarkRootType.MarkSizedRef] == 0.0)
+                        item.Value.MarkTimes[(int)MarkRootType.MarkSizedRef] = GCStartRelativeMSec;
+
+                    if (GCGeneration == 2)
+                        item.Value.MarkTimes[(int)MarkRootType.MarkOlder] = 0;
+                    else
+                        item.Value.MarkTimes[(int)MarkRootType.MarkOlder] -= item.Value.MarkTimes[(int)MarkRootType.MarkHandles];
+
+                    item.Value.MarkTimes[(int)MarkRootType.MarkHandles] -= item.Value.MarkTimes[(int)MarkRootType.MarkFQ];
+                    item.Value.MarkTimes[(int)MarkRootType.MarkFQ] -= item.Value.MarkTimes[(int)MarkRootType.MarkStack];
+                    item.Value.MarkTimes[(int)MarkRootType.MarkStack] -= item.Value.MarkTimes[(int)MarkRootType.MarkSizedRef];
+                    item.Value.MarkTimes[(int)MarkRootType.MarkSizedRef] -= GCStartRelativeMSec;
+                }
+            }
+        }
+
+        // When survival rate is 0, for certain releases (see comments for GetUserAllocatedPerHeap)
+        // we need to estimate.
+        private double EstimateAllocSurv0(int HeapIndex, Gens gen)
+        {
+            if (HasAllocTickEvents)
+            {
+                return AllocedSinceLastGCBasedOnAllocTickMB[(gen == Gens.Gen0) ? 0 : 1];
+            }
+            else
+            {
+                if (Index > 0)
+                {
+                    // If the prevous GC has that heap get its size.  
+                    var perHeapGenData = Events[Index - 1].PerHeapGenData;
+                    if (HeapIndex < perHeapGenData.Length)
+                        return perHeapGenData[HeapIndex][(int)gen].Budget;
+                }
+                return 0;
+            }
+        }
+
+        private int FindFirstHighestCondemnedHeap()
+        {
+            int GenNumberHighest = (int)GCGeneration;
+            for (int HeapIndex = 0; HeapIndex < PerHeapCondemnedReasons.Length; HeapIndex++)
+            {
+                int gen = PerHeapCondemnedReasons[HeapIndex].CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Final_Generation];
+                if (gen == GenNumberHighest)
+                {
+                    return HeapIndex;
+                }
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// For a given heap, get what's allocated into gen0 or gen3.
+        /// We calculate this differently on 4.0, 4.5 Beta and 4.5 RC+.
+        /// The caveat with 4.0 and 4.5 Beta is that when survival rate is 0,
+        /// We don't know how to calculate the allocated - so we just use the
+        /// last GC's budget (We should indicate this in the tool)
+        /// </summary>
+        private double GetUserAllocatedPerHeap(int HeapIndex, Gens gen)
+        {
+            long prevObjSize = 0;
+            if (Index > 0)
+            {
+                // If the prevous GC has that heap get its size.  
+                var perHeapGenData = Events[Index - 1].PerHeapGenData;
+                if (HeapIndex < perHeapGenData.Length)
+                    prevObjSize = perHeapGenData[HeapIndex][(int)gen].ObjSizeAfter;
+            }
+            GCPerHeapHistoryGenData currentGenData = PerHeapGenData[HeapIndex][(int)gen];
+            long survRate = currentGenData.SurvRate;
+            long currentObjSize = currentGenData.ObjSizeAfter;
+            double Allocated;
+
+            if (Version == PerHeapEventVersion.V4_0)
+            {
+                if (survRate == 0)
+                    Allocated = EstimateAllocSurv0(HeapIndex, gen);
+                else
+                    Allocated = (currentGenData.Out + currentObjSize) * 100 / survRate - prevObjSize;
+            }
+            else
+            {
+                Allocated = currentGenData.ObjSpaceBefore - prevObjSize;
+            }
+
+            return Allocated;
+        }
+
+        private void GetVersion()
+        {
+            if (Version == PerHeapEventVersion.V0)
+            {
+                if (PerHeapHistories[0].V4_0)
+                    Version = PerHeapEventVersion.V4_0;
+                else if (PerHeapHistories[0].V4_5)
+                {
+                    Version = PerHeapEventVersion.V4_5;
+                    Debug.Assert(PerHeapHistories[0].Version == 2);
+                }
+                else
+                {
+                    Version = PerHeapEventVersion.V4_6;
+                    Debug.Assert(PerHeapHistories[0].Version == 3);
+                }
+            }
+        }
+        #endregion
+
+        #region Inner Private Structs
+        private struct EncodedCondemnedReasons
+        {
+            public int Reasons;
+            public int ReasonsEx;
+        }
+        #endregion
+
+        #region Inner Public Classes
+        public class MarkInfo
+        {
+            public long[] MarkPromoted;
+
+            // Note that in 4.5 and prior (ie, from GCMark events, not GCMarkWithType), the first stage of the time 
+            // includes scanning sizedref handles(which can be very significant). We could distinguish that by interpreting 
+            // the Join events which I haven't done yet.
+            public double[] MarkTimes;
+            public MarkInfo(bool initPromoted = true)
+            {
+                MarkTimes = new double[(int)MarkRootType.MarkMax];
+                if (initPromoted)
+                    MarkPromoted = new long[(int)MarkRootType.MarkMax];
+            }
+        };
+
+        public class PinnedPlug
+        {
+            public ulong End;
+            public bool PinnedByUser;
+            public ulong Start;
+            public PinnedPlug(ulong s, ulong e)
+            {
+                Start = s;
+                End = e;
+                PinnedByUser = false;
+            }
+        };
+
+        public class ServerGcHistory
+        {
+            public int GcWorkingThreadId;
+            public int GcWorkingThreadPriority;
+            public int HeapId;
+            public GCEvent Parent;
+            public int ProcessId;
+            public List<GcWorkSpan> SampleSpans = new List<GcWorkSpan>();
+            public List<GcWorkSpan> SwitchSpans = new List<GcWorkSpan>();
+
+            //list of times in msc starting from GC start when GCJoin events were fired for this heap
+            private List<GcJoin> GcJoins = new List<GcJoin>();
+            public enum WorkSpanType
+            {
+                GcThread,
+                RivalThread,
+                LowPriThread,
+                Idle
+            }
+
+            public double TimeBaseMsc { get { return Parent.PauseStartRelativeMSec; } }
+            public void AddSampleEvent(ThreadWorkSpan sample)
+            {
+                GcWorkSpan lastSpan = SampleSpans.Count > 0 ? SampleSpans[SampleSpans.Count - 1] : null;
+                if (lastSpan != null && lastSpan.ThreadId == sample.ThreadId && lastSpan.ProcessId == sample.ProcessId)
+                {
+                    lastSpan.DurationMsc++;
+                }
+                else
+                {
+                    SampleSpans.Add(new GcWorkSpan(sample)
+                    {
+                        Type = GetSpanType(sample),
+                        RelativeTimestampMsc = sample.AbsoluteTimestampMsc - TimeBaseMsc,
+                        DurationMsc = 1
+                    });
+                }
+            }
+
+            public void AddSwitchEvent(ThreadWorkSpan switchData)
+            {
+                GcWorkSpan lastSpan = SwitchSpans.Count > 0 ? SwitchSpans[SwitchSpans.Count - 1] : null;
+                if (switchData.ThreadId == GcWorkingThreadId && switchData.ProcessId == ProcessId)
+                {
+                    //update gc thread priority since we have new data
+                    GcWorkingThreadPriority = switchData.Priority;
+                }
+
+                if (lastSpan != null)
+                {
+                    //updating duration of the last one, based on a timestamp from the new one
+                    lastSpan.DurationMsc = switchData.AbsoluteTimestampMsc - lastSpan.AbsoluteTimestampMsc;
+
+                    //updating wait readon of the last one
+                    lastSpan.WaitReason = switchData.WaitReason;
+                }
+
+                SwitchSpans.Add(new GcWorkSpan(switchData)
+                {
+                    Type = GetSpanType(switchData),
+                    RelativeTimestampMsc = switchData.AbsoluteTimestampMsc - TimeBaseMsc,
+                    Priority = switchData.Priority
+                });
+            }
+
+            internal void AddJoin(GCJoinTraceData data)
+            {
+                GcJoins.Add(new GcJoin
+                {
+                    Heap = data.ProcessorNumber, //data.Heap is not reliable for reset events, so we use ProcessorNumber
+                    AbsoluteTimestampMsc = data.TimeStampRelativeMSec,
+                    RelativeTimestampMsc = data.TimeStampRelativeMSec - Parent.PauseStartRelativeMSec,
+                    Type = data.JoinType,
+                    Time = data.JoinTime,
+                });
+            }
+
+            internal void GCEnd()
+            {
+                GcWorkSpan lastSpan = SwitchSpans.Count > 0 ? SwitchSpans[SwitchSpans.Count - 1] : null;
+                if (lastSpan != null)
+                {
+                    lastSpan.DurationMsc = Parent.PauseDurationMSec - lastSpan.RelativeTimestampMsc;
+                }
+            }
+
+            private WorkSpanType GetSpanType(ThreadWorkSpan span)
+            {
+                if (span.ThreadId == GcWorkingThreadId && span.ProcessId == ProcessId)
+                    return WorkSpanType.GcThread;
+                if (span.ProcessId == 0)
+                    return WorkSpanType.Idle;
+
+                if (span.Priority >= GcWorkingThreadPriority || span.Priority == -1)
+                    return WorkSpanType.RivalThread;
+                else
+                    return WorkSpanType.LowPriThread;
+            }
+
+            public class GcJoin
+            {
+                public double AbsoluteTimestampMsc;
+                public int Heap;
+                public double RelativeTimestampMsc;
+                public GcJoinTime Time;
+                public GcJoinType Type;
+            }
+
+            public class GcWorkSpan : ThreadWorkSpan
+            {
+                public double RelativeTimestampMsc;
+                public WorkSpanType Type;
+                public GcWorkSpan(ThreadWorkSpan span)
+                    : base(span)
+                {
+                }
+            }
+        }
+#endregion
+
+        #region Inner Private Classes
+        private class GCCondemnedReasons
+        {
+            /// <summary>
+            /// This records which reasons are used and the value. Since the biggest value
+            /// we need to record is the generation number a byte is sufficient.
+            /// </summary>
+            public byte[] CondemnedReasonGroups;
+
+            public EncodedCondemnedReasons EncodedReasons;
+
+#if HAS_PRIVATE_GC_EVENTS
+            public Dictionary<int, BGCAllocWaitInfo> LOHWaitThreads;
+#endif
+
+            enum Condemned_Reason_Condition
+            {
+                CRC_induced_fullgc_p = 0,
+                CRC_expand_fullgc_p = 1,
+                CRC_high_mem_p = 2,
+                CRC_very_high_mem_p = 3,
+                CRC_low_ephemeral_p = 4,
+                CRC_low_card_p = 5,
+                CRC_eph_high_frag_p = 6,
+                CRC_max_high_frag_p = 7,
+                CRC_max_high_frag_e_p = 8,
+                CRC_max_high_frag_m_p = 9,
+                CRC_max_high_frag_vm_p = 10,
+                CRC_max_gen1 = 11,
+                CRC_before_oom = 12,
+                CRC_gen2_too_small = 13,
+                CRC_induced_noforce_p = 14,
+                CRC_before_bgc = 15,
+                CRC_max = 16,
+            };
+
+            // These values right now are the same as the first 4 in CondemnedReasonGroup.
+            enum Condemned_Reason_Generation
+            {
+                CRG_initial = 0,
+                CRG_final_per_heap = 1,
+                CRG_alloc_budget = 2,
+                CRG_time_tuning = 3,
+                CRG_max = 4,
+            };
+            public void Decode(PerHeapEventVersion Version)
+            {
+                // First decode the reasons that return us a generation number. 
+                // It's the same in 4.0 and 4.5.
+                for (Condemned_Reason_Generation i = 0; i < Condemned_Reason_Generation.CRG_max; i++)
+                {
+                    CondemnedReasonGroups[(int)i] = (byte)GetReasonWithGenNumber(i);
+                }
+
+                // Then decode the reasons that just indicate true or false.
+                for (Condemned_Reason_Condition i = 0; i < Condemned_Reason_Condition.CRC_max; i++)
+                {
+                    if (GetReasonWithCondition(i, Version))
+                    {
+                        switch (i)
+                        {
+                            case Condemned_Reason_Condition.CRC_induced_fullgc_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Induced] = (byte)InducedType.Blocking;
+                                break;
+                            case Condemned_Reason_Condition.CRC_induced_noforce_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Induced] = (byte)InducedType.NotForced;
+                                break;
+                            case Condemned_Reason_Condition.CRC_low_ephemeral_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Low_Ephemeral] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_low_card_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Internal_Tuning] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_eph_high_frag_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Fragmented_Ephemeral] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_max_high_frag_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Fragmented_Gen2] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_max_high_frag_e_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Fragmented_Gen1_To_Gen2] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_max_high_frag_m_p:
+                            case Condemned_Reason_Condition.CRC_max_high_frag_vm_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Fragmented_Gen2_High_Mem] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_max_gen1:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Alloc_Exceeded] = 2;
+                                break;
+                            case Condemned_Reason_Condition.CRC_expand_fullgc_p:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Expand_Heap] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_before_oom:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_GC_Before_OOM] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_gen2_too_small:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Too_Small_For_BGC] = 1;
+                                break;
+                            case Condemned_Reason_Condition.CRC_before_bgc:
+                                CondemnedReasonGroups[(int)CondemnedReasonGroup.CRG_Ephemeral_Before_BGC] = 1;
+                                break;
+                            default:
+                                Debug.Assert(false, "Unexpected reason");
+                                break;
+                        }
+                    }
+                }
+            }
+
+            private bool GetReasonWithCondition(Condemned_Reason_Condition Reason_Condition, PerHeapEventVersion Version)
+            {
+                bool ConditionIsSet = false;
+                if (Version == PerHeapEventVersion.V4_0)
+                {
+                    Debug.Assert((int)Reason_Condition < 16);
+                    ConditionIsSet = ((EncodedReasons.Reasons & (1 << (int)(Reason_Condition + 16))) != 0);
+                }
+                else
+                {
+                    ConditionIsSet = ((EncodedReasons.ReasonsEx & (1 << (int)Reason_Condition)) != 0);
+                }
+                return ConditionIsSet;
+            }
+
+            private int GetReasonWithGenNumber(Condemned_Reason_Generation Reason_GenNumber)
+            {
+                int GenNumber = ((EncodedReasons.Reasons >> ((int)Reason_GenNumber * 2)) & 0x3);
+                return GenNumber;
+            }
+        }
+        #endregion
+    }
+}
+
+#endif

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/GCInfo.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/GCInfo.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    /// <summary>
+    /// GCInfo are accumulated statistics per generation.  
+    /// </summary>    
+    internal class GCInfo
+    {
+        public int GCCount;
+        public int NumInduced;
+        public long PinnedObjectSizes;
+        public int PinnedObjectPercentage;
+        public long NumGCWithPinEvents;
+        public long NumGCWithPinPlugEvents;
+        public double MaxPauseDurationMSec;
+        public double MeanPauseDurationMSec { get { return TotalPauseTimeMSec / GCCount; } }
+        public double MeanSizeAfterMB { get { return TotalSizeAfterMB / GCCount; } }
+        public double MeanSizePeakMB { get { return TotalSizePeakMB / GCCount; } }
+        public double MeanAllocatedMB { get { return TotalAllocatedMB / GCCount; } }
+        public double RatioMeanPeakAfter { get { return MeanSizePeakMB / MeanSizeAfterMB; } }
+        public double MeanGCCpuMSec { get { return TotalGCCpuMSec / GCCount; } }
+
+        public double TotalPauseTimeMSec;
+        public double MaxSuspendDurationMSec;
+        public double MaxSizePeakMB;
+        public double MaxAllocRateMBSec;
+
+        public double TotalAllocatedMB;
+        public double TotalGCCpuMSec;
+        public double TotalPromotedMB;
+
+        // these do not have a useful meaning so we hide them. 
+        internal double TotalSizeAfterMB;
+        internal double TotalSizePeakMB;
+    }
+}
+
+#endif

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/GCProcess.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/GCProcess.cs
@@ -1,0 +1,1256 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS
+
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Etlx;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+using Microsoft.Diagnostics.Tracing.Stacks;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+#if HAS_PRIVATE_GC_EVENTS
+using Microsoft.Diagnostics.Tracing.Parsers.ClrPrivate;
+#endif
+
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    /// <summary>
+    /// GCProcess holds information about GCs in a particular process. 
+    /// </summary>
+    /// 
+    // Notes on parsing GC events:
+    // GC events need to be interpreted in sequence and if we attach we 
+    // may not get the whole sequence of a GC. We discard the incomplete
+    // GC from the beginning and ending. 
+    //
+    // We can make the assumption if we have the events from the private 
+    // provider it means we have events from public provider, but not the
+    // other way around.
+    //
+    // All GC events are at informational level except the following:
+    // AllocTick from the public provider
+    // GCJoin from the private provider
+    // We may only have events at the informational level, not verbose level.
+    //
+    internal class GCProcess
+    {
+        internal static IDictionary<int, GCProcess> Collect(
+            TraceEventSource source, 
+            float sampleIntervalMSec, 
+            IDictionary<int, GCProcess> perProc = null, 
+            MutableTraceEventStackSource stackSource = null,
+            Predicate<TraceEvent> filterFunc = null)
+        {
+            if (perProc == null)
+            {
+                perProc = new Dictionary<int, GCProcess>();
+            }
+
+            source.Kernel.AddCallbackForEvents(delegate (ProcessCtrTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                var stats = perProc.GetOrCreate(data.ProcessID);
+                stats.PeakVirtualMB = ((double)data.PeakVirtualSize) / 1000000.0;
+                stats.PeakWorkingSetMB = ((double)data.PeakWorkingSetSize) / 1000000.0;
+            });
+
+            Action<RuntimeInformationTraceData> doAtRuntimeStart = delegate (RuntimeInformationTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                var stats = perProc.GetOrCreate(data.ProcessID);
+                stats.RuntimeVersion = "V " + data.VMMajorVersion.ToString() + "." + data.VMMinorVersion + "." + data.VMBuildNumber
+                    + "." + data.VMQfeNumber;
+                stats.StartupFlags = data.StartupFlags;
+                stats.Bitness = (data.RuntimeDllPath.ToLower().Contains("framework64") ? 64 : 32);
+                if (stats.CommandLine == null)
+                    stats.CommandLine = data.CommandLine;
+            };
+
+            // log at both startup and rundown
+            //var clrRundown = new ClrRundownTraceEventParser(source);
+            //clrRundown.RuntimeStart += doAtRuntimeStart;
+            source.Clr.AddCallbackForEvent("Runtime/Start", doAtRuntimeStart);
+
+            Action<ProcessTraceData> processStartCallback = data =>
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                var stats = perProc.GetOrCreate(data.ProcessID);
+
+                if (!string.IsNullOrEmpty(data.KernelImageFileName))
+                {
+                    // When we just have an EventSource (eg, the source was created by 
+                    // ETWTraceEventSource), we don't necessarily have the process names
+                    // decoded - it all depends on whether we have seen a ProcessStartGroup 
+                    // event or not. When the trace was taken after the process started we 
+                    // know we didn't see such an event.
+                    string name = GetImageName(data.KernelImageFileName);
+
+                    // Strictly speaking, this is not really fixing it 'cause 
+                    // it doesn't handle when a process with the same name starts
+                    // with the same pid. The chance of that happening is really small.
+                    if (stats.isDead == true)
+                    {
+                        stats = new GCProcess();
+                        stats.Init(data);
+                        perProc[data.ProcessID] = stats;
+                    }
+                }
+
+                var commandLine = data.CommandLine;
+                if (!string.IsNullOrEmpty(commandLine))
+                    stats.CommandLine = commandLine;
+            };
+
+            source.Kernel.AddCallbackForEvent("Process/Start", processStartCallback);
+            source.Kernel.AddCallbackForEvent("Process/DCStart", processStartCallback);
+
+            Action<ProcessTraceData> processEndCallback = delegate (ProcessTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                var stats = perProc.GetOrCreate(data.ProcessID);
+
+                if (string.IsNullOrEmpty(stats.ProcessName))
+                {
+                    stats.ProcessName = GetImageName(data.KernelImageFileName);
+                }
+
+                if (data.OpcodeName == "Stop")
+                {
+                    stats.isDead = true;
+                }
+            };
+
+            source.Kernel.AddCallbackForEvent("Process/Stop", processEndCallback);
+            source.Kernel.AddCallbackForEvent("Process/DCStop", processEndCallback);
+
+#if (!CAP)
+            CircularBuffer<ThreadWorkSpan> RecentThreadSwitches = new CircularBuffer<ThreadWorkSpan>(10000);
+            source.Kernel.AddCallbackForEvent("Thread/CSwitch", delegate (CSwitchTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                RecentThreadSwitches.Add(new ThreadWorkSpan(data));
+                GCProcess stats;
+                if (perProc.TryGetValue(data.ProcessID, out stats))
+                {
+                    stats.ThreadId2Priority[data.NewThreadID] = data.NewThreadPriority;
+                    if (stats.IsServerGCThread(data.ThreadID) > -1)
+                    {
+                        stats.ServerGcHeap2ThreadId[data.ProcessorNumber] = data.ThreadID;
+                    }
+                }
+
+                foreach (var gcProcess in perProc.Values)
+                {
+                    GCEvent _event = gcProcess.GetCurrentGC();
+                    // If we are in the middle of a GC.
+                    if (_event != null)
+                    {
+                        if ((_event.Type != GCType.BackgroundGC) && (gcProcess.isServerGCUsed == 1))
+                        {
+                            _event.AddServerGcThreadSwitch(new ThreadWorkSpan(data));
+                        }
+                    }
+                }
+            });
+
+            CircularBuffer<ThreadWorkSpan> RecentCpuSamples = new CircularBuffer<ThreadWorkSpan>(1000);
+            StackSourceSample sample = new StackSourceSample(stackSource);
+
+            source.Kernel.AddCallbackForEvent("PerfInfo/Sample", delegate (SampledProfileTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                RecentCpuSamples.Add(new ThreadWorkSpan(data));
+                GCProcess processWithGc = null;
+                foreach (var gcProcess in perProc.Values)
+                {
+                    GCEvent e = gcProcess.GetCurrentGC();
+                    // If we are in the middle of a GC.
+                    if (e != null)
+                    {
+                        if ((e.Type != GCType.BackgroundGC) && (gcProcess.isServerGCUsed == 1))
+                        {
+                            e.AddServerGcSample(new ThreadWorkSpan(data));
+                            processWithGc = gcProcess;
+                        }
+                    }
+                }
+
+                if (stackSource != null && processWithGc != null)
+                {
+                    GCEvent e = processWithGc.GetCurrentGC();
+                    sample.Metric = 1;
+                    sample.TimeRelativeMSec = data.TimeStampRelativeMSec;
+                    var nodeName = string.Format("Server GCs #{0} in {1} (PID:{2})", e.GCNumber, processWithGc.ProcessName, processWithGc.ProcessID);
+                    var nodeIndex = stackSource.Interner.FrameIntern(nodeName);
+                    sample.StackIndex = stackSource.Interner.CallStackIntern(nodeIndex, stackSource.GetCallStack(data.CallStackIndex(), data));
+                    stackSource.AddSample(sample);
+                }
+
+                GCProcess stats;
+                if (perProc.TryGetValue(data.ProcessID, out stats))
+                {
+                    if (stats.IsServerGCThread(data.ThreadID) > -1)
+                    {
+                        stats.ServerGcHeap2ThreadId[data.ProcessorNumber] = data.ThreadID;
+                    }
+
+                    var cpuIncrement = sampleIntervalMSec;
+                    stats.ProcessCpuMSec += cpuIncrement;
+
+                    GCEvent _event = stats.GetCurrentGC();
+                    // If we are in the middle of a GC.
+                    if (_event != null)
+                    {
+                        bool isThreadDoingGC = false;
+                        if ((_event.Type != GCType.BackgroundGC) && (stats.isServerGCUsed == 1))
+                        {
+                            int heapIndex = stats.IsServerGCThread(data.ThreadID);
+                            if (heapIndex != -1)
+                            {
+                                _event.AddServerGCThreadTime(heapIndex, cpuIncrement);
+                                isThreadDoingGC = true;
+                            }
+                        }
+                        else if (data.ThreadID == stats.suspendThreadIDGC)
+                        {
+                            _event.GCCpuMSec += cpuIncrement;
+                            isThreadDoingGC = true;
+                        }
+                        else if (stats.IsBGCThread(data.ThreadID))
+                        {
+                            Debug.Assert(stats.currentBGC != null);
+                            if (stats.currentBGC != null)
+                                stats.currentBGC.GCCpuMSec += cpuIncrement;
+                            isThreadDoingGC = true;
+                        }
+
+                        if (isThreadDoingGC)
+                        {
+                            stats.GCCpuMSec += cpuIncrement;
+                        }
+                    }
+                }
+            });
+#endif
+
+
+            source.Clr.AddCallbackForEvent("GC/SuspendEEStart", delegate (GCSuspendEETraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                var stats = perProc.GetOrCreate(data.ProcessID);
+                switch (data.Reason)
+                {
+                    case GCSuspendEEReason.SuspendForGC:
+                        stats.suspendThreadIDGC = data.ThreadID;
+                        break;
+                    case GCSuspendEEReason.SuspendForGCPrep:
+                        stats.suspendThreadIDBGC = data.ThreadID;
+                        break;
+                    default:
+                        stats.suspendThreadIDOther = data.ThreadID;
+                        break;
+                }
+
+                stats.suspendTimeRelativeMSec = data.TimeStampRelativeMSec;
+            });
+
+            // In 2.0 we didn't have this event.
+
+            source.Clr.AddCallbackForEvent("GC/SuspendEEStop", delegate (GCNoUserDataTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+
+                if ((stats.suspendThreadIDBGC > 0) && (stats.currentBGC != null))
+                {
+                    stats.currentBGC._SuspendDurationMSec += data.TimeStampRelativeMSec - stats.suspendTimeRelativeMSec;
+                }
+
+                stats.suspendEndTimeRelativeMSec = data.TimeStampRelativeMSec;
+            });
+
+            source.Clr.AddCallbackForEvent("GC/RestartEEStop", delegate (GCNoUserDataTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if (_event.Type == GCType.BackgroundGC)
+                    {
+                        stats.AddConcurrentPauseTime(_event, data.TimeStampRelativeMSec);
+                    }
+                    else
+                    {
+                        Debug.Assert(_event.PauseStartRelativeMSec != 0);
+                        // In 2.0 Concurrent GC, since we don't know the GC's type we can't tell if it's concurrent 
+                        // or not. But we know we don't have nested GCs there so simply check if we have received the
+                        // GCStop event; if we have it means it's a blocking GC; otherwise it's a concurrent GC so 
+                        // simply add the pause time to the GC without making the GC complete.
+                        if (_event.GCDurationMSec == 0)
+                        {
+                            Debug.Assert(_event.is20Event);
+                            _event.isConcurrentGC = true;
+                            stats.AddConcurrentPauseTime(_event, data.TimeStampRelativeMSec);
+                        }
+                        else
+                        {
+                            _event.PauseDurationMSec = data.TimeStampRelativeMSec - _event.PauseStartRelativeMSec;
+                            if (_event.HeapStats != null)
+                            {
+                                _event.isComplete = true;
+                                stats.lastCompletedGC = _event;
+                            }
+                        }
+                    }
+                }
+
+                // We don't change between a GC end and the pause resume.   
+                //Debug.Assert(stats.allocTickAtLastGC == stats.allocTickCurrentMB);
+                // Mark that we are not in suspension anymore.  
+                stats.suspendTimeRelativeMSec = -1;
+                stats.suspendThreadIDOther = -1;
+                stats.suspendThreadIDBGC = -1;
+                stats.suspendThreadIDGC = -1;
+            });
+
+            source.Clr.AddCallbackForEvent("GC/AllocationTick", delegate (GCAllocationTickTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+
+                if (stats.HasAllocTickEvents == false)
+                {
+                    stats.HasAllocTickEvents = true;
+                }
+
+                double valueMB = data.GetAllocAmount(ref stats.SeenBadAllocTick) / 1000000.0;
+
+                if (data.AllocationKind == GCAllocationKind.Small)
+                {
+                    // Would this do the right thing or is it always 0 for SOH since AllocationAmount 
+                    // is an int??? 
+                    stats.allocTickCurrentMB[0] += valueMB;
+                }
+                else
+                {
+                    stats.allocTickCurrentMB[1] += valueMB;
+                }
+            });
+
+            source.Clr.AddCallbackForEvent("GC/Start", delegate (GCStartTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+
+                // We need to filter the scenario where we get 2 GCStart events for each GC.
+                if ((stats.suspendThreadIDGC > 0) &&
+                    !((stats.events.Count > 0) && stats.events[stats.events.Count - 1].GCNumber == data.Count))
+                {
+                    GCEvent _event = new GCEvent(stats);
+                    Debug.Assert(0 <= data.Depth && data.Depth <= 2);
+                    // _event.GCGeneration = data.Depth;   Old style events only have this in the GCStop event.  
+                    _event.Reason = data.Reason;
+                    _event.GCNumber = data.Count;
+                    _event.Type = data.Type;
+                    _event.Index = stats.events.Count;
+                    _event.is20Event = data.IsClassicProvider;
+                    bool isEphemeralGCAtBGCStart = false;
+                    // Detecting the ephemeral GC that happens at the beginning of a BGC.
+                    if (stats.events.Count > 0)
+                    {
+                        GCEvent lastGCEvent = stats.events[stats.events.Count - 1];
+                        if ((lastGCEvent.Type == GCType.BackgroundGC) &&
+                            (!lastGCEvent.isComplete) &&
+                            (data.Type == GCType.NonConcurrentGC))
+                        {
+                            isEphemeralGCAtBGCStart = true;
+                        }
+                    }
+
+                    Debug.Assert(stats.suspendTimeRelativeMSec != -1);
+                    if (isEphemeralGCAtBGCStart)
+                    {
+                        _event.PauseStartRelativeMSec = data.TimeStampRelativeMSec;
+                    }
+                    else
+                    {
+                        _event.PauseStartRelativeMSec = stats.suspendTimeRelativeMSec;
+                        if (stats.suspendEndTimeRelativeMSec == -1)
+                        {
+                            stats.suspendEndTimeRelativeMSec = data.TimeStampRelativeMSec;
+                        }
+
+                        _event._SuspendDurationMSec = stats.suspendEndTimeRelativeMSec - stats.suspendTimeRelativeMSec;
+                    }
+
+                    _event.GCStartRelativeMSec = data.TimeStampRelativeMSec;
+                    stats.events.Add(_event);
+
+                    if (_event.Type == GCType.BackgroundGC)
+                    {
+                        stats.currentBGC = _event;
+                        _event.ProcessCpuAtLastGC = stats.ProcessCpuAtLastGC;
+                    }
+
+#if (!CAP)
+                    if ((_event.Type != GCType.BackgroundGC) && (stats.isServerGCUsed == 1))
+                    {
+                        _event.SetUpServerGcHistory();
+                        foreach (var s in RecentCpuSamples)
+                            _event.AddServerGcSample(s);
+                        foreach (var s in RecentThreadSwitches)
+                            _event.AddServerGcThreadSwitch(s);
+                    }
+#endif 
+                }
+            });
+
+            source.Clr.AddCallbackForEvent("GC/PinObjectAtGCTime", delegate (PinObjectAtGCTimeTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if (!_event.PinnedObjects.ContainsKey(data.ObjectID))
+                    {
+                        _event.PinnedObjects.Add(data.ObjectID, data.ObjectSize);
+                    }
+                    else
+                    {
+                        _event.duplicatedPinningReports++;
+                    }
+                }
+            });
+
+            // Some builds have this as a public event, and some have it as a private event.
+            // All will move to the private event, so we'll remove this code afterwards.
+            source.Clr.AddCallbackForEvent("GC/PinPlugAtGCTime", delegate (PinPlugAtGCTimeTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    // ObjectID is supposed to be an IntPtr. But "Address" is defined as UInt64 in 
+                    // TraceEvent.
+                    _event.PinnedPlugs.Add(new GCEvent.PinnedPlug(data.PlugStart, data.PlugEnd));
+                }
+            });
+
+            source.Clr.AddCallbackForEvent("GC/Mark", delegate (GCMarkWithTypeTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                stats.AddServerGCThreadFromMark(data.ThreadID, data.HeapNum);
+
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if (_event.PerHeapMarkTimes == null)
+                    {
+                        _event.PerHeapMarkTimes = new Dictionary<int, GCEvent.MarkInfo>();
+                    }
+
+                    if (!_event.PerHeapMarkTimes.ContainsKey(data.HeapNum))
+                    {
+                        _event.PerHeapMarkTimes.Add(data.HeapNum, new GCEvent.MarkInfo());
+                    }
+
+                    _event.PerHeapMarkTimes[data.HeapNum].MarkTimes[(int)data.Type] = data.TimeStampRelativeMSec;
+                    _event.PerHeapMarkTimes[data.HeapNum].MarkPromoted[(int)data.Type] = data.Promoted;
+                }
+            });
+
+            source.Clr.AddCallbackForEvent("GC/GlobalHeapHistory", delegate (GCGlobalHeapHistoryTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                stats.ProcessGlobalHistory(data);
+            });
+
+            source.Clr.AddCallbackForEvent("GC/PerHeapHistory", delegate (GCPerHeapHistoryTraceData3 data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                stats.ProcessPerHeapHistory(data);
+            });
+
+#if HAS_PRIVATE_GC_EVENTS
+            // See if the source knows about the CLR Private provider, if it does, then 
+            var gcPrivate = new ClrPrivateTraceEventParser(source);
+
+            gcPrivate.GCPinPlugAtGCTime += delegate (PinPlugAtGCTimeTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    // ObjectID is supposed to be an IntPtr. But "Address" is defined as UInt64 in 
+                    // TraceEvent.
+                    _event.PinnedPlugs.Add(new GCEvent.PinnedPlug(data.PlugStart, data.PlugEnd));
+                }
+            };
+
+            // Sometimes at the end of a trace I see only some mark events are included in the trace and they
+            // are not in order, so need to anticipate that scenario.
+            gcPrivate.GCMarkStackRoots += delegate (GCMarkTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                stats.AddServerGCThreadFromMark(data.ThreadID, data.HeapNum);
+
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if (_event.PerHeapMarkTimes == null)
+                    {
+                        _event.PerHeapMarkTimes = new Dictionary<int, GCEvent.MarkInfo>();
+                    }
+
+                    if (!_event.PerHeapMarkTimes.ContainsKey(data.HeapNum))
+                    {
+                        _event.PerHeapMarkTimes.Add(data.HeapNum, new GCEvent.MarkInfo(false));
+                    }
+
+                    _event.PerHeapMarkTimes[data.HeapNum].MarkTimes[(int)MarkRootType.MarkStack] = data.TimeStampRelativeMSec;
+                }
+            };
+
+            gcPrivate.GCMarkFinalizeQueueRoots += delegate (GCMarkTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if ((_event.PerHeapMarkTimes != null) && _event.PerHeapMarkTimes.ContainsKey(data.HeapNum))
+                    {
+                        _event.PerHeapMarkTimes[data.HeapNum].MarkTimes[(int)MarkRootType.MarkFQ] =
+                            data.TimeStampRelativeMSec;
+                    }
+                }
+            };
+
+            gcPrivate.GCMarkHandles += delegate (GCMarkTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if ((_event.PerHeapMarkTimes != null) && _event.PerHeapMarkTimes.ContainsKey(data.HeapNum))
+                    {
+                        _event.PerHeapMarkTimes[data.HeapNum].MarkTimes[(int)MarkRootType.MarkHandles] =
+                           data.TimeStampRelativeMSec;
+                    }
+                }
+            };
+
+            gcPrivate.GCMarkCards += delegate (GCMarkTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    if ((_event.PerHeapMarkTimes != null) && _event.PerHeapMarkTimes.ContainsKey(data.HeapNum))
+                    {
+                        _event.PerHeapMarkTimes[data.HeapNum].MarkTimes[(int)MarkRootType.MarkOlder] =
+                            data.TimeStampRelativeMSec;
+                    }
+                }
+            };
+
+            gcPrivate.GCGlobalHeapHistory += delegate (GCGlobalHeapHistoryTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                stats.ProcessGlobalHistory(data);
+            };
+
+            gcPrivate.GCPerHeapHistory += delegate (GCPerHeapHistoryTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                stats.ProcessPerHeapHistory(data);
+            };
+
+            gcPrivate.GCBGCStart += delegate (GCNoUserDataTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                if (stats.currentBGC != null)
+                {
+                    if (stats.backgroundGCThreads == null)
+                    {
+                        stats.backgroundGCThreads = new Dictionary<int, object>(16);
+                    }
+                    stats.backgroundGCThreads[data.ThreadID] = null;
+                }
+            };
+#endif
+
+            source.Clr.AddCallbackForEvent("GC/Stop", delegate (GCEndTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                GCEvent _event = stats.GetCurrentGC();
+                if (_event != null)
+                {
+                    _event.GCDurationMSec = data.TimeStampRelativeMSec - _event.GCStartRelativeMSec;
+                    _event.GCGeneration = data.Depth;
+                    _event.GCEnd();
+                }
+            });
+
+            source.Clr.AddCallbackForEvent("GC/HeapStats", delegate (GCHeapStatsTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                GCEvent _event = stats.GetCurrentGC();
+
+                var sizeAfterMB = (data.GenerationSize1 + data.GenerationSize2 + data.GenerationSize3) / 1000000.0;
+                if (_event != null)
+                {
+                    _event.HeapStats = (GCHeapStatsTraceData)data.Clone();
+
+                    if (_event.Type == GCType.BackgroundGC)
+                    {
+                        _event.ProcessCpuMSec = stats.ProcessCpuMSec - _event.ProcessCpuAtLastGC;
+                        _event.DurationSinceLastRestartMSec = data.TimeStampRelativeMSec - stats.lastRestartEndTimeRelativeMSec;
+                    }
+                    else
+                    {
+                        _event.ProcessCpuMSec = stats.ProcessCpuMSec - stats.ProcessCpuAtLastGC;
+                        _event.DurationSinceLastRestartMSec = _event.PauseStartRelativeMSec - stats.lastRestartEndTimeRelativeMSec;
+                    }
+
+                    if (stats.HasAllocTickEvents)
+                    {
+                        _event.HasAllocTickEvents = true;
+                        _event.AllocedSinceLastGCBasedOnAllocTickMB[0] = stats.allocTickCurrentMB[0] - stats.allocTickAtLastGC[0];
+                        _event.AllocedSinceLastGCBasedOnAllocTickMB[1] = stats.allocTickCurrentMB[1] - stats.allocTickAtLastGC[1];
+                    }
+
+                    // This is where a background GC ends.
+                    if ((_event.Type == GCType.BackgroundGC) && (stats.currentBGC != null))
+                    {
+                        stats.currentBGC.isComplete = true;
+                        stats.lastCompletedGC = stats.currentBGC;
+                        stats.currentBGC = null;
+                    }
+
+                    if (_event.isConcurrentGC)
+                    {
+                        Debug.Assert(_event.is20Event);
+                        _event.isComplete = true;
+                        stats.lastCompletedGC = _event;
+                    }
+                }
+
+                stats.ProcessCpuAtLastGC = stats.ProcessCpuMSec;
+                stats.allocTickAtLastGC[0] = stats.allocTickCurrentMB[0];
+                stats.allocTickAtLastGC[1] = stats.allocTickCurrentMB[1];
+                stats.lastRestartEndTimeRelativeMSec = data.TimeStampRelativeMSec;
+            });
+
+            source.Clr.AddCallbackForEvent("GC/TerminateConcurrentThread", delegate (GCTerminateConcurrentThreadTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc.GetOrCreate(data.ProcessID);
+                if (stats.backgroundGCThreads != null)
+                {
+                    stats.backgroundGCThreads = null;
+                }
+            });
+
+#if HAS_PRIVATE_GC_EVENTS
+            gcPrivate.GCBGCAllocWaitStart += delegate (BGCAllocWaitTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+                Debug.Assert(stats.currentBGC != null);
+
+                if (stats.currentBGC != null)
+                {
+                    stats.currentBGC.AddLOHWaitThreadInfo(data.ThreadID, data.TimeStampRelativeMSec, data.Reason, true);
+                }
+            };
+
+            gcPrivate.GCBGCAllocWaitStop += delegate (BGCAllocWaitTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess stats = perProc[data];
+
+                GCEvent _event = stats.GetLastBGC();
+
+                if (_event != null)
+                {
+                    _event.AddLOHWaitThreadInfo(data.ThreadID, data.TimeStampRelativeMSec, data.Reason, false);
+                }
+            };
+
+            gcPrivate.GCJoin += delegate (GCJoinTraceData data)
+            {
+                if (filterFunc != null && !filterFunc.Invoke(data))
+                {
+                    return;
+                }
+
+                GCProcess gcProcess = perProc[data];
+                GCEvent _event = gcProcess.GetCurrentGC();
+                if (_event != null)
+                {
+                    _event.AddGcJoin(data);
+                }
+            };
+
+            source.Process();
+#endif
+            return perProc;
+        }
+
+        public int ProcessID { get; set; }
+        public string ProcessName { get; set; }
+        bool isDead;
+        public bool Interesting { get { return Total.GCCount > 0 || RuntimeVersion != null; } }
+        public bool InterestingForAnalysis
+        {
+            get
+            {
+                return ((Total.GCCount > 3) &&
+                        ((GetGCPauseTimePercentage() > 1.0) || (Total.MaxPauseDurationMSec > 200.0)));
+            }
+        }
+
+        // A process can have one or more SBAs associated with it.
+        public GCInfo[] Generations = new GCInfo[3] { new GCInfo(), new GCInfo(), new GCInfo() };
+        public GCInfo Total = new GCInfo();
+        public float ProcessCpuMSec;     // Total CPU time used in process (approximate)
+        public float GCCpuMSec;          // CPU time used in the GC (approximate)
+        public int NumberOfHeaps = 1;
+
+        // Of all the CPU, how much as a percentage is spent in the GC. 
+        public float PercentTimeInGC { get { return GCCpuMSec * 100 / ProcessCpuMSec; } }
+
+        public static string GetImageName(string path)
+        {
+            int startIdx = path.LastIndexOf('\\');
+            if (0 <= startIdx)
+                startIdx++;
+            else
+                startIdx = 0;
+            int endIdx = path.LastIndexOf('.');
+            if (endIdx <= startIdx)
+                endIdx = path.Length;
+            string name = path.Substring(startIdx, endIdx - startIdx);
+            return name;
+        }
+
+        // This is calculated based on the GC events which is fine for the GC analysis purpose.
+        public double ProcessDuration
+        {
+            get
+            {
+                double startRelativeMSec = 0.0;
+
+                for (int i = 0; i < events.Count; i++)
+                {
+                    if (events[i].isComplete)
+                    {
+                        startRelativeMSec = events[i].PauseStartRelativeMSec;
+                        break;
+                    }
+                }
+
+                if (startRelativeMSec == 0.0)
+                    return 0;
+
+                // Get the end time of the last GC.
+                double endRelativeMSec = lastRestartEndTimeRelativeMSec;
+                return (endRelativeMSec - startRelativeMSec);
+            }
+        }
+
+        public StartupFlags StartupFlags;
+        public string RuntimeVersion;
+        public int Bitness = -1;
+        public Dictionary<int, int> ThreadId2Priority = new Dictionary<int, int>();
+        public Dictionary<int, int> ServerGcHeap2ThreadId = new Dictionary<int, int>();
+
+        public string CommandLine { get; set; }
+
+        public double PeakWorkingSetMB { get; set; }
+        public double PeakVirtualMB { get; set; }
+
+        /// <summary>
+        /// Means it detected that the ETW information is in a format it does not understand.
+        /// </summary>
+        public bool GCVersionInfoMismatch { get; private set; }
+
+        public double GetGCPauseTimePercentage()
+        {
+            return ((ProcessDuration == 0) ? 0.0 : ((Total.TotalPauseTimeMSec * 100) / ProcessDuration));
+        }
+
+        internal static void ComputeRollup(IDictionary<int, GCProcess> perProc)
+        {
+            // Compute rollup information.  
+            foreach (GCProcess stats in perProc.Values)
+            {
+                for (int i = 0; i < stats.events.Count; i++)
+                {
+                    GCEvent _event = stats.events[i];
+                    if (!_event.isComplete)
+                    {
+                        continue;
+                    }
+
+                    _event.Index = i;
+                    if (_event.DetailedGenDataAvailable())  //per heap histories is not null
+                        stats.m_detailedGCInfo = true;
+
+                    // Update the per-generation information 
+                    stats.Generations[_event.GCGeneration].GCCount++;
+                    bool isInduced = ((_event.Reason == GCReason.Induced) || (_event.Reason == GCReason.InducedNotForced));
+                    if (isInduced)
+                        (stats.Generations[_event.GCGeneration].NumInduced)++;
+
+                    long PinnedObjectSizes = _event.GetPinnedObjectSizes();
+                    if (PinnedObjectSizes != 0)
+                    {
+                        stats.Generations[_event.GCGeneration].PinnedObjectSizes += PinnedObjectSizes;
+                        stats.Generations[_event.GCGeneration].NumGCWithPinEvents++;
+                    }
+
+                    int PinnedObjectPercentage = _event.GetPinnedObjectPercentage();
+                    if (PinnedObjectPercentage != -1)
+                    {
+                        stats.Generations[_event.GCGeneration].PinnedObjectPercentage += _event.GetPinnedObjectPercentage();
+                        stats.Generations[_event.GCGeneration].NumGCWithPinPlugEvents++;
+                    }
+
+                    stats.Generations[_event.GCGeneration].TotalGCCpuMSec += _event.GetTotalGCTime();
+                    stats.Generations[_event.GCGeneration].TotalSizeAfterMB += _event.HeapSizeAfterMB;
+
+                    stats.Generations[_event.GCGeneration].TotalSizePeakMB += _event.HeapSizePeakMB;
+                    stats.Generations[_event.GCGeneration].TotalPromotedMB += _event.PromotedMB;
+                    stats.Generations[_event.GCGeneration].TotalPauseTimeMSec += _event.PauseDurationMSec;
+                    stats.Generations[_event.GCGeneration].TotalAllocatedMB += _event.AllocedSinceLastGCMB;
+                    stats.Generations[_event.GCGeneration].MaxPauseDurationMSec = Math.Max(stats.Generations[_event.GCGeneration].MaxPauseDurationMSec, _event.PauseDurationMSec);
+                    stats.Generations[_event.GCGeneration].MaxSizePeakMB = Math.Max(stats.Generations[_event.GCGeneration].MaxSizePeakMB, _event.HeapSizePeakMB);
+                    stats.Generations[_event.GCGeneration].MaxAllocRateMBSec = Math.Max(stats.Generations[_event.GCGeneration].MaxAllocRateMBSec, _event.AllocRateMBSec);
+                    stats.Generations[_event.GCGeneration].MaxPauseDurationMSec = Math.Max(stats.Generations[_event.GCGeneration].MaxPauseDurationMSec, _event.PauseDurationMSec);
+                    stats.Generations[_event.GCGeneration].MaxSuspendDurationMSec = Math.Max(stats.Generations[_event.GCGeneration].MaxSuspendDurationMSec, _event._SuspendDurationMSec);
+
+                    // And the totals 
+                    stats.Total.GCCount++;
+                    if (isInduced)
+                        stats.Total.NumInduced++;
+                    if (PinnedObjectSizes != 0)
+                    {
+                        stats.Total.PinnedObjectSizes += PinnedObjectSizes;
+                        stats.Total.NumGCWithPinEvents++;
+                    }
+                    if (PinnedObjectPercentage != -1)
+                    {
+                        stats.Total.PinnedObjectPercentage += _event.GetPinnedObjectPercentage();
+                        stats.Total.NumGCWithPinPlugEvents++;
+                    }
+                    stats.Total.TotalGCCpuMSec += _event.GetTotalGCTime();
+                    stats.Total.TotalSizeAfterMB += _event.HeapSizeAfterMB;
+                    stats.Total.TotalPromotedMB += _event.PromotedMB;
+                    stats.Total.TotalSizePeakMB += _event.HeapSizePeakMB;
+                    stats.Total.TotalPauseTimeMSec += _event.PauseDurationMSec;
+                    stats.Total.TotalAllocatedMB += _event.AllocedSinceLastGCMB;
+                    stats.Total.MaxPauseDurationMSec = Math.Max(stats.Total.MaxPauseDurationMSec, _event.PauseDurationMSec);
+                    stats.Total.MaxSizePeakMB = Math.Max(stats.Total.MaxSizePeakMB, _event.HeapSizePeakMB);
+                    stats.Total.MaxAllocRateMBSec = Math.Max(stats.Total.MaxAllocRateMBSec, _event.AllocRateMBSec);
+                    stats.Total.MaxSuspendDurationMSec = Math.Max(stats.Total.MaxSuspendDurationMSec, _event._SuspendDurationMSec);
+                }
+            }
+        }
+
+#region private
+        protected virtual void Init(TraceEvent data)
+        {
+            ProcessID = data.ProcessID;
+            ProcessName = data.ProcessName;
+            isDead = false;
+        }
+        private GCEvent GetCurrentGC()
+        {
+            if (events.Count > 0)
+            {
+                if (!events[events.Count - 1].isComplete)
+                {
+                    return events[events.Count - 1];
+                }
+                else if (currentBGC != null)
+                {
+                    return currentBGC;
+                }
+            }
+
+            return null;
+        }
+
+        // This is the last GC in progress. We need this for server Background GC.
+        // See comments for lastCompletedGC.
+        private GCEvent GetLastGC()
+        {
+            GCEvent _event = GetCurrentGC();
+            if ((isServerGCUsed == 1) &&
+                (_event == null))
+            {
+                if (lastCompletedGC != null)
+                {
+                    Debug.Assert(lastCompletedGC.Type == GCType.BackgroundGC);
+                    _event = lastCompletedGC;
+                }
+            }
+
+            return _event;
+        }
+
+        private GCEvent GetLastBGC()
+        {
+            if (currentBGC != null)
+            {
+                return currentBGC;
+            }
+
+            if ((lastCompletedGC != null) && (lastCompletedGC.Type == GCType.BackgroundGC))
+            {
+                return lastCompletedGC;
+            }
+
+            // Otherwise we search till we find the last BGC if we have seen one.
+            for (int i = (events.Count - 1); i >= 0; i--)
+            {
+                if (events[i].Type == GCType.BackgroundGC)
+                {
+                    return events[i];
+                }
+            }
+
+            return null;
+        }
+
+        private void AddConcurrentPauseTime(GCEvent _event, double RestartEEMSec)
+        {
+            if (suspendThreadIDBGC > 0)
+            {
+                _event.PauseDurationMSec += RestartEEMSec - suspendTimeRelativeMSec;
+            }
+            else
+            {
+                Debug.Assert(_event.PauseDurationMSec == 0);
+                _event.PauseDurationMSec = RestartEEMSec - _event.PauseStartRelativeMSec;
+            }
+        }
+
+        private void AddServerGCThreadFromMark(int ThreadID, int HeapNum)
+        {
+            if (isServerGCUsed == 1)
+            {
+                Debug.Assert(heapCount > 1);
+
+                if (serverGCThreads.Count < heapCount)
+                {
+                    // I am seeing that sometimes we are not getting these events from all heaps
+                    // for a complete GC so I have to check for that.
+                    if (!serverGCThreads.ContainsKey(ThreadID))
+                    {
+                        serverGCThreads.Add(ThreadID, HeapNum);
+                    }
+                }
+            }
+        }
+
+        private void ProcessGlobalHistory(GCGlobalHeapHistoryTraceData data)
+        {
+            if (isServerGCUsed == -1)
+            {
+                // We detected whether we are using Server GC now.
+                isServerGCUsed = ((data.NumHeaps > 1) ? 1 : 0);
+                if (heapCount == -1)
+                {
+                    heapCount = data.NumHeaps;
+                }
+
+                if (isServerGCUsed == 1)
+                {
+                    serverGCThreads = new Dictionary<int, int>(data.NumHeaps);
+                }
+            }
+
+            GCEvent _event = GetLastGC();
+            if (_event != null)
+            {
+                _event.GlobalHeapHistory = (GCGlobalHeapHistoryTraceData)data.Clone();
+                _event.SetHeapCount(heapCount);
+            }
+        }
+
+        private void ProcessPerHeapHistory(GCPerHeapHistoryTraceData data)
+        {
+            if (!data.VersionRecognized)
+            {
+                GCVersionInfoMismatch = true;
+                return;
+            }
+
+            GCEvent _event = GetLastGC();
+            if (_event != null)
+            {
+                if (_event.PerHeapHistories == null)
+                    _event.PerHeapHistories = new List<GCPerHeapHistoryTraceData>();
+                _event.PerHeapHistories.Add((GCPerHeapHistoryTraceData)data.Clone());
+            }
+        }
+
+        public IList<GCEvent> Events
+        {
+            get
+            {
+                return events;
+            }
+        }
+
+        private List<GCEvent> events = new List<GCEvent>();
+
+        // The amount of memory allocated by the user threads. So they are divided up into gen0 and LOH allocations.
+        double[] allocTickCurrentMB = { 0.0, 0.0 };
+        double[] allocTickAtLastGC = { 0.0, 0.0 };
+        bool HasAllocTickEvents = false;
+        bool SeenBadAllocTick = false;
+
+        double lastRestartEndTimeRelativeMSec;
+
+        // EE can be suspended via different reasons. The only ones we care about are
+        // SuspendForGC(1) - suspending for GC start
+        // SuspendForGCPrep(6) - BGC uses it in the middle of a BGC.
+        // We need to filter out the rest of the suspend/resume events.
+        // Keep track of the last time we started suspending the EE.  Will use in 'Start' to set PauseStartRelativeMSec
+        int suspendThreadIDOther = -1;
+        int suspendThreadIDBGC = -1;
+        // This is either the user thread (in workstation case) or a server GC thread that called SuspendEE to do a GC
+        int suspendThreadIDGC = -1;
+        double suspendTimeRelativeMSec = -1;
+        double suspendEndTimeRelativeMSec = -1;
+
+        // This records the amount of CPU time spent at the end of last GC.
+        float ProcessCpuAtLastGC = 0;
+
+        // This is the BGC that's in progress as we are parsing. We need to remember this 
+        // so we can correctly attribute the suspension time.
+        GCEvent currentBGC = null;
+        Dictionary<int, object> backgroundGCThreads = null;
+        bool IsBGCThread(int threadID)
+        {
+            if (backgroundGCThreads != null)
+                return backgroundGCThreads.ContainsKey(threadID);
+            return false;
+        }
+
+        // I keep this for the purpose of server Background GC. Unfortunately for server background 
+        // GC we are firing the GCEnd/GCHeaps events and Global/Perheap events in the reversed order.
+        // This is so that the Global/Perheap events can still be attributed to the right BGC.
+        GCEvent lastCompletedGC = null;
+        // We don't necessarily have the GCSettings event (only fired at the beginning if we attach)
+        // So we have to detect whether we are running server GC or not.
+        // Till we get our first GlobalHeapHistory event which indicates whether we use server GC 
+        // or not this remains -1.
+        public int isServerGCUsed = -1;
+        public int heapCount = -1;
+        // This is the server GC threads. It's built up in the 2nd server GC we see. 
+        Dictionary<int, int> serverGCThreads = null;
+
+
+        internal bool m_detailedGCInfo;
+        int IsServerGCThread(int threadID)
+        {
+            int heapIndex;
+            if (serverGCThreads != null)
+            {
+                if (serverGCThreads.TryGetValue(threadID, out heapIndex))
+                {
+                    return heapIndex;
+                }
+            }
+            return -1;
+        }
+#endregion
+    }
+
+#if HAS_PRIVATE_GC_EVENTS
+    class BGCAllocWaitInfo
+    {
+        public double WaitStartRelativeMSec;
+        public double WaitStopRelativeMSec;
+        public BGCAllocWaitReason Reason;
+
+        public bool GetWaitTime(ref double pauseMSec)
+        {
+            if ((WaitStartRelativeMSec != 0) &&
+                (WaitStopRelativeMSec != 0))
+            {
+                pauseMSec = WaitStopRelativeMSec - WaitStartRelativeMSec;
+                return true;
+            }
+            return false;
+        }
+
+        public bool IsLOHWaitLong(double pauseMSecMin)
+        {
+            double pauseMSec = 0;
+            if (GetWaitTime(ref pauseMSec))
+            {
+                return (pauseMSec > pauseMSecMin);
+            }
+            return false;
+        }
+
+        public override string ToString()
+        {
+            if ((Reason == BGCAllocWaitReason.GetLOHSeg) ||
+                (Reason == BGCAllocWaitReason.AllocDuringSweep))
+            {
+                return "Waiting for BGC to thread free lists";
+            }
+            else
+            {
+                Debug.Assert(Reason == BGCAllocWaitReason.AllocDuringBGC);
+                return "Allocated too much during BGC, waiting for BGC to finish";
+            }
+        }
+    }
+#endif
+}
+
+#endif

--- a/tests/src/GC/Performance/Framework/Metrics/Builders/ThreadWorkSpan.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/Builders/ThreadWorkSpan.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS
+
+using Microsoft.Diagnostics.Tracing.Parsers.Kernel;
+
+namespace GCPerfTestFramework.Metrics.Builders
+{
+    /// <summary>
+    /// Span of thread work recorded by CSwitch or CPU Sample Profile events
+    /// </summary>
+    internal class ThreadWorkSpan
+    {
+        public int ThreadId;
+        public int ProcessId;
+        public string ProcessName;
+        public int ProcessorNumber;
+        public double AbsoluteTimestampMsc;
+        public double DurationMsc;
+        public int Priority = -1;
+        public int WaitReason = -1;
+
+        public ThreadWorkSpan(CSwitchTraceData switchData)
+        {
+            ProcessName = switchData.NewProcessName;
+            ThreadId = switchData.NewThreadID;
+            ProcessId = switchData.NewProcessID;
+            ProcessorNumber = switchData.ProcessorNumber;
+            AbsoluteTimestampMsc = switchData.TimeStampRelativeMSec;
+            Priority = switchData.NewThreadPriority;
+            WaitReason = (int)switchData.OldThreadWaitReason;
+        }
+
+        public ThreadWorkSpan(ThreadWorkSpan span)
+        {
+            ProcessName = span.ProcessName;
+            ThreadId = span.ThreadId;
+            ProcessId = span.ProcessId;
+            ProcessorNumber = span.ProcessorNumber;
+            AbsoluteTimestampMsc = span.AbsoluteTimestampMsc;
+            DurationMsc = span.DurationMsc;
+            Priority = span.Priority;
+            WaitReason = span.WaitReason;
+        }
+
+        public ThreadWorkSpan(SampledProfileTraceData sample)
+        {
+            ProcessName = sample.ProcessName;
+            ProcessId = sample.ProcessID;
+            ThreadId = sample.ThreadID;
+            ProcessorNumber = sample.ProcessorNumber;
+            AbsoluteTimestampMsc = sample.TimeStampRelativeMSec;
+            DurationMsc = 1;
+            Priority = 0;
+        }
+    }
+}
+
+#endif

--- a/tests/src/GC/Performance/Framework/Metrics/CollectGCMetricsAttribute.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/CollectGCMetricsAttribute.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Xunit.Performance.Sdk;
+using System;
+
+namespace GCPerfTestFramework.Metrics
+{
+    /// <summary>
+    /// This attribute marks a xunit-performance test artifact as requiring GC metrics. When this attribute adorns
+    /// a test artifact, xunit-performance creates an instance of <see cref="GCMetricDiscoverer"/> and uses
+    /// it to populate the list of metrics provided for that artifact.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly)]
+#if WINDOWS
+    [PerformanceMetricDiscoverer("GCPerfTestFramework.Metrics.GCMetricDiscoverer", "Framework")]
+#endif
+    public class CollectGCMetricsAttribute : 
+        Attribute
+#if WINDOWS
+        , IPerformanceMetricAttribute
+#endif
+    {
+    }
+}

--- a/tests/src/GC/Performance/Framework/Metrics/GCMetricDiscoverer.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/GCMetricDiscoverer.cs
@@ -1,0 +1,234 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS
+
+using GCPerfTestFramework.Metrics.Builders;
+using Microsoft.Diagnostics.Tracing;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Microsoft.Xunit.Performance;
+using Microsoft.Xunit.Performance.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Xunit.Abstractions;
+
+namespace GCPerfTestFramework.Metrics
+{
+    /// <summary>
+    /// GCMetricDiscoverer is one of two publicly-exposed classes from the library and is the
+    /// portion of this library that speaks directly to xunit-performance. When a
+    /// <see cref="CollectGCMetricsAttribute"/> is observed when xunit-performance is enumerating
+    /// the attributes on a test method, it instantiates an instance of this class and calls
+    /// GetMetrics on it, which yields the list of metrics that this library provides.
+    /// 
+    /// This class and <see cref="CollectGCMetricsAttribute"/> should be the *only* classes
+    /// exposed by this namespace.
+    /// </summary>
+    public class GCMetricDiscoverer : IPerformanceMetricDiscoverer
+    {
+        /// <summary>
+        /// Yields all current custom GC metrics.
+        /// </summary>
+        /// <param name="metricAttribute">Unused.</param>
+        /// <returns>An enumerator yielding new instances of all of the existing custom GC metrics.</returns>
+        public IEnumerable<PerformanceMetricInfo> GetMetrics(IAttributeInfo metricAttribute)
+        {
+            yield return new GCMaxPauseMetric();
+            yield return new GCMeanPauseMetric();
+            yield return new GCPeakVirtualMemoryMetric();
+            yield return new GCPeakWorkingSetMetric();
+            yield return new GCTotalPauseTimeMetric();
+            yield return new GCCpuTimeInGCMetric();
+            yield return new GCGenZeroMeanPauseDuration();
+            yield return new GCGenOneMeanPauseDuration();
+            yield return new GCGenTwoMeanPauseDuration();
+            yield return new GCGenZeroCount();
+            yield return new GCGenOneCount();
+            yield return new GCGenTwoBGCCount();
+            yield return new GCGenTwoGCCount();
+        }
+    }
+    
+    /// <summary>
+    /// Base class for all GC-related metrics that handles provider registration for child metrics, since
+    /// all GC-related metrics will be listening to the same trace providers.
+    /// </summary>
+    internal abstract class GCMetric : PerformanceMetric
+    {
+        /// <summary>
+        /// Number of bytes in a megabyte, for convenience.
+        /// </summary>
+        public const int BytesInMegabyte = 1048576;
+
+        /// <summary>
+        /// Creates a new GCMetric with the given ID, display name, and unit.
+        /// </summary>
+        /// <param name="id">The ID of the metric</param>
+        /// <param name="displayName">A human-friendly display name of the metric</param>
+        /// <param name="unit">The unit of the metric</param>
+        public GCMetric(string id, string displayName, string unit)
+            : base(id, displayName, unit)
+        {
+        }
+
+        /// <summary>
+        /// Indicates to xunit-performance what trace providers that these metrics
+        /// require.
+        /// </summary>
+        public override IEnumerable<ProviderInfo> ProviderInfo
+        {
+            get
+            {
+                yield return new KernelProviderInfo()
+                {
+                    Keywords = (ulong)(KernelTraceEventParser.Keywords.ContextSwitch
+                        | KernelTraceEventParser.Keywords.Profile
+                        | KernelTraceEventParser.Keywords.ProcessCounters)
+                };
+                yield return new UserProviderInfo()
+                {
+                    ProviderGuid = ClrTraceEventParser.ProviderGuid,
+                    Level = TraceEventLevel.Verbose,
+                    Keywords = (ulong)ClrTraceEventParser.Keywords.GC
+                };
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new PerformanceMetricEvaluator for this metric. Implementors of a custom metric must override
+        /// this method and instruct it to instantiate the GCEvaluator for that custom metric.
+        /// </summary>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public abstract override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context);
+    }
+
+    /// <summary>
+    /// Base class for all GC-related metric evaluators that handles the complexity of multiplexing possibly many
+    /// GC metrics on top of a single "trace session" using a reference-counting strategy.
+    /// </summary>
+    internal abstract class GCEvaluator : PerformanceMetricEvaluator
+    {
+        /// <summary>
+        /// The sample rate used by xunit-performance when collecting ETW traces. Used
+        /// to infer the total time spent in GC based on CPU samples.
+        /// </summary>
+        const float SampleRate = 1.0f;
+
+        // These three fields are part of a bit of a hack to avoid having to re-parse the ETL file
+        // every time a new metric is evaluated.
+        //
+        // The idea here is that every class that derives from GCEvaluator increments the
+        // reference count whenever an iteration begins and decrements it whenever an iteration ends.
+        // When the reference count is zero, the session is nulled out for the next iteration.
+        // If _session is null when an iteration begins, the first metric to reach it will set it up
+        // to trace the session. In this way, the first metric in sets up the session and the last one
+        // out tears it down in preparation for the next iteration.
+        //
+        // This scheme is not thread-safe and will break if xunit-performance ever runs benchmarks in
+        // parallel, although that's pretty unlikely for a benchmarking framework.
+        private static IDictionary<int, GCProcess> s_session;
+        private static int s_sessionRefCount;
+        private static bool s_hasComputedRollup;
+
+        private readonly PerformanceMetricEvaluationContext _context;
+
+        /// <summary>
+        /// Property exposed to child metrics that automatically ensures that the session is valid and that
+        /// rollup information has been calculated, calculating it if it has not happened already.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if this property is unable to determine an
+        /// appropriate process for analysis. Usually this occurs when
+        /// the test framework itself crashes and fails to launch a test.
+        /// </exception>
+        protected GCProcess ProcessInfo
+        {
+            get
+            {
+                if (!s_hasComputedRollup)
+                {
+                    GCProcess.ComputeRollup(s_session);
+                    s_hasComputedRollup = true;
+                }
+
+                // Since we are spawning this process with UseShellExecute set to false,
+                // the spawned process itself spawns an instance of "conhost.exe" on Windows.
+                // We want to be sure we don't pick out that one for analysis.
+                foreach (var candidate in s_session.Values)
+                {
+                    if (candidate.CommandLine != null)
+                    {
+                        if (!candidate.CommandLine.Contains("conhost.exe"))
+                        {
+                            return candidate;
+                        }
+                    }
+                }
+
+                // This should never happen in GC-related tests, which are always required to spawn an additional process.
+                throw new InvalidOperationException("Failed to find an appropriate target process for analysis!");
+            }
+        }
+
+        /// <summary>
+        /// Constructs a new GCEvaluator and sets its content to the given PerformanceMetricEvaluationContext.
+        /// </summary>
+        /// <param name="context">The context received from the test framework</param>
+        public GCEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            Debug.Assert(context.TraceEventSource is TraceEventDispatcher);
+            _context = context;
+        }
+
+        /// <summary>
+        /// Creates a session if it does not exist and increments the reference count on the session.
+        /// </summary>
+        /// <param name="beginEvent">Unused.</param>
+        public override void BeginIteration(TraceEvent beginEvent)
+        {
+            if (s_session == null)
+            {
+                // The filter function here is to filter out events that we are not concerned with collecting, i.e. events from
+                // processes not spawned by us.
+                s_session = GCProcess.Collect(_context.TraceEventSource as TraceEventDispatcher, SampleRate, filterFunc: _context.IsTestEvent);
+                s_hasComputedRollup = false;
+            }
+
+            s_sessionRefCount++;
+        }
+
+        /// <summary>
+        /// Yields the metric and decrements the reference count on the session, disposing it
+        /// if the reference count is zero.
+        /// </summary>
+        /// <param name="endEvent">Unused.</param>
+        /// <returns>The value of the metric calculated by this class</returns>
+        public override double EndIteration(TraceEvent endEvent)
+        {
+            var metric = YieldMetric();
+            s_sessionRefCount--;
+            if (s_sessionRefCount == 0)
+            {
+                s_session = null;
+
+                // not doing this results in tremendous memory leaks!
+                _context.TraceEventSource.Kernel.RemoveCallback<TraceEvent>(null);
+                _context.TraceEventSource.Clr.RemoveCallback<TraceEvent>(null);
+            }
+
+            return metric;
+        }
+
+        /// <summary>
+        /// Overriden by child metrics to determine how to yield the value of the metric
+        /// that the child metric provides. In general, overriders of this method
+        /// do something with the value of the <see cref="ProcessInfo"/> property.
+        /// </summary>
+        /// <returns>The value of this metric</returns>
+        protected abstract double YieldMetric();
+    }
+}
+
+#endif

--- a/tests/src/GC/Performance/Framework/Metrics/GCMetrics.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/GCMetrics.cs
@@ -1,0 +1,411 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if WINDOWS
+
+using System.Linq;
+using Microsoft.Xunit.Performance.Sdk;
+using Microsoft.Diagnostics.Tracing.Parsers.Clr;
+
+/// <summary>
+/// This file contains a number of GC-related metrics that are provided to xunit-performance.
+/// Each one of these derives from GCMetric, which manages the creation of the GC object model
+/// from an ETL trace - these classes are only responsible for using it to produce a meaningful
+/// metric.
+/// 
+/// Each one of these metrics should be fairly self-explanatory.
+/// </summary>
+namespace GCPerfTestFramework.Metrics
+{
+    #region Maximum Pause Duration
+    internal class GCMaxPauseMetric : GCMetric
+    {
+        public GCMaxPauseMetric()
+            : base("GCMaxPause", "Maximum GC Pause Duraction", PerformanceMetricUnits.Milliseconds)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCMaxPauseEvaluator(context);
+        }
+    }
+
+    internal class GCMaxPauseEvaluator : GCEvaluator
+    {
+        public GCMaxPauseEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Total.MaxPauseDurationMSec;
+        }
+    }
+    #endregion
+
+    #region Mean Pause Duration
+    internal class GCMeanPauseMetric : GCMetric
+    {
+        public GCMeanPauseMetric()
+            : base("GCMeanPause", "Mean GC Pause Duraction", PerformanceMetricUnits.Milliseconds)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCMeanPauseEvaluator(context);
+        }
+    }
+
+    internal class GCMeanPauseEvaluator : GCEvaluator
+    {
+        public GCMeanPauseEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Total.MeanPauseDurationMSec;
+        }
+    }
+    #endregion
+
+    #region Peak Virtual Memory Size
+    internal class GCPeakVirtualMemoryMetric : GCMetric
+    {
+        public GCPeakVirtualMemoryMetric()
+            : base("GCPeakVirtualMemory", "Process Peak Virtual Memory", PerformanceMetricUnits.Bytes)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCPeakVirtualMemoryMetricEvaluator(context);
+        }
+    }
+
+    internal class GCPeakVirtualMemoryMetricEvaluator : GCEvaluator
+    {
+        public GCPeakVirtualMemoryMetricEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.PeakVirtualMB * GCMetric.BytesInMegabyte;
+        }
+    }
+    #endregion
+
+    #region Peak Working Set Size
+    internal class GCPeakWorkingSetMetric : GCMetric
+    {
+        public GCPeakWorkingSetMetric()
+            : base("GCPeakWorkingSet", "Process Peak Working Set", PerformanceMetricUnits.Bytes)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCPeakWorkingSetMetricEvaluator(context);
+        }
+    }
+
+    internal class GCPeakWorkingSetMetricEvaluator : GCEvaluator
+    {
+        public GCPeakWorkingSetMetricEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.PeakWorkingSetMB * GCMetric.BytesInMegabyte;
+        }
+    }
+    #endregion
+
+    #region Total Pause Time
+    internal class GCTotalPauseTimeMetric : GCMetric
+    {
+        public GCTotalPauseTimeMetric()
+            : base("GCTotalPauseTime", "Total time spent paused due to GC activity", PerformanceMetricUnits.Milliseconds)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCTotalPauseTimeMetricEvaluator(context);
+        }
+    }
+
+    internal class GCTotalPauseTimeMetricEvaluator : GCEvaluator
+    {
+        public GCTotalPauseTimeMetricEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Total.TotalPauseTimeMSec;
+        }
+    }
+    #endregion
+
+    #region CPU time in GC
+    internal class GCCpuTimeInGCMetric : GCMetric
+    {
+        public GCCpuTimeInGCMetric()
+            : base("GCCpuTimeInGC", "Total CPU time spent in GC activity", PerformanceMetricUnits.Milliseconds)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCCpuTimeInGCMetricEvaluator(context);
+        }
+    }
+
+    internal class GCCpuTimeInGCMetricEvaluator : GCEvaluator
+    {
+        public GCCpuTimeInGCMetricEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Total.TotalGCCpuMSec;
+        }
+    }
+    #endregion
+
+    #region Generation Zero Mean Pause Duration
+    internal class GCGenZeroMeanPauseDuration : GCMetric
+    {
+        public GCGenZeroMeanPauseDuration()
+            : base("GCGenZeroMeanPauseDuration", "Mean pause duration for Gen0 collections", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenZeroMeanPauseDurationEvaluator(context);
+        }
+    }
+
+    internal class GCGenZeroMeanPauseDurationEvaluator : GCEvaluator
+    {
+        public GCGenZeroMeanPauseDurationEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Generations[0].MeanPauseDurationMSec;
+        }
+    }
+    #endregion
+
+    #region Generation One Mean Pause Duration
+    internal class GCGenOneMeanPauseDuration : GCMetric
+    {
+        public GCGenOneMeanPauseDuration()
+            : base("GCGenOneMeanPauseDuration", "Mean pause duration for Gen1 collections", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenOneMeanPauseDurationEvaluator(context);
+        }
+    }
+
+    internal class GCGenOneMeanPauseDurationEvaluator : GCEvaluator
+    {
+        public GCGenOneMeanPauseDurationEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Generations[0].MeanPauseDurationMSec;
+        }
+    }
+    #endregion
+
+    #region Generation Two Mean Pause Duration
+    internal class GCGenTwoMeanPauseDuration : GCMetric
+    {
+        public GCGenTwoMeanPauseDuration()
+            : base("GCGenTwoMeanPauseDuration", "Mean pause duration for Gen2 collections", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenTwoMeanPauseDurationEvaluator(context);
+        }
+    }
+
+    internal class GCGenTwoMeanPauseDurationEvaluator : GCEvaluator
+    {
+        public GCGenTwoMeanPauseDurationEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Generations[2].MeanPauseDurationMSec;
+        }
+    }
+    #endregion
+
+    #region Generation Zero GC Count
+    internal class GCGenZeroCount : GCMetric
+    {
+        public GCGenZeroCount()
+            : base("GCGenZeroCount", "Number of Generation 0 GCs", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenZeroCountEvaluator(context);
+        }
+    }
+
+    internal class GCGenZeroCountEvaluator : GCEvaluator
+    {
+        public GCGenZeroCountEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Generations[0].GCCount;
+        }
+    }
+    #endregion
+
+    #region Generation One GC Count
+    internal class GCGenOneCount : GCMetric
+    {
+        public GCGenOneCount()
+            : base("GCGenOneCount", "Number of Generation 1 GCs", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenOneCountEvaluator(context);
+        }
+    }
+
+    internal class GCGenOneCountEvaluator : GCEvaluator
+    {
+        public GCGenOneCountEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Generations[1].GCCount;
+        }
+    }
+    #endregion
+
+    #region Generation 2 Background GC Count
+    internal class GCGenTwoBGCCount : GCMetric
+    {
+        public GCGenTwoBGCCount()
+            : base("GCGenTwoBGCCount", "Number of Generation 2 background GCs", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenTwoBGCCountEvaluator(context);
+        }
+    }
+
+    internal class GCGenTwoBGCCountEvaluator : GCEvaluator
+    {
+        public GCGenTwoBGCCountEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Events.Count(e => e.Generation == 2 && e.Type == GCType.BackgroundGC);
+        }
+    }
+    #endregion
+
+    #region Generation 2 Blocking GC Count
+    internal class GCGenTwoGCCount : GCMetric
+    {
+        public GCGenTwoGCCount()
+            : base("GCGenTwoGCCount", "Number of Generation 2 blocking GCs", PerformanceMetricUnits.Count)
+        {
+
+        }
+
+        public override PerformanceMetricEvaluator CreateEvaluator(PerformanceMetricEvaluationContext context)
+        {
+            return new GCGenTwoGCCountEvaluator(context);
+        }
+    }
+
+    internal class GCGenTwoGCCountEvaluator : GCEvaluator
+    {
+        public GCGenTwoGCCountEvaluator(PerformanceMetricEvaluationContext context)
+            : base(context)
+        {
+
+        }
+
+        protected override double YieldMetric()
+        {
+            return ProcessInfo.Events.Count(e => e.Generation == 2 && e.Type == GCType.NonConcurrentGC);
+        }
+    }
+    #endregion
+}
+
+#endif

--- a/tests/src/GC/Performance/Framework/PerfTests.cs
+++ b/tests/src/GC/Performance/Framework/PerfTests.cs
@@ -1,0 +1,340 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using GCPerfTestFramework.Metrics;
+using Microsoft.Xunit.Performance;
+using System.Collections.Generic;
+
+[assembly: CollectGCMetrics]
+
+namespace GCPerfTestFramework
+{
+    public class PerfTests
+    {
+        const string ConcurrentGC = "COMPLUS_gcConcurrent";
+        const string ServerGC = "COMPLUS_gcServer";
+
+        [Benchmark]
+        public void ClientSimulator_Concurrent()
+        {
+            var exe = ProcessFactory.ProbeForFile("GCSimulator.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ConcurrentGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "-i 100", env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ClientSimulator_Server()
+        {
+            var exe = ProcessFactory.ProbeForFile("GCSimulator.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "-i 100", env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ClientSimulator_Server_One_Thread()
+        {
+            var exe = ProcessFactory.ProbeForFile("GCSimulator.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "-i 10 -notimer -dp 0.0", env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ClientSimulator_Server_Two_Threads()
+        {
+            var exe = ProcessFactory.ProbeForFile("GCSimulator.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "-i 10 -notimer -dp 0.0 -t 2", env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ClientSimulator_Server_Four_Threads()
+        {
+            var exe = ProcessFactory.ProbeForFile("GCSimulator.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "-i 10 -notimer -dp 0.0 -t 4", env);
+                }
+            }
+        }
+
+
+        [Benchmark]
+        public void LargeStringConcat()
+        {
+            var exe = ProcessFactory.ProbeForFile("LargeStrings.exe");
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void LargeStringConcat_Server()
+        {
+            var exe = ProcessFactory.ProbeForFile("LargeStrings.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void LargeStringConcat_Workstation()
+        {
+            var exe = ProcessFactory.ProbeForFile("LargeStrings.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "0"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void MidLife_Concurrent()
+        {
+            var exe = ProcessFactory.ProbeForFile("MidLife.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ConcurrentGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void MidLife_Server()
+        {
+            var exe = ProcessFactory.ProbeForFile("MidLife.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void MidLife_Workstation()
+        {
+            var exe = ProcessFactory.ProbeForFile("MidLife.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "0"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ConcurrentSpin()
+        {
+            var exe = ProcessFactory.ProbeForFile("ConcurrentSpin.exe");
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ConcurrentSpin_Server()
+        {
+            var exe = ProcessFactory.ProbeForFile("ConcurrentSpin.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ConcurrentSpin_Server_NonConcurrent()
+        {
+            var exe = ProcessFactory.ProbeForFile("ConcurrentSpin.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1",
+                [ConcurrentGC] = "0"
+            };
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void ConcurrentSpin_Workstation()
+        {
+            var exe = ProcessFactory.ProbeForFile("ConcurrentSpin.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "0",
+            };
+
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void Allocation_Server()
+        {
+            var exe = ProcessFactory.ProbeForFile("Allocation.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1",
+                [ConcurrentGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "5000000000 95000", env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void Allocation_Server_NonConcurrent()
+        {
+            var exe = ProcessFactory.ProbeForFile("Allocation.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1",
+                [ConcurrentGC] = "0"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, "5000000000 95000", env);
+                }
+            }
+        }
+
+
+        [Benchmark]
+        public void EE_GC_Server()
+        {
+            var exe = ProcessFactory.ProbeForFile("EEGC.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "1"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void EE_GC_Workstation()
+        {
+            var exe = ProcessFactory.ProbeForFile("EEGC.exe");
+            var env = new Dictionary<string, string>()
+            {
+                [ServerGC] = "0"
+            };
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                using (iteration.StartMeasurement())
+                {
+                    ProcessFactory.LaunchProcess(exe, environmentVariables: env);
+                }
+            }
+        }
+
+    }
+}

--- a/tests/src/GC/Performance/Framework/ProcessFactory.cs
+++ b/tests/src/GC/Performance/Framework/ProcessFactory.cs
@@ -1,0 +1,256 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+
+namespace GCPerfTestFramework
+{
+    public static class ProcessFactory
+    {
+        const string ProbePathEnvironmentVariable = "GC_PERF_TEST_PROBE_PATH";
+        const string CoreRunProbePathEnvironmentVariable = "GC_PERF_TEST_CORE_RUN_PROBE_PATH";
+        const string UseCoreCLREnvironmentVariable = "GC_PERF_TEST_CORECLR";
+        const string ConcurrentGCVariable = "COMPLUS_gcConcurrent";
+        const string ServerGCVariable = "COMPLUS_gcServer";
+        const string CoreRunName = "CoreRun.exe";
+        const string UnixCoreRunName = "corerun";
+
+        // The default timeout for a test is half an hour. If a test takes that long, it is
+        // definitely not responding.
+        const int DefaultTimeout = 1800000 /* ms */;
+
+        /// <summary>
+        /// Location of the CoreRun hosting process, for use in CoreCLR performance runs
+        /// when the operating system can't launch a managed assembly directly. This runs
+        /// as part of the static constructor and so all tests will fail if CoreRun cannot
+        /// be found.
+        /// </summary>
+        private static string s_coreRun = LocateCoreRun();
+
+        /// <summary>
+        /// Launches a process that is part of a test scenario, waits for it complete, and returns.
+        ///  This API does several things specific to this test framework:
+        /// 
+        ///  1. The fileName argument is absolute, and must be resolved using executable probing:
+        ///     see <see cref="ProbeForFile"/> for more information. The reason why this function does not
+        ///     perform the probing is that this function is invoked while "on the clock" by the benchmarking process
+        ///     and file system probing is costly and only needs to be done once, before the test begins.
+        ///     The general pattern for perf tests is that the test executable is located before beginning the benchmark
+        ///     step to avoid doing file system lookups while on the clock.
+        ///  2. The arguments argument is passed verbatim to the Process that is spawned,
+        ///  3. The passed environment variables are set for the child process, replacing any variables
+        ///     in the existing process. xunit-performance by default turns off ConcurrentGC and ServerGC, 
+        ///     and we need to restore that when our process is completed.
+        ///  4. The timeout parameter controls how long this function will wait once a process is spawned.
+        ///     if the supplied timeout is less than or equal to zero, this function will wait indefinitely for the child process.
+        ///     If a process does timeout, this function throws a <see cref="TimeoutException"/>.
+        /// 
+        /// This method delegates partially to a platform-specific implementation which determines whether or not the operating
+        /// system is capable of executing a managed assembly directly or if a hosting process needs to be used.
+        /// Currently, this means that the executable will be directly executed on Desktop CLR, running on Windows, while
+        /// CoreCLR on any platform will need to invoke a hosting process.
+        /// </summary>
+        /// <param name="fileName">The absolute path to the executable to execute</param>
+        /// <param name="arguments">The arguments to pass to the executable</param>
+        /// <param name="environmentVariables">Any environment variables to pass to the child process</param>
+        /// <param name="timeout">How long to wait, in milliseconds, on the child process. If less than or equal to zero,
+        /// no timeout is used.</param>
+        /// <exception cref="TimeoutException">Thrown if the process takes longer than timout to terminate.</exception>
+        public static void LaunchProcess(
+            string fileName,
+            string arguments = "",
+            IDictionary<string, string> environmentVariables = null,
+            int timeout = DefaultTimeout)
+        {
+            var previousEnvironmentVars = new Dictionary<string, string>();
+
+            if (environmentVariables != null)
+            {
+                foreach (var pair in environmentVariables)
+                {
+                    var replacedValue = Environment.GetEnvironmentVariable(pair.Key);
+                    previousEnvironmentVars.Add(pair.Key, replacedValue);
+                    Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+                }
+            }
+
+            try
+            {
+                Process process;
+
+                // for CoreCLR, we need to launch using the CoreRun hosting process.
+                if (ShouldUseCoreRun())
+                {
+                    process = LaunchProcessCoreClrImpl(fileName, arguments);
+                }
+                else
+                {
+                    process = LaunchProcessDesktopImpl(fileName, arguments);
+                }
+
+                if (timeout > 0)
+                {
+                    // the caller has specified a timeout. Use it.
+                    if (!process.WaitForExit(timeout))
+                    {
+                        process.Kill();
+                        throw new TimeoutException("Process did not complete within the allotted time");
+                    }
+
+                    return;
+                }
+
+                process.WaitForExit();
+            }
+            finally
+            {
+                // Restore the original environment variables
+                if (environmentVariables != null)
+                {
+                    foreach (var pair in previousEnvironmentVars)
+                    {
+                        Environment.SetEnvironmentVariable(pair.Key, pair.Value);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Launches a process directly by allowing the underlying operating system to invoke the managed
+        /// assembly.
+        /// </summary>
+        /// <param name="fileName">The absolute path of the executable to run</param>
+        /// <param name="arguments">The arguments to the target executable</param>
+        private static Process LaunchProcessDesktopImpl(string fileName, string arguments)
+        {
+            var process = new Process();
+            process.StartInfo.FileName = fileName;
+            process.StartInfo.Arguments = arguments;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = false;
+            process.Start();
+            return process;
+        }
+
+        /// <summary>
+        /// Launches a process indirectly by invoking a hosting process that will invoke the given managed assembly.
+        /// This is usually called "corerun" for CoreCLR.
+        /// </summary>
+        /// <param name="fileName">The absolute path of the executable to run</param>
+        /// <param name="arguments">The arguments to the target executable</param>
+        private static Process LaunchProcessCoreClrImpl(string fileName, string arguments)
+        {
+            var process = new Process();
+            process.StartInfo.FileName = s_coreRun;
+            process.StartInfo.Arguments = fileName + " " + arguments;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = false;
+            process.Start();
+            return process;
+        }
+
+        /// <summary>
+        /// Locates the CoreRun executable based on the probe path given in the CoreRunProbePathEnvironmentVariable
+        /// environment variable.
+        /// </summary>
+        /// <returns>The located path of CoreRun.exe</returns>
+        /// <exception cref="InvalidOperationException">If CoreRun.exe cannot be found on the given path.</exception>
+        private static string LocateCoreRun()
+        {
+            if (!ShouldUseCoreRun())
+            {
+                // no need to locate CoreRun if it won't be used.
+                return string.Empty;
+            }
+
+            var coreRunProbePath = Environment.GetEnvironmentVariable(CoreRunProbePathEnvironmentVariable);
+            if (coreRunProbePath == null)
+            {
+                throw new InvalidOperationException($"Environment variable {CoreRunProbePathEnvironmentVariable} must be set for CoreCLR performance runs!");
+            }
+
+            var path = ProbeForFileImpl(CoreRunName, coreRunProbePath);
+
+#if !WINDOWS
+            // CoreRun.exe may not have the .exe extension on non-Windows platforms.
+            if (path == null)
+            {
+                path = ProbeForFileImpl(UnixCoreRunName, coreRunProbePath);
+            }
+#endif
+
+            if (path == null)
+            {
+                throw new InvalidOperationException($"Failed to locate {CoreRunName} on search path {coreRunProbePath}");
+            }
+
+            return path;
+        }
+
+        private static bool ShouldUseCoreRun()
+        {
+#if WINDOWS
+            return Environment.GetEnvironmentVariable(UseCoreCLREnvironmentVariable) == "1";
+#else
+            return true;
+#endif
+        }
+
+        /// <summary>
+        /// Probes for a file named fileName starting recursively from the directory named in the ProbePathEnvironmentVariable.
+        /// </summary>
+        /// <param name="fileName">The filename to probe for</param>
+        /// <returns>An absolute path to the located file</returns>
+        /// <exception cref="InvalidOperationException">
+        /// If the probe path environment variable is not set, or the named file cannot be found
+        /// in the probe path.
+        /// </exception>
+        public static string ProbeForFile(string fileName)
+        {
+            var probePath = Environment.GetEnvironmentVariable(ProbePathEnvironmentVariable);
+            if (probePath == null)
+            {
+                throw new InvalidOperationException($"Environment variable {ProbePathEnvironmentVariable} must be set!");
+            }
+
+            var path = ProbeForFileImpl(fileName, probePath);
+            if (path == null)
+            {
+                throw new InvalidOperationException($"Failed to locate file \"{ fileName }\" on path \"{probePath}\"");
+            }
+
+            return path;
+        }
+
+        /// <summary>
+        /// Starting at probePath, probe all files in that directory and all directories
+        /// recursively for a file named fileName. The filename equality check is case-insensitive.
+        /// </summary>
+        /// <param name="fileName">The name of the file to search for</param>
+        /// <param name="probePath">The directory to start the recursive search</param>
+        /// <returns>An absolute path to the file if found, or null if the file is not found.</returns>
+        private static string ProbeForFileImpl(string fileName, string probePath)
+        {
+            // probe from the top down - we don't want to waste lots of time doing a bottom up
+            // search in a deep directory tree if the files we are looking for are at the top-level.
+            foreach (var file in Directory.EnumerateFiles(probePath))
+            {
+                if (StringComparer.OrdinalIgnoreCase.Equals(Path.GetFileName(file), fileName))
+                {
+                    return file;
+                }
+            }
+
+            foreach (var directory in Directory.EnumerateDirectories(probePath))
+            {
+                var result = ProbeForFileImpl(fileName, directory);
+                if (result != null) return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/tests/src/GC/Performance/Framework/project.json
+++ b/tests/src/GC/Performance/Framework/project.json
@@ -1,0 +1,49 @@
+﻿{
+  "version": "1.0.0-*",
+  "description": "GCPerfTestFramework Class Library",
+  "authors": [ "segilles" ],
+  "tags": [ "" ],
+  "projectUrl": "",
+  "licenseUrl": "",
+
+  "dependencies": {
+    "xunit": "2.1.0",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0027"
+  },
+
+  "frameworks": {
+    "dnxcore5": {
+      "compilationOptions": {
+        "warningsAsErrors": true
+      },
+      "dependencies": {
+        "System.Diagnostics.Process": "4.0.0-beta-23302",
+        "System.IO": "4.0.10-beta-23302",
+        "System.IO.FileSystem": "4.0.0-beta-23302",
+        "System.IO.FileSystem.Primitives": "4.0.0-beta-23302",
+        "System.Runtime": "4.0.20-beta-23302",
+        "System.Runtime.Extensions": "4.0.10-beta-23302",
+        "System.Runtime.Handles": "4.0.0-beta-23302",
+        "System.Runtime.Loader": "4.0.0-beta-23302",
+        "System.Threading": "4.0.10-beta-23302",
+        "System.Globalization.Calendars": "4.0.0-beta-23302",
+        "System.Globalization": "4.0.10-beta-23302",
+        "System.Text.Encoding": "4.0.10-beta-23302",
+        "System.Runtime.InteropServices": "4.0.20-beta-23302",
+        "System.Collections": "4.0.10-beta-23302",
+        "System.Console": "4.0.0-beta-23302",
+        "System.Reflection": "4.0.10-beta-23302",
+        "System.Reflection.Primitives": "4.0.0-beta-23302",
+        "System.ComponentModel": "4.0.1-beta-23302",
+        "System.Xml.ReaderWriter": "4.0.11-beta-23302",
+        "System.Collections.NonGeneric": "4.0.1-beta-23302",
+        "System.Collections.Specialized": "4.0.1-beta-23302",
+        "System.Linq": "4.0.1-beta-23302",
+        "System.Linq.Queryable": "4.0.1-beta-23302",
+        "System.Xml.XmlSerializer": "4.0.11-beta-23302",
+        "System.Xml.XmlDocument": "4.0.1-beta-23302",
+        "System.Xml.XDocument": "4.0.11-beta-23302"
+      }
+    }
+  }
+}

--- a/tests/src/GC/Performance/Framework/project.lock.json
+++ b/tests/src/GC/Performance/Framework/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
@@ -33,13 +33,35 @@
           "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
-        "type": "package"
-      },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
+      "Microsoft.Win32.Primitives/4.0.0": {
         "type": "package",
         "dependencies": {
-          "xunit.runner.console": "2.1.0"
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -54,34 +76,71 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10": {
+      "System.Collections.NonGeneric/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Console.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -94,6 +153,48 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Process/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23302",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23302",
+          "System.Threading.ThreadPool": "4.0.10-beta-23302"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
@@ -118,6 +219,35 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -170,7 +300,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0": {
+      "System.Linq/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -186,43 +316,48 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.0": {
+      "System.Linq.Expressions/4.0.10": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
           "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23516": {
+      "System.Linq.Queryable/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Globalization": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.4/System.Numerics.Vectors.dll": {}
+          "ref/dotnet/System.Linq.Queryable.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
+          "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
       "System.ObjectModel/4.0.0": {
@@ -234,7 +369,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23127": {
+      "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -255,6 +390,36 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -282,6 +447,19 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
       "System.Resources.ResourceManager/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -296,10 +474,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23127": {
+      "System.Runtime/4.0.20": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23127"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -308,10 +486,10 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "System.Runtime.Extensions/4.0.10": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23127"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -347,15 +525,18 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.WindowsRuntime/4.0.0": {
+      "System.Runtime.Loader/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.WindowsRuntime.dll": {}
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -438,7 +619,32 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10": {
+      "System.Threading.Thread/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -463,11 +669,12 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.10": {
+      "System.Xml.XDocument/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Reflection": "4.0.10",
@@ -483,6 +690,54 @@
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -521,33 +776,6 @@
         },
         "runtime": {
           "lib/dotnet/xunit.assert.dll": {}
-        }
-      },
-      "xunit.console.netcore/1.0.2-prerelease-00128": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.10",
-          "System.Console": "4.0.0-beta-23213",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.XDocument": "4.0.10",
-          "xunit.runner.utility": "2.1.0"
-        },
-        "compile": {
-          "lib/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/dnxcore50/_._": {}
         }
       },
       "xunit.core/2.1.0": {
@@ -605,33 +833,6 @@
         },
         "runtime": {
           "lib/dotnet/xunit.execution.dotnet.dll": {}
-        }
-      },
-      "xunit.runner.console/2.1.0": {
-        "type": "package"
-      },
-      "xunit.runner.utility/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
         }
       }
     },
@@ -666,33 +867,35 @@
           "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
-        "type": "package"
-      },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
+      "Microsoft.Win32.Primitives/4.0.0": {
         "type": "package",
         "dependencies": {
-          "xunit.runner.console": "2.1.0"
-        }
-      },
-      "runtime.win7.System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10"
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/_._": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -707,34 +910,71 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10": {
+      "System.Collections.NonGeneric/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Console.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -747,6 +987,48 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Process/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23302",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23302",
+          "System.Threading.ThreadPool": "4.0.10-beta-23302"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
@@ -771,6 +1053,35 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -823,7 +1134,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0": {
+      "System.Linq/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -839,43 +1150,48 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.0": {
+      "System.Linq.Expressions/4.0.10": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
           "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23516": {
+      "System.Linq.Queryable/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Globalization": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.4/System.Numerics.Vectors.dll": {}
+          "ref/dotnet/System.Linq.Queryable.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
+          "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
       "System.ObjectModel/4.0.0": {
@@ -887,7 +1203,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23127": {
+      "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -908,6 +1224,51 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -935,6 +1296,19 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
       "System.Resources.ResourceManager/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -949,10 +1323,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23127": {
+      "System.Runtime/4.0.20": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23127"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -961,10 +1335,10 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "System.Runtime.Extensions/4.0.10": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23127"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -1000,15 +1374,18 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.WindowsRuntime/4.0.0": {
+      "System.Runtime.Loader/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.WindowsRuntime.dll": {}
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1091,7 +1468,32 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10": {
+      "System.Threading.Thread/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1116,11 +1518,12 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.10": {
+      "System.Xml.XDocument/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Reflection": "4.0.10",
@@ -1136,6 +1539,54 @@
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -1174,36 +1625,6 @@
         },
         "runtime": {
           "lib/dotnet/xunit.assert.dll": {}
-        }
-      },
-      "xunit.console.netcore/1.0.2-prerelease-00128": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.10",
-          "System.Console": "4.0.0-beta-23213",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.XDocument": "4.0.10",
-          "xunit.runner.utility": "2.1.0"
-        },
-        "compile": {
-          "lib/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/dnxcore50/_._": {}
-        },
-        "native": {
-          "runtimes/any/native/xunit.console.netcore.exe": {}
         }
       },
       "xunit.core/2.1.0": {
@@ -1261,33 +1682,6 @@
         },
         "runtime": {
           "lib/dotnet/xunit.execution.dotnet.dll": {}
-        }
-      },
-      "xunit.runner.console/2.1.0": {
-        "type": "package"
-      },
-      "xunit.runner.utility/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
         }
       }
     },
@@ -1322,33 +1716,35 @@
           "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
         }
       },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
-        "type": "package"
-      },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
+      "Microsoft.Win32.Primitives/4.0.0": {
         "type": "package",
         "dependencies": {
-          "xunit.runner.console": "2.1.0"
-        }
-      },
-      "runtime.win7.System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10"
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/_._": {}
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -1363,34 +1759,71 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10": {
+      "System.Collections.NonGeneric/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Console.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -1403,6 +1836,48 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Process/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23302",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23302",
+          "System.Threading.ThreadPool": "4.0.10-beta-23302"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Diagnostics.Tracing/4.0.20": {
@@ -1427,6 +1902,35 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -1479,7 +1983,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0": {
+      "System.Linq/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1495,43 +1999,48 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.0": {
+      "System.Linq.Expressions/4.0.10": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
           "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23516": {
+      "System.Linq.Queryable/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Globalization": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.4/System.Numerics.Vectors.dll": {}
+          "ref/dotnet/System.Linq.Queryable.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
+          "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
       "System.ObjectModel/4.0.0": {
@@ -1543,7 +2052,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23127": {
+      "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1564,6 +2073,51 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -1591,6 +2145,19 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
       "System.Resources.ResourceManager/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -1605,10 +2172,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23127": {
+      "System.Runtime/4.0.20": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23127"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -1617,10 +2184,10 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "System.Runtime.Extensions/4.0.10": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23127"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -1656,15 +2223,18 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.WindowsRuntime/4.0.0": {
+      "System.Runtime.Loader/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.WindowsRuntime.dll": {}
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1747,7 +2317,32 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10": {
+      "System.Threading.Thread/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1772,11 +2367,12 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.10": {
+      "System.Xml.XDocument/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Reflection": "4.0.10",
@@ -1792,6 +2388,54 @@
         },
         "runtime": {
           "lib/dotnet/System.Xml.XDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlDocument/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -1830,36 +2474,6 @@
         },
         "runtime": {
           "lib/dotnet/xunit.assert.dll": {}
-        }
-      },
-      "xunit.console.netcore/1.0.2-prerelease-00128": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.10",
-          "System.Console": "4.0.0-beta-23213",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.XDocument": "4.0.10",
-          "xunit.runner.utility": "2.1.0"
-        },
-        "compile": {
-          "lib/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/dnxcore50/_._": {}
-        },
-        "native": {
-          "runtimes/any/native/xunit.console.netcore.exe": {}
         }
       },
       "xunit.core/2.1.0": {
@@ -1918,33 +2532,6 @@
         "runtime": {
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
-      },
-      "xunit.runner.console/2.1.0": {
-        "type": "package"
-      },
-      "xunit.runner.utility/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        }
       }
     }
   },
@@ -1968,62 +2555,50 @@
         "Microsoft.DotNet.xunit.performance.nuspec"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
+    "Microsoft.Win32.Primitives/4.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "w/6R/4EBbESpNYyPgp7TDNISOvj8ucrv5FN9X3defsgD1ZAO+4Z+fu9DCZWd78+A0MEQPGIaCKssLgGlzQf6xw==",
+      "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0027.nupkg",
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0027.nupkg.sha512",
-        "Microsoft.DotNet.xunit.performance.analysis.nuspec",
-        "tools/MathNet.Numerics.dll",
-        "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
-        "tools/xunit.performance.analysis.exe",
-        "tools/xunit.performance.analysis.exe.config",
-        "tools/xunit.performance.analysis.pdb"
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "Microsoft.Win32.Primitives.4.0.0.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
+    "Microsoft.Win32.Registry/4.0.0-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CMFSRSg26B7Z1dB3IUppS2Ry1aLiCcwyVvK2+BjR0hEIYQ8+PcyhAmnSUxQhKMJ/80ho0HdXhxWbKFB/XmgTWg==",
+      "sha512": "63Vc0lDW+pMCSd6ygScz/XTiJE3Ou5Sr7yrZ0HE/Ym/Bi/mN0LMAJqUtAUSJxVBuqbozW/q39RpNLIZ+QlJvig==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0027.nupkg",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0027.nupkg.sha512",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.nuspec",
-        "tools/amd64/KernelTraceControl.dll",
-        "tools/amd64/msdia140.dll",
-        "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
-        "tools/ProcDomain.dll",
-        "tools/ProcDomain.pdb",
-        "tools/x86/KernelTraceControl.dll",
-        "tools/x86/msdia140.dll",
-        "tools/xunit.abstractions.dll",
-        "tools/xunit.core.dll",
-        "tools/xunit.performance.core.dll",
-        "tools/xunit.performance.core.pdb",
-        "tools/xunit.performance.logger.exe",
-        "tools/xunit.performance.logger.pdb",
-        "tools/xunit.performance.metrics.dll",
-        "tools/xunit.performance.metrics.pdb",
-        "tools/xunit.performance.run.exe",
-        "tools/xunit.performance.run.exe.config",
-        "tools/xunit.performance.run.pdb",
-        "tools/xunit.runner.utility.desktop.dll",
-        "tools/xunit.runner.utility.desktop.pdb"
-      ]
-    },
-    "runtime.win7.System.Console/4.0.0-beta-23516": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "TJZhrw44Bf7sYqne+CX5II/PaNf5L7oKVfl0FLkr4pj76KS8hSsJzsKL0IvxC+bi4d51+wTbv91kF1kgPyHMVw==",
-      "files": [
-        "ref/dotnet/_._",
-        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg",
-        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg.sha512",
-        "runtime.win7.System.Console.nuspec",
-        "runtimes/win7/lib/dotnet5.4/System.Console.dll",
-        "runtimes/win7/lib/net/_._"
+        "lib/DNXCore50/Microsoft.Win32.Registry.dll",
+        "lib/net46/Microsoft.Win32.Registry.dll",
+        "Microsoft.Win32.Registry.4.0.0-beta-23302.nupkg",
+        "Microsoft.Win32.Registry.4.0.0-beta-23302.nupkg.sha512",
+        "Microsoft.Win32.Registry.nuspec",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.Collections/4.0.10": {
@@ -2060,67 +2635,91 @@
         "System.Collections.nuspec"
       ]
     },
-    "System.Collections.Concurrent/4.0.10": {
+    "System.Collections.NonGeneric/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
+      "sha512": "pSTpxEZ8/VRqmMnAP4Nfs7pdC8JpggNdnfGD225uIeEdNnc4m6xu3guu4BrFD3qrrBY1qSZCuNyY4DNJgq877A==",
       "files": [
-        "lib/dotnet/System.Collections.Concurrent.dll",
+        "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net46/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
-        "ref/dotnet/fr/System.Collections.Concurrent.xml",
-        "ref/dotnet/it/System.Collections.Concurrent.xml",
-        "ref/dotnet/ja/System.Collections.Concurrent.xml",
-        "ref/dotnet/ko/System.Collections.Concurrent.xml",
-        "ref/dotnet/ru/System.Collections.Concurrent.xml",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net46/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.4.0.10.nupkg",
-        "System.Collections.Concurrent.4.0.10.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec"
+        "System.Collections.NonGeneric.4.0.1-beta-23302.nupkg",
+        "System.Collections.NonGeneric.4.0.1-beta-23302.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23516": {
+    "System.Collections.Specialized/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tzF4Dbbv+5bcbQ7GHuuKafkaDZThiUiwxqCc1ngewnMWZ5YmIgjQZjs+E1DNhoMVAvkH0tSmLJvsDlx9dFg+Aw==",
+      "sha512": "v1eYdfSH6ttx2QYSbvArTqlumBamCij2R8iNtdA2tBq0QmWseW5Nc+H3Ut1JHa9T1q3jWuk0NR95zMBwty3Q+Q==",
       "files": [
+        "lib/dotnet/System.Collections.Specialized.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.Specialized.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.Specialized.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.Specialized.4.0.1-beta-23302.nupkg",
+        "System.Collections.Specialized.4.0.1-beta-23302.nupkg.sha512",
+        "System.Collections.Specialized.nuspec"
+      ]
+    },
+    "System.ComponentModel/4.0.1-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Ju+nhdZ8gMwZAXRIr/ACoME9I9SpxeS+Xw4Bouok4xTvbbwkjlT55Mr9gybqcGMp4F/hzS55RnQDIiRN70fEdg==",
+      "files": [
+        "lib/dotnet/System.ComponentModel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ComponentModel.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.ComponentModel.4.0.1-beta-23302.nupkg",
+        "System.ComponentModel.4.0.1-beta-23302.nupkg.sha512",
+        "System.ComponentModel.nuspec"
+      ]
+    },
+    "System.Console/4.0.0-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "rpWEkJWW29TjVZdDz5zr8VnBv4IN9BQHmP4Ky9tEbvkdhkJRb0ZO59acXMpVD1tSM2VhGlLnq0kpdjOLNmejNA==",
+      "files": [
+        "lib/DNXCore50/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Console.xml",
-        "ref/dotnet5.1/es/System.Console.xml",
-        "ref/dotnet5.1/fr/System.Console.xml",
-        "ref/dotnet5.1/it/System.Console.xml",
-        "ref/dotnet5.1/ja/System.Console.xml",
-        "ref/dotnet5.1/ko/System.Console.xml",
-        "ref/dotnet5.1/ru/System.Console.xml",
-        "ref/dotnet5.1/System.Console.dll",
-        "ref/dotnet5.1/System.Console.xml",
-        "ref/dotnet5.1/zh-hans/System.Console.xml",
-        "ref/dotnet5.1/zh-hant/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Console.4.0.0-beta-23516.nupkg",
-        "System.Console.4.0.0-beta-23516.nupkg.sha512",
+        "System.Console.4.0.0-beta-23302.nupkg",
+        "System.Console.4.0.0-beta-23302.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -2156,6 +2755,62 @@
         "System.Diagnostics.Debug.4.0.10.nupkg",
         "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Diagnostics.Process/4.0.0-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "FtflxzCJUdgw+4suLaWz82EOLxVa7X6DWbY4eSRIomDlMwYrsof8Ewz81XhKMWY0EOY/5Nx+r/oPTbFUECAiUg==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Process.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Diagnostics.Process.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Diagnostics.Process.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Diagnostics.Process.4.0.0-beta-23302.nupkg",
+        "System.Diagnostics.Process.4.0.0-beta-23302.nupkg.sha512",
+        "System.Diagnostics.Process.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tools.xml",
+        "ref/dotnet/it/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.4.0.0.nupkg",
+        "System.Diagnostics.Tools.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Diagnostics.Tracing/4.0.20": {
@@ -2223,6 +2878,71 @@
         "System.Globalization.4.0.10.nupkg",
         "System.Globalization.4.0.10.nupkg.sha512",
         "System.Globalization.nuspec"
+      ]
+    },
+    "System.Globalization.Calendars/4.0.0": {
+      "type": "package",
+      "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.Calendars.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
+        "ref/dotnet/fr/System.Globalization.Calendars.xml",
+        "ref/dotnet/it/System.Globalization.Calendars.xml",
+        "ref/dotnet/ja/System.Globalization.Calendars.xml",
+        "ref/dotnet/ko/System.Globalization.Calendars.xml",
+        "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.4.0.0.nupkg",
+        "System.Globalization.Calendars.4.0.0.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec"
+      ]
+    },
+    "System.Globalization.Extensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
+      "files": [
+        "lib/dotnet/System.Globalization.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
+        "ref/dotnet/fr/System.Globalization.Extensions.xml",
+        "ref/dotnet/it/System.Globalization.Extensions.xml",
+        "ref/dotnet/ja/System.Globalization.Extensions.xml",
+        "ref/dotnet/ko/System.Globalization.Extensions.xml",
+        "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Globalization.Extensions.4.0.0.nupkg",
+        "System.Globalization.Extensions.4.0.0.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
@@ -2324,10 +3044,10 @@
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
-    "System.Linq/4.0.0": {
+    "System.Linq/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "sha512": "s6DNPrcinU2thnbDGyYfvK/2B6RXPvIjNyNFCyFDEPpKKb0dlURf/VSX0HQRbaxi0sXuSSrTCHPXhh75jpx3Pw==",
       "files": [
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
@@ -2335,41 +3055,29 @@
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/de/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
-        "ref/dotnet/fr/System.Linq.xml",
-        "ref/dotnet/it/System.Linq.xml",
-        "ref/dotnet/ja/System.Linq.xml",
-        "ref/dotnet/ko/System.Linq.xml",
-        "ref/dotnet/ru/System.Linq.xml",
         "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Linq.dll",
-        "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.4.0.0.nupkg",
-        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.4.0.1-beta-23302.nupkg",
+        "System.Linq.4.0.1-beta-23302.nupkg.sha512",
         "System.Linq.nuspec"
       ]
     },
-    "System.Linq.Expressions/4.0.0": {
+    "System.Linq.Expressions/4.0.10": {
       "type": "package",
-      "sha512": "wlfVllrKi+evu4Hi8yoJP1dSOVXbvsy7Hs1+oz4Cykfdf6MQTPlD3LI4WKWhprn8FpU5MS3spPSbcMX5sAoJSw==",
+      "serviceable": true,
+      "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "files": [
+        "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net45/_._",
-        "lib/win8/_._",
-        "lib/wp80/_._",
-        "lib/wpa81/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "License.rtf",
         "ref/dotnet/de/System.Linq.Expressions.xml",
         "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
@@ -2383,62 +3091,36 @@
         "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net45/_._",
-        "ref/netcore50/de/System.Linq.Expressions.xml",
-        "ref/netcore50/es/System.Linq.Expressions.xml",
-        "ref/netcore50/fr/System.Linq.Expressions.xml",
-        "ref/netcore50/it/System.Linq.Expressions.xml",
-        "ref/netcore50/ja/System.Linq.Expressions.xml",
-        "ref/netcore50/ko/System.Linq.Expressions.xml",
-        "ref/netcore50/ru/System.Linq.Expressions.xml",
-        "ref/netcore50/System.Linq.Expressions.dll",
-        "ref/netcore50/System.Linq.Expressions.xml",
-        "ref/netcore50/zh-hans/System.Linq.Expressions.xml",
-        "ref/netcore50/zh-hant/System.Linq.Expressions.xml",
-        "ref/win8/_._",
-        "ref/wp80/_._",
-        "ref/wpa81/_._",
+        "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Linq.Expressions.4.0.0.nupkg",
-        "System.Linq.Expressions.4.0.0.nupkg.sha512",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.4.0.10.nupkg",
+        "System.Linq.Expressions.4.0.10.nupkg.sha512",
         "System.Linq.Expressions.nuspec"
       ]
     },
-    "System.Numerics.Vectors/4.1.1-beta-23516": {
+    "System.Linq.Queryable/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FCYCEjc3BXBTpVZTxMqf2m/sGYyDzLwICy5lNKgZzT8WfshJhsTGjJuETwsh1Cwi6bksw9YiTB6yeeWBBJDnTA==",
+      "sha512": "DtZNIidKpY95mLklcL4yfLYJCw3cAvfcoLxk8a+BqCAlMWXDmLDz2zizgyPWv2FwIUs7l+Jf9Znvz0yY/ip79Q==",
       "files": [
-        "lib/dotnet5.4/System.Numerics.Vectors.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/_._",
-        "lib/net46/System.Numerics.Vectors.dll",
-        "lib/portable-net45+win8/System.Numerics.Vectors.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Numerics.Vectors.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/_._",
-        "ref/net46/System.Numerics.Vectors.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Numerics.Vectors.4.1.1-beta-23516.nupkg",
-        "System.Numerics.Vectors.4.1.1-beta-23516.nupkg.sha512",
-        "System.Numerics.Vectors.nuspec"
-      ]
-    },
-    "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "raAfPq7NkxI3XPap2aKrlqKpCPE0QTj7gO1Z+yI48ksIK20HSBJei8tim7d99OaqQ1bLkTZ/W/KeYMESURNJ8g==",
-      "files": [
-        "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll",
-        "System.Numerics.Vectors.WindowsRuntime.4.0.1-beta-23516.nupkg",
-        "System.Numerics.Vectors.WindowsRuntime.4.0.1-beta-23516.nupkg.sha512",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec"
+        "lib/dotnet/System.Linq.Queryable.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Queryable.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.Queryable.4.0.1-beta-23302.nupkg",
+        "System.Linq.Queryable.4.0.1-beta-23302.nupkg.sha512",
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.ObjectModel/4.0.0": {
@@ -2489,18 +3171,18 @@
         "System.ObjectModel.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.0-beta-23127": {
+    "System.Private.Uri/4.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KT9JGnTYRf51pwPluZtpewmdBPiROzemamLmpzgzl3Pu3Y0vmH2CBLZktngD4I4YPNFO6ieCupeM0X3R1u26kA==",
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "files": [
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.4.0.0-beta-23127.nupkg",
-        "System.Private.Uri.4.0.0-beta-23127.nupkg.sha512",
+        "System.Private.Uri.4.0.0.nupkg",
+        "System.Private.Uri.4.0.0.nupkg.sha512",
         "System.Private.Uri.nuspec"
       ]
     },
@@ -2535,6 +3217,86 @@
         "System.Reflection.4.0.10.nupkg",
         "System.Reflection.4.0.10.nupkg.sha512",
         "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Emit/4.0.0": {
+      "type": "package",
+      "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.xml",
+        "ref/dotnet/it/System.Reflection.Emit.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/net45/_._",
+        "ref/xamarinmac20/_._",
+        "System.Reflection.Emit.4.0.0.nupkg",
+        "System.Reflection.Emit.4.0.0.nupkg.sha512",
+        "System.Reflection.Emit.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.0": {
+      "type": "package",
+      "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.ILGeneration.4.0.0.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.0.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.Lightweight/4.0.0": {
+      "type": "package",
+      "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.Lightweight.4.0.0.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.0.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
@@ -2605,6 +3367,40 @@
         "System.Reflection.Primitives.nuspec"
       ]
     },
+    "System.Reflection.TypeExtensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec"
+      ]
+    },
     "System.Resources.ResourceManager/4.0.0": {
       "type": "package",
       "serviceable": true,
@@ -2639,10 +3435,10 @@
         "System.Resources.ResourceManager.nuspec"
       ]
     },
-    "System.Runtime/4.0.20-beta-23127": {
+    "System.Runtime/4.0.20": {
       "type": "package",
       "serviceable": true,
-      "sha512": "naLsXkry4PBYCdXLOGx2r9TRuFWJpdZvV7W9rk4QRTPTS7H9911J09o8KXrhX+NW28YVsCgvcw8Wr0JsFEQdLQ==",
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -2668,15 +3464,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.20-beta-23127.nupkg",
-        "System.Runtime.4.0.20-beta-23127.nupkg.sha512",
+        "System.Runtime.4.0.20.nupkg",
+        "System.Runtime.4.0.20.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
-    "System.Runtime.Extensions/4.0.10-beta-23127": {
+    "System.Runtime.Extensions/4.0.10": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YwtpybYxpRqjF+TnBzmNdgGq2jNtEO9MkxYSIMW36lV7F6qEph+nCcKDLsCslgSz7dn44eSCnnsgBQQsF85eQQ==",
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
@@ -2702,8 +3498,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
-        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg",
-        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg.sha512",
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
         "System.Runtime.Extensions.nuspec"
       ]
     },
@@ -2775,42 +3571,16 @@
         "System.Runtime.InteropServices.nuspec"
       ]
     },
-    "System.Runtime.WindowsRuntime/4.0.0": {
+    "System.Runtime.Loader/4.0.0-beta-23302": {
       "type": "package",
-      "sha512": "IvSI0X1wIgQ2yFCXnV0EJc1FFE4xxzSPqX1r6ikhcLPuKmXjBglB0IrJBmWAK8vaPkyjBIwf7ks2VSdFazXwhA==",
+      "serviceable": true,
+      "sha512": "b4NcLjIIX8W3TY3MR8nNp2c+JgZFWcf1Nr5W3FfrM6Takr1BjBsDKv40cqK1yP2UsEnaIjGkAzXOph4fF4I40A==",
       "files": [
-        "lib/win8/_._",
-        "lib/wp80/_._",
-        "lib/wpa81/_._",
-        "License.rtf",
-        "ref/dotnet/de/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/es/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/fr/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/it/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/ja/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/ko/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/ru/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/System.Runtime.WindowsRuntime.dll",
-        "ref/dotnet/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/zh-hans/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/de/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/es/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/fr/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/it/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/ja/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/ko/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/ru/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/System.Runtime.WindowsRuntime.dll",
-        "ref/netcore50/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/zh-hans/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/zh-hant/System.Runtime.WindowsRuntime.xml",
-        "ref/win8/_._",
-        "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.WindowsRuntime.4.0.0.nupkg",
-        "System.Runtime.WindowsRuntime.4.0.0.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.nuspec"
+        "lib/DNXCore50/System.Runtime.Loader.dll",
+        "ref/dotnet/System.Runtime.Loader.dll",
+        "System.Runtime.Loader.4.0.0-beta-23302.nupkg",
+        "System.Runtime.Loader.4.0.0-beta-23302.nupkg.sha512",
+        "System.Runtime.Loader.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
@@ -3004,10 +3774,54 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Xml.ReaderWriter/4.0.10": {
+    "System.Threading.Thread/4.0.0-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
+      "sha512": "0tn5ET6NNDVjJdpacPXM9lwa3tZeKiIYZHOZPtsbORXop84IN93KenlcqEdPizxPsnOAgauVIgeKftnvwcvlsQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Thread.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Thread.4.0.0-beta-23302.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23302.nupkg.sha512",
+        "System.Threading.Thread.nuspec"
+      ]
+    },
+    "System.Threading.ThreadPool/4.0.10-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "dwwA7ce4yVXenjpJU20JyNn3zrXsWWkbw9UMNK49C09D7tmrYLSxzWSzY7/4034okFcOjQmtP5g36ZRZANZL9A==",
+      "files": [
+        "lib/DNXCore50/System.Threading.ThreadPool.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.ThreadPool.4.0.10-beta-23302.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23302.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.11-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "z9D4/CQ9FytubW6CuTFkv7nb9jPHEvTlOUCXD83oEh5gYfw6RfRJGVPpqY+eJLQOqnBS0wgCPck3zNKEWGCFEA==",
       "files": [
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
@@ -3015,31 +3829,21 @@
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/it/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
         "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.4.0.10.nupkg",
-        "System.Xml.ReaderWriter.4.0.10.nupkg.sha512",
+        "System.Xml.ReaderWriter.4.0.11-beta-23302.nupkg",
+        "System.Xml.ReaderWriter.4.0.11-beta-23302.nupkg.sha512",
         "System.Xml.ReaderWriter.nuspec"
       ]
     },
-    "System.Xml.XDocument/4.0.10": {
+    "System.Xml.XDocument/4.0.11-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
+      "sha512": "ugSaPpuT0ImDyfbRtUdsBd6PMWaTYGbeRg1jO6/2tW0cBYIUU5h9496L2Pjm4l6UYa4v2G1+IH1CE/a19D+qSQ==",
       "files": [
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
@@ -3047,25 +3851,62 @@
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
-        "ref/dotnet/fr/System.Xml.XDocument.xml",
-        "ref/dotnet/it/System.Xml.XDocument.xml",
-        "ref/dotnet/ja/System.Xml.XDocument.xml",
-        "ref/dotnet/ko/System.Xml.XDocument.xml",
-        "ref/dotnet/ru/System.Xml.XDocument.xml",
         "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.XDocument.4.0.10.nupkg",
-        "System.Xml.XDocument.4.0.10.nupkg.sha512",
+        "System.Xml.XDocument.4.0.11-beta-23302.nupkg",
+        "System.Xml.XDocument.4.0.11-beta-23302.nupkg.sha512",
         "System.Xml.XDocument.nuspec"
+      ]
+    },
+    "System.Xml.XmlDocument/4.0.1-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "cv14snu2E01I+Ar4Kb8bNfPLdh3+OZDnJArvaRWzdpM1XAnY5SwrsbZLEOE6h6wAIFp3aefU8IbcbnXOMRATlQ==",
+      "files": [
+        "lib/dotnet/System.Xml.XmlDocument.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Xml.XmlDocument.4.0.1-beta-23302.nupkg",
+        "System.Xml.XmlDocument.4.0.1-beta-23302.nupkg.sha512",
+        "System.Xml.XmlDocument.nuspec"
+      ]
+    },
+    "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "aLVJmiBKKGhPYAa3zaojjowvsNuFA5hBmDC6aN8Iv+UAr0WIIPOFy9ASp8oTx6VQ7kEhjxCQXC+pWU21597wXA==",
+      "files": [
+        "lib/DNXCore50/System.Xml.XmlSerializer.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Xml.XmlSerializer.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "System.Xml.XmlSerializer.4.0.11-beta-23302.nupkg",
+        "System.Xml.XmlSerializer.4.0.11-beta-23302.nupkg.sha512",
+        "System.Xml.XmlSerializer.nuspec"
       ]
     },
     "xunit/2.1.0": {
@@ -3103,19 +3944,6 @@
         "xunit.assert.2.1.0.nupkg",
         "xunit.assert.2.1.0.nupkg.sha512",
         "xunit.assert.nuspec"
-      ]
-    },
-    "xunit.console.netcore/1.0.2-prerelease-00128": {
-      "type": "package",
-      "sha512": "GAyZZAl3u4QzI1kJI/zqXDcWoiJz/3ryPNwM1o2JZyNpn5TmKDqEkrXUnmVoBoICYwh5OGebcBwXStr8cPBeDQ==",
-      "files": [
-        "lib/aspnetcore50/xunit.console.netcore.exe",
-        "lib/dnxcore50/_._",
-        "lib/dotnet/_._",
-        "runtimes/any/native/xunit.console.netcore.exe",
-        "xunit.console.netcore.1.0.2-prerelease-00128.nupkg",
-        "xunit.console.netcore.1.0.2-prerelease-00128.nupkg.sha512",
-        "xunit.console.netcore.nuspec"
       ]
     },
     "xunit.core/2.1.0": {
@@ -3197,62 +4025,40 @@
         "xunit.extensibility.execution.2.1.0.nupkg.sha512",
         "xunit.extensibility.execution.nuspec"
       ]
-    },
-    "xunit.runner.console/2.1.0": {
-      "type": "package",
-      "sha512": "dryP6nBDWD2aH6OUidwoPQLebelnfA6DDKUs9PxJ6iPDbT9t5eSKyjqLSas/nQFEJZwXXWVnbImrgK/IgiyOdQ==",
-      "files": [
-        "tools/HTML.xslt",
-        "tools/NUnitXml.xslt",
-        "tools/xunit.abstractions.dll",
-        "tools/xunit.console.exe",
-        "tools/xunit.console.exe.config",
-        "tools/xunit.console.x86.exe",
-        "tools/xunit.console.x86.exe.config",
-        "tools/xunit.runner.reporters.desktop.dll",
-        "tools/xunit.runner.utility.desktop.dll",
-        "tools/xUnit1.xslt",
-        "xunit.runner.console.2.1.0.nupkg",
-        "xunit.runner.console.2.1.0.nupkg.sha512",
-        "xunit.runner.console.nuspec"
-      ]
-    },
-    "xunit.runner.utility/2.1.0": {
-      "type": "package",
-      "sha512": "jJJHROwskIhdQuYw7exe7KaW20dOCa+lzV/lY7Zdh1ZZzdUPpScMi9ReJIutqiyjhemGF8V/GaMIPrcjyZ4ioQ==",
-      "files": [
-        "lib/dnx451/xunit.runner.utility.dotnet.dll",
-        "lib/dnx451/xunit.runner.utility.dotnet.pdb",
-        "lib/dnx451/xunit.runner.utility.dotnet.xml",
-        "lib/dotnet/xunit.runner.utility.dotnet.dll",
-        "lib/dotnet/xunit.runner.utility.dotnet.pdb",
-        "lib/dotnet/xunit.runner.utility.dotnet.xml",
-        "lib/net35/xunit.runner.utility.desktop.dll",
-        "lib/net35/xunit.runner.utility.desktop.pdb",
-        "lib/net35/xunit.runner.utility.desktop.xml",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.dotnet.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.dotnet.pdb",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.dotnet.xml",
-        "xunit.runner.utility.2.1.0.nupkg",
-        "xunit.runner.utility.2.1.0.nupkg.sha512",
-        "xunit.runner.utility.nuspec"
-      ]
     }
   },
   "projectFileDependencyGroups": {
     "": [
-      "Microsoft.DotNet.xunit.performance >= 1.0.0-alpha-build0027",
-      "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0027",
-      "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0027",
-      "System.Console >= 4.0.0-beta-*",
-      "System.Runtime >= 4.0.20-beta-*",
-      "System.Runtime.Extensions >= 4.0.10-beta-*",
-      "System.Numerics.Vectors >= 4.1.1-beta-*",
-      "System.Numerics.Vectors.WindowsRuntime >= 4.0.1-beta-*",
       "xunit >= 2.1.0",
-      "xunit.console.netcore >= 1.0.2-prerelease-00128",
-      "xunit.runner.utility >= 2.1.0"
+      "Microsoft.DotNet.xunit.performance >= 1.0.0-alpha-build0027"
     ],
-    "DNXCore,Version=v5.0": []
+    "DNXCore,Version=v5.0": [
+      "System.Diagnostics.Process >= 4.0.0-beta-23302",
+      "System.IO >= 4.0.10-beta-23302",
+      "System.IO.FileSystem >= 4.0.0-beta-23302",
+      "System.IO.FileSystem.Primitives >= 4.0.0-beta-23302",
+      "System.Runtime >= 4.0.20-beta-23302",
+      "System.Runtime.Extensions >= 4.0.10-beta-23302",
+      "System.Runtime.Handles >= 4.0.0-beta-23302",
+      "System.Runtime.Loader >= 4.0.0-beta-23302",
+      "System.Threading >= 4.0.10-beta-23302",
+      "System.Globalization.Calendars >= 4.0.0-beta-23302",
+      "System.Globalization >= 4.0.10-beta-23302",
+      "System.Text.Encoding >= 4.0.10-beta-23302",
+      "System.Runtime.InteropServices >= 4.0.20-beta-23302",
+      "System.Collections >= 4.0.10-beta-23302",
+      "System.Console >= 4.0.0-beta-23302",
+      "System.Reflection >= 4.0.10-beta-23302",
+      "System.Reflection.Primitives >= 4.0.0-beta-23302",
+      "System.ComponentModel >= 4.0.1-beta-23302",
+      "System.Xml.ReaderWriter >= 4.0.11-beta-23302",
+      "System.Collections.NonGeneric >= 4.0.1-beta-23302",
+      "System.Collections.Specialized >= 4.0.1-beta-23302",
+      "System.Linq >= 4.0.1-beta-23302",
+      "System.Linq.Queryable >= 4.0.1-beta-23302",
+      "System.Xml.XmlSerializer >= 4.0.11-beta-23302",
+      "System.Xml.XmlDocument >= 4.0.1-beta-23302",
+      "System.Xml.XDocument >= 4.0.11-beta-23302"
+    ]
   }
 }

--- a/tests/src/GC/Performance/README.md
+++ b/tests/src/GC/Performance/README.md
@@ -1,0 +1,106 @@
+# CLR Garbage Collector Performance Tests
+This folder houses both the test framework and test artifacts for performance tests
+targeting the garbage collector. These tests are run using the 
+[xunit-performance](https://github.com/Microsoft/xunit-performance) performance testing
+framework and can be used with the standard tools provided by that repository.
+
+The performance tests themselves, as defined in the `Framework` folder in `PerfTests.cs`,
+all invoke one of the test artifacts (as defined in the `Tests` assembly) and collects the duration
+in which the child process runs, as well as a number of other metrics on Windows platforms.
+
+## Building the test framework
+The test framework currently does not build as part of the CoreCLR test build. The framework
+builds using the `dnu` build tool in order to target both DNX46 (Desktop) or DNXCORE5 (CoreCLR)
+depending on the platform on which the tests are to be invoked.
+
+The Desktop (DNX46) target of the test framework contains a number of custom metrics that are given
+to `xunit.performance` to evaluate the test run. These metrics provide a number of interesting
+statistics about the performance of the GC, like the duration of the longest pause, the average pause
+durations, and number of garbage collections for each generation.
+
+The CoreCLR (DNXCORE5) target of the test framework consists only of the tests themselves and not
+the metrics. This is because metric definitions have a dependency on TraceEvent, which is itself
+not available currently on CoreCLR.
+
+## Running the tests on Windows
+Since the Desktop CLR is already installed on Windows machines, we can use the host CLR to
+invoke the `xunit.performance.run` test runner, even if we are testing CoreCLR.
+
+Regardless of whether or not we are testing the Desktop CLR or CoreCLR, we need to copy all of our
+test dependencies to the same location, some sort of scratch folder:
+
+```
+mkdir sandbox
+pushd sandbox
+
+REM Get the xunit-performance console runner
+xcopy /s C:\<path_to_your_coreclr>\coreclr\tests\packages\Microsoft.DotNet.xunit.performance.runner.Windows\1.0.0-alpha-build0025\tools\* .
+
+REM Get the xunit-performance analysis engine
+xcopy /sy C:\<path_to_your_coreclr>\coreclr\tests\packages\Microsoft.DotNet.xunit.performance.analysis\1.0.0-alpha-build0025\tools\* .
+
+REM Get the xunit console runner
+xcopy /sy C:\<path_to_your_coreclr>\coreclr\tests\packages\xunit.console.netcore\1.0.2-prerelease-00128\runtimes\any\native\* .
+
+REM Get the test executables' dependencies
+xcopy /sy C:\<path_to_your_coreclr>\coreclr\bin\tests\Windows_NT.x64.Release\Tests\Core_Root\* .
+
+REM Get the test executables themselves
+for /r C:\<path_to_your_coreclr>\coreclr\bin\tests\Windows_NT.x64.Release\GC\Performance\Tests\ %ff in (*) do xcopy "%%f" .
+
+REM Get the test framework assembly
+xcopy /sy C:\<path_to_your_coreclr>\coreclr\tests\src\GC\Performance\Framework\bin\Debug\dnx46\* .
+```
+
+Once all of our dependencies are in the same place, we can run the tests:
+```
+xunit.performance.run.exe Framework.dll -runner xunit.console.exe -verbose -runid PerformanceTest
+```
+
+In order to test CoreCLR, we need to set two environment variables: `GC_PERF_TEST_CORE_RUN_PROBE_PATH`, indicating
+where to look for `CoreRun.exe`, and `GC_PERF_TEST_CORECLR`, which when set to "1" indicates the test runner
+to launch subprocesses under `CoreRun`. All other commands should be exactly the same. (See the Environment Variables
+section for more details on what environment variables the test framework respects).
+
+The result of this invocation will be `PerformanceTest.etl`, an ETW trace, and `PerformanceTest.xml`, a file
+containing a summary of every test run and the metrics that were calculated for every test iteration. A summary
+XML file can be created using the analysis executable:
+
+```
+xunit.performance.analysis.exe PerformanceTest.xml -xml PerformanceTestSummary.xml
+```
+
+## Running on other platforms
+In order to run performance tests on other platforms, it's necessary to obtain the required components as
+specified above, possibly from an existing CoreCLR build on Windows. However, there are three major differences:
+
+First, instead of using the `xunit.performance.run.exe` obtained from the 
+`Microsoft.DotNet.xunit.performance.runner.Windows` nuget package, we must instead install the command:
+
+```
+dnu commands install Microsoft.DotNet.xunit.performance.runner.dnx 1.0.0-alpha-build0027 -f https://www.myget.org/F/dotnet-buildtools/
+```
+
+Second, instead of using the `xunit.console.exe` test runner, we must use `xunit.console.netcore.exe`, which
+is available as part of the CoreCLR test build, through NuGet at https://www.myget.org/F/dotnet-buildtools/, or
+on GitHub: https://github.com/dotnet/buildtools/tree/master/src/xunit.console.netcore.
+
+Finally, we must use the `dnxcore5` target when building the test framework, since custom metrics are not available
+on non-Windows platforms currently.
+
+With all of the above in place, we can run:
+
+```
+xunit.performance.run.exe Framework.dll -verbose -runner ./xunit.console.netcore.exe -runnerhost ./corerun -runid PerformanceTest.xml
+```
+
+Only the Duration metric will be available in the resulting XML.
+
+## Environment Variables
+On Windows, the test runner respects the following environment variables:
+* `GC_PERF_TEST_PROBE_PATH`, a path used to probe for test executables,
+* `GC_PERF_TEST_CORE_RUN_PROBE_PATH`, a path used to probe for the CoreRun executable if running on CoreCLR,
+* `GC_PERF_TEST_CORECLR`, instructs the runner to use CoreCLR (and CoreRun) if set to 1.
+
+On Unixes, the test runner respects the same variables except for the final variable, which is assumed to
+always be 1 on non-Windows platforms.

--- a/tests/src/GC/Performance/Tests/Allocation.cs
+++ b/tests/src/GC/Performance/Tests/Allocation.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+//Measure allocation time when allocating objects on a single thread.
+//Should be run with server GC
+
+class Allocation
+{     
+    static void Main(string[] args)
+    {
+        if ((args.Length > 0) && (args.Length < 2))
+        {
+            Console.WriteLine("Usage: Allocation.exe <maxbytes> <byteArraySize> ");
+            return;
+        }
+
+        string processor = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
+        Console.WriteLine("Running on {0}", processor);
+
+        UInt64 MaxBytes = 1500000000;
+        if (processor.ToLower() == "amd64")
+        {
+            MaxBytes = 5000000000;
+        }
+
+        int byteArraySize = 95000;
+
+        if (args.Length >= 2)
+        {
+            if (!UInt64.TryParse(args[0], out MaxBytes))
+            {
+                Console.WriteLine("Usage: Allocation.exe <maxbytes> <byteArraySize> ");
+                return;
+            }
+
+            if (!Int32.TryParse(args[1], out byteArraySize))
+            {
+                Console.WriteLine("Usage: Allocation.exe <maxbytes> <byteArraySize> ");
+                return;
+            }
+        }
+
+
+        //check if running on server GC:
+        if (!System.Runtime.GCSettings.IsServerGC)
+        {
+            Console.WriteLine("GCSettings is not server GC!");
+            return;
+        }
+
+        //Allocate memory
+
+        UInt64 objCount = MaxBytes / (UInt64)byteArraySize;
+
+        Console.WriteLine("Creating a list of {0} objects", objCount);
+        if (objCount > 0X7FEFFFFF)
+        {
+            Console.WriteLine("Exceeded the max number of objects in a list");
+            Console.WriteLine("Creating a list with {0} objects", 0X7FEFFFFF);
+            objCount = 0X7FEFFFFF;
+        }
+
+        Console.WriteLine("Byte array size is " + byteArraySize);
+
+        Object[] objList = new Object[objCount];
+        long timerStart = Environment.TickCount;
+        int count = (int)objCount;
+        for (int i = 0; i < count; i++)
+        {
+            objList[i] = new byte[byteArraySize];
+        }
+        long timerEnd = Environment.TickCount;
+        long allocTime = timerEnd - timerStart;
+        Console.WriteLine("Allocation time= {0} ms", allocTime);
+
+        Console.WriteLine("GC count: ");
+        Console.WriteLine("gen0: " + GC.CollectionCount(0));
+        Console.WriteLine("gen1: " + GC.CollectionCount(1));
+        Console.WriteLine("gen2: " + GC.CollectionCount(2));
+
+    }
+
+}
+
+

--- a/tests/src/GC/Performance/Tests/Allocation.csproj
+++ b/tests/src/GC/Performance/Tests/Allocation.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Allocation.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/GC/Performance/Tests/ConcurrentSpin.cs
+++ b/tests/src/GC/Performance/Tests/ConcurrentSpin.cs
@@ -1,0 +1,169 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+
+class PriorityTest
+{
+    private byte[][] old;
+    private byte[][] med;
+    private Random rand;
+
+    private int oldDataSize;
+    private int medDataSize;
+    private int iterCount;
+    private int meanAllocSize;
+    private int medTime;
+    private int youngTime;
+
+    
+    public PriorityTest(int oldDataSize, int medDataSize,
+                        int iterCount, int meanAllocSize,
+                        int medTime, int youngTime)
+    {
+        rand = new Random(314159);
+        this.oldDataSize = oldDataSize;
+        this.medDataSize = medDataSize;
+        this.iterCount = iterCount;
+        this.meanAllocSize = meanAllocSize;
+        this.medTime = medTime;
+        this.youngTime = youngTime;
+    }
+
+    // creates initial arrays
+    void AllocTest(int oldDataSize, int medDataSize, int meanAllocSize)
+    {
+        old = new byte[oldDataSize][];
+        med = new byte[medDataSize][];
+
+        for (int i = 0; i < old.Length; i++)
+        {
+            old[i] =  new byte[meanAllocSize];
+        }
+
+        for (int i = 0; i < med.Length; i++)
+        {
+            med[i] = new byte[meanAllocSize];
+        }
+    }
+
+    // churns data in the heap by replacing byte arrays with new ones of random length
+    // this should induce concurrent GCs
+    void SteadyState(int oldDataSize, int medDataSize,
+                        int iterCount, int meanAllocSize,
+                        int medTime, int youngTime)
+    {
+
+        for (int i = 0; i < iterCount; i++)
+        {
+            byte[] newarray  = new byte [meanAllocSize];
+
+            if ((i % medTime) == 0)
+            {
+                old[rand.Next(0,old.Length)] = newarray;
+            }
+            if ((i % youngTime) == 0)
+            {
+                med[rand.Next(0,med.Length)] = newarray;
+            }
+            if ((i % 5000) == 0)
+            {
+                Thread.Sleep(200);
+            }
+        }
+    }
+
+    // method that runs the test
+    public void RunTest()
+    {
+        for (int iteration=0; iteration < iterCount; iteration++)
+        {
+            AllocTest (oldDataSize, medDataSize, meanAllocSize);
+
+            SteadyState (oldDataSize, medDataSize,
+                iterCount, meanAllocSize,
+                medTime, youngTime);
+        }
+
+    }
+
+}
+
+
+class ConcurrentRepro
+{
+
+    public static void Usage()
+    {
+        Console.WriteLine("Usage:");
+        Console.WriteLine("\t<num iterations> <num threads>");
+    }
+    
+    public static int[] ParseArgs(string[] args)
+    {
+        int[] parameters = new int[2];
+        
+        // set defaults
+        parameters[0] = 100;
+        parameters[1] = 4;
+
+        if (args.Length==0)
+        {
+            //use defaults
+            return parameters;
+        }
+        if (args.Length==parameters.Length)
+        {
+            for (int i=0; i<args.Length; i++)
+            {
+                int j = 0;
+                if (!int.TryParse(args[i], out j))
+                {
+                    Usage();
+                    return null;
+                }
+                parameters[i] = j;
+            }
+            
+            return parameters;
+        }
+        
+        // incorrect number of arguments        
+        Usage();
+        return null;              
+    }
+    
+
+    public static void Main(string[] args)
+    {
+    
+        // parse arguments
+        int[] parameters = ParseArgs(args);
+        if (parameters==null)
+        {
+            return;
+        }
+
+
+        PriorityTest priorityTest = new PriorityTest(1000000, 5000, parameters[0], 17, 30, 3);
+        ThreadStart startDelegate = new ThreadStart(priorityTest.RunTest);
+
+        // create threads
+        Thread[] threads = new Thread[parameters[1]];
+        for (int i=0; i<threads.Length; i++)
+        {
+            threads[i] = new Thread(startDelegate);
+            threads[i].Name = String.Format("Thread{0}", i);
+            threads[i].Start();
+        }
+
+        // wait for threads to complete
+        for (int i=0; i<threads.Length; i++)
+        {
+            threads[i].Join();
+        }
+    }
+}
+
+

--- a/tests/src/GC/Performance/Tests/ConcurrentSpin.csproj
+++ b/tests/src/GC/Performance/Tests/ConcurrentSpin.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ConcurrentSpin.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/GC/Performance/Tests/EEGC.cs
+++ b/tests/src/GC/Performance/Tests/EEGC.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace EEGC
+{
+    using System;
+    using System.Threading;
+
+    public class EEGC
+    {
+        internal static int kStretchTreeDepth;
+        internal static int kLongLivedTreeDepth;
+        internal static int kShortLivedTreeDepth;
+        const int NUM_ITERATIONS = 200;
+
+        internal static void Populate(int iDepth, Node thisNode)
+        {
+            if (iDepth <= 0)
+                return;
+
+            else
+            {
+                iDepth--;
+                thisNode.left = new Node();
+                thisNode.right = new Node();
+                Populate(iDepth, thisNode.left);
+                Populate(iDepth, thisNode.right);
+            }
+        }
+
+        public static void Main(string[] p_args)
+        {
+            Node root;
+            Node longLivedTree;
+            Node tempTree;
+            Thread sleepThread;
+
+            kStretchTreeDepth = 19;     // about 24MB
+            kLongLivedTreeDepth = 18;   // about 12MB
+            kShortLivedTreeDepth = 13;  // about 0.4MB
+
+            tempTree = new Node();
+            Populate(kStretchTreeDepth, tempTree);
+            tempTree = null;
+
+            longLivedTree = new Node();
+            Populate(kLongLivedTreeDepth, longLivedTree);
+
+            SleepThread sThread;
+            sThread = new SleepThread(100);
+            sleepThread = new Thread(new ThreadStart(SleepThread.ThreadStart));
+
+            sleepThread.Start();
+
+            for (long i = 0; i < NUM_ITERATIONS; i++)
+            {
+                root = new Node();
+                Populate(kShortLivedTreeDepth, root);
+            }
+
+            root = longLivedTree;
+
+            SleepThread.shouldContinue = false;
+            sleepThread.Join(500);
+        }
+    }
+}

--- a/tests/src/GC/Performance/Tests/EEGC.csproj
+++ b/tests/src/GC/Performance/Tests/EEGC.csproj
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="EEGC.cs" />
+    <Compile Include="Node.cs" />
+    <Compile Include="SleepThread.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/GC/Performance/Tests/GCSimulator.cs
+++ b/tests/src/GC/Performance/Tests/GCSimulator.cs
@@ -1,0 +1,520 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Threading;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using LifeTimeFX;
+
+interface PinnedObject
+{
+    void CleanUp();
+    bool IsPinned();
+
+}
+
+namespace GCSimulator
+{
+       
+    class RandomLifeTimeStrategy : LifeTimeStrategy
+    {
+        private int counter = 0;
+        private int mediumLifeTime = 30;
+        private int shortLifeTime = 3;
+        private int mediumDataCount = 1000000;
+        private int shortDataCount = 5000;
+
+        private Random rand = new Random(123456);
+
+        public RandomLifeTimeStrategy(int mediumlt, int shortlt, int mdc, int sdc)
+        {
+            mediumLifeTime = mediumlt;
+            shortLifeTime = shortlt;
+            mediumDataCount = mdc;
+            shortDataCount = sdc;
+
+        }
+        public int MediumLifeTime
+        {
+            set
+            {
+                mediumLifeTime = value;
+            }
+        }
+        public int ShortLifeTime
+        {
+            set
+            {
+                shortLifeTime = value;
+            }
+        }
+
+        public int NextObject(LifeTimeENUM lifeTime)
+        {
+            switch (lifeTime)
+            {
+                case LifeTimeENUM.Short:
+                    return rand.Next() % shortDataCount;
+
+                case LifeTimeENUM.Medium:
+                    return (rand.Next() % mediumDataCount) + shortDataCount;
+
+
+                case LifeTimeENUM.Long:
+                    return 0;
+            }
+            return 0;
+        }
+        public bool ShouldDie(LifeTime o, int index)
+        {
+            counter++;
+            LifeTimeENUM lifeTime = o.LifeTime;
+            switch (lifeTime)
+            {
+                case LifeTimeENUM.Short:
+                    if (counter % shortLifeTime == 0)
+                        return true;
+                    break;
+                case LifeTimeENUM.Medium:
+                    if (counter % mediumLifeTime == 0)
+                        return true;
+                    break;
+                case LifeTimeENUM.Long:
+                    return false;
+
+            }
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// we might want to implement a different strategy that decide the life time of the object based on the time 
+    /// elabsed since the last object acceess.
+    /// 
+    /// </summary>
+    class TimeBasedLifeTimeStrategy : LifeTimeStrategy
+    {
+        private int lastMediumTickCount = Environment.TickCount;
+        private int lastShortTickCount = Environment.TickCount;
+        private int lastMediumIndex = 0;
+        private int lastShortIndex = 0;
+
+        public int NextObject(LifeTimeENUM lifeTime)
+        {
+            switch (lifeTime)
+            {
+                case LifeTimeENUM.Short:
+                    return lastShortIndex;
+                case LifeTimeENUM.Medium:
+                    return lastMediumIndex;
+                case LifeTimeENUM.Long:
+                    return 0;
+            }
+            return 0;
+        }
+
+        public bool ShouldDie(LifeTime o, int index)
+        {
+
+            LifeTimeENUM lifeTime = o.LifeTime;
+            // short objects will live for 20 seconds, long objects will live for more.
+            switch (lifeTime)
+            {
+                case LifeTimeENUM.Short:
+                    if (Environment.TickCount - lastShortTickCount > 1) // this is in accureat enumber, since
+                    // we will be finsh iterating throuh the short life time object in less than 1 ms , so we need
+                    // to switch either to QueryPeroformanceCounter, or to block the loop for some time through 
+                    // Thread.Sleep, the other solution is to increase the number of objects a lot.
+                    {
+                        lastShortTickCount = Environment.TickCount;
+                        lastShortIndex = index;
+                        return true;
+                    }
+
+                    break;
+                case LifeTimeENUM.Medium:
+                    if (Environment.TickCount - lastMediumTickCount > 20)
+                    {
+                        lastMediumTickCount = Environment.TickCount;
+                        lastMediumIndex = index;
+                        return true;
+                    }
+
+                    break;
+                case LifeTimeENUM.Long:
+                    break;
+            }
+            return false;
+        }
+    }
+
+    class ObjectWrapper : LifeTime, PinnedObject
+    {
+
+        private bool pinned;
+        private bool weakReferenced;
+        private GCHandle gcHandle;
+        private LifeTimeENUM lifeTime;
+        private WeakReference weakRef;
+
+        private byte[] data;
+        private int dataSize;
+        public int DataSize
+        {
+            set
+            {
+                dataSize = value;
+                data = new byte[dataSize];
+                if (pinned)
+                {
+                    gcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+                }
+                
+                if (weakReferenced)
+                {
+                    weakRef = new WeakReference(data);
+                }
+            }
+
+        }
+
+        public LifeTimeENUM LifeTime
+        {
+            get
+            {
+                return lifeTime;
+            }
+            set
+            {
+                this.lifeTime = value;
+            }
+        }
+
+        public bool IsPinned()
+        {
+            return pinned;
+        }
+        
+        public bool IsWeak()
+        {
+            return weakReferenced;
+        }
+        
+       
+        public void CleanUp()
+        {
+            if (pinned)
+            {
+                gcHandle.Free();
+            }
+        }
+
+        public ObjectWrapper(bool runFinalizer, bool pinned, bool weakReferenced)
+        {
+            this.pinned = pinned;
+            this.weakReferenced = weakReferenced;
+            if (!runFinalizer)
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
+
+        ~ObjectWrapper()
+        {
+            // DO SOMETHING BAD IN FINALIZER
+            data = new byte[dataSize];
+        }
+    }
+
+    class ClientSimulator
+    {
+        [ThreadStatic]
+        private static ObjectLifeTimeManager lifeTimeManager;
+
+        private static int meanAllocSize = 17;
+
+        private static int mediumLifeTime = 30;
+        private static int shortLifeTime = 3;
+
+        private static int mediumDataSize = meanAllocSize;
+        private static int shortDataSize = meanAllocSize;
+
+        private static int mediumDataCount = 1000000;
+        private static int shortDataCount = 5000;
+
+        private static int countIters = 500;
+        private static float percentPinned = 0.02F;
+        private static float percentWeak = 0.0F;
+
+        private static int numThreads = 1;
+
+        private static bool runFinalizer = false;
+        private static string strategy = "Random";
+
+        private static bool noTimer = false;
+        
+        private static string objectGraph = "List";
+
+
+        private static List<Thread> threadList = new List<Thread>();
+        public static void Main(string[] args)
+        {
+
+            bool shouldContinue = ParseArgs(args);
+            if (!shouldContinue)
+            {
+                return;
+            }
+                       
+            int timer = 0;
+            // Run the test.
+
+            for (int i = 0; i < numThreads; ++i)
+            {
+                Thread thread = new Thread(RunTest);                               
+                threadList.Add(thread);                                
+                thread.Start();
+                
+            }
+
+            foreach (Thread t in threadList)
+            {
+                t.Join();
+            }
+        }
+        
+
+        public static void RunTest(object threadInfoObj)
+        {
+            
+            // Allocate the objects.
+            lifeTimeManager = new ObjectLifeTimeManager();                                    
+            LifeTimeStrategy ltStrategy;           
+
+            int threadMediumLifeTime = mediumLifeTime;
+            int threadShortLifeTime = shortLifeTime;
+            int threadMediumDataSize = mediumDataSize;
+            int threadShortDataSize = shortDataSize;
+            int threadMediumDataCount = mediumDataCount;
+            int threadShortDataCount = shortDataCount;
+            float threadPercentPinned = percentPinned;
+            float threadPercentWeak = percentWeak;
+            bool threadRunFinalizer = runFinalizer;
+            string threadStrategy = strategy;
+            string threadObjectGraph = objectGraph;                       
+            
+            if (threadObjectGraph.ToLower() == "tree")
+            {
+                lifeTimeManager.SetObjectContainer(new BinaryTreeObjectContainer<LifeTime>());   
+            }
+            else
+            {
+                lifeTimeManager.SetObjectContainer(new ArrayObjectContainer<LifeTime>());
+            }
+            
+            lifeTimeManager.Init(threadShortDataCount + threadMediumDataCount);    
+            
+
+            if (threadStrategy.ToLower()=="random")
+            {
+                ltStrategy = new RandomLifeTimeStrategy(threadMediumLifeTime, threadShortLifeTime, threadMediumDataCount, threadShortDataCount);
+            }
+            else
+            {
+                // may be we need to specify the elapsed time.
+                ltStrategy = new TimeBasedLifeTimeStrategy();
+            }
+
+            lifeTimeManager.LifeTimeStrategy = ltStrategy;
+            lifeTimeManager.objectDied += new ObjectDiedEventHandler(objectDied);
+
+            for (int i=0; i < threadShortDataCount + threadMediumDataCount; ++i)
+            {
+                bool pinned = false;
+                if (threadPercentPinned!=0)
+                {
+                    pinned = (i % ((int)(1/threadPercentPinned))==0);
+                }
+
+                bool weak = false;
+                if (threadPercentWeak!=0)
+                {
+                    weak = (i % ((int)(1/threadPercentWeak))==0);
+                }
+
+                ObjectWrapper oWrapper = new ObjectWrapper(threadRunFinalizer, pinned, weak);                
+                if (i < threadShortDataCount)
+                {
+                    oWrapper.DataSize = threadShortDataSize;
+                    oWrapper.LifeTime = LifeTimeENUM.Short;
+                }
+                else
+                {
+                    oWrapper.DataSize = threadMediumDataSize;
+                    oWrapper.LifeTime = LifeTimeENUM.Medium;                
+                }                
+
+                lifeTimeManager.AddObject(oWrapper, i);
+            }
+
+            for (int i = 0; i < countIters; ++i)
+            {
+            
+                // Run the test.
+                lifeTimeManager.Run();
+            }
+
+        }
+
+        private static void objectDied(LifeTime lifeTime, int index)
+        {
+            // put a new fresh object instead;
+
+            LifeTimeENUM lifeTimeEnum;
+            lifeTimeEnum = lifeTime.LifeTime;
+
+            ObjectWrapper oWrapper = lifeTime as ObjectWrapper;
+            bool weakReferenced = oWrapper.IsWeak();
+            bool pinned = oWrapper.IsPinned();
+            if (pinned)
+            { 
+                oWrapper.CleanUp(); 
+            }
+                        
+            oWrapper = new ObjectWrapper(runFinalizer, pinned, weakReferenced);
+            oWrapper.LifeTime = lifeTimeEnum;
+            oWrapper.DataSize = lifeTime.LifeTime == LifeTimeENUM.Short ? shortDataSize : mediumDataSize;
+            lifeTimeManager.AddObject(oWrapper, index);
+        }
+
+        /// <summary>
+        /// Parse the arguments, no error checking is done yet.
+        /// TODO: Add more error checking.
+        ///
+        ///  Populate variables with defaults, then overwrite them with config settings.  Finally overwrite them with command line parameters
+        /// </summary>
+        public static bool ParseArgs(string[] args)
+        {
+
+            for (int i = 0; i < args.Length; ++i)
+            {
+                string currentArg = args[i];
+                string currentArgValue;
+                if (currentArg.StartsWith("-") || currentArg.StartsWith("/"))
+                {
+                    currentArg = currentArg.Substring(1);
+                }
+                else
+                {
+                    continue;
+                }
+
+                if (currentArg.StartsWith("?"))
+                {
+                    Usage();
+                    return false;
+                }
+                if (currentArg.StartsWith("iter") || currentArg.Equals("i")) // number of iterations
+                {
+                    currentArgValue = args[++i];
+                    countIters = Int32.Parse(currentArgValue);
+                }
+                if (currentArg.StartsWith("datasize") || currentArg.Equals("dz"))
+                {
+                    currentArgValue = args[++i];
+                    mediumDataSize = Int32.Parse(currentArgValue);
+                }
+
+                if (currentArg.StartsWith("sdatasize") || currentArg.Equals("sdz"))
+                {
+                    currentArgValue = args[++i];
+                    shortDataSize = Int32.Parse(currentArgValue);
+                }
+
+                if (currentArg.StartsWith("datacount") || currentArg.Equals("dc"))
+                {
+                    currentArgValue = args[++i];
+                    mediumDataCount = Int32.Parse(currentArgValue);
+                }
+
+                if (currentArg.StartsWith("sdatacount") || currentArg.Equals("sdc"))
+                {
+                    currentArgValue = args[++i];
+                    shortDataCount = Int32.Parse(currentArgValue);
+                }
+
+
+                if (currentArg.StartsWith("lifetime") || currentArg.Equals("lt"))
+                {
+                    currentArgValue = args[++i];
+                    shortLifeTime = Int32.Parse(currentArgValue);
+                    mediumLifeTime = shortLifeTime * 10;
+                }
+
+                if (currentArg.StartsWith("threads") || currentArg.Equals("t"))
+                {
+                    currentArgValue = args[++i];
+                    numThreads = Int32.Parse(currentArgValue);
+                }
+                if (currentArg.StartsWith("fin") || currentArg.Equals("f"))
+                {
+                    runFinalizer = true;
+                }
+
+                if (currentArg.StartsWith("datapinned") || currentArg.StartsWith("dp")) // percentage data pinned
+                {
+                    currentArgValue = args[++i];
+                    percentPinned = float.Parse(currentArgValue);
+                }
+
+                if (currentArg.StartsWith("strategy")) //strategy that if the object died or not
+                {
+                    currentArgValue = args[++i];
+                    strategy = currentArgValue;
+                }
+                
+                if (currentArg.StartsWith("notimer"))
+                {
+                    noTimer = true;
+                }
+                
+                if (currentArg.StartsWith("dataweak") || currentArg.StartsWith("dw") )
+                {
+                    currentArgValue = args[++i];
+                    percentWeak = float.Parse(currentArgValue);
+                }
+                
+                if (currentArg.StartsWith("objectgraph") || currentArg.StartsWith("og") )
+                {
+                    currentArgValue = args[++i];
+                    objectGraph = currentArgValue;
+                }
+            }
+
+            return true;
+        }
+
+        public static void Usage()
+        {
+            Console.WriteLine("GCSimulator [-?] [-i <num Iterations>] [-dz <data size in bytes>] [-lt <life time>] [-t <num threads>] [-f] [-dp <percent data pinned>]");
+            Console.WriteLine("Options");
+            Console.WriteLine("-? Display the usage and exit");
+            Console.WriteLine("-i [-iter] <num iterations> : specify number of iterations for the test, default is " + countIters);
+            Console.WriteLine("-dz [-datasize] <data size> : specify the data size in bytes, default is " + mediumDataSize);
+            Console.WriteLine("-sdz [sdatasize] <data size> : specify the short lived  data size in bytes, default is " + shortDataSize);
+            Console.WriteLine("-dc [datacount] <data count> : specify the medium lived  data count , default is " + mediumDataCount);
+            Console.WriteLine("-sdc [sdatacount] <data count> : specify the short lived  data count, default is " + shortDataCount);
+            Console.WriteLine("-lt [-lifetime] <number> : specify the life time of the objects, default is " + shortLifeTime);
+            Console.WriteLine("-t [-threads] <number of threads> : specifiy number of threads , default is " + numThreads);
+            Console.WriteLine("-f [-fin]  : specify whether to do allocation in finalizer or not, default is no");
+            Console.WriteLine("-dp [-datapinned] <percent of data pinned> : specify the percentage of data that we want to pin, default is " + percentPinned);
+            Console.WriteLine("-dw [-dataweak] <percent of data weak referenced> : specify the percentage of data that we want to weak reference, default is " + percentWeak);
+            Console.WriteLine("-strategy < indicate the strategy for deciding when the objects should die, right now we support only Random and Time strategy, default is Random");
+            Console.WriteLine("-og [-objectgraph] <List|Tree> : specify whether to use a List- or Tree-based object graph, default is " + objectGraph);                
+            Console.WriteLine("-notimer < indicate that we do not want to run the performance timer and output any results , default is no");                
+        }
+
+    }
+}

--- a/tests/src/GC/Performance/Tests/GCSimulator.csproj
+++ b/tests/src/GC/Performance/Tests/GCSimulator.csproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="GCSimulator.cs" />
+    <Compile Include="lifetimefx.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/GC/Performance/Tests/LargeStrings.cs
+++ b/tests/src/GC/Performance/Tests/LargeStrings.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+using System.Threading;
+
+public class StringConcat
+{
+    // Objects used by test. init before Main is entered.
+
+    const int NUM_ITERS_CONCAT = 10;
+    const int NUM_ITERS = 5000;
+
+    public static String s1 = "11234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s2 = "21234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s3 = "31234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s4 = "41234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s5 = "51234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s6 = "61234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s7 = "71234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s8 = "81234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s9 = "91234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    public static String s10 = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    public static void Main(string[] p_args)
+    {
+        string str = null;
+
+        for (long i = 0; i < NUM_ITERS; i++)
+        {
+            for (int j = 0; j < NUM_ITERS_CONCAT; j++)
+            {
+                str += s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10
+                    + s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10;
+            }
+
+            str = "";
+        }
+    }
+}
+

--- a/tests/src/GC/Performance/Tests/LargeStrings.csproj
+++ b/tests/src/GC/Performance/Tests/LargeStrings.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="LargeStrings.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/GC/Performance/Tests/MidLife.cs
+++ b/tests/src/GC/Performance/Tests/MidLife.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Text;
+
+public class AppendTest
+{
+    public static string[] _strings=null;
+    public static int _numStrings = 10000000;
+    public static Random rand = new Random(1);
+    const int NumIterations = 5000;
+                                                                               
+    public static string CreateString(int num)
+    {
+        int length = rand.Next(1, 20);
+        char[] ch = new char[length];
+        for(int i = 0; i<length; i++) 
+        {
+            ch[i] = (char) rand.Next(32, 127);
+        }
+        _strings[num] = new String(ch);
+        return _strings[num];
+    }
+    
+    public static void CreateTable()
+    {
+        // Creates an array of character arrays, and an array of strings
+        // corresponding to those char arrays.
+        _strings = new String[_numStrings];
+        for(int i=0; i<_numStrings; i++) 
+        {
+            string str = CreateString(i);
+        }
+    }
+
+    public static void AppendString(long iterations)
+    {        
+        for (long i=0; i<iterations; i++)
+        {
+            StringBuilder sb = new StringBuilder();
+            for (int j=0; j<10; j++)
+            {
+                sb.Append(_strings[(i+j)%_numStrings]);
+            }
+        }
+    }
+    
+
+    public static void Main(string [] real_args)
+    {    
+        CreateTable();
+        
+        // warmup
+        AppendString(100);
+        AppendString(NumIterations);    
+    }
+}

--- a/tests/src/GC/Performance/Tests/MidLife.csproj
+++ b/tests/src/GC/Performance/Tests/MidLife.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DefineConstants>$(DefineConstants);STATIC;PROJECTK_BUILD</DefineConstants>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MidLife.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/GC/Performance/Tests/Node.cs
+++ b/tests/src/GC/Performance/Tests/Node.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace EEGC
+{
+    public class Node
+    {
+        public Node left;
+        public Node right;
+    }
+}

--- a/tests/src/GC/Performance/Tests/SleepThread.cs
+++ b/tests/src/GC/Performance/Tests/SleepThread.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace EEGC{
+	using System;
+	using System.Threading;
+	
+	public class SleepThread{
+		private static int m_sleepTime;
+		public static bool shouldContinue; 
+	
+		public SleepThread(int time){
+			m_sleepTime = time;
+		}
+		
+		public static void ThreadStart(){
+			run();
+		}
+		
+		public static void run(){
+			long tElapsed, t1, t2;
+			int cIteration;
+			cIteration = 0;
+			
+			while(Volatile.Read(ref shouldContinue))
+			{
+				cIteration++;
+				
+				t1 = Environment.TickCount;
+				
+				Thread.Sleep(m_sleepTime);
+			
+				t2 = Environment.TickCount;
+				
+				if(t2 - t1 > m_sleepTime * 1.4)
+				{
+					tElapsed = t2 - t1;
+#if VERBOSE
+					Console.WriteLine("Thread 2. Iteration " + cIteration + ". " + tElapsed + "ms elapsed");
+#endif
+				}
+			}
+		}
+	}
+}
+			

--- a/tests/src/GC/Performance/Tests/app.config
+++ b/tests/src/GC/Performance/Tests/app.config
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Globalization" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/GC/Performance/Tests/lifetimefx.cs
+++ b/tests/src/GC/Performance/Tests/lifetimefx.cs
@@ -1,0 +1,309 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*
+ *  A Simple Framework to manage the life time of of objects
+ * Objects are required to implement LifeTime Interface in order to keep track of their lifetime.
+ * TODO: we need to add flexibility to the framework to control the type of datastructure used to keep track
+ * of the objects. Right now we are using a simple 1 D array , but other interesting datastructures can be
+ *    used instead like a HashTable.
+ */
+using System;
+using System.Collections.Generic;
+
+namespace LifeTimeFX
+{
+    public enum LifeTimeENUM
+    {
+        Short,
+        Medium,
+        Long
+    }
+
+    public interface LifeTime
+    {
+        LifeTimeENUM LifeTime
+        {
+            get;
+            set;
+        }
+        
+    }
+
+    public interface LifeTimeStrategy
+    {
+        int  NextObject(LifeTimeENUM lifeTime);
+        bool ShouldDie(LifeTime o, int index);
+    }
+
+    /// <summary>
+    /// This interfact abstract the object contaienr , allowing us to specify differnt datastructures
+    /// implementation.
+    /// The only restriction on the ObjectContainer is that the objects contained in it must implement
+    /// LifeTime interface.
+    /// Right now we have a simple array container as a stock implementation for that. for more information 
+    /// see code:#ArrayContainer
+    /// </summary>
+    /// <param name="o"></param>
+    /// <param name="index"></param>
+
+    public interface ObjectContainer<T> where T:LifeTime
+    {
+        void Init(int numberOfObjects);
+        void AddObjectAt(T o, int index);
+        T GetObject(int index);
+        T SetObjectAt(T o , int index);
+        int Count
+        {
+            get;
+        }
+    }
+    
+    
+    public sealed class BinaryTreeObjectContainer<T> : ObjectContainer<T> where T:LifeTime
+    {
+    
+        class Node
+        {
+            public Node LeftChild;
+            public Node RightChild;
+            public int id;
+            public T Data;
+        
+        }
+        
+
+        
+        private Node root;
+        private int count;
+        
+        public BinaryTreeObjectContainer()
+        {
+            root = null;
+            count = 0;
+        }
+    
+        public void Init(int numberOfObjects)
+        {
+               
+            if (numberOfObjects<=0)
+            {
+                return;
+            }
+            
+            root = new Node();
+            root.id = 0;
+            count = numberOfObjects;
+            if (numberOfObjects>1)
+            {
+                int depth = (int)Math.Log(numberOfObjects,2)+1;         
+
+                root.LeftChild = CreateTree(depth-1, 1);
+                root.RightChild = CreateTree(depth-1, 2);
+            }
+            
+          
+        }
+        
+        public void AddObjectAt(T o, int index)
+        {                           
+            Node node = Find(index);
+            
+            if (node!=null)
+            {
+                node.Data = o;               
+            }
+
+        }
+        
+        
+        public T GetObject(int index)
+        {
+            
+           
+            Node node = Find(index);
+            
+            if (node==null)
+            {
+                return default(T);
+            }
+            
+            return node.Data;
+                                    
+        }
+        
+        public T SetObjectAt(T o , int index)
+        {
+            
+            Node node = Find(index);
+
+            if (node==null)
+            {
+                return default(T);
+            }
+                        
+            T old = node.Data;
+            node.Data = o;
+            return old;
+            
+        }        
+        
+        public int Count
+        {
+            get
+            {
+                return count;
+            }
+        }        
+    
+    
+
+        private Node CreateTree(int depth, int id)
+        {
+            if (depth<=0)
+            {
+                return null;
+            }
+
+            Node node = new Node();
+            node.id = id;
+            node.LeftChild = CreateTree(depth-1, id*2+1);
+            node.RightChild = CreateTree(depth-1, id*2+2);
+            
+            return node;
+        }    
+        
+        private Node Find(int id)
+        {
+                      
+            List<int> path = new List<int>();            
+            
+            // find the path from node to root
+            int n=id;
+            while (n>0)
+            {
+                path.Add(n);
+                n = (int)Math.Ceiling( ((double)n/2.0) ) - 1;
+            }
+
+            // follow the path from root to node
+            Node node = root;             
+            for (int i=path.Count-1; i>=0; i--)
+            {
+                if (path[i]==(id*2+1))
+                {                    
+                    node = node.LeftChild;
+                }
+                else
+                {
+                    node = node.RightChild;
+                }
+                                
+            }
+            
+            return node;            
+        }
+            
+    }
+    
+    
+    
+//#ArrayContainer Simple Array Stock Implemntation for ObjectContainer
+    public sealed class ArrayObjectContainer<T> : ObjectContainer<T> where T:LifeTime
+    {
+        private T[] objContainer = null;
+        public void Init(int numberOfObjects)
+        {
+            objContainer = new T[numberOfObjects];
+
+        }
+
+        public void AddObjectAt(T o, int index)
+        {
+            objContainer[index] = o;
+        }
+
+        public T GetObject(int index)
+        {
+            return  objContainer[index];
+        }
+
+        public T SetObjectAt(T o, int index)
+        {
+            T old = objContainer[index];
+            objContainer[index] = o;
+            return old;
+        }
+
+        public int Count
+        {
+            get
+            {
+                return objContainer.Length;
+            }
+        }
+    }   
+    
+
+
+    public delegate void ObjectDiedEventHandler(LifeTime o, int index );
+
+    public sealed class ObjectLifeTimeManager
+    {
+        private LifeTimeStrategy strategy;
+
+        private ObjectContainer<LifeTime> objectContainer = null;
+       // 
+
+        public void SetObjectContainer (ObjectContainer<LifeTime> objectContainer)
+        {
+            this.objectContainer = objectContainer;
+        }
+        
+        public event ObjectDiedEventHandler objectDied;
+
+        public void Init(int numberObjects)
+        {
+            objectContainer.Init(numberObjects);
+            //objContainer = new object[numberObjects];
+        }
+
+        public LifeTimeStrategy LifeTimeStrategy
+        {
+            set
+            {
+                strategy = value;
+            }
+        }
+
+        public void AddObject(LifeTime o, int index)
+        {
+            objectContainer.AddObjectAt(o, index);
+            //objContainer[index] = o;
+        }
+
+        public void Run()
+        {
+        
+        
+            LifeTime objLifeTime;
+
+            for (int i = 0; i < objectContainer.Count; ++i)
+            {
+                objLifeTime = objectContainer.GetObject(i);
+                //object o = objContainer[i];
+                //objLifeTime = o as LifeTime;
+
+                if (strategy.ShouldDie(objLifeTime, i))
+                {
+                    int index = strategy.NextObject(objLifeTime.LifeTime);
+                    LifeTime oldObject  = objectContainer.SetObjectAt(null, index);
+                    //objContainer[index] = null;
+                    // fire the event 
+                    objectDied(oldObject, index);
+                }
+
+            }
+        }
+    }
+}

--- a/tests/src/GC/Performance/Tests/project.json
+++ b/tests/src/GC/Performance/Tests/project.json
@@ -1,0 +1,33 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Process": "4.0.0-beta-23302",
+    "System.IO": "4.0.10-beta-23302",
+    "System.IO.FileSystem": "4.0.0-beta-23302",
+    "System.IO.FileSystem.Primitives": "4.0.0-beta-23302",
+    "System.Runtime": "4.0.20-beta-23302",
+    "System.Runtime.Extensions": "4.0.10-beta-23302",
+    "System.Runtime.Handles": "4.0.0-beta-23302",
+    "System.Runtime.Loader": "4.0.0-beta-23302",
+    "System.Threading": "4.0.10-beta-23302",
+    "System.Globalization.Calendars": "4.0.0-beta-23302",
+    "System.Globalization": "4.0.10-beta-23302",
+    "System.Text.Encoding": "4.0.10-beta-23302",
+    "System.Runtime.InteropServices": "4.0.20-beta-23302",
+    "System.Collections": "4.0.10-beta-23302",
+    "System.Console": "4.0.0-beta-23302",
+    "System.Reflection": "4.0.10-beta-23302",
+    "System.Reflection.Primitives": "4.0.0-beta-23302",
+    "System.ComponentModel": "4.0.1-beta-23302",
+    "System.Xml.ReaderWriter": "4.0.11-beta-23302",
+    "System.Collections.NonGeneric": "4.0.1-beta-23302",
+    "System.Collections.Specialized": "4.0.1-beta-23302",
+    "System.Linq": "4.0.1-beta-23302",
+    "System.Linq.Queryable": "4.0.1-beta-23302",
+    "System.Xml.XmlSerializer": "4.0.11-beta-23302",
+    "System.Xml.XmlDocument": "4.0.1-beta-23302",
+    "System.Xml.XDocument": "4.0.11-beta-23302"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/tests/src/GC/Performance/Tests/project.lock.json
+++ b/tests/src/GC/Performance/Tests/project.lock.json
@@ -1,45 +1,37 @@
 {
-  "locked": true,
+  "locked": false,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
-      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0027": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "2.1.0",
-          "xunit.extensibility.execution": "2.1.0"
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "lib/dotnet/xunit.performance.core.dll": {},
-          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
         },
         "runtime": {
-          "lib/dotnet/xunit.performance.core.dll": {},
-          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
-        }
-      },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
-        "type": "package"
-      },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
-        "type": "package",
-        "dependencies": {
-          "xunit.runner.console": "2.1.0"
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -54,34 +46,71 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10": {
+      "System.Collections.NonGeneric/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Console.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -96,16 +125,46 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.20": {
+      "System.Diagnostics.Process/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23302",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23302",
+          "System.Threading.ThreadPool": "4.0.10-beta-23302"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Globalization/4.0.10": {
@@ -118,6 +177,35 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -170,7 +258,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0": {
+      "System.Linq/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -186,43 +274,48 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.0": {
+      "System.Linq.Expressions/4.0.10": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
           "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23516": {
+      "System.Linq.Queryable/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Globalization": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.4/System.Numerics.Vectors.dll": {}
+          "ref/dotnet/System.Linq.Queryable.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
+          "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
       "System.ObjectModel/4.0.0": {
@@ -234,7 +327,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23127": {
+      "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -255,6 +348,36 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -282,6 +405,19 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
       "System.Resources.ResourceManager/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -296,10 +432,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23127": {
+      "System.Runtime/4.0.20": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23127"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -308,10 +444,10 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "System.Runtime.Extensions/4.0.10": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23127"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -347,15 +483,18 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.WindowsRuntime/4.0.0": {
+      "System.Runtime.Loader/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.WindowsRuntime.dll": {}
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -438,7 +577,32 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10": {
+      "System.Threading.Thread/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -463,11 +627,12 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.10": {
+      "System.Xml.XDocument/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Reflection": "4.0.10",
@@ -485,214 +650,85 @@
           "lib/dotnet/System.Xml.XDocument.dll": {}
         }
       },
-      "xunit/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "xunit.assert": "[2.1.0]",
-          "xunit.core": "[2.1.0]"
-        }
-      },
-      "xunit.abstractions/2.0.0": {
-        "type": "package",
-        "compile": {
-          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
-        }
-      },
-      "xunit.assert/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.assert.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.assert.dll": {}
-        }
-      },
-      "xunit.console.netcore/1.0.2-prerelease-00128": {
+      "System.Xml.XmlDocument/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.10",
-          "System.Console": "4.0.0-beta-23213",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.XDocument": "4.0.10",
-          "xunit.runner.utility": "2.1.0"
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "lib/dnxcore50/_._": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
         },
         "runtime": {
-          "lib/dnxcore50/_._": {}
-        }
-      },
-      "xunit.core/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "[2.1.0]",
-          "xunit.extensibility.execution": "[2.1.0]"
-        }
-      },
-      "xunit.extensibility.core/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "xunit.abstractions": "[2.0.0]"
-        },
-        "compile": {
-          "lib/dotnet/xunit.core.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.core.dll": {},
-          "lib/dotnet/xunit.runner.tdnet.dll": {},
-          "lib/dotnet/xunit.runner.utility.desktop.dll": {}
-        }
-      },
-      "xunit.extensibility.execution/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Linq.Expressions": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.Encoding": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "[2.1.0]"
-        },
-        "compile": {
-          "lib/dotnet/xunit.execution.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.execution.dotnet.dll": {}
-        }
-      },
-      "xunit.runner.console/2.1.0": {
-        "type": "package"
-      },
-      "xunit.runner.utility/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       }
     },
     "DNXCore,Version=v5.0/win7-x86": {
-      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0027": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "2.1.0",
-          "xunit.extensibility.execution": "2.1.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.performance.core.dll": {},
-          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.performance.core.dll": {},
-          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
-        }
-      },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
-        "type": "package"
-      },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
-        "type": "package",
-        "dependencies": {
-          "xunit.runner.console": "2.1.0"
-        }
-      },
-      "runtime.win7.System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10"
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/_._": {}
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -707,34 +743,71 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10": {
+      "System.Collections.NonGeneric/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Console.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -749,16 +822,46 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.20": {
+      "System.Diagnostics.Process/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23302",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23302",
+          "System.Threading.ThreadPool": "4.0.10-beta-23302"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Globalization/4.0.10": {
@@ -771,6 +874,35 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -823,7 +955,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0": {
+      "System.Linq/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -839,43 +971,48 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.0": {
+      "System.Linq.Expressions/4.0.10": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
           "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23516": {
+      "System.Linq.Queryable/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Globalization": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.4/System.Numerics.Vectors.dll": {}
+          "ref/dotnet/System.Linq.Queryable.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
+          "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
       "System.ObjectModel/4.0.0": {
@@ -887,7 +1024,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23127": {
+      "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -908,6 +1045,51 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -935,6 +1117,19 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
       "System.Resources.ResourceManager/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -949,10 +1144,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23127": {
+      "System.Runtime/4.0.20": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23127"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -961,10 +1156,10 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "System.Runtime.Extensions/4.0.10": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23127"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -1000,15 +1195,18 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.WindowsRuntime/4.0.0": {
+      "System.Runtime.Loader/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.WindowsRuntime.dll": {}
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1091,7 +1289,32 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10": {
+      "System.Threading.Thread/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1116,11 +1339,12 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.10": {
+      "System.Xml.XDocument/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Reflection": "4.0.10",
@@ -1138,217 +1362,85 @@
           "lib/dotnet/System.Xml.XDocument.dll": {}
         }
       },
-      "xunit/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "xunit.assert": "[2.1.0]",
-          "xunit.core": "[2.1.0]"
-        }
-      },
-      "xunit.abstractions/2.0.0": {
-        "type": "package",
-        "compile": {
-          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
-        }
-      },
-      "xunit.assert/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.assert.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.assert.dll": {}
-        }
-      },
-      "xunit.console.netcore/1.0.2-prerelease-00128": {
+      "System.Xml.XmlDocument/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.10",
-          "System.Console": "4.0.0-beta-23213",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.XDocument": "4.0.10",
-          "xunit.runner.utility": "2.1.0"
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "lib/dnxcore50/_._": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
         },
         "runtime": {
-          "lib/dnxcore50/_._": {}
-        },
-        "native": {
-          "runtimes/any/native/xunit.console.netcore.exe": {}
-        }
-      },
-      "xunit.core/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "[2.1.0]",
-          "xunit.extensibility.execution": "[2.1.0]"
-        }
-      },
-      "xunit.extensibility.core/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "xunit.abstractions": "[2.0.0]"
-        },
-        "compile": {
-          "lib/dotnet/xunit.core.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.core.dll": {},
-          "lib/dotnet/xunit.runner.tdnet.dll": {},
-          "lib/dotnet/xunit.runner.utility.desktop.dll": {}
-        }
-      },
-      "xunit.extensibility.execution/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Linq.Expressions": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.Encoding": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "[2.1.0]"
-        },
-        "compile": {
-          "lib/dotnet/xunit.execution.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.execution.dotnet.dll": {}
-        }
-      },
-      "xunit.runner.console/2.1.0": {
-        "type": "package"
-      },
-      "xunit.runner.utility/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       }
     },
     "DNXCore,Version=v5.0/win7-x64": {
-      "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0027": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "Microsoft.Win32.Registry/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "2.1.0",
-          "xunit.extensibility.execution": "2.1.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.performance.core.dll": {},
-          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.performance.core.dll": {},
-          "lib/dotnet/xunit.performance.execution.dotnet.dll": {}
-        }
-      },
-      "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
-        "type": "package"
-      },
-      "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
-        "type": "package",
-        "dependencies": {
-          "xunit.runner.console": "2.1.0"
-        }
-      },
-      "runtime.win7.System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10"
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet/_._": {}
+          "ref/dotnet/Microsoft.Win32.Registry.dll": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
+          "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -1363,34 +1455,71 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.10": {
+      "System.Collections.NonGeneric/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.Collections.Specialized/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.Globalization": "4.0.10",
+          "System.Globalization.Extensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Specialized.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.Specialized.dll": {}
+        }
+      },
+      "System.ComponentModel/4.0.1-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.dll": {}
+        }
+      },
+      "System.Console/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
+          "ref/dotnet/System.Console.dll": {}
         },
         "runtime": {
-          "lib/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Console/4.0.0-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "lib/DNXCore50/System.Console.dll": {}
         }
       },
       "System.Diagnostics.Debug/4.0.10": {
@@ -1405,16 +1534,46 @@
           "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.20": {
+      "System.Diagnostics.Process/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23302",
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23302",
+          "System.Threading.ThreadPool": "4.0.10-beta-23302"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Process.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Process.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
         },
         "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
       "System.Globalization/4.0.10": {
@@ -1427,6 +1586,35 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.Globalization.Calendars/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Calendars.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
+        }
+      },
+      "System.Globalization.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Globalization.Extensions.dll": {}
         }
       },
       "System.IO/4.0.10": {
@@ -1479,7 +1667,7 @@
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.Linq/4.0.0": {
+      "System.Linq/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1495,43 +1683,48 @@
           "lib/dotnet/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.0": {
+      "System.Linq.Expressions/4.0.10": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.0",
           "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Linq.Expressions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23516": {
+      "System.Linq.Queryable/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
-          "System.Globalization": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Linq.Expressions": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.4/System.Numerics.Vectors.dll": {}
+          "ref/dotnet/System.Linq.Queryable.dll": {}
         },
         "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
-        }
-      },
-      "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-        "type": "package",
-        "dependencies": {
-          "System.Numerics.Vectors": "4.1.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.WindowsRuntime": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll": {}
+          "lib/dotnet/System.Linq.Queryable.dll": {}
         }
       },
       "System.ObjectModel/4.0.0": {
@@ -1543,7 +1736,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.0-beta-23127": {
+      "System.Private.Uri/4.0.0": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1564,6 +1757,51 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.dll": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.ILGeneration.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Emit.Lightweight.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
       "System.Reflection.Extensions/4.0.0": {
@@ -1591,6 +1829,19 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
       "System.Resources.ResourceManager/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -1605,10 +1856,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.20-beta-23127": {
+      "System.Runtime/4.0.20": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.0-beta-23127"
+          "System.Private.Uri": "4.0.0"
         },
         "compile": {
           "ref/dotnet/System.Runtime.dll": {}
@@ -1617,10 +1868,10 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.10-beta-23127": {
+      "System.Runtime.Extensions/4.0.10": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.20-beta-23127"
+          "System.Runtime": "4.0.20"
         },
         "compile": {
           "ref/dotnet/System.Runtime.Extensions.dll": {}
@@ -1656,15 +1907,18 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.WindowsRuntime/4.0.0": {
+      "System.Runtime.Loader/4.0.0-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Runtime.WindowsRuntime.dll": {}
+          "ref/dotnet/System.Runtime.Loader.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1747,7 +2001,32 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.10": {
+      "System.Threading.Thread/4.0.0-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
+      "System.Threading.ThreadPool/4.0.10-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.ThreadPool.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
+        }
+      },
+      "System.Xml.ReaderWriter/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1772,11 +2051,12 @@
           "lib/dotnet/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.10": {
+      "System.Xml.XDocument/4.0.11-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tools": "4.0.0",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Reflection": "4.0.10",
@@ -1794,236 +2074,101 @@
           "lib/dotnet/System.Xml.XDocument.dll": {}
         }
       },
-      "xunit/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "xunit.assert": "[2.1.0]",
-          "xunit.core": "[2.1.0]"
-        }
-      },
-      "xunit.abstractions/2.0.0": {
-        "type": "package",
-        "compile": {
-          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
-        },
-        "runtime": {
-          "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll": {}
-        }
-      },
-      "xunit.assert/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.assert.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.assert.dll": {}
-        }
-      },
-      "xunit.console.netcore/1.0.2-prerelease-00128": {
+      "System.Xml.XmlDocument/4.0.1-beta-23302": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.10",
-          "System.Console": "4.0.0-beta-23213",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Xml.XmlDocument.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Xml.XmlDocument.dll": {}
+        }
+      },
+      "System.Xml.XmlSerializer/4.0.11-beta-23302": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.XDocument": "4.0.10",
-          "xunit.runner.utility": "2.1.0"
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
         },
         "compile": {
-          "lib/dnxcore50/_._": {}
+          "ref/dotnet/System.Xml.XmlSerializer.dll": {}
         },
         "runtime": {
-          "lib/dnxcore50/_._": {}
-        },
-        "native": {
-          "runtimes/any/native/xunit.console.netcore.exe": {}
-        }
-      },
-      "xunit.core/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "[2.1.0]",
-          "xunit.extensibility.execution": "[2.1.0]"
-        }
-      },
-      "xunit.extensibility.core/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "xunit.abstractions": "[2.0.0]"
-        },
-        "compile": {
-          "lib/dotnet/xunit.core.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.core.dll": {},
-          "lib/dotnet/xunit.runner.tdnet.dll": {},
-          "lib/dotnet/xunit.runner.utility.desktop.dll": {}
-        }
-      },
-      "xunit.extensibility.execution/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Linq.Expressions": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.Encoding": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0",
-          "xunit.extensibility.core": "[2.1.0]"
-        },
-        "compile": {
-          "lib/dotnet/xunit.execution.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.execution.dotnet.dll": {}
-        }
-      },
-      "xunit.runner.console/2.1.0": {
-        "type": "package"
-      },
-      "xunit.runner.utility/2.1.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Text.RegularExpressions": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0",
-          "xunit.abstractions": "2.0.0"
-        },
-        "compile": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       }
     }
   },
   "libraries": {
-    "Microsoft.DotNet.xunit.performance/1.0.0-alpha-build0027": {
-      "type": "package",
-      "sha512": "Ic8LKByvYV0C/3/4G2mcQ7tigJyQb79c7eagSywTfSLGYJa0sBkzFyVDgXqCOQm/T0EUYOc6Oqj//avSqfHnLQ==",
-      "files": [
-        "lib/dotnet/xunit.performance.core.dll",
-        "lib/dotnet/xunit.performance.core.pdb",
-        "lib/dotnet/xunit.performance.core.XML",
-        "lib/dotnet/xunit.performance.execution.dotnet.dll",
-        "lib/dotnet/xunit.performance.execution.dotnet.pdb",
-        "lib/net46/xunit.performance.core.dll",
-        "lib/net46/xunit.performance.core.pdb",
-        "lib/net46/xunit.performance.core.XML",
-        "lib/net46/xunit.performance.execution.desktop.dll",
-        "lib/net46/xunit.performance.execution.desktop.pdb",
-        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0027.nupkg",
-        "Microsoft.DotNet.xunit.performance.1.0.0-alpha-build0027.nupkg.sha512",
-        "Microsoft.DotNet.xunit.performance.nuspec"
-      ]
-    },
-    "Microsoft.DotNet.xunit.performance.analysis/1.0.0-alpha-build0027": {
+    "Microsoft.Win32.Primitives/4.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "w/6R/4EBbESpNYyPgp7TDNISOvj8ucrv5FN9X3defsgD1ZAO+4Z+fu9DCZWd78+A0MEQPGIaCKssLgGlzQf6xw==",
+      "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0027.nupkg",
-        "Microsoft.DotNet.xunit.performance.analysis.1.0.0-alpha-build0027.nupkg.sha512",
-        "Microsoft.DotNet.xunit.performance.analysis.nuspec",
-        "tools/MathNet.Numerics.dll",
-        "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
-        "tools/xunit.performance.analysis.exe",
-        "tools/xunit.performance.analysis.exe.config",
-        "tools/xunit.performance.analysis.pdb"
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "Microsoft.Win32.Primitives.4.0.0.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
       ]
     },
-    "Microsoft.DotNet.xunit.performance.runner.Windows/1.0.0-alpha-build0027": {
+    "Microsoft.Win32.Registry/4.0.0-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CMFSRSg26B7Z1dB3IUppS2Ry1aLiCcwyVvK2+BjR0hEIYQ8+PcyhAmnSUxQhKMJ/80ho0HdXhxWbKFB/XmgTWg==",
+      "sha512": "63Vc0lDW+pMCSd6ygScz/XTiJE3Ou5Sr7yrZ0HE/Ym/Bi/mN0LMAJqUtAUSJxVBuqbozW/q39RpNLIZ+QlJvig==",
       "files": [
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0027.nupkg",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.1.0.0-alpha-build0027.nupkg.sha512",
-        "Microsoft.DotNet.xunit.performance.runner.Windows.nuspec",
-        "tools/amd64/KernelTraceControl.dll",
-        "tools/amd64/msdia140.dll",
-        "tools/Microsoft.Diagnostics.Tracing.TraceEvent.dll",
-        "tools/ProcDomain.dll",
-        "tools/ProcDomain.pdb",
-        "tools/x86/KernelTraceControl.dll",
-        "tools/x86/msdia140.dll",
-        "tools/xunit.abstractions.dll",
-        "tools/xunit.core.dll",
-        "tools/xunit.performance.core.dll",
-        "tools/xunit.performance.core.pdb",
-        "tools/xunit.performance.logger.exe",
-        "tools/xunit.performance.logger.pdb",
-        "tools/xunit.performance.metrics.dll",
-        "tools/xunit.performance.metrics.pdb",
-        "tools/xunit.performance.run.exe",
-        "tools/xunit.performance.run.exe.config",
-        "tools/xunit.performance.run.pdb",
-        "tools/xunit.runner.utility.desktop.dll",
-        "tools/xunit.runner.utility.desktop.pdb"
-      ]
-    },
-    "runtime.win7.System.Console/4.0.0-beta-23516": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "TJZhrw44Bf7sYqne+CX5II/PaNf5L7oKVfl0FLkr4pj76KS8hSsJzsKL0IvxC+bi4d51+wTbv91kF1kgPyHMVw==",
-      "files": [
-        "ref/dotnet/_._",
-        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg",
-        "runtime.win7.System.Console.4.0.0-beta-23516.nupkg.sha512",
-        "runtime.win7.System.Console.nuspec",
-        "runtimes/win7/lib/dotnet5.4/System.Console.dll",
-        "runtimes/win7/lib/net/_._"
+        "lib/DNXCore50/Microsoft.Win32.Registry.dll",
+        "lib/net46/Microsoft.Win32.Registry.dll",
+        "Microsoft.Win32.Registry.4.0.0-beta-23302.nupkg",
+        "Microsoft.Win32.Registry.4.0.0-beta-23302.nupkg.sha512",
+        "Microsoft.Win32.Registry.nuspec",
+        "ref/dotnet/Microsoft.Win32.Registry.dll",
+        "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
     "System.Collections/4.0.10": {
@@ -2060,67 +2205,91 @@
         "System.Collections.nuspec"
       ]
     },
-    "System.Collections.Concurrent/4.0.10": {
+    "System.Collections.NonGeneric/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZtMEqOPAjAIqR8fqom9AOKRaB94a+emO2O8uOP6vyJoNswSPrbiwN7iH53rrVpvjMVx0wr4/OMpI7486uGZjbw==",
+      "sha512": "pSTpxEZ8/VRqmMnAP4Nfs7pdC8JpggNdnfGD225uIeEdNnc4m6xu3guu4BrFD3qrrBY1qSZCuNyY4DNJgq877A==",
       "files": [
-        "lib/dotnet/System.Collections.Concurrent.dll",
+        "lib/dotnet/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net46/_._",
+        "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Collections.Concurrent.xml",
-        "ref/dotnet/es/System.Collections.Concurrent.xml",
-        "ref/dotnet/fr/System.Collections.Concurrent.xml",
-        "ref/dotnet/it/System.Collections.Concurrent.xml",
-        "ref/dotnet/ja/System.Collections.Concurrent.xml",
-        "ref/dotnet/ko/System.Collections.Concurrent.xml",
-        "ref/dotnet/ru/System.Collections.Concurrent.xml",
-        "ref/dotnet/System.Collections.Concurrent.dll",
-        "ref/dotnet/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hans/System.Collections.Concurrent.xml",
-        "ref/dotnet/zh-hant/System.Collections.Concurrent.xml",
+        "ref/dotnet/System.Collections.NonGeneric.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net46/_._",
+        "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.4.0.10.nupkg",
-        "System.Collections.Concurrent.4.0.10.nupkg.sha512",
-        "System.Collections.Concurrent.nuspec"
+        "System.Collections.NonGeneric.4.0.1-beta-23302.nupkg",
+        "System.Collections.NonGeneric.4.0.1-beta-23302.nupkg.sha512",
+        "System.Collections.NonGeneric.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23516": {
+    "System.Collections.Specialized/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tzF4Dbbv+5bcbQ7GHuuKafkaDZThiUiwxqCc1ngewnMWZ5YmIgjQZjs+E1DNhoMVAvkH0tSmLJvsDlx9dFg+Aw==",
+      "sha512": "v1eYdfSH6ttx2QYSbvArTqlumBamCij2R8iNtdA2tBq0QmWseW5Nc+H3Ut1JHa9T1q3jWuk0NR95zMBwty3Q+Q==",
       "files": [
+        "lib/dotnet/System.Collections.Specialized.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Collections.Specialized.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Collections.Specialized.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Collections.Specialized.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Collections.Specialized.4.0.1-beta-23302.nupkg",
+        "System.Collections.Specialized.4.0.1-beta-23302.nupkg.sha512",
+        "System.Collections.Specialized.nuspec"
+      ]
+    },
+    "System.ComponentModel/4.0.1-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Ju+nhdZ8gMwZAXRIr/ACoME9I9SpxeS+Xw4Bouok4xTvbbwkjlT55Mr9gybqcGMp4F/hzS55RnQDIiRN70fEdg==",
+      "files": [
+        "lib/dotnet/System.ComponentModel.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.ComponentModel.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.ComponentModel.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.ComponentModel.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.ComponentModel.4.0.1-beta-23302.nupkg",
+        "System.ComponentModel.4.0.1-beta-23302.nupkg.sha512",
+        "System.ComponentModel.nuspec"
+      ]
+    },
+    "System.Console/4.0.0-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "rpWEkJWW29TjVZdDz5zr8VnBv4IN9BQHmP4Ky9tEbvkdhkJRb0ZO59acXMpVD1tSM2VhGlLnq0kpdjOLNmejNA==",
+      "files": [
+        "lib/DNXCore50/System.Console.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Console.xml",
-        "ref/dotnet5.1/es/System.Console.xml",
-        "ref/dotnet5.1/fr/System.Console.xml",
-        "ref/dotnet5.1/it/System.Console.xml",
-        "ref/dotnet5.1/ja/System.Console.xml",
-        "ref/dotnet5.1/ko/System.Console.xml",
-        "ref/dotnet5.1/ru/System.Console.xml",
-        "ref/dotnet5.1/System.Console.dll",
-        "ref/dotnet5.1/System.Console.xml",
-        "ref/dotnet5.1/zh-hans/System.Console.xml",
-        "ref/dotnet5.1/zh-hant/System.Console.xml",
+        "ref/dotnet/System.Console.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Console.4.0.0-beta-23516.nupkg",
-        "System.Console.4.0.0-beta-23516.nupkg.sha512",
+        "System.Console.4.0.0-beta-23302.nupkg",
+        "System.Console.4.0.0-beta-23302.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
@@ -2158,38 +2327,60 @@
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.Tracing/4.0.20": {
+    "System.Diagnostics.Process/4.0.0-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gn/wexGHc35Fv++5L1gYHMY5g25COfiZ0PGrL+3PfwzoJd4X2LbTAm/U8d385SI6BKQBI/z4dQfvneS9J27+Tw==",
+      "sha512": "FtflxzCJUdgw+4suLaWz82EOLxVa7X6DWbY4eSRIomDlMwYrsof8Ewz81XhKMWY0EOY/5Nx+r/oPTbFUECAiUg==",
       "files": [
-        "lib/DNXCore50/System.Diagnostics.Tracing.dll",
+        "lib/DNXCore50/System.Diagnostics.Process.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net46/_._",
-        "lib/netcore50/System.Diagnostics.Tracing.dll",
+        "lib/net46/System.Diagnostics.Process.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/es/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/fr/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/it/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/ja/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/ko/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/ru/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/System.Diagnostics.Tracing.dll",
-        "ref/dotnet/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hans/System.Diagnostics.Tracing.xml",
-        "ref/dotnet/zh-hant/System.Diagnostics.Tracing.xml",
+        "ref/dotnet/System.Diagnostics.Process.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net46/_._",
+        "ref/net46/System.Diagnostics.Process.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.4.0.20.nupkg",
-        "System.Diagnostics.Tracing.4.0.20.nupkg.sha512",
-        "System.Diagnostics.Tracing.nuspec"
+        "System.Diagnostics.Process.4.0.0-beta-23302.nupkg",
+        "System.Diagnostics.Process.4.0.0-beta-23302.nupkg.sha512",
+        "System.Diagnostics.Process.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tools.xml",
+        "ref/dotnet/it/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.4.0.0.nupkg",
+        "System.Diagnostics.Tools.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec"
       ]
     },
     "System.Globalization/4.0.10": {
@@ -2223,6 +2414,71 @@
         "System.Globalization.4.0.10.nupkg",
         "System.Globalization.4.0.10.nupkg.sha512",
         "System.Globalization.nuspec"
+      ]
+    },
+    "System.Globalization.Calendars/4.0.0": {
+      "type": "package",
+      "sha512": "cL6WrdGKnNBx9W/iTr+jbffsEO4RLjEtOYcpVSzPNDoli6X5Q6bAfWtJYbJNOPi8Q0fXgBEvKK1ncFL/3FTqlA==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.Calendars.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Calendars.dll",
+        "lib/netcore50/System.Globalization.Calendars.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.Calendars.xml",
+        "ref/dotnet/es/System.Globalization.Calendars.xml",
+        "ref/dotnet/fr/System.Globalization.Calendars.xml",
+        "ref/dotnet/it/System.Globalization.Calendars.xml",
+        "ref/dotnet/ja/System.Globalization.Calendars.xml",
+        "ref/dotnet/ko/System.Globalization.Calendars.xml",
+        "ref/dotnet/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet/System.Globalization.Calendars.dll",
+        "ref/dotnet/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Calendars.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Calendars.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Calendars.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
+        "System.Globalization.Calendars.4.0.0.nupkg",
+        "System.Globalization.Calendars.4.0.0.nupkg.sha512",
+        "System.Globalization.Calendars.nuspec"
+      ]
+    },
+    "System.Globalization.Extensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "rqbUXiwpBCvJ18ySCsjh20zleazO+6fr3s5GihC2sVwhyS0MUl6+oc5Rzk0z6CKkS4kmxbZQSeZLsK7cFSO0ng==",
+      "files": [
+        "lib/dotnet/System.Globalization.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Globalization.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.Extensions.xml",
+        "ref/dotnet/es/System.Globalization.Extensions.xml",
+        "ref/dotnet/fr/System.Globalization.Extensions.xml",
+        "ref/dotnet/it/System.Globalization.Extensions.xml",
+        "ref/dotnet/ja/System.Globalization.Extensions.xml",
+        "ref/dotnet/ko/System.Globalization.Extensions.xml",
+        "ref/dotnet/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet/System.Globalization.Extensions.dll",
+        "ref/dotnet/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Globalization.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Globalization.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Globalization.Extensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Globalization.Extensions.4.0.0.nupkg",
+        "System.Globalization.Extensions.4.0.0.nupkg.sha512",
+        "System.Globalization.Extensions.nuspec"
       ]
     },
     "System.IO/4.0.10": {
@@ -2324,10 +2580,10 @@
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
-    "System.Linq/4.0.0": {
+    "System.Linq/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "sha512": "s6DNPrcinU2thnbDGyYfvK/2B6RXPvIjNyNFCyFDEPpKKb0dlURf/VSX0HQRbaxi0sXuSSrTCHPXhh75jpx3Pw==",
       "files": [
         "lib/dotnet/System.Linq.dll",
         "lib/net45/_._",
@@ -2335,41 +2591,29 @@
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
-        "ref/dotnet/de/System.Linq.xml",
-        "ref/dotnet/es/System.Linq.xml",
-        "ref/dotnet/fr/System.Linq.xml",
-        "ref/dotnet/it/System.Linq.xml",
-        "ref/dotnet/ja/System.Linq.xml",
-        "ref/dotnet/ko/System.Linq.xml",
-        "ref/dotnet/ru/System.Linq.xml",
         "ref/dotnet/System.Linq.dll",
-        "ref/dotnet/System.Linq.xml",
-        "ref/dotnet/zh-hans/System.Linq.xml",
-        "ref/dotnet/zh-hant/System.Linq.xml",
         "ref/net45/_._",
         "ref/netcore50/System.Linq.dll",
-        "ref/netcore50/System.Linq.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.4.0.0.nupkg",
-        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.4.0.1-beta-23302.nupkg",
+        "System.Linq.4.0.1-beta-23302.nupkg.sha512",
         "System.Linq.nuspec"
       ]
     },
-    "System.Linq.Expressions/4.0.0": {
+    "System.Linq.Expressions/4.0.10": {
       "type": "package",
-      "sha512": "wlfVllrKi+evu4Hi8yoJP1dSOVXbvsy7Hs1+oz4Cykfdf6MQTPlD3LI4WKWhprn8FpU5MS3spPSbcMX5sAoJSw==",
+      "serviceable": true,
+      "sha512": "qhFkPqRsTfXBaacjQhxwwwUoU7TEtwlBIULj7nG7i4qAkvivil31VvOvDKppCSui5yGw0/325ZeNaMYRvTotXw==",
       "files": [
+        "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net45/_._",
-        "lib/win8/_._",
-        "lib/wp80/_._",
-        "lib/wpa81/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "License.rtf",
         "ref/dotnet/de/System.Linq.Expressions.xml",
         "ref/dotnet/es/System.Linq.Expressions.xml",
         "ref/dotnet/fr/System.Linq.Expressions.xml",
@@ -2383,62 +2627,36 @@
         "ref/dotnet/zh-hant/System.Linq.Expressions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
-        "ref/net45/_._",
-        "ref/netcore50/de/System.Linq.Expressions.xml",
-        "ref/netcore50/es/System.Linq.Expressions.xml",
-        "ref/netcore50/fr/System.Linq.Expressions.xml",
-        "ref/netcore50/it/System.Linq.Expressions.xml",
-        "ref/netcore50/ja/System.Linq.Expressions.xml",
-        "ref/netcore50/ko/System.Linq.Expressions.xml",
-        "ref/netcore50/ru/System.Linq.Expressions.xml",
-        "ref/netcore50/System.Linq.Expressions.dll",
-        "ref/netcore50/System.Linq.Expressions.xml",
-        "ref/netcore50/zh-hans/System.Linq.Expressions.xml",
-        "ref/netcore50/zh-hant/System.Linq.Expressions.xml",
-        "ref/win8/_._",
-        "ref/wp80/_._",
-        "ref/wpa81/_._",
+        "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Linq.Expressions.4.0.0.nupkg",
-        "System.Linq.Expressions.4.0.0.nupkg.sha512",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
+        "System.Linq.Expressions.4.0.10.nupkg",
+        "System.Linq.Expressions.4.0.10.nupkg.sha512",
         "System.Linq.Expressions.nuspec"
       ]
     },
-    "System.Numerics.Vectors/4.1.1-beta-23516": {
+    "System.Linq.Queryable/4.0.1-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FCYCEjc3BXBTpVZTxMqf2m/sGYyDzLwICy5lNKgZzT8WfshJhsTGjJuETwsh1Cwi6bksw9YiTB6yeeWBBJDnTA==",
+      "sha512": "DtZNIidKpY95mLklcL4yfLYJCw3cAvfcoLxk8a+BqCAlMWXDmLDz2zizgyPWv2FwIUs7l+Jf9Znvz0yY/ip79Q==",
       "files": [
-        "lib/dotnet5.4/System.Numerics.Vectors.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/_._",
-        "lib/net46/System.Numerics.Vectors.dll",
-        "lib/portable-net45+win8/System.Numerics.Vectors.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Numerics.Vectors.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/_._",
-        "ref/net46/System.Numerics.Vectors.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Numerics.Vectors.4.1.1-beta-23516.nupkg",
-        "System.Numerics.Vectors.4.1.1-beta-23516.nupkg.sha512",
-        "System.Numerics.Vectors.nuspec"
-      ]
-    },
-    "System.Numerics.Vectors.WindowsRuntime/4.0.1-beta-23516": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "raAfPq7NkxI3XPap2aKrlqKpCPE0QTj7gO1Z+yI48ksIK20HSBJei8tim7d99OaqQ1bLkTZ/W/KeYMESURNJ8g==",
-      "files": [
-        "lib/dotnet5.4/System.Numerics.Vectors.WindowsRuntime.dll",
-        "System.Numerics.Vectors.WindowsRuntime.4.0.1-beta-23516.nupkg",
-        "System.Numerics.Vectors.WindowsRuntime.4.0.1-beta-23516.nupkg.sha512",
-        "System.Numerics.Vectors.WindowsRuntime.nuspec"
+        "lib/dotnet/System.Linq.Queryable.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Queryable.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/System.Linq.Queryable.dll",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.Queryable.dll",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.Queryable.4.0.1-beta-23302.nupkg",
+        "System.Linq.Queryable.4.0.1-beta-23302.nupkg.sha512",
+        "System.Linq.Queryable.nuspec"
       ]
     },
     "System.ObjectModel/4.0.0": {
@@ -2489,18 +2707,18 @@
         "System.ObjectModel.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.0-beta-23127": {
+    "System.Private.Uri/4.0.0": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KT9JGnTYRf51pwPluZtpewmdBPiROzemamLmpzgzl3Pu3Y0vmH2CBLZktngD4I4YPNFO6ieCupeM0X3R1u26kA==",
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "files": [
         "lib/DNXCore50/System.Private.Uri.dll",
         "lib/netcore50/System.Private.Uri.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
-        "System.Private.Uri.4.0.0-beta-23127.nupkg",
-        "System.Private.Uri.4.0.0-beta-23127.nupkg.sha512",
+        "System.Private.Uri.4.0.0.nupkg",
+        "System.Private.Uri.4.0.0.nupkg.sha512",
         "System.Private.Uri.nuspec"
       ]
     },
@@ -2535,6 +2753,86 @@
         "System.Reflection.4.0.10.nupkg",
         "System.Reflection.4.0.10.nupkg.sha512",
         "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Emit/4.0.0": {
+      "type": "package",
+      "sha512": "CqnQz5LbNbiSxN10cv3Ehnw3j1UZOBCxnE0OO0q/keGQ5ENjyFM6rIG4gm/i0dX6EjdpYkAgKcI/mhZZCaBq4A==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.dll",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.Emit.xml",
+        "ref/dotnet/es/System.Reflection.Emit.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.xml",
+        "ref/dotnet/it/System.Reflection.Emit.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.xml",
+        "ref/dotnet/System.Reflection.Emit.dll",
+        "ref/dotnet/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/net45/_._",
+        "ref/xamarinmac20/_._",
+        "System.Reflection.Emit.4.0.0.nupkg",
+        "System.Reflection.Emit.4.0.0.nupkg.sha512",
+        "System.Reflection.Emit.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.ILGeneration/4.0.0": {
+      "type": "package",
+      "sha512": "02okuusJ0GZiHZSD2IOLIN41GIn6qOr7i5+86C98BPuhlwWqVABwebiGNvhDiXP1f9a6CxEigC7foQD42klcDg==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.ILGeneration.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/es/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/it/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.dll",
+        "ref/dotnet/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.ILGeneration.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.ILGeneration.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.ILGeneration.4.0.0.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.0.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.nuspec"
+      ]
+    },
+    "System.Reflection.Emit.Lightweight/4.0.0": {
+      "type": "package",
+      "sha512": "DJZhHiOdkN08xJgsJfDjkuOreLLmMcU8qkEEqEHqyhkPUZMMQs0lE8R+6+68BAFWgcdzxtNu0YmIOtEug8j00w==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Emit.Lightweight.dll",
+        "lib/wp80/_._",
+        "ref/dotnet/de/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/es/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/fr/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/it/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ja/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ko/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/ru/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.dll",
+        "ref/dotnet/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Emit.Lightweight.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Emit.Lightweight.xml",
+        "ref/net45/_._",
+        "ref/wp80/_._",
+        "System.Reflection.Emit.Lightweight.4.0.0.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.0.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
     "System.Reflection.Extensions/4.0.0": {
@@ -2605,6 +2903,40 @@
         "System.Reflection.Primitives.nuspec"
       ]
     },
+    "System.Reflection.TypeExtensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec"
+      ]
+    },
     "System.Resources.ResourceManager/4.0.0": {
       "type": "package",
       "serviceable": true,
@@ -2639,10 +2971,10 @@
         "System.Resources.ResourceManager.nuspec"
       ]
     },
-    "System.Runtime/4.0.20-beta-23127": {
+    "System.Runtime/4.0.20": {
       "type": "package",
       "serviceable": true,
-      "sha512": "naLsXkry4PBYCdXLOGx2r9TRuFWJpdZvV7W9rk4QRTPTS7H9911J09o8KXrhX+NW28YVsCgvcw8Wr0JsFEQdLQ==",
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -2668,15 +3000,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.20-beta-23127.nupkg",
-        "System.Runtime.4.0.20-beta-23127.nupkg.sha512",
+        "System.Runtime.4.0.20.nupkg",
+        "System.Runtime.4.0.20.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
-    "System.Runtime.Extensions/4.0.10-beta-23127": {
+    "System.Runtime.Extensions/4.0.10": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YwtpybYxpRqjF+TnBzmNdgGq2jNtEO9MkxYSIMW36lV7F6qEph+nCcKDLsCslgSz7dn44eSCnnsgBQQsF85eQQ==",
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/MonoAndroid10/_._",
@@ -2702,8 +3034,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
-        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg",
-        "System.Runtime.Extensions.4.0.10-beta-23127.nupkg.sha512",
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
         "System.Runtime.Extensions.nuspec"
       ]
     },
@@ -2775,42 +3107,16 @@
         "System.Runtime.InteropServices.nuspec"
       ]
     },
-    "System.Runtime.WindowsRuntime/4.0.0": {
+    "System.Runtime.Loader/4.0.0-beta-23302": {
       "type": "package",
-      "sha512": "IvSI0X1wIgQ2yFCXnV0EJc1FFE4xxzSPqX1r6ikhcLPuKmXjBglB0IrJBmWAK8vaPkyjBIwf7ks2VSdFazXwhA==",
+      "serviceable": true,
+      "sha512": "b4NcLjIIX8W3TY3MR8nNp2c+JgZFWcf1Nr5W3FfrM6Takr1BjBsDKv40cqK1yP2UsEnaIjGkAzXOph4fF4I40A==",
       "files": [
-        "lib/win8/_._",
-        "lib/wp80/_._",
-        "lib/wpa81/_._",
-        "License.rtf",
-        "ref/dotnet/de/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/es/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/fr/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/it/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/ja/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/ko/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/ru/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/System.Runtime.WindowsRuntime.dll",
-        "ref/dotnet/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/zh-hans/System.Runtime.WindowsRuntime.xml",
-        "ref/dotnet/zh-hant/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/de/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/es/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/fr/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/it/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/ja/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/ko/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/ru/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/System.Runtime.WindowsRuntime.dll",
-        "ref/netcore50/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/zh-hans/System.Runtime.WindowsRuntime.xml",
-        "ref/netcore50/zh-hant/System.Runtime.WindowsRuntime.xml",
-        "ref/win8/_._",
-        "ref/wp80/_._",
-        "ref/wpa81/_._",
-        "System.Runtime.WindowsRuntime.4.0.0.nupkg",
-        "System.Runtime.WindowsRuntime.4.0.0.nupkg.sha512",
-        "System.Runtime.WindowsRuntime.nuspec"
+        "lib/DNXCore50/System.Runtime.Loader.dll",
+        "ref/dotnet/System.Runtime.Loader.dll",
+        "System.Runtime.Loader.4.0.0-beta-23302.nupkg",
+        "System.Runtime.Loader.4.0.0-beta-23302.nupkg.sha512",
+        "System.Runtime.Loader.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
@@ -3004,10 +3310,54 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Xml.ReaderWriter/4.0.10": {
+    "System.Threading.Thread/4.0.0-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VdmWWMH7otrYV7D+cviUo7XjX0jzDnD/lTGSZTlZqfIQ5PhXk85j+6P0TK9od3PnOd5ZIM+pOk01G/J+3nh9/w==",
+      "sha512": "0tn5ET6NNDVjJdpacPXM9lwa3tZeKiIYZHOZPtsbORXop84IN93KenlcqEdPizxPsnOAgauVIgeKftnvwcvlsQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Thread.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.Thread.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Thread.4.0.0-beta-23302.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23302.nupkg.sha512",
+        "System.Threading.Thread.nuspec"
+      ]
+    },
+    "System.Threading.ThreadPool/4.0.10-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "dwwA7ce4yVXenjpJU20JyNn3zrXsWWkbw9UMNK49C09D7tmrYLSxzWSzY7/4034okFcOjQmtP5g36ZRZANZL9A==",
+      "files": [
+        "lib/DNXCore50/System.Threading.ThreadPool.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.ThreadPool.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Threading.ThreadPool.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.ThreadPool.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.ThreadPool.4.0.10-beta-23302.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23302.nupkg.sha512",
+        "System.Threading.ThreadPool.nuspec"
+      ]
+    },
+    "System.Xml.ReaderWriter/4.0.11-beta-23302": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "z9D4/CQ9FytubW6CuTFkv7nb9jPHEvTlOUCXD83oEh5gYfw6RfRJGVPpqY+eJLQOqnBS0wgCPck3zNKEWGCFEA==",
       "files": [
         "lib/dotnet/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
@@ -3015,31 +3365,21 @@
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/es/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/fr/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/it/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/ja/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/ko/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/ru/System.Xml.ReaderWriter.xml",
         "ref/dotnet/System.Xml.ReaderWriter.dll",
-        "ref/dotnet/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hans/System.Xml.ReaderWriter.xml",
-        "ref/dotnet/zh-hant/System.Xml.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.4.0.10.nupkg",
-        "System.Xml.ReaderWriter.4.0.10.nupkg.sha512",
+        "System.Xml.ReaderWriter.4.0.11-beta-23302.nupkg",
+        "System.Xml.ReaderWriter.4.0.11-beta-23302.nupkg.sha512",
         "System.Xml.ReaderWriter.nuspec"
       ]
     },
-    "System.Xml.XDocument/4.0.10": {
+    "System.Xml.XDocument/4.0.11-beta-23302": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+ej0g0INnXDjpS2tDJsLO7/BjyBzC+TeBXLeoGnvRrm4AuBH9PhBjjZ1IuKWOhCkxPkFognUOKhZHS2glIOlng==",
+      "sha512": "ugSaPpuT0ImDyfbRtUdsBd6PMWaTYGbeRg1jO6/2tW0cBYIUU5h9496L2Pjm4l6UYa4v2G1+IH1CE/a19D+qSQ==",
       "files": [
         "lib/dotnet/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
@@ -3047,211 +3387,93 @@
         "lib/net46/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Xml.XDocument.xml",
-        "ref/dotnet/es/System.Xml.XDocument.xml",
-        "ref/dotnet/fr/System.Xml.XDocument.xml",
-        "ref/dotnet/it/System.Xml.XDocument.xml",
-        "ref/dotnet/ja/System.Xml.XDocument.xml",
-        "ref/dotnet/ko/System.Xml.XDocument.xml",
-        "ref/dotnet/ru/System.Xml.XDocument.xml",
         "ref/dotnet/System.Xml.XDocument.dll",
-        "ref/dotnet/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hans/System.Xml.XDocument.xml",
-        "ref/dotnet/zh-hant/System.Xml.XDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.XDocument.4.0.10.nupkg",
-        "System.Xml.XDocument.4.0.10.nupkg.sha512",
+        "System.Xml.XDocument.4.0.11-beta-23302.nupkg",
+        "System.Xml.XDocument.4.0.11-beta-23302.nupkg.sha512",
         "System.Xml.XDocument.nuspec"
       ]
     },
-    "xunit/2.1.0": {
+    "System.Xml.XmlDocument/4.0.1-beta-23302": {
       "type": "package",
-      "sha512": "u/7VQSOSXa7kSG4iK6Lcn7RqKZQ3hk7cnyMNVMpXHSP0RI5VQEtc44hvkG3LyWOVsx1dhUDD3rPAHAxyOUDQJw==",
+      "serviceable": true,
+      "sha512": "cv14snu2E01I+Ar4Kb8bNfPLdh3+OZDnJArvaRWzdpM1XAnY5SwrsbZLEOE6h6wAIFp3aefU8IbcbnXOMRATlQ==",
       "files": [
-        "xunit.2.1.0.nupkg",
-        "xunit.2.1.0.nupkg.sha512",
-        "xunit.nuspec"
+        "lib/dotnet/System.Xml.XmlDocument.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Xml.XmlDocument.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlDocument.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Xml.XmlDocument.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Xml.XmlDocument.4.0.1-beta-23302.nupkg",
+        "System.Xml.XmlDocument.4.0.1-beta-23302.nupkg.sha512",
+        "System.Xml.XmlDocument.nuspec"
       ]
     },
-    "xunit.abstractions/2.0.0": {
+    "System.Xml.XmlSerializer/4.0.11-beta-23302": {
       "type": "package",
-      "sha512": "NAdxKQRzuLnCZ0g++x6i87/8rMBpQoRiRlRNLAqfODm2zJPbteHRoSER3DXfxnqrHXyBJT8rFaZ8uveBeQyaMA==",
+      "serviceable": true,
+      "sha512": "aLVJmiBKKGhPYAa3zaojjowvsNuFA5hBmDC6aN8Iv+UAr0WIIPOFy9ASp8oTx6VQ7kEhjxCQXC+pWU21597wXA==",
       "files": [
-        "lib/net35/xunit.abstractions.dll",
-        "lib/net35/xunit.abstractions.xml",
-        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.dll",
-        "lib/portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS/xunit.abstractions.xml",
-        "xunit.abstractions.2.0.0.nupkg",
-        "xunit.abstractions.2.0.0.nupkg.sha512",
-        "xunit.abstractions.nuspec"
-      ]
-    },
-    "xunit.assert/2.1.0": {
-      "type": "package",
-      "sha512": "Hhhw+YaTe+BGhbr57dxVE+6VJk8BfThqFFii1XIsSZ4qx+SSCixprJC10JkiLRVSTfWyT8W/4nAf6NQgIrmBxA==",
-      "files": [
-        "lib/dotnet/xunit.assert.dll",
-        "lib/dotnet/xunit.assert.pdb",
-        "lib/dotnet/xunit.assert.xml",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.pdb",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.assert.xml",
-        "xunit.assert.2.1.0.nupkg",
-        "xunit.assert.2.1.0.nupkg.sha512",
-        "xunit.assert.nuspec"
-      ]
-    },
-    "xunit.console.netcore/1.0.2-prerelease-00128": {
-      "type": "package",
-      "sha512": "GAyZZAl3u4QzI1kJI/zqXDcWoiJz/3ryPNwM1o2JZyNpn5TmKDqEkrXUnmVoBoICYwh5OGebcBwXStr8cPBeDQ==",
-      "files": [
-        "lib/aspnetcore50/xunit.console.netcore.exe",
-        "lib/dnxcore50/_._",
-        "lib/dotnet/_._",
-        "runtimes/any/native/xunit.console.netcore.exe",
-        "xunit.console.netcore.1.0.2-prerelease-00128.nupkg",
-        "xunit.console.netcore.1.0.2-prerelease-00128.nupkg.sha512",
-        "xunit.console.netcore.nuspec"
-      ]
-    },
-    "xunit.core/2.1.0": {
-      "type": "package",
-      "sha512": "jlbYdPbnkPIRwJllcT/tQZCNsSElVDEymdpJfH79uTUrPARkELVYw9o/zhAjKZXmeikGqGK5C2Yny4gTNoEu0Q==",
-      "files": [
-        "build/_desktop/xunit.execution.desktop.dll",
-        "build/dnx451/_._",
-        "build/monoandroid/_._",
-        "build/monotouch/_._",
-        "build/net45/_._",
-        "build/portable-net45+win8+wp8+wpa81/xunit.core.props",
-        "build/win8/_._",
-        "build/win81/xunit.core.props",
-        "build/wp8/_._",
-        "build/wpa81/xunit.core.props",
-        "build/xamarinios/_._",
-        "xunit.core.2.1.0.nupkg",
-        "xunit.core.2.1.0.nupkg.sha512",
-        "xunit.core.nuspec"
-      ]
-    },
-    "xunit.extensibility.core/2.1.0": {
-      "type": "package",
-      "sha512": "ANWM3WxeaeHjACLRlmrv+xOc0WAcr3cvIiJE+gqbdzTv1NCH4p1VDyT+8WmmdCc9db0WFiJLaDy4YTYsL1wWXw==",
-      "files": [
-        "lib/dotnet/xunit.core.dll",
-        "lib/dotnet/xunit.core.dll.tdnet",
-        "lib/dotnet/xunit.core.pdb",
-        "lib/dotnet/xunit.core.xml",
-        "lib/dotnet/xunit.runner.tdnet.dll",
-        "lib/dotnet/xunit.runner.utility.desktop.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.core.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.core.dll.tdnet",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.core.pdb",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.core.xml",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.tdnet.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.desktop.dll",
-        "xunit.extensibility.core.2.1.0.nupkg",
-        "xunit.extensibility.core.2.1.0.nupkg.sha512",
-        "xunit.extensibility.core.nuspec"
-      ]
-    },
-    "xunit.extensibility.execution/2.1.0": {
-      "type": "package",
-      "sha512": "tAoNafoVknKa3sZJPMvtZRnhOSk3gasEGeceSm7w/gyGwsR/OXFxndWJB1xSHeoy33d3Z6jFqn4A3j+pWCF0Ew==",
-      "files": [
-        "lib/dnx451/xunit.execution.dotnet.dll",
-        "lib/dnx451/xunit.execution.dotnet.pdb",
-        "lib/dnx451/xunit.execution.dotnet.xml",
-        "lib/dotnet/xunit.execution.dotnet.dll",
-        "lib/dotnet/xunit.execution.dotnet.pdb",
-        "lib/dotnet/xunit.execution.dotnet.xml",
-        "lib/monoandroid/xunit.execution.dotnet.dll",
-        "lib/monoandroid/xunit.execution.dotnet.pdb",
-        "lib/monoandroid/xunit.execution.dotnet.xml",
-        "lib/monotouch/xunit.execution.dotnet.dll",
-        "lib/monotouch/xunit.execution.dotnet.pdb",
-        "lib/monotouch/xunit.execution.dotnet.xml",
-        "lib/net45/xunit.execution.desktop.dll",
-        "lib/net45/xunit.execution.desktop.pdb",
-        "lib/net45/xunit.execution.desktop.xml",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.pdb",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.execution.dotnet.xml",
-        "lib/win8/xunit.execution.dotnet.dll",
-        "lib/win8/xunit.execution.dotnet.pdb",
-        "lib/win8/xunit.execution.dotnet.xml",
-        "lib/wp8/xunit.execution.dotnet.dll",
-        "lib/wp8/xunit.execution.dotnet.pdb",
-        "lib/wp8/xunit.execution.dotnet.xml",
-        "lib/wpa81/xunit.execution.dotnet.dll",
-        "lib/wpa81/xunit.execution.dotnet.pdb",
-        "lib/wpa81/xunit.execution.dotnet.xml",
-        "lib/xamarinios/xunit.execution.dotnet.dll",
-        "lib/xamarinios/xunit.execution.dotnet.pdb",
-        "lib/xamarinios/xunit.execution.dotnet.xml",
-        "xunit.extensibility.execution.2.1.0.nupkg",
-        "xunit.extensibility.execution.2.1.0.nupkg.sha512",
-        "xunit.extensibility.execution.nuspec"
-      ]
-    },
-    "xunit.runner.console/2.1.0": {
-      "type": "package",
-      "sha512": "dryP6nBDWD2aH6OUidwoPQLebelnfA6DDKUs9PxJ6iPDbT9t5eSKyjqLSas/nQFEJZwXXWVnbImrgK/IgiyOdQ==",
-      "files": [
-        "tools/HTML.xslt",
-        "tools/NUnitXml.xslt",
-        "tools/xunit.abstractions.dll",
-        "tools/xunit.console.exe",
-        "tools/xunit.console.exe.config",
-        "tools/xunit.console.x86.exe",
-        "tools/xunit.console.x86.exe.config",
-        "tools/xunit.runner.reporters.desktop.dll",
-        "tools/xunit.runner.utility.desktop.dll",
-        "tools/xUnit1.xslt",
-        "xunit.runner.console.2.1.0.nupkg",
-        "xunit.runner.console.2.1.0.nupkg.sha512",
-        "xunit.runner.console.nuspec"
-      ]
-    },
-    "xunit.runner.utility/2.1.0": {
-      "type": "package",
-      "sha512": "jJJHROwskIhdQuYw7exe7KaW20dOCa+lzV/lY7Zdh1ZZzdUPpScMi9ReJIutqiyjhemGF8V/GaMIPrcjyZ4ioQ==",
-      "files": [
-        "lib/dnx451/xunit.runner.utility.dotnet.dll",
-        "lib/dnx451/xunit.runner.utility.dotnet.pdb",
-        "lib/dnx451/xunit.runner.utility.dotnet.xml",
-        "lib/dotnet/xunit.runner.utility.dotnet.dll",
-        "lib/dotnet/xunit.runner.utility.dotnet.pdb",
-        "lib/dotnet/xunit.runner.utility.dotnet.xml",
-        "lib/net35/xunit.runner.utility.desktop.dll",
-        "lib/net35/xunit.runner.utility.desktop.pdb",
-        "lib/net35/xunit.runner.utility.desktop.xml",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.dotnet.dll",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.dotnet.pdb",
-        "lib/portable-net45+win8+wp8+wpa81/xunit.runner.utility.dotnet.xml",
-        "xunit.runner.utility.2.1.0.nupkg",
-        "xunit.runner.utility.2.1.0.nupkg.sha512",
-        "xunit.runner.utility.nuspec"
+        "lib/DNXCore50/System.Xml.XmlSerializer.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Xml.XmlSerializer.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/System.Xml.XmlSerializer.dll",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
+        "System.Xml.XmlSerializer.4.0.11-beta-23302.nupkg",
+        "System.Xml.XmlSerializer.4.0.11-beta-23302.nupkg.sha512",
+        "System.Xml.XmlSerializer.nuspec"
       ]
     }
   },
   "projectFileDependencyGroups": {
     "": [
-      "Microsoft.DotNet.xunit.performance >= 1.0.0-alpha-build0027",
-      "Microsoft.DotNet.xunit.performance.analysis >= 1.0.0-alpha-build0027",
-      "Microsoft.DotNet.xunit.performance.runner.Windows >= 1.0.0-alpha-build0027",
-      "System.Console >= 4.0.0-beta-*",
-      "System.Runtime >= 4.0.20-beta-*",
-      "System.Runtime.Extensions >= 4.0.10-beta-*",
-      "System.Numerics.Vectors >= 4.1.1-beta-*",
-      "System.Numerics.Vectors.WindowsRuntime >= 4.0.1-beta-*",
-      "xunit >= 2.1.0",
-      "xunit.console.netcore >= 1.0.2-prerelease-00128",
-      "xunit.runner.utility >= 2.1.0"
+      "System.Diagnostics.Process >= 4.0.0-beta-23302",
+      "System.IO >= 4.0.10-beta-23302",
+      "System.IO.FileSystem >= 4.0.0-beta-23302",
+      "System.IO.FileSystem.Primitives >= 4.0.0-beta-23302",
+      "System.Runtime >= 4.0.20-beta-23302",
+      "System.Runtime.Extensions >= 4.0.10-beta-23302",
+      "System.Runtime.Handles >= 4.0.0-beta-23302",
+      "System.Runtime.Loader >= 4.0.0-beta-23302",
+      "System.Threading >= 4.0.10-beta-23302",
+      "System.Globalization.Calendars >= 4.0.0-beta-23302",
+      "System.Globalization >= 4.0.10-beta-23302",
+      "System.Text.Encoding >= 4.0.10-beta-23302",
+      "System.Runtime.InteropServices >= 4.0.20-beta-23302",
+      "System.Collections >= 4.0.10-beta-23302",
+      "System.Console >= 4.0.0-beta-23302",
+      "System.Reflection >= 4.0.10-beta-23302",
+      "System.Reflection.Primitives >= 4.0.0-beta-23302",
+      "System.ComponentModel >= 4.0.1-beta-23302",
+      "System.Xml.ReaderWriter >= 4.0.11-beta-23302",
+      "System.Collections.NonGeneric >= 4.0.1-beta-23302",
+      "System.Collections.Specialized >= 4.0.1-beta-23302",
+      "System.Linq >= 4.0.1-beta-23302",
+      "System.Linq.Queryable >= 4.0.1-beta-23302",
+      "System.Xml.XmlSerializer >= 4.0.11-beta-23302",
+      "System.Xml.XmlDocument >= 4.0.1-beta-23302",
+      "System.Xml.XDocument >= 4.0.11-beta-23302"
     ],
     "DNXCore,Version=v5.0": []
   }

--- a/tests/src/JIT/config/benchmark/project.json
+++ b/tests/src/JIT/config/benchmark/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0025",
-    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0025",
-    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0025",
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0027",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0027",
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0027",
     "System.Console": "4.0.0-beta-*",
     "System.Runtime": "4.0.20-beta-*",
     "System.Runtime.Extensions": "4.0.10-beta-*",


### PR DESCRIPTION
This PR is the initial work that I've made towards creating a framework which can be used to run cross-platform benchmarks targeted at the GC. There are several components in this PR:

1. The test artifacts used by the performance tests. Each GC performance test case has a corresponding executable that is executed and benchmarked - this is to avoid undue influence of the benchmarking process's garbage collector across multiple iterations of the same test. This also has the added benefit of allowing us to run the performance test on a Desktop/Mono CLR, while executing the tests themselves on CoreCLR, which simplifies running the tests a little, especially on Windows (see the readme for more information on that). These tests all live in the `GC\Performance\Tests` directory and are compiled as part of the CoreCLR test build on Windows.

2. The test "framework", contained in `GC\Performance\Framework`, which is really a wrapper around each one of these executables that exposes it to the `xunit-performance` benchmarking framework. This is located in `GC\Performance\Framework\PerfTests.cs`. There is also a file that handles the launching of child processes across both Desktop CLR and CoreCLR.

3. The test "metrics", exposed to `xunit-performance` and contain in `GC\Performance\Framework\Metrics`. `xunit-performance` allows for test writers to define their own "test metrics", which are values that are recorded by the benchmarking process and output as part of the performance test results. There are many GC-related test metrics defined here that are used on platforms that support TraceEvent, which as of now is Windows-only. Some of the defined metrics include statistics such as the length of the longest GC pause, the average length of GC pauses across all collections, the number of collections triggered for each generation, and several others.

4. GC object model "builders", contained in `GC\Performance\Framework\Metrics\Builders`. This is
existing code that is designed to transform an ETW trace into a garbage collection object model that is much easier to use when calculating statistics about the traced process. In this framework, it is used to calculate most of the metrics provided to `xunit-performance`. This code has a dependency on TraceEvent and as such is only compiled on the DNX46 target of the test framework (more on that below).

The test framework itself builds using `dnx` and supports two targets: DNX46, which defines the `WINDOWS` preprocessor directive, and DNXCORE5, representing non-Windows CoreCLR. The compilation target is chosen by *what platform the tests will be run on*. When running on Windows, the DNX46 target should be used as it contains the additional metrics from point 3 above. The DNXCORE5 target does not contain the additional metrics and, as such, does not depend on TraceEvent, making it runnable on non-Windows platforms.

Some caveats about this PR:

1. This PR cannot be merged right now because it will fail the CI build, due to the fact that a new NuGet package was just introduced to enable the DNX46 target of the test framework to build correctly and it hasn't been persisted to our MyGet feed yet: see microsoft/xunit-performance#112 for more details on this. If this ends up blocking the merge after review, I can temporarily remove the DNX46 target to get this merged.
2. The test *framework* does not currently build as part of the CoreCLR test build, although the test *artifacts* do. This is because the project that builds the tests only builds csproj and ilproj files. I attempted to tweak it to build xproj files as well, but I got this stack trace during the build:

```
System.IO.FileNotFoundException: Could not load the specified file.
  File name: 'Microsoft.DNX.PackageManager'
     at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyName(AssemblyName assemblyName)
     at Microsoft.Dnx.Runtime.Loader.LoadContext.Microsoft.Extensions.PlatformAbstractions.IAssemblyLoadContext.Load(As
  semblyName assemblyName)
     at Microsoft.Dnx.Host.Bootstrapper.RunAsync(List`1 args, IRuntimeEnvironment env, String appBase, FrameworkName ta
  rgetFramework)
     at Microsoft.Dnx.Host.RuntimeBootstrapper.ExecuteAsync(String[] args, BootstrapperContext bootstrapperContext)
     at Microsoft.Dnx.Host.RuntimeBootstrapper.Execute(String[] args, BootstrapperContext bootstrapperContext)
```

To avoid blocking the CI build, I have it set to not build by default. Users of this framework will have to build it manually before using it for now.

I'd appreciate any and all feedback! The objective for this framework is to eventually have it running nightly or somewhat-nightly to start gathering performance data on our GC across multiple platforms. We can use this data to 1) identify where platforms are slower or faster than others, and 2) evaluate potential changes to the GC for performance regressions, catching them before they happen.