### PR TITLE
Disable h/w exceptions for coreclr (non-DAC) builds.

### DIFF
--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -84,6 +84,7 @@ if(WIN32)
     ntdll.lib
   )
 else(WIN32)
+  add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
   add_definitions(-DPAL_STDCPP_COMPAT=1)
   add_compile_options(-Wno-null-arithmetic)
   add_compile_options(-Wno-format)

--- a/src/inc/ex.h
+++ b/src/inc/ex.h
@@ -11,6 +11,7 @@ void RetailAssertIfExpectedClean();             // Defined in src/utilcode/debug
 
 #ifdef FEATURE_PAL
 #define EX_TRY_HOLDER                                   \
+    HardwareExceptionHolder                             \
     NativeExceptionHolderCatchAll __exceptionHolder;    \
     __exceptionHolder.Push();                           \
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6744,6 +6744,11 @@ public:
     static bool IsEnabled();
 };
 
+//
+// NOTE: Catching hardware exceptions are only enabled in the DAC and SOS 
+// builds. A hardware exception in coreclr code will fail fast/terminate
+// the process.
+//
 #ifdef FEATURE_ENABLE_HARDWARE_EXCEPTIONS
 #define HardwareExceptionHolder CatchHardwareExceptionHolder __catchHardwareException;
 #else
@@ -6760,7 +6765,7 @@ extern "C++" {
 // filter to be called during the first pass to better emulate SEH
 // the xplat platforms that only have C++ exception support.
 //
-class NativeExceptionHolderBase : CatchHardwareExceptionHolder
+class NativeExceptionHolderBase
 {
     // Save the address of the holder head so the destructor 
     // doesn't have access the slow (on Linux) TLS value again.
@@ -6870,6 +6875,7 @@ public:
     };                                                                          \
     try                                                                         \
     {                                                                           \
+        HardwareExceptionHolder                                                 \
         auto __exceptionHolder = NativeExceptionHolderFactory::CreateHolder(&exceptionFilter); \
         __exceptionHolder.Push();                                               \
         tryBlock(__param);                                                      \

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -263,7 +263,6 @@ __declspec(thread)
 static NativeExceptionHolderBase *t_nativeExceptionHolderHead = nullptr;
 
 NativeExceptionHolderBase::NativeExceptionHolderBase()
-    : CatchHardwareExceptionHolder()
 {
     m_head = nullptr;
     m_next = nullptr;

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/CMakeLists.txt
@@ -3,7 +3,8 @@ cmake_minimum_required(VERSION 2.8.12.2)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 if(CLR_CMAKE_PLATFORM_UNIX)
-   add_compile_options(-fPIC)
+    add_compile_options(-fPIC)
+    add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 # Test DLL1


### PR DESCRIPTION
Fixes the recursive GC crash.

Also fixed sos "clrstack -i". The sos data target needed to implement ICorDebugDataTarget4::VirtualUnwind too.