### PR TITLE
Fix an omission to treat as having side effects intrinsics that are

### DIFF
--- a/src/jit/assertionprop.cpp
+++ b/src/jit/assertionprop.cpp
@@ -4528,6 +4528,7 @@ void Compiler::optVnNonNullPropCurStmt(BasicBlock* block, GenTreePtr stmt, GenTr
 {
     ASSERT_TP empty = BitVecOps::MakeEmpty(apTraits);
     GenTreePtr newTree = nullptr;
+    // TODO: Handle intrinsic implemented as call. We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
     if (tree->OperGet() == GT_CALL)
     {
         newTree = optNonNullAssertionProp_Call(empty, tree, stmt);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7191,6 +7191,9 @@ bool Compiler::fgCastNeeded(GenTreePtr tree, var_types toType)
     {
         fromType = tree->CastToType();
     }
+    // TODO: Handle intrinsic modeled as calls. (Like obj.GetType()) 
+    // TODO: I think we are fine here since the else case below will cover the intrinsic that is 
+    //       rewritten later to a call. Please confirm that. Keyword: IntrinsicsModeledAsACall
     else if (tree->OperGet() == GT_CALL)
     {
         fromType = (var_types) tree->gtCall.gtReturnType;
@@ -21539,6 +21542,10 @@ void                Compiler::fgInline()
             expr = stmt->gtStmtExpr;
 
             // See if we can expand the inline candidate.
+            // TODO: Handle intrinsics modeled as method calls (Would we inline obj.GetType() here?) 
+            //        We might have to add a GT_INTRINSIC check here? Are we allowing inlining of such intrinsics?
+            //        Keyword: IntrinsicsModeledAsACall
+
             if ((expr->gtOper == GT_CALL) && ((expr->gtFlags & GTF_CALL_INLINE_CANDIDATE) != 0))
             {
                 fgMorphStmt = stmt;
@@ -21559,6 +21566,8 @@ void                Compiler::fgInline()
 
             // See if stmt is of the form GT_COMMA(call, nop)
             // If yes, we can get rid of GT_COMMA.            
+            // TODO: Handle intrinsics modeled as method calls???
+            //        We might have to add a GT_INTRINSIC check here as well? Keyword: IntrinsicsModeledAsACall
             if (expr->OperGet() == GT_COMMA &&
                 expr->gtOp.gtOp1->OperGet() == GT_CALL &&
                 expr->gtOp.gtOp2->OperGet() == GT_NOP)

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -11147,6 +11147,13 @@ GenTreePtr          Compiler::gtNewRefCOMfield(GenTreePtr   objPtr,
 
 bool                Compiler::gtNodeHasSideEffects(GenTreePtr tree, unsigned flags)
 {
+    // If this is an intrinsic, implemented as a call, it always has a side effect - 
+    // it can throw NullReferenceException if the target of the call is null.    
+    if (tree->OperGet() == GT_INTRINSIC && ((flags & GTF_CALL) != 0))
+    {
+        return true;
+    }
+
     if (flags & GTF_ASG)
     {
         if  ((tree->OperKind() & GTK_ASGOP) || 
@@ -11234,6 +11241,13 @@ bool                Compiler::gtNodeHasSideEffects(GenTreePtr tree, unsigned fla
 bool                Compiler::gtTreeHasSideEffects(GenTreePtr tree,
                                                    unsigned   flags /* = GTF_SIDE_EFFECT*/)
 {
+    // If this is an intrinsic, implemented as a call, it always has a side effect - 
+    // it can throw NullReferenceException if the target of the call is null.    
+    if (tree->OperGet() == GT_INTRINSIC && ((flags & GTF_CALL) != 0))
+    {
+        return true;
+    }
+
     // These are the side effect flags that we care about for this tree
     unsigned sideEffectFlags = tree->gtFlags & flags;
 
@@ -11438,6 +11452,8 @@ void                Compiler::gtExtractSideEffList(GenTreePtr expr, GenTreePtr *
         }
     }
 
+    // TODO: Handle intrinsics modeled as method calls?? (Think of obj.GetType() being the call?)
+    //       We might have to add a GT_INTRINSIC check here ? Keyword : IntrinsicsModeledAsACall
     if (expr->OperGet() == GT_CALL)
     {
         // Generally all GT_CALL nodes are considered to have side-effects.
@@ -11652,6 +11668,8 @@ bool            Compiler::gtHasCatchArg(GenTreePtr tree)
          i++)
     {
         GenTree *node = parentStack->Index(i);
+        // TODO: Handle intrinsics modeled as method calls?? (Think of obj.GetType() being the call?)
+        //        We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
         if (node->OperGet() == GT_CALL)
         {
             return true;
@@ -11727,6 +11745,8 @@ void Compiler::gtCheckQuirkAddrExposedLclVar(GenTreePtr tree, GenTreeStack* pare
 //  3) a local variable of type RuntimeType.
 bool Compiler::gtCanOptimizeTypeEquality(GenTreePtr tree)
 {
+    // TODO: Handle intrinsics modeled as method calls?? (Think of obj.GetType() being the call?)
+    //        We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
     if (tree->gtOper == GT_CALL)
     {
         if (tree->gtCall.gtCallType == CT_HELPER)

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3244,7 +3244,8 @@ InterlockedBinOpCommon:
 
 #ifndef LEGACY_BACKEND
     case CORINFO_INTRINSIC_Object_GetType:
-
+        // TODO: What if the object type is tail prefixed? Don't convert to intrinsic. 
+        //       Will we end up ignoring the tail call prefix in such case? Keyword: IntrinsicsModeledAsACall       
         op1 = impPopStack().val;
         op1 = new (this, GT_INTRINSIC) GenTreeIntrinsic(genActualType(callType), op1, intrinsicID, method);
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13140,6 +13140,8 @@ bool                Compiler::fgFoldConditional(BasicBlock * block)
 
         noway_assert(stmt->gtNext == NULL);
 
+        // TODO: Handle intrinsics modeled as method calls?? (Think of an intrinsic that is modeled as a call returning an int).
+        //       Will we miss opportunity for optimization without it? We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
         if (stmt->gtStmt.gtStmtExpr->gtOper == GT_CALL)
         {
             noway_assert(fgRemoveRestOfBlock);
@@ -13347,6 +13349,8 @@ DONE_COND:
 
         noway_assert(stmt->gtNext == NULL);
 
+        // TODO: Handle intrinsics modeled as method calls?? (Think of intrinsic returning a null being the call?)
+        //       Will we miss opportunity for optimization without it? We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
         if (stmt->gtStmt.gtStmtExpr->gtOper == GT_CALL)
         {
             noway_assert(fgRemoveRestOfBlock);

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -186,6 +186,10 @@ Compiler::fgWalkResult      Compiler::optPropagateNonCSE(GenTreePtr *pTree, fgWa
     Compiler* comp = data->compiler;
 
     /* Calls get DONT_CSE implicitly */
+    // TODO: Handle intrinsics modeled as method calls??? (Think of obj.GetType() being the call?)
+    //       Will we miss opportunity for optimization without it? Or is it possible to CSE an expression 
+    //       with side effect, thus altering the program behavior?
+    //       We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
     if (tree->OperGet() == GT_CALL)
     {
         if (!IsSharedStaticHelper(tree))

--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -5068,6 +5068,8 @@ Compiler::fgWalkResult      Compiler::optIsVarAssgCB(GenTreePtr *pTree, fgWalkDa
             desc->ivaMaskInd = varRefKinds(desc->ivaMaskInd | refs);
         }
     }
+    // TODO: Handle intrinsics modeled as method calls?? (Think of obj.GetType() being the call?)
+    //      We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
     else if (tree->gtOper == GT_CALL)
     {
         isVarAssgDsc *  desc = (isVarAssgDsc*)data->pCallbackData;
@@ -5901,6 +5903,9 @@ bool Compiler::optHoistLoopExprsForTree(GenTreePtr tree,
         // If it's a call, it must be a helper call, and be pure.
         // Further, if it may run a cctor, it must be labeled as "Hoistable" 
         // (meaning it won't run a cctor because the class is not precise-init).
+        // TODO: Handle intrinsics modeled as method calls?? (Think of obj.GetType() being the call?)
+        //       Will we miss-hoist an expression with side effect? What would the result be if that happens?
+        //       We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
         if (treeIsHoistable && tree->OperGet() == GT_CALL)
         {
             GenTreeCall* call = tree->AsCall();
@@ -6536,6 +6541,9 @@ void                Compiler::optComputeLoopSideEffectsOfBlock(BasicBlock* blk)
             // Even after we set heapHavoc we still may want to know if a loop contains calls
             if (heapHavoc)
             {
+                // TODO: Handle intrinsics modeled as method calls?? (Think of obj.GetType() being the call?)
+                //       If we have the intrinsic, that is later converted to a call, would we miss this expression?
+                //       We might have to add a GT_INTRINSIC check here? Keyword: IntrinsicsModeledAsACall
                 if (oper == GT_CALL)
                 {
                     // Record that this loop contains a call


### PR DESCRIPTION
modeled as calls.

Coverting some special calls to intrinsics for the purposes of the optimizers, so they can be better optimized. Such call
is object.GetType(). The new intrinsic is marked as no-side-effect if the
result of the call is not used the optimizer decided to eliminate the call
altogether. In caseswhere object is null, the NullReferenceException is
removed.

This fix adds the necessary code to treat such intrinsics as always having
side effects.