### PR TITLE
Modify Array.BinarySearch to return the first matching element

### DIFF
--- a/src/classlibnative/bcltype/arrayhelpers.h
+++ b/src/classlibnative/bcltype/arrayhelpers.h
@@ -87,7 +87,7 @@ public:
                 hi = i;
             }
         }
-        if ((hi == lo) && (length > 0) && array[lo] == value))
+        if ((hi == lo) && (length > 0) && (array[lo] == value))
             return lo;
         else
             // not found

--- a/src/classlibnative/bcltype/arrayhelpers.h
+++ b/src/classlibnative/bcltype/arrayhelpers.h
@@ -71,24 +71,27 @@ public:
 
         // Prefast: mscorlib.dll!System.Array.BinarySearch(Array,int,int,Object,IComparer) 
         // guarantees index and length are in the array bounds and do not overflow
-        PREFIX_ASSUME(index >= 0 && length >= 0 && INT32_MAX >= index + length - 1);
-        int hi = index + length - 1; 
- 
-        // Note: if length == 0, hi will be Int32.MinValue, and our comparison
-        // here between 0 & -1 will prevent us from breaking anything.
-        while (lo <= hi) {
+        PREFIX_ASSUME(index >= 0 && length >= 0 && INT32_MAX >= index + length);
+
+        // Deferred detection of equality: Each binary search will complete the entire search
+        // regardless of when the desired element is found. This preserves order of elements
+        // by returning the first instance of the desire value within the array.
+        int hi = index + length; 
+        while (lo < hi) 
+        {
             int i = lo + ((hi - lo) >> 1);
             if (array[i] < value) {
                 lo = i + 1;
             } 
-            else if (array[i] > value){
-                hi = i - 1;
-            }
             else {
-                return i;
+                hi = i;
             }
         }
-        return ~lo;
+        if ((hi == lo) && (length > 0) && array[lo] == value))
+            return lo;
+        else
+            // not found
+            return ~lo;
     }
 
     inline static void SwapIfGreaterWithItems(KIND keys[], KIND items[], int a, int b) {

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -914,47 +914,62 @@ namespace System {
             }
 
             int lo = index;
-            int hi = index + length - 1;   
+            int hi = index + length;
+            int c;
             Object[] objArray = array as Object[];
             if(objArray != null) {
-                while (lo <= hi) {
+                while (lo < hi) {
                     // i might overflow if lo and hi are both large positive numbers. 
                     int i = GetMedian(lo, hi);
 
-                    int c;
                     try {
                         c = comparer.Compare(objArray[i], value);
                     }
                     catch (Exception e) {
                         throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_IComparerFailed"), e);
                     }
-                    if (c == 0) return i;
                     if (c < 0) {
                         lo = i + 1;
                     }
                     else {
-                        hi = i - 1;
+                        hi = i;
                     }
+                }
+                if ((hi == lo) && (length > 0)) {
+                    try {
+                        c = comparer.Compare(objArray[i], value);
+                    }
+                    catch (Exception e) {
+                        throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_IComparerFailed"), e);
+                    }
+                    return c == 0 ? lo : ~lo;
                 }
             }
             else {
-                while (lo <= hi) {
+                while (lo < hi) {
                     int i = GetMedian(lo, hi);                    
 
-                    int c;
                     try {
                         c = comparer.Compare(array.GetValue(i), value);
                     }
                     catch (Exception e) {
                         throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_IComparerFailed"), e);
                     }
-                    if (c == 0) return i;
                     if (c < 0) {
                         lo = i + 1;
                     }
                     else {
-                        hi = i - 1;
+                        hi = i;
                     }
+                }
+                if ((hi == lo) && (length > 0)) {
+                    try {
+                        c = comparer.Compare(array.GetValue(i), value);
+                    }
+                    catch (Exception e) {
+                        throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_IComparerFailed"), e);
+                    }
+                    return c == 0 ? lo : ~lo;
                 }
             }
             return ~lo;

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -937,7 +937,7 @@ namespace System {
                 }
                 if ((hi == lo) && (length > 0)) {
                     try {
-                        c = comparer.Compare(objArray[i], value);
+                        c = comparer.Compare(objArray[lo], value);
                     }
                     catch (Exception e) {
                         throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_IComparerFailed"), e);
@@ -964,7 +964,7 @@ namespace System {
                 }
                 if ((hi == lo) && (length > 0)) {
                     try {
-                        c = comparer.Compare(array.GetValue(i), value);
+                        c = comparer.Compare(array.GetValue(lo), value);
                     }
                     catch (Exception e) {
                         throw new InvalidOperationException(Environment.GetResourceString("InvalidOperation_IComparerFailed"), e);


### PR DESCRIPTION
The BinarySearch methods used by the Array class perform a tradtional iterative search to find the desired value and quit iteration when that value is found. This commit modifies those searches to instead perform a deferred termination search that has the effect of returning the matching value in the array that is at the lowest index instead of returning whichever value is found first. The negative affect of this is that in situations where the value is discovered early the search must complete as if it wasn't found.

resolves https://github.com/dotnet/corefx/issues/4698

@hickford @stephentoub 