### PR TITLE
Debugger transport pipe file cleanup - Part 2

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -569,6 +569,24 @@ PALAPI
 PAL_TerminateEx(
     int exitCode);
 
+/*++
+Function:
+  PAL_SetShutdownCallback
+
+Abstract:
+  Sets a callback that is executed when the PAL is shut down because of
+  ExitProcess, TerminateProcess or PAL_Shutdown but not PAL_Terminate/Ex.
+
+  NOTE: Currently only one callback can be set at a time.
+--*/
+typedef VOID (*PSHUTDOWN_CALLBACK)(void);
+
+PALIMPORT
+VOID
+PALAPI
+PAL_SetShutdownCallback(
+    IN PSHUTDOWN_CALLBACK callback);
+
 PALIMPORT
 void
 PALAPI

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4655,7 +4655,8 @@ VOID DECLSPEC_NORETURN UnwindManagedExceptionPass1(PAL_SEHException& ex)
                     LONG disposition = InternalUnhandledExceptionFilter_Worker(&ex.ExceptionPointers);
                     _ASSERTE(disposition == EXCEPTION_CONTINUE_SEARCH);
                 }
-                EEPOLICY_HANDLE_FATAL_ERROR(COR_E_EXECUTIONENGINE);                    
+                TerminateProcess(GetCurrentProcess(), 1);
+                UNREACHABLE();
             }
 
             UINT_PTR parentSp = GetSP(&frameContext);


### PR DESCRIPTION
Clean up the pipe files in /tmp for unhandled managed exception termination.

Added a simple PAL shutdown API to set (one) shutdown callback handler which is used
by the debugger code to cleanup the transport thus removing the pipe files from /tmp.

This callback is executed PAL_Shutdown, ExitProcess and TerminateProcess, the later used
to terminate the process for an unhandled managed exception.