### PR TITLE
Fix for a bug in recursive tail call to loop transformation.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6190,7 +6190,9 @@ void Compiler::fgMorphRecursiveFastTailCallIntoLoop(BasicBlock* block, GenTreeCa
     GenTreePtr paramAssignmentInsertionPoint = last;
 
     // Process early args. They may contain both setup statements for late args and actual args.
-    int earlyArgIndex = 0;
+    // Early args don't include 'this' arg. We need to account for that so that the call to gtArgEntryByArgNum
+    // below has the correct second argument.
+    int earlyArgIndex = (thisArg == nullptr) ? 0 : 1;
     for (GenTreeArgList* earlyArgs = recursiveTailCall->gtCallArgs;
          earlyArgs != nullptr;
          (earlyArgIndex++, earlyArgs = earlyArgs->Rest()))

--- a/tests/src/JIT/CodeGenBringUpTests/RecursiveTailCall.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/RecursiveTailCall.cs
@@ -1,0 +1,143 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Runtime.CompilerServices;
+
+public struct Struct1
+{
+    public bool bfield;
+
+    public Struct1(bool b)
+    {
+        bfield = b;
+    }
+}
+
+public struct Struct8
+{
+    public double dfield;
+
+    public Struct8(double d)
+    {
+        dfield = d;
+    }
+}
+
+public class Test
+{
+    // Test a recursive tail call with a 1-byte struct parameter.
+    static bool TestStruct1Param(Struct1 str1, int count)
+    {
+        Console.WriteLine(count);
+        Console.WriteLine(count);
+        Console.WriteLine(count);
+        Console.WriteLine(count);
+        if (!CheckStruct1(str1))
+        {
+            return false;
+        }
+
+        if (count <= 0)
+        {
+            return true;
+        }
+
+        return TestStruct1Param(str1, count - 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool CheckStruct1(Struct1 str1)
+    {
+        return str1.bfield;
+    }
+
+    // Test a recursive tail call with an 8-byte struct parameter.
+    static bool TestStruct8Param(Struct8 str8, int count)
+    {
+        Console.WriteLine(count);
+        Console.WriteLine(count);
+        Console.WriteLine(count);
+        Console.WriteLine(count);
+        if (!CheckStruct8(str8))
+        {
+            return false;
+        }
+
+        if (count <= 0)
+        {
+            return true;
+        }
+
+        return TestStruct8Param(str8, count - 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool CheckStruct8(Struct8 str8)
+    {
+        return (str8.dfield == 1.0);
+    }
+
+    // Test a recursive tail call to a method with generic sharing.
+    bool TestGenericSharing<T>()
+    {
+        if (typeof(T) == typeof(string))
+        {
+            return true;
+        }
+        else
+        {
+            return TestGenericSharing<string>();
+        }
+    }
+
+    // Test a recursive tail call to a method that has a 'this' parameter
+    // and a parameter passed on the stack.
+    bool TestStackParam(int i1, int i2, int i3, int i4)
+    {
+        if ((i3 != 5) || (i4 != 7))
+        {
+            return false;
+        }
+        if (i1 == 0)
+        {
+            return true;
+        }
+        return TestStackParam(i1 - 1, i2, i3, i4);
+    }
+
+    public static int Main()
+    {
+        const int Pass = 100;
+        const int Fail = -1;
+
+        Struct1 str1 = new Struct1(true);
+
+        if (!TestStruct1Param(str1, 4))
+        {
+            return Fail;
+        }
+
+        Struct8 str8 = new Struct8(1.0);
+
+        if (!TestStruct8Param(str8, 4))
+        {
+            return Fail;
+        }
+
+        Test test = new Test();
+
+        if (!test.TestGenericSharing<object>())
+        {
+            return Fail;
+        }
+
+        if (!test.TestStackParam(1, 0, 5, 7))
+        {
+            return Fail;
+        }
+
+        return Pass;
+    }
+}

--- a/tests/src/JIT/CodeGenBringUpTests/RecursiveTailCall.csproj
+++ b/tests/src/JIT/CodeGenBringUpTests/RecursiveTailCall.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)threading+thread\project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RecursiveTailCall.cs" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The bug affects recursive tail calls where there is both a this arg and
an argument passed in outgoing arg space.

I brought over RecursiveTailCall tests and added TestStackParam test
that was a repro for the bug.

/cc @dotnet/jit-contrib
