### PR TITLE
Fix for special number handling in ildasm

### DIFF
--- a/src/ildasm/dasm.cpp
+++ b/src/ildasm/dasm.cpp
@@ -2041,7 +2041,7 @@ BYTE* PrettyPrintCABlobValue(PCCOR_SIGNATURE &typePtr,
                     float df = (float)atof(str);
                     // Must compare as underlying bytes, not floating point otherwise optmizier will
                     // try to enregister and comapre 80-bit precision number with 32-bit precision number!!!!
-                    if((*(ULONG*)&df != (ULONG)GET_UNALIGNED_VAL32(dataPtr))||(strchr(str,'#') != NULL))
+                    if((*(ULONG*)&df != (ULONG)GET_UNALIGNED_VAL32(dataPtr))||IsSpecialNumber(str))
                         sprintf_s(str, 64,"0x%08X",(ULONG)GET_UNALIGNED_VAL32(dataPtr));
                     appendStr(out,str);
                     dataPtr +=4;
@@ -2060,7 +2060,7 @@ BYTE* PrettyPrintCABlobValue(PCCOR_SIGNATURE &typePtr,
                     double df = strtod(str, &pch);
                     // Must compare as underlying bytes, not floating point otherwise optmizier will
                     // try to enregister and comapre 80-bit precision number with 64-bit precision number!!!!
-                    if((*(ULONGLONG*)&df != (ULONGLONG)GET_UNALIGNED_VAL64(dataPtr))||(strchr(str,'#') != NULL))
+                    if((*(ULONGLONG*)&df != (ULONGLONG)GET_UNALIGNED_VAL64(dataPtr))||IsSpecialNumber(str))
                         sprintf_s(str, 64, "0x%I64X",(ULONGLONG)GET_UNALIGNED_VAL64(dataPtr));
                     appendStr(out,str);
                     dataPtr +=8;
@@ -2733,7 +2733,7 @@ void DumpDefaultValue(mdToken tok, __inout __nullterminated char* szString, void
                 float df = (float)atof(szf);
                 // Must compare as underlying bytes, not floating point otherwise optmizier will
                 // try to enregister and comapre 80-bit precision number with 32-bit precision number!!!!
-                if((*(ULONG*)&df == MDDV.m_ulValue)&&(strchr(szf,'#') == NULL))
+                if((*(ULONG*)&df == MDDV.m_ulValue)&&!IsSpecialNumber(szf))
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr)," = %s(%s)",KEYWORD("float32"),szf);
                 else
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), " = %s(0x%08X)",KEYWORD("float32"),MDDV.m_ulValue);
@@ -2748,7 +2748,7 @@ void DumpDefaultValue(mdToken tok, __inout __nullterminated char* szString, void
                 szf[31]=0;
                 // Must compare as underlying bytes, not floating point otherwise optmizier will
                 // try to enregister and comapre 80-bit precision number with 64-bit precision number!!!!
-                if((*(ULONGLONG*)&df == MDDV.m_ullValue)&&(strchr(szf,'#') == NULL))
+                if((*(ULONGLONG*)&df == MDDV.m_ullValue)&&!IsSpecialNumber(szf))
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr)," = %s(%s)",KEYWORD("float64"),szf);
                 else
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), " = %s(0x%I64X) // %s",KEYWORD("float64"),MDDV.m_ullValue,szf);

--- a/src/ildasm/dis.cpp
+++ b/src/ildasm/dis.cpp
@@ -1600,7 +1600,7 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                 float fd = (float)atof(szf);
                 // Must compare as underlying bytes, not floating point otherwise optmizier will
                 // try to enregister and comapre 80-bit precision number with 32-bit precision number!!!!
-                if(((__int32&)fd == v)&&(strchr(szf,'#') == NULL))
+                if(((__int32&)fd == v)&&!IsSpecialNumber(szf))
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), "%-10s %s", pszInstrName, szf);
                 else
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), "%-10s (%2.2X %2.2X %2.2X %2.2X)",
@@ -1639,7 +1639,7 @@ BOOL Disassemble(IMDInternalImport *pImport, BYTE *ILHeader, void *GUICookie, md
                 double df = strtod(szf, &pch); //atof(szf);
                 // Must compare as underlying bytes, not floating point otherwise optmizier will
                 // try to enregister and comapre 80-bit precision number with 64-bit precision number!!!!
-                if(((__int64&)df == v)&&(strchr(szf,'#') == NULL))
+                if (((__int64&)df == v)&&!IsSpecialNumber(szf))
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), "%-10s %s", pszInstrName, szf);
                 else
                     szptr+=sprintf_s(szptr,SZSTRING_REMAINING_SIZE(szptr), "%-10s (%2.2X %2.2X %2.2X %2.2X %2.2X %2.2X %2.2X %2.2X)",
@@ -2789,3 +2789,9 @@ static BOOL ConvToLiteral(__inout __nullterminated char* retBuff, const WCHAR* s
     return ret;
 }
 
+bool IsSpecialNumber(const char* szf)
+{
+    return (strchr(szf, '#') != NULL)
+        || (strstr(szf, "nan") != NULL) || (strstr(szf, "NAN") != NULL)
+        || (strstr(szf, "inf") != NULL) || (strstr(szf, "INF") != NULL);
+}

--- a/src/ildasm/dis.h
+++ b/src/ildasm/dis.h
@@ -85,6 +85,7 @@ char* DumpUnicodeString(void* GUICookie,
 
 void TokenSigInit(IMDInternalImport *pImport);
 void TokenSigDelete();
+bool IsSpecialNumber(const char*);
 
 
 //---------------- see DMAN.CPP--------------------------------------------------


### PR DESCRIPTION
During the test bring-up, I noticed that _gcvt_s (CRT call) has slightly different output for special number like NAN/INF in between VS2013 and VS2015.
For instance, the former prints "1.#INF" while the latter prints "inf".
Unfortunately ildasm checks "#" to detect such case.
The fix here is to add an explicit check if string contains "inf"/"nan".