### PR TITLE
[BUILD] Fix for #2338

### DIFF
--- a/src/coreclr/hosts/unixcoreruncommon/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreruncommon/CMakeLists.txt
@@ -5,3 +5,4 @@ add_library(unixcoreruncommon
     coreruncommon.cpp
 )
 
+target_link_libraries(unixcoreruncommon dl)

--- a/src/coreclr/hosts/unixcoreruncommon/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreruncommon/CMakeLists.txt
@@ -5,4 +5,6 @@ add_library(unixcoreruncommon
     coreruncommon.cpp
 )
 
-target_link_libraries(unixcoreruncommon dl)
+if(CLR_CMAKE_PLATFORM_LINUX)
+  target_link_libraries(unixcoreruncommon dl)
+endif(CLR_CMAKE_PLATFORM_LINUX)


### PR DESCRIPTION
Link unixcoreruncommon with dl, which is needed on Linux systems to use dynamic linking.
Fixes #2338 