### PR TITLE
Fix C++ exception handling when coreclr is loaded before C++ runtime

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -203,11 +203,8 @@ add_library(coreclrpal
 )
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  # On ARM linking with libunwind will break C++ exceptions unless we first
-  # link with gcc_s, this is a libunwind issue
   if(PAL_CMAKE_PLATFORM_ARCH_ARM)
     target_link_libraries(coreclrpal
-      gcc_s
       unwind-arm
     )
   endif()
@@ -219,6 +216,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   endif()
     
   target_link_libraries(coreclrpal
+    gcc_s
     pthread
     rt
     dl


### PR DESCRIPTION
This change fixes a problem that happens when libcoreclr.so is loaded before
C++ runtime libraries. In that case, linker resolves the C++ exception handling
functions against the libunwind8 and exception handling doesn't work.

The fix is the same as someone has already made in the past for ARM - to
add gcc_s to the library list of coreclrpal before the libunwind8. Then
the linker does the right thing. So I have moved the gcc_s out of the ARM specific 
path to the general one.