### PR TITLE
Fix assertion in ilasm

### DIFF
--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -2274,7 +2274,7 @@ void Assembler::EmitSecurityInfo(mdToken            token,
     mdTypeRef           tkTypeRef;
     BinStr             *pSig;
     char               *szMemberName;
-    DWORD               dwErrorIndex;
+    DWORD               dwErrorIndex = 0;
 
     if (pPermissions) {
 
@@ -2320,18 +2320,15 @@ void Assembler::EmitSecurityInfo(mdToken            token,
                                                        uCount,
                                                        &dwErrorIndex)))
             {
+                _ASSERT(uCount >= dwErrorIndex);
                 if (dwErrorIndex == uCount)
                 {
                     report->error("Failed to define security attribute set for 0x%08X\n", token);
                 }
                 else
                 {
-                    _ASSERT(uCount > dwErrorIndex);
-                    if (uCount > dwErrorIndex)
-                    {
-                        report->error("Failed to define security attribute set for 0x%08X\n  (error in permission %u)\n",
-                                      token, uCount - dwErrorIndex);
-                    }
+                    report->error("Failed to define security attribute set for 0x%08X\n  (error in permission %u)\n",
+                                  token, uCount - dwErrorIndex);
                 }
             }
             delete [] pAttrs;


### PR DESCRIPTION
This is a simple fix for incorrect assertion.
Assertion location is changed and dwErrorIndex is zero-initialized.
ilasm on coreclr does not handle permission set/security attribute which coreclr does not support.
So, such attempt will end up with emitting error on coreclr instead of failing to assert.