### PR TITLE
Add a new COMPLUS_JITMinOptsName to force MinOpts for a named function

### DIFF
--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -439,6 +439,7 @@ CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_JITMinOptsInstrCount, W("JITMinOptsInst
 CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_JITMinOptsLvNumcount, W("JITMinOptsLvNumcount"), "Internal jit control of MinOpts")
 CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_JITMinOptsLvRefcount, W("JITMinOptsLvRefcount"), "Internal jit control of MinOpts")
 CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_JITBreakOnMinOpts, W("JITBreakOnMinOpts"), "Halt if jit switches to MinOpts")
+CONFIG_STRING_INFO_EX(INTERNAL_JITMinOptsName, W("JITMinOptsName"), "Forces MinOpts for a named function", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_STRING_INFO(EXTERNAL_JitName, W("JitName"), "Primary Jit to use")
 #if defined(ALLOW_SXS_JIT)
 RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_AltJitName, W("AltJitName"), "Alternative Jit to use, will fall back to primary jit.", CLRConfig::REGUTIL_default)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3239,6 +3239,15 @@ void                 Compiler::compSetOptimizationLevel()
             break;
         }
     }
+    
+    if (!theMinOptsValue)
+    {
+        static ConfigMethodSet jitMinOptsName;
+        jitMinOptsName.ensureInit(CLRConfig::INTERNAL_JITMinOptsName);
+
+        if (jitMinOptsName.contains(info.compMethodName, info.compClassName, info.compMethodInfo->args.pSig))
+            theMinOptsValue = true;
+    }
 
     if (compStressCompile(STRESS_MIN_OPTS, 5))
     {


### PR DESCRIPTION
This uses the same name syntax as other variables taking names, like JitDump.
It is useful When tracking down silent bad codegen bugs, where you have a name
but no repeatable function number, such as due to a multithreaded app.