### PR TITLE
Fix pipe file cleanup in /tmp directory.

### DIFF
--- a/src/debug/shared/dbgtransportsession.cpp
+++ b/src/debug/shared/dbgtransportsession.cpp
@@ -160,7 +160,7 @@ void DbgTransportSession::Shutdown()
             SessionState ePreviousState = m_eState;
             m_eState = SS_Closed;
 
-            if ((ePreviousState != SS_Opening_NC) && (ePreviousState != SS_Resync_NC) && (ePreviousState != SS_Closed))
+            if (ePreviousState != SS_Closed)
             {
                 m_pipe.Disconnect();
             }
@@ -171,10 +171,6 @@ void DbgTransportSession::Shutdown()
         // Signal the m_hSessionOpenEvent now to quickly error out any callers of WaitForSessionToOpen().
         SetEvent(m_hSessionOpenEvent);
 #endif // RIGHT_SIDE_COMPILE
-
-        // Now let the transport thread shut itself down cleanly. This will take care of emptying the send queue
-        // as well.
-        WaitForSingleObject(m_hTransportThread, INFINITE);
     }
 
     // No other threads are now using session resources. We're free to deallocate them as we wish (if they

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1952,6 +1952,12 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         
         FastInterlockExchange((LONG*)&g_fForbidEnterEE, TRUE);
 
+#if defined(DEBUGGING_SUPPORTED) && defined(FEATURE_PAL)
+        // Terminate the debugging services in the first phase for PAL based platforms
+        // because EEDllMain's DLL_PROCESS_DETACH is NOT going to be called.
+        TerminateDebugger();
+#endif // DEBUGGING_SUPPORTED && FEATURE_PAL
+
         if (g_fProcessDetach)
         {
             ThreadStore::TrapReturningThreads(TRUE);


### PR DESCRIPTION
The debugger/transport shutdown was not being called because we don't emulate
coreclr's DllMain DLL_PROCESS_DETACH callbacks. Adding the DLL_PROCESS_DETACH
DllMain callbacks will potentially crash deadlocks and other problems.  Added the
debugger terminate/shutdown call to EEShutDown's first phase.

The pipe files are not currently cleaned up for unhandled managed exceptions (which terminate the process) but I'm looking into it.