### PR TITLE
Cleanup warnings in native test projects

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 # Compile options
 
 if (WIN32)
-    add_compile_options(-wd4820)
+    add_compile_options(-wd4100 -wd4514 -wd4668 -wd4710 -wd4711 -wd4820)
 endif()
 
 if(CLR_CMAKE_PLATFORM_UNIX)

--- a/tests/src/Common/Platform/platformdefines.cpp
+++ b/tests/src/Common/Platform/platformdefines.cpp
@@ -31,7 +31,6 @@ LPSTR HackyConvertToSTR(LPWSTR pwszInput)
 {
 	size_t cchInput;
 	LPSTR  pszOutput;
-	LPWSTR pStr;
 
 	if (NULL == pwszInput) return NULL;
 
@@ -49,7 +48,7 @@ LPSTR HackyConvertToSTR(LPWSTR pwszInput)
 
 error_t TP_scpy_s(LPWSTR strDestination, size_t sizeInWords, LPCWSTR strSource)
 {
-	int cnt;
+	size_t cnt;
 	// copy sizeInBytes bytes of strSource into strDestination
 
 	if (NULL == strDestination || NULL == strSource) return 1;
@@ -189,7 +188,7 @@ void TP_ZeroMemory(LPVOID buffer, size_t sizeInBytes)
 	if (NULL == buffer) return;
 
 	bBuf = (BYTE*)buffer;
-	for(int i=0; i<sizeInBytes; i++)
+	for(size_t i=0; i<sizeInBytes; i++)
 	{
 		bBuf[i] = 0;
 	}
@@ -197,7 +196,7 @@ void TP_ZeroMemory(LPVOID buffer, size_t sizeInBytes)
 
 error_t TP_itow_s(int num, LPWSTR buffer, size_t sizeInCharacters, int radix)
 {
-	int len;
+	size_t len;
 	int tmpNum;
 
 	// only support radix == 10 and only positive numbers
@@ -226,11 +225,10 @@ error_t TP_itow_s(int num, LPWSTR buffer, size_t sizeInCharacters, int radix)
 
 	// convert num into a string (backwards)
 	buffer[len] = '\0';
-	len--;
-	while(0 < num && 0 <= len)
+	while(0 < num && 0 < len)
 	{
+        len--;
 		buffer[len] = (WCHAR)((num % 10) + '0');
-		len--;
 		num /= 10;
 	}
 

--- a/tests/src/JIT/Directed/StructABI/CMakeLists.txt
+++ b/tests/src/JIT/Directed/StructABI/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required (VERSION 2.6)
 project (StructABILib)
 include_directories(${INC_PLATFORM_DIR})
 
+if(!WIN32)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
+endif()
 
 # add the executable
 add_library (StructABILib SHARED StructABI.c)

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structinregs.cpp
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structinregs.cpp
@@ -319,12 +319,12 @@ EXPORT(void) InvokeCallback20(PFNACTION20 callback, S20 s)
 
 EXPORT(void) InvokeCallback28(PFNACTION28 callback, S28 s)
 {
-    printf("Native S28: %X object, %d\n", (unsigned int)s.x, s.y);
+    printf("Native S28: %p object, %d\n", s.x, s.y);
     callback(s);
 }
 EXPORT(void) InvokeCallback29(PFNACTION29 callback, S29 s)
 {
-    printf("Native S29: %d, %X object\n", s.x, (unsigned int)s.y);
+    printf("Native S29: %d, %p object\n", s.x, s.y);
     callback(s);
 }
 
@@ -463,13 +463,13 @@ EXPORT(S20) InvokeCallback20R(PFNACTION20 callback, S20 s)
 
 EXPORT(S28) InvokeCallback28R(PFNACTION28 callback, S28 s)
 {
-    printf("Native S28: %X object, %d\n", (unsigned int)s.x, s.y);
+    printf("Native S28: %p object, %d\n", s.x, s.y);
     callback(s);
     return s;
 }
 EXPORT(S29) InvokeCallback29R(PFNACTION29 callback, S29 s)
 {
-    printf("Native S29: %d, %X object\n", s.x, (unsigned int)s.y);
+    printf("Native S29: %d, %p object\n", s.x, s.y);
     callback(s);
     return s;
 }

--- a/tests/src/JIT/jit64/mcc/interop/native_i0c.cpp
+++ b/tests/src/JIT/jit64/mcc/interop/native_i0c.cpp
@@ -8,8 +8,8 @@
 MCC_API VType0 __cdecl sum(unsigned __int64 first, ...) {
     VType0 result;
 
-    unsigned int count = 0;
-    unsigned __int64 sum = 0;
+    int count = 0;
+    __int64 sum = 0;
     unsigned __int64 val = first;
     va_list args;
 

--- a/tests/src/JIT/jit64/mcc/interop/native_i0s.cpp
+++ b/tests/src/JIT/jit64/mcc/interop/native_i0s.cpp
@@ -20,7 +20,7 @@ MCC_API MyValueType WINAPI  sum(
     unsigned __int64 a10, unsigned __int64 a11, unsigned __int64 a12) {
     MyValueType result;
 
-    result.sum = a01 + a02 + a03 + a04 + a05 + a06 + a07 + a08 + a09 + a10 + a11 + a12;
+    result.sum = static_cast<__int64>(a01 + a02 + a03 + a04 + a05 + a06 + a07 + a08 + a09 + a10 + a11 + a12);
     result.count = 12;
     result.average = (double)result.sum / result.count;
     result.dummy1 = result.sum;

--- a/tests/src/JIT/jit64/mcc/interop/native_i1c.cpp
+++ b/tests/src/JIT/jit64/mcc/interop/native_i1c.cpp
@@ -4,8 +4,10 @@
 #include <stdarg.h>
 #include "native.h"
 
+#ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvarargs"
+#endif
 
 MCC_API VType1 __cdecl sum(float first, ...) {
     VType1 result;
@@ -52,4 +54,6 @@ MCC_API VType1 __cdecl sum(float first, ...) {
     return result;
 }
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Most of the warnings (>10000) are generated by /Wall. It doesn't make much sense to use /Wall but since there's only a small number of warning types that cause issues I left /Wall in and disabled those particular warning types.

A few other warnings were caused by actual code issues (signed/unsigned mismatch, pointer cast to int, unused variables) which I fixed.