### PR TITLE
Fix a bug in morphing GT_COMMA with op1 being the new GetType() intri…

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -4691,6 +4691,20 @@ bool                GenTree::OperMayThrow()
 
         return true;
 
+    case GT_INTRINSIC:
+        // If this is an intrinsic that represents the object.GetType(), it can throw an NullReferenceException.
+        // Report it as may throw.
+        // Note: Some of the rest of the existing intrinsics could potentially throw an exception (for example
+        //       the array and string element access ones). They are handled differently than the GetType intrinsic
+        //       and are not marked with GTF_EXCEPT. If these are revisited at some point to be marked as GTF_EXCEPT, 
+        //       the code below might need to be specialized to handle them properly.
+        if ((this->gtFlags & GTF_EXCEPT) != 0)
+        {
+            return true;
+        }
+
+        break;
+
     case GT_ARR_BOUNDS_CHECK:
     case GT_ARR_ELEM:
     case GT_ARR_INDEX:

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -3249,7 +3249,9 @@ InterlockedBinOpCommon:
         op1 = new (this, GT_INTRINSIC) GenTreeIntrinsic(genActualType(callType), op1, intrinsicID, method);
 
         // Set the CALL flag to indicate that the operator is implemented by a call. 
-        op1->gtFlags |= GTF_CALL;
+        // Set also the EXCEPTION flag because the native implementation of 
+        // CORINFO_INTRINSIC_Object_GetType intrinsic can throw NullReferenceException.
+        op1->gtFlags |= (GTF_CALL | GTF_EXCEPT);
         return op1;
 #endif
 


### PR DESCRIPTION
…nsic.

The GetType intrinsic is side effect free and the morphing of GT_COMMA is
optimizing out side effect free op1a. The native implementation of GetType
- NativeObject::GetClass - can throw NullReferenceException and such
optimizing the call out is illegal in such case. Also added GTF_EXCEPT
to the intrinsic node to note the other optimizers that the call can
throw an exception.

The coreclr and corefx tests passed. Also minimal, correct asmdifs. The
daily tests passed as well.