### PR TITLE
Fix transparency annotations

### DIFF
--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
@@ -3,18 +3,22 @@
 
 using System;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
 
 internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
     }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -10,35 +10,45 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern SafeSortHandle GetSortHandle(byte[] localeName);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern void CloseSortHandle(IntPtr handle);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern int CompareString(SafeSortHandle sortHandle, char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len, CompareOptions options);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern int LastIndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern int IndexOfOrdinalIgnoreCase(string target, int cwTargetLength, char* pSource, int cwSourceLength, bool findLast);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool StartsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool EndsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern int GetSortKey(SafeSortHandle sortHandle, string str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);
 
+        [SecurityCritical]
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
         internal unsafe static extern int CompareStringOrdinalIgnoreCase(char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len);
 
@@ -52,6 +62,7 @@ internal static partial class Interop
 
             public override bool IsInvalid
             {
+                [SecurityCritical]
                 get { return handle == IntPtr.Zero; }
             }
 

--- a/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CalendarData.Unix.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
 
 namespace System.Globalization
@@ -69,6 +70,7 @@ namespace System.Globalization
         }
 
         // Call native side to figure out which calendars are allowed
+        [SecuritySafeCritical]
         internal static int GetCalendars(string localeName, bool useUserOverride, CalendarId[] calendars)
         {
             // NOTE: there are no 'user overrides' on Linux
@@ -91,6 +93,7 @@ namespace System.Globalization
 
         // PAL Layer ends here
 
+        [SecuritySafeCritical]
         private static bool GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, out string calendarString)
         {
             calendarString = null;
@@ -265,6 +268,7 @@ namespace System.Globalization
             return index - startIndex;
         }
 
+        [SecuritySafeCritical]
         private static bool EnumMonthNames(string localeName, CalendarId calendarId, CalendarDataType dataType, out string[] monthNames)
         {
             monthNames = null;
@@ -286,6 +290,7 @@ namespace System.Globalization
             return result;
         }
 
+        [SecuritySafeCritical]
         private static bool EnumEraNames(string localeName, CalendarId calendarId, CalendarDataType dataType, out string[] eraNames)
         {
             bool result = EnumCalendarInfo(localeName, calendarId, dataType, out eraNames);
@@ -301,6 +306,7 @@ namespace System.Globalization
             return result;
         }
 
+        [SecuritySafeCritical]
         internal static bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, out string[] calendarData)
         {
             calendarData = null;
@@ -315,6 +321,7 @@ namespace System.Globalization
             return result;
         }
 
+        [SecuritySafeCritical]
         private static bool EnumCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType dataType, CallbackContext callbackContext)
         {
             GCHandle context = GCHandle.Alloc(callbackContext);
@@ -328,6 +335,7 @@ namespace System.Globalization
             }
         }
 
+        [SecuritySafeCritical]
         private static void EnumCalendarInfoCallback(string calendarString, IntPtr context)
         {
             CallbackContext callbackContext = (CallbackContext)((GCHandle)context).Target;

--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -10,8 +10,10 @@ namespace System.Globalization
 {
     public partial class CompareInfo
     {
+        [SecurityCritical]
         private readonly Interop.GlobalizationInterop.SafeSortHandle m_sortHandle;
 
+        [SecuritySafeCritical]
         internal CompareInfo(CultureInfo culture)
         {
             m_name = culture.m_name;
@@ -19,6 +21,7 @@ namespace System.Globalization
             m_sortHandle = Interop.GlobalizationInterop.GetSortHandle(System.Text.Encoding.UTF8.GetBytes(m_sortName));
         }
 
+        [SecurityCritical]
         internal static unsafe int IndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             Contract.Assert(source != null);
@@ -63,6 +66,7 @@ namespace System.Globalization
             return -1;
         }
 
+        [SecurityCritical]
         internal static unsafe int LastIndexOfOrdinal(string source, string value, int startIndex, int count, bool ignoreCase)
         {
             Contract.Assert(source != null);
@@ -110,7 +114,7 @@ namespace System.Globalization
             return -1;
         }
 
-        private unsafe int GetHashCodeOfStringCore(string source, CompareOptions options)
+        private int GetHashCodeOfStringCore(string source, CompareOptions options)
         {
             Contract.Assert(source != null);
             Contract.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
@@ -118,13 +122,13 @@ namespace System.Globalization
             return GetHashCodeOfStringCore(source, options, forceRandomizedHashing: false, additionalEntropy: 0);
         }
 
-        [System.Security.SecuritySafeCritical]
+        [SecurityCritical]
         private static unsafe int CompareStringOrdinalIgnoreCase(char* string1, int count1, char* string2, int count2)
         {
             return Interop.GlobalizationInterop.CompareStringOrdinalIgnoreCase(string1, count1, string2, count2);
         }
 
-        [System.Security.SecuritySafeCritical]
+        [SecurityCritical]
         private unsafe int CompareString(string string1, int offset1, int length1, string string2, int offset2, int length2, CompareOptions options)
         {
             Contract.Assert(string1 != null);
@@ -140,7 +144,7 @@ namespace System.Globalization
             }
         }
 
-        [System.Security.SecuritySafeCritical]
+        [SecurityCritical]
         private unsafe int IndexOfCore(string source, string target, int startIndex, int count, CompareOptions options)
         {
             Contract.Assert(!string.IsNullOrEmpty(source));
@@ -165,6 +169,7 @@ namespace System.Globalization
             }
         }
 
