### PR TITLE
Update IL.targets to handle more properties

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -40,5 +40,14 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b99969\b99969\*" >
             <Issue>2286</Issue>
         </ExcludeList>
+	<ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
+	     <Issue>2329</Issue>
+	</ExcludeList>
+	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbgarrres\_il_dbgarrres.cmd" >
+	     <Issue>2330</Issue>
+	</ExcludeList>
+	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relarrres\_il_relarrres.cmd" >
+	     <Issue>2330</Issue>
+	</ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/src/IL.targets
+++ b/tests/src/IL.targets
@@ -13,11 +13,17 @@
     <PropertyGroup>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">/DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">/EXE</_OutputTypeArgument>
-
-      <_KeyFileArgument Condition="'$(KeyOriginatorFile)' != ''">/KEY=$(KeyOriginatorFile)</_KeyFileArgument>
+      <_IlasmSwitches>/QUIET /NOLOGO</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(KeyOriginatorFile)' != ''">$(_IlasmSwitches) /KEY=$(KeyOriginatorFile)</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(FoldIdenticalMethods)' == 'True'">$(_IlasmSwitches) /FOLD</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(SizeOfStackReserve)' != ''">$(_IlasmSwitches) /STACK=$(SizeOfStackReserve)</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'Full'">$(_IlasmSwitches) /DEBUG</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'Impl'">$(_IlasmSwitches) /DEBUG=IMPL</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(DebugType)' == 'PdbOnly'">$(_IlasmSwitches) /DEBUG=OPT</_IlasmSwitches>
+      <_IlasmSwitches Condition="'$(Optimize)' == 'True'">$(_IlasmSwitches) /OPTIMIZE</_IlasmSwitches>
     </PropertyGroup>
 
-    <Exec Command="ilasm /QUIET $(_OutputTypeArgument) /OUTPUT=@(IntermediateAssembly) $(_KeyFileArgument) @(Compile)">
+    <Exec Command="ilasm $(_OutputTypeArgument) /OUTPUT=@(IntermediateAssembly) $(_IlasmSwitches) @(Compile)">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
     <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -111,3 +111,8 @@ JIT/opt/Tailcall/TailcallVerifyWithPrefix/TailcallVerifyWithPrefix.sh
 Loader/NativeLibs/FromNativePaths/FromNativePaths.sh
 JIT/Methodical/Boxing/misc/_dbgconcurgc_il/_dbgconcurgc_il.sh
 JIT/jit64/gc/regress/vswhidbey/143837/143837.sh
+JIT/Methodical/Invoke/25params/25param1c_il_d/25param1c_il_d.sh
+JIT/Methodical/Invoke/25params/25param3c_il_d/25param3c_il_d.sh
+JIT/Methodical/Invoke/25params/25paramMixed_il_d/25paramMixed_il_d.sh
+JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b79250/b79250/b79250.sh
+JIT/Methodical/Boxing/misc/_relconcurgc_il/_relconcurgc_il.sh


### PR DESCRIPTION
Some of the ilasm tests we are porting require setting ilasm switches.
This change adds new properties that if provided set ilasm switches.

If FoldIdenticalMethods is True, provide /fold
If SizeOfStackReserve is not '', provide /stack=value
These DebugType values are recognized:

- Full => /DEBUG
- Impl => /DEBUG=IMPL
- PdbOnly => /DEBUG=OPT
- Any other value, including "" or "NONE" gives no /DEBUG switch

If Optimize = 'True', provide /OPTIMIZE