### PR TITLE
Reduce iterations in SqMtx

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
@@ -16,7 +16,7 @@ public static class SqMtx
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 1000;
+    public const int Iterations = 4000;
 #endif
 
     const int MatrixSize = 40;
@@ -71,18 +71,13 @@ public static class SqMtx
     public static void Test() {
         foreach (var iteration in Benchmark.Iterations) {
             using (iteration.StartMeasurement()) {
-                for (int i = 0; i < Iterations; i++) {
-                   Bench();
-                }
+                Bench();
             }
         }
     }
 
     static bool TestBase() {
-        bool result = true;
-        for (int i = 0; i < Iterations; i++) {
-            result &= Bench();
-        }
+        bool result = Bench();
         return result;
     }
 


### PR DESCRIPTION
This test had two nested loops using `Iterations` and so ran for quite a long time. Remove the outer nest and then bump up the `Iterations` value so the test runs for about 1 second from command line and 10 seconds under xunit-performance.