+        [SecurityCritical]
         private unsafe int LastIndexOfCore(string source, string target, int startIndex, int count, CompareOptions options)
         {
             Contract.Assert(!string.IsNullOrEmpty(source));
@@ -193,6 +198,7 @@ namespace System.Globalization
             }
         }
 
+        [SecuritySafeCritical]
         private bool StartsWith(string source, string prefix, CompareOptions options)
         {
             Contract.Assert(!string.IsNullOrEmpty(source));
@@ -202,6 +208,7 @@ namespace System.Globalization
             return Interop.GlobalizationInterop.StartsWith(m_sortHandle, prefix, prefix.Length, source, source.Length, options);
         }
 
+        [SecuritySafeCritical]
         private bool EndsWith(string source, string suffix, CompareOptions options)
         {
             Contract.Assert(!string.IsNullOrEmpty(source));
@@ -215,6 +222,7 @@ namespace System.Globalization
         // ---- PAL layer ends here ----
         // -----------------------------
 
+        [SecuritySafeCritical]
         internal unsafe int GetHashCodeOfStringCore(string source, CompareOptions options, bool forceRandomizedHashing, long additionalEntropy)
         {
             Contract.Assert(source != null);
@@ -239,7 +247,7 @@ namespace System.Globalization
             }
         }
 
-        [System.Security.SecurityCritical]
+        [SecurityCritical]
         [DllImport(JitHelpers.QCall)]
         [SuppressUnmanagedCodeSecurity]
         private static unsafe extern int InternalHashSortKey(byte* sortKey, int sortKeyLength, [MarshalAs(UnmanagedType.Bool)] bool forceRandomizedHashing, long additionalEntropy);

--- a/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CultureData.Unix.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
+using System.Security;
 using System.Text;
 
 namespace System.Globalization
@@ -22,6 +23,7 @@ namespace System.Globalization
         /// This method uses the sRealName field (which is initialized by the constructor before this is called) to
         /// initialize the rest of the state of CultureData based on the underlying OS globalization library.
         /// </summary>
+        [SecuritySafeCritical]
         private unsafe bool InitCultureData()
         {
             Contract.Assert(this.sRealName != null);
@@ -86,6 +88,7 @@ namespace System.Globalization
             return true;
         }
 
+        [SecuritySafeCritical]
         internal static bool GetLocaleName(string localeName, out string windowsName)
         {
             // Get the locale name from ICU
@@ -102,6 +105,7 @@ namespace System.Globalization
             return true;
         }
 
