### PR TITLE
Add StringBuilder constuctors to StringBuilder

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -7656,6 +7656,9 @@
       <Member Name="#ctor(System.String,System.Int32)" />
       <Member Name="#ctor(System.String,System.Int32,System.Int32,System.Int32)" />
       <Member Status="ImplRoot" Name="#ctor(System.Runtime.Serialization.SerializationInfo,System.Runtime.Serialization.StreamingContext)" />
+      <Member Name="#ctor(System.Text.StringBuilder)" />
+      <Member Name="#ctor(System.Text.StringBuilder,System.Int32)" />
+      <Member Name="#ctor(System.Text.StringBuilder,System.Int32,System.Int32,System.Int32)" />
       <Member Name="Append(System.Boolean)" />
       <Member Name="Append(System.Byte)" />
       <Member Name="Append(System.Char)" />

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -80,98 +80,163 @@ namespace System.Text {
         //
         //
 
-        // Creates a new empty string builder (i.e., it represents String.Empty)
-        // with the default capacity (16 characters).
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class.
+        /// </summary>
         public StringBuilder()
         {
             m_MaxCapacity = int.MaxValue;
             m_ChunkChars = new char[DefaultCapacity];
         }
 
-        // Create a new empty string builder (i.e., it represents String.Empty)
-        // with the specified capacity.
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class using the specified capacity.
+        /// </summary>
         public StringBuilder(int capacity)
             : this(capacity, int.MaxValue)
         {
         }
 
-        // Creates a new string builder from the specified string.  If value
-        // is a null String (i.e., if it represents String.NullString)
-        // then the new string builder will also be null (i.e., it will also represent
-        //  String.NullString).
-        // 
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class using the specified string.
+        /// </summary>
+        /// <param name="value">The string used to initialize the value of the instance. If value is null, the new StringBuilder will contain the empty string (that is, it contains Empty).</param>
         public StringBuilder(String value)
-            : this(value, DefaultCapacity) {
+            : this(value, DefaultCapacity)
+        {
         }
 
-        // Creates a new string builder from the specified string with the specified 
-        // capacity.  If value is a null String (i.e., if it represents 
-        // String.NullString) then the new string builder will also be null 
-        // (i.e., it will also represent String.NullString).
-        // The maximum number of characters this string may contain is set by capacity.
-        // 
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class using the specified string and capacity.
+        /// </summary>
+        /// <param name="value">The string used to initialize the value of the instance. If value is null, the new StringBuilder will contain the empty string (that is, it contains Empty).</param>
+        /// <param name="capacity">The suggested starting size of the StringBuilder.</param>
         public StringBuilder(String value, int capacity)
-            : this(value, 0, ((value != null) ? value.Length : 0), capacity) {
+            : this(value, 0, ((value != null) ? value.Length : 0), capacity)
+        {
         }
 
-        // Creates a new string builder from the specifed substring with the specified
-        // capacity.  The maximum number of characters is set by capacity.
-        // 
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class from the specified substring and capacity.
+        /// </summary>
+        /// <param name="value">The string that contains the substring used to initialize the value of this instance. If value is null, the new StringBuilder will contain the empty string (that is, it contains Empty).</param>
+        /// <param name="startIndex">The position within value where the substring begins.</param>
+        /// <param name="length">The number of characters in the substring.</param>
+        /// <param name="capacity">The suggested starting size of the StringBuilder.</param>
         [System.Security.SecuritySafeCritical]  // auto-generated
-        public StringBuilder(String value, int startIndex, int length, int capacity) {
-            if (capacity<0) {
-                throw new ArgumentOutOfRangeException("capacity",
-                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
-            }
-            if (length<0) {
-                throw new ArgumentOutOfRangeException("length",
-                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "length"));
-            }
-            if (startIndex<0) {
+        public StringBuilder(String value, int startIndex, int length, int capacity)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
+
+            if (length < 0)
+                throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "length"));
+
+            if (startIndex < 0)
                 throw new ArgumentOutOfRangeException("startIndex", Environment.GetResourceString("ArgumentOutOfRange_StartIndex"));
-            }
+
             Contract.EndContractBlock();
 
-            if (value == null) {
+            if (value == null)
                 value = String.Empty;
-            }
-            if (startIndex > value.Length - length) {
+
+            if (startIndex > value.Length - length)
                 throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_IndexLength"));
-            }
+
             m_MaxCapacity = Int32.MaxValue;
-            if (capacity == 0) {
+            if (capacity == 0)
                 capacity = DefaultCapacity;
-            }
             if (capacity < length)
                 capacity = length;
 
             m_ChunkChars = new char[capacity];
             m_ChunkLength = length;
 
-            unsafe {
-                fixed (char* sourcePtr = value)
-                    ThreadSafeCopy(sourcePtr + startIndex, m_ChunkChars, 0, length);
+            if (length > 0)
+            {
+                unsafe
+                {
+                    fixed (char* sourcePtr = value)
+                        ThreadSafeCopy(sourcePtr + startIndex, m_ChunkChars, 0, length);
+                }
             }
         }
 
-        // Creates an empty StringBuilder with a minimum capacity of capacity
-        // and a maximum capacity of maxCapacity.
-        public StringBuilder(int capacity, int maxCapacity) {
-            if (capacity>maxCapacity) {
-                throw new ArgumentOutOfRangeException("capacity", Environment.GetResourceString("ArgumentOutOfRange_Capacity"));
-            }
-            if (maxCapacity<1) {
-                throw new ArgumentOutOfRangeException("maxCapacity", Environment.GetResourceString("ArgumentOutOfRange_SmallMaxCapacity"));
-            }
-            if (capacity<0) {
-                throw new ArgumentOutOfRangeException("capacity",
-                                                      Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
-            }
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class using the specified StringBuilder.
+        /// </summary>
+        /// <param name="value">The StringBuilder used to initialize the value of the instance. If value is null, the new StringBuilder will contain the empty string (that is, it contains Empty).</param>
+        public StringBuilder(StringBuilder value)
+            : this(value, DefaultCapacity)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class using the specified StringBuilder and capacity.
+        /// </summary>
+        /// <param name="value">The StringBuilder used to initialize the value of the instance. If value is null, the new StringBuilder will contain the empty string (that is, it contains Empty).</param>
+        /// <param name="capacity">The suggested starting size of the StringBuilder.</param>
+        public StringBuilder(StringBuilder value, int capacity)
+            : this(value, 0, ((value != null) ? value.Length : 0), capacity)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class from the specified StringBuilder substring and capacity.
+        /// </summary>
+        /// <param name="value">The StringBuilder that contains the substring used to initialize the value of this instance. If value is null, the new StringBuilder will contain the empty string (that is, it contains Empty).</param>
+        /// <param name="startIndex">The position within value where the substring begins.</param>
+        /// <param name="length">The number of characters in the substring.</param>
+        /// <param name="capacity">The suggested starting size of the StringBuilder.</param>
+        public StringBuilder(StringBuilder value, int startIndex, int length, int capacity)
+        {
+            if (capacity < 0)
+                throw new ArgumentOutOfRangeException("capacity", Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
+
+            if (length < 0)
+                throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_MustBeNonNegNum", "length"));
+
+            if (startIndex < 0)
+                throw new ArgumentOutOfRangeException("startIndex", Environment.GetResourceString("ArgumentOutOfRange_StartIndex"));
+
             Contract.EndContractBlock();
 
-            if (capacity == 0) {
+            int valueLength = value == null ? 0 : value.Length;
+
+            if (startIndex > valueLength - length)
+                throw new ArgumentOutOfRangeException("length", Environment.GetResourceString("ArgumentOutOfRange_IndexLength"));
+
+            m_MaxCapacity = Int32.MaxValue;
+            if (capacity == 0)
+                capacity = DefaultCapacity;
+            if (capacity < length)
+                capacity = length;
+
+            m_ChunkChars = new char[capacity];
+            m_ChunkLength = length;
+
+            if (length > 0)
+                value.CopyTo(startIndex, m_ChunkChars, 0, length);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the StringBuilder class that starts with a specified capacity and can grow to a specified maximum.
+        /// </summary>
+        /// <param name="capacity">The suggested starting size of the StringBuilder.</param>
+        /// <param name="maxCapacity">The maximum number of characters the StringBuilder can contain.</param>
+        public StringBuilder(int capacity, int maxCapacity)
+        {
+            if (capacity > maxCapacity)
+                throw new ArgumentOutOfRangeException("capacity", Environment.GetResourceString("ArgumentOutOfRange_Capacity"));
+            if (maxCapacity < 1)
+                throw new ArgumentOutOfRangeException("maxCapacity", Environment.GetResourceString("ArgumentOutOfRange_SmallMaxCapacity"));
+            if (capacity<0)
+                throw new ArgumentOutOfRangeException("capacity", Environment.GetResourceString("ArgumentOutOfRange_MustBePositive", "capacity"));
+
+            Contract.EndContractBlock();
+
+            if (capacity == 0)
                 capacity = Math.Min(DefaultCapacity, maxCapacity);
-            }
 
             m_MaxCapacity = maxCapacity;
             m_ChunkChars = new char[capacity];
@@ -2020,7 +2085,7 @@ namespace System.Text {
             int newBlockLength = Math.Max(minBlockCharCount, Math.Min(Length, MaxChunkSize));
 
             // Copy the current block to the new block, and initialize this to point at the new buffer. 
-            m_ChunkPrevious = new StringBuilder(this);
+            m_ChunkPrevious = new StringBuilder(m_ChunkLength, m_ChunkOffset, m_ChunkChars, m_ChunkPrevious, m_MaxCapacity);
             m_ChunkOffset += m_ChunkLength;
             m_ChunkLength = 0;
 
@@ -2040,13 +2105,13 @@ namespace System.Text {
         /// In particular the buffer is shared.  It is expected that 'from' chunk (which represents
         /// the whole list, is then updated to point to point to this new chunk. 
         /// </summary>
-        private StringBuilder(StringBuilder from)
+        private StringBuilder(int chunkLength, int chunkOffset, char[] chunkChars, StringBuilder chunkPrevious, int maxCapacity)
         {
-            m_ChunkLength = from.m_ChunkLength;
-            m_ChunkOffset = from.m_ChunkOffset;
-            m_ChunkChars = from.m_ChunkChars;
-            m_ChunkPrevious = from.m_ChunkPrevious;
-            m_MaxCapacity = from.m_MaxCapacity;
+            m_ChunkLength = chunkLength;
+            m_ChunkOffset = chunkOffset;
+            m_ChunkChars = chunkChars;
+            m_ChunkPrevious = chunkPrevious;
+            m_MaxCapacity = maxCapacity;
             VerifyClassInvariant();
         }
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/StringBuilderctor7.csproj
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/StringBuilderctor7.csproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{2B567C0B-39C0-4F87-B5BA-CF5D53C72E87}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <!-- Add Compile Object Here -->
+    <Compile Include="stringbuilderctor7.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+    <ProjectReference Include="../../../../../Common/CoreCLRTestLibrary/CoreCLRTestLibrary.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor7.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor7.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Text;
+/// <summary>
+/// StringBuilder.ctor(StringBuilder)
+/// </summary>
+public class StringBuilderctor7
+{
+    public static int Main()
+    {
+        StringBuilderctor7 sbctor7 = new StringBuilderctor7();
+        TestLibrary.TestFramework.BeginTestCase("StringBuilderctor7");
+        if (sbctor7.RunTests())
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("PASS");
+            return 100;
+        }
+        else
+        {
+            TestLibrary.TestFramework.EndTestCase();
+            TestLibrary.TestFramework.LogInformation("FAIL");
+            return 0;
+        }
+    }
+    public bool RunTests()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.LogInformation("[Positive]");
+        retVal = PosTest1() && retVal;
+        retVal = PosTest2() && retVal;
+        retVal = PosTest3() && retVal;
+        return retVal;
+    }
+    #region PositiveTest
+    public bool PosTest1()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest1:Construct the StringBuilder with null StringBuilder");
+        try
+        {
+            StringBuilder strValue = null;
+            StringBuilder sb = new StringBuilder(strValue);
+            if (sb == null || sb.Length != 0 || sb.Capacity != 16)
+            {
+                TestLibrary.TestFramework.LogError("001", "The ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("002", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    public bool PosTest2()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest2:Construct the StringBuilder with empty StringBuilder");
+        try
+        {
+            StringBuilder strValue = new StringBuilder();
+            StringBuilder sb = new StringBuilder(strValue);
+            if (sb == null || sb.Length != 0 || sb.Capacity != 16)
+            {
+                TestLibrary.TestFramework.LogError("003", "The ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    public bool PosTest3()
+    {
+        bool retVal = true;
+        TestLibrary.TestFramework.BeginScenario("PosTest3:Construct the StringBuilder with random string StringBuilder");
+        try
+        {
+            string strValue = TestLibrary.Generator.GetString(-55, false, 8, 256);
+            StringBuilder sb = new StringBuilder(strValue);
+            if (sb == null || sb.Length != strValue.Length)
+            {
+                TestLibrary.TestFramework.LogError("005", "The string ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+            
+            StringBuilder sb2 = new StringBuilder(sb);
+            if (sb2 == null || sb2.Length != sb.Length)
+            {
+                TestLibrary.TestFramework.LogError("006", "The StringBuilder ExpectResult is not the ActualResult");
+                retVal = false;
+            }
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("007", "Unexpect exception:" + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    #endregion
+}


### PR DESCRIPTION
Allow construction of StringBuilders from StringBuilders. This allows for more
complicated composition of strings and multiple stage string interop scenarios.

Skip pinning the input string if the copy length is 0.

Update constructors to current style guidelines.

Add initial test to match existing constructor tests- will add others after feedback.

See #1843. #1844 would be the other piece needed to avoid unnecessary string allocations when interoping (P/Invoke) with StringBuilder.

@vancem, @stephentoub 