+        [SecuritySafeCritical]
         internal static bool GetDefaultLocaleName(out string windowsName)
         {
             // Get the default (system) locale name from ICU
@@ -126,6 +130,7 @@ namespace System.Globalization
 
         // For LOCALE_SPARENT we need the option of using the "real" name (forcing neutral names) instead of the
         // "windows" name, which can be specific for downlevel (< windows 7) os's.
+        [SecuritySafeCritical]
         private string GetLocaleInfo(string localeName, LocaleStringData type)
         {
             Contract.Assert(localeName != null, "[CultureData.GetLocaleInfo] Expected localeName to be not be null");
@@ -151,6 +156,7 @@ namespace System.Globalization
             return StringBuilderCache.GetStringAndRelease(sb);
         }
 
+        [SecuritySafeCritical]
         private int GetLocaleInfo(LocaleNumberData type)
         {
             Contract.Assert(this.sWindowsName != null, "[CultureData.GetLocaleInfo(LocaleNumberData)] Expected this.sWindowsName to be populated already");
@@ -174,6 +180,7 @@ namespace System.Globalization
             return value;
         }
 
+        [SecuritySafeCritical]
         private int[] GetLocaleInfo(LocaleGroupingData type)
         {
             Contract.Assert(this.sWindowsName != null, "[CultureData.GetLocaleInfo(LocaleGroupingData)] Expected this.sWindowsName to be populated already");
@@ -199,6 +206,7 @@ namespace System.Globalization
             return GetTimeFormatString(false);
         }
 
+        [SecuritySafeCritical]
         private string GetTimeFormatString(bool shortFormat)
         {
             Contract.Assert(this.sWindowsName != null, "[CultureData.GetTimeFormatString(bool shortFormat)] Expected this.sWindowsName to be populated already");

--- a/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/JapaneseCalendar.Unix.cs
@@ -2,11 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Security;
 
 namespace System.Globalization
 {
     public partial class JapaneseCalendar : Calendar
     {
+        [SecuritySafeCritical]
         private static EraInfo[] GetJapaneseEras()
         {
             string[] eraNames;
@@ -63,6 +65,7 @@ namespace System.Globalization
             return eraNames[eraIndex].Substring(0, 1);
         }
 
+        [SecuritySafeCritical]
         private static bool GetJapaneseEraStartDate(int era, out DateTime dateTime)
         {
             dateTime = default(DateTime);

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics.Contracts;
+using System.Security;
 using System.Text;
 
 namespace System.Globalization
@@ -25,7 +26,7 @@ namespace System.Globalization
             m_needsTurkishCasing = NeedsTurkishCasing(m_textInfoName);
         }
 
-        [System.Security.SecuritySafeCritical]
+        [SecuritySafeCritical]
         private unsafe string ChangeCase(string s, bool toUpper)
         {
             Contract.Assert(s != null);
@@ -70,7 +71,7 @@ namespace System.Globalization
             return result;
         }
 
-        [System.Security.SecuritySafeCritical]
+        [SecuritySafeCritical]
         private unsafe char ChangeCase(char c, bool toUpper)
         {
             char dst = default(char);
@@ -92,6 +93,7 @@ namespace System.Globalization
 
         private bool IsInvariant { get { return m_cultureName.Length == 0; } }
 
+        [SecurityCritical]
         internal unsafe void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper)
         {
             if (IsInvariant)

--- a/src/mscorlib/corefx/System/Globalization/TextInfo.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.cs
@@ -86,6 +86,7 @@ namespace System.Globalization
         }
 
         // Currently we don't have native functions to do this, so we do it the hard way
+        [SecuritySafeCritical]
         internal static int IndexOfStringOrdinalIgnoreCase(String source, String value, int startIndex, int count)
         {
             if (count > source.Length || count < 0 || startIndex < 0 || startIndex >= source.Length || startIndex + count > source.Length)
@@ -97,6 +98,7 @@ namespace System.Globalization
         }
 
         // Currently we don't have native functions to do this, so we do it the hard way
+        [SecuritySafeCritical]
         internal static int LastIndexOfStringOrdinalIgnoreCase(String source, String value, int startIndex, int count)
         {
             if (count > source.Length || count < 0 || startIndex < 0 || startIndex > source.Length - 1 || (startIndex - count + 1 < 0))

--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -2327,6 +2327,7 @@ namespace System {
         /// Finds the time zone id by using 'readlink' on the path to see if tzFilePath is
         /// a symlink to a file 
         /// </summary>
+        [SecuritySafeCritical]
         private static string FindTimeZoneIdUsingReadLink(string tzFilePath)
         {
             string id = null;


### PR DESCRIPTION
The cross platform globalization code had some incorrect transparency
annotations. This was causing problems for crossgen and would also
trigger issues if CoreCLR was run in a mode to enable transparency
checks (which were disabled by default in 725d6a9).

I ran SecAnnotate over the Unix build of mscorlib.dll and fixed up the
problems. There were a few cases where we had some functions that were
marked a SecuritySafeCritical but they were better marked as
SecurityCritical (since they didn't do bounds checks, instead relying on
upstack code to do so) and I updated them when I was in the area.

Fixes #2314