### PR TITLE
Enable ildasm/ilasm round trip testing

### DIFF
--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -33,6 +33,7 @@ if /i "%1" == "vs2013"   (set __VSVersion=%1&shift&goto Arg_Loop)
 if /i "%1" == "vs2015"   (set __VSVersion=%1&shift&goto Arg_Loop)
 
 if /i "%1" == "crossgen" (set _crossgen=true&shift&goto Arg_Loop)
+if /i "%1" == "ilasmroundtrip" (set _ilasmroundtrip=true&shift&goto Arg_Loop)
 if /i "%1" == "priority" (set _priorityvalue=%2&shift&shift&goto Arg_Loop)
 
 if /i "%1" == "verbose" (set _verbosity=detailed&shift&goto Arg_Loop)
@@ -43,6 +44,7 @@ goto Usage
 :ArgsDone
 
 if defined _crossgen echo Building tests with CrossGen enabled.&set _buildParameters=%_buildParameters% /p:CrossGen=true
+if defined _ilasmroundtrip echo Building tests with IlasmRoundTrip enabled.&set _buildParameters=%_buildParameters% /p:IlasmRoundTrip=true
 if defined _priorityvalue echo Building Test Priority %_priorityvalue%&set _buildParameters=%_buildParameters% /p:CLRTestPriorityToBuild=%_priorityvalue%
 if defined _verbosity echo Enabling verbose file logging
 if not defined _verbosity set _verbosity=normal
@@ -221,5 +223,6 @@ echo Clean - optional argument to force a clean build.
 echo VSVersion - optional argument to use VS2013 or VS2015  (default VS2015)
 echo CrossGen - Enables the tests to run crossgen on the test executables before executing them. 
 echo Priority (N) where N is a number greater than zero that signifies the set of tests that will be built and consequently run.
+echo IlasmRoundTrip - Enables ilasm round trip build and run of the tests before executing them.
 echo Verbose - Enables detailed file logging for the msbuild tasks.
 exit /b 1

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -46,6 +46,38 @@ if not exist "$(MSBuildProjectName).ni.exe" "%CORE_ROOT%\crossgen.exe" /Platform
     </PropertyGroup>
   </Target>
 
+  <Target
+    Name="GetIlasmRoundTripBatchScript"
+    Returns="$(IlasmRoundTripBatchScript)">
+    <PropertyGroup>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'RunOnly'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</InputAssemblyName>
+      <InputAssemblyName Condition="'$(CLRTestKind)' == 'BuildAndRun'">$(MSBuildProjectName).exe</InputAssemblyName>
+      <DisassemblyName>$(MSBuildProjectName).dasm.il</DisassemblyName>
+      <TargetAssemblyName>$(MSBuildProjectName).asm.exe</TargetAssemblyName>
+
+      <!-- If a test is built against mscorlib instead of dotnet Core, permission attributes can be embedded, which CoreCLR does not support. -->
+      <IlasmRoundTrip Condition="'$(ReferenceLocalMscorlib)'!=''">false</IlasmRoundTrip>
+
+       <!-- https://github.com/dotnet/coreclr/issues/2481. Delete /raweh to ildasm once it is resolved.-->
+      <IlasmRoundTripBatchScript Condition="'$(IlasmRoundTrip)'=='true'">
+      <![CDATA[
+ECHO %CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+%CORE_ROOT%\ildasm.exe /raweh /out=$(DisassemblyName) $(InputAssemblyName)
+IF NOT "!ERRORLEVEL!"=="0" (
+  ECHO EXECUTION OF ILDASM - FAILED !ERRORLEVEL!
+  Exit /b 1
+)
+ECHO %CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+%CORE_ROOT%\ilasm.exe /output=$(TargetAssemblyName) $(_IlasmSwitches) $(DisassemblyName)
+IF NOT "!ERRORLEVEL!"=="0" (
+  ECHO EXECUTION OF ILASM - FAILED !ERRORLEVEL!
+  Exit /b 1
+)
+      ]]>
+      </IlasmRoundTripBatchScript>
+    </PropertyGroup>
+  </Target>
+
   <!-- This is here because of this bug: http://blogs.msdn.com/b/msbuild/archive/2006/01/03/508629.aspx-->
   <Target Name="FetchExternalProperties">
     <!--Call GetExecuteShFullPath to get ToRunProject cmd file Path  -->
@@ -88,7 +120,7 @@ if not exist "$(MSBuildProjectName).ni.exe" "%CORE_ROOT%\crossgen.exe" /Platform
   <Target Name="GenerateBatchExecutionScript"
     Inputs="$(MSBuildProjectFullPath)"
     Outputs="$(OutputPath)\$(MSBuildProjectName).cmd"
-    DependsOnTargets="FetchExternalProperties;GetCrossgenBatchScript">
+    DependsOnTargets="FetchExternalProperties;GetCrossgenBatchScript;GetIlasmRoundTripBatchScript">
 
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
@@ -154,7 +186,7 @@ IF NOT "%CLRTestExitCode%"=="%CLRTestExpectedExitCode%" (
 
       <BatchCLRTestExecutionScriptArgument Include="coreroot">
         <HasParam>true</HasParam>
-        <ParamName>envScriptFullPath</ParamName>
+        <ParamName>CoreRootFullPath</ParamName>
         <Command><![CDATA[
     set CORE_ROOT=%2
         ]]></Command>
@@ -168,33 +200,24 @@ IF NOT "%CLRTestExitCode%"=="%CLRTestExpectedExitCode%" (
     </ItemGroup>
 
     <PropertyGroup> 
-      <_CLRTestExeFile Condition="'$(_CLRTestNeedsProjectToRun)' == 'true'">$(_CLRTestToRunFileFullPath)</_CLRTestExeFile>
-      <_CLRTestExeFile Condition="'$(_CLRTestNeedsProjectToRun)' == 'false'">$(MSBuildProjectName).exe</_CLRTestExeFile>
-      <_CLRTestExeFile Condition="'$(CLRTestIsHosted)'=='true' And '$(_CLRTestNeedsProjectToRun)'=='true'">$([MSBuild]::MakeRelative($(OutputPath), $(_CLRTestToRunFileFullPath)))</_CLRTestExeFile>
-      <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"%CORE_ROOT%\corerun.exe" "$(_CLRTestExeFile)"</_CLRTestRunFile>
-      <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='false'">"$(_CLRTestExeFile)"</_CLRTestRunFile>
+      <_CLRTestRunFile Condition="'$(CLRTestIsHosted)'=='true'">"%CORE_ROOT%\corerun.exe"</_CLRTestRunFile>
+      <BatchCLRTestLaunchCmds Condition=" '$(IlasmRoundTrip)'=='true' "><![CDATA[
+ECHO $(_CLRTestRunFile) $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+$(_CLRTestRunFile) $(TargetAssemblyName) %CLRTestExecutionArguments% %Host_Args%
 
-      <BatchCLRTestLaunchCmds Condition=" '$(BatchCLRTestLaunchCmds)'=='' "><![CDATA[
-IF NOT "%CLRCustomTestLauncher%"=="" (
-  goto :CustomLauncher
-) ELSE (
-  goto :DefaultLauncher
+IF NOT "!ERRORLEVEL!"=="%CLRTestExpectedExitCode%" (
+  ECHO END EXECUTION OF IL{D}ASM BINARY - FAILED !ERRORLEVEL! vs %CLRTestExpectedExitCode%
+  ECHO FAILED
+  Exit /b 1
 )
-
-:CustomLauncher
-  call %CLRCustomTestLauncher% %~dp0 $(_CLRTestExeFile) %CLRTestExecutionArguments% %Host_Args%
-  set CLRTestExitCode=%ERRORLEVEL%
-  goto :EndLauncher
-
-:DefaultLauncher
-  ECHO $(_CLRTestRunFile) %CLRTestExecutionArguments% %Host_Args%
-  %_DebuggerFullPath% $(_CLRTestRunFile) %CLRTestExecutionArguments% %Host_Args%
-  set CLRTestExitCode=%ERRORLEVEL%
-
-:EndLauncher
-
       ]]></BatchCLRTestLaunchCmds>
-    </PropertyGroup>   
+      <BatchCLRTestLaunchCmds><![CDATA[
+$(BatchCLRTestLaunchCmds)
+ECHO %_DebuggerFullPath% $(_CLRTestRunFile) $(InputAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+%_DebuggerFullPath% $(_CLRTestRunFile) $(InputAssemblyName) %CLRTestExecutionArguments% %Host_Args%
+set CLRTestExitCode=!ERRORLEVEL!
+      ]]></BatchCLRTestLaunchCmds>
+    </PropertyGroup>
     <PropertyGroup>
       <BatchEnvironmentVariables>
 @(CLRTestBatchEnvironmentVariable -> '%(Identity)', '%0d%0a')
@@ -269,7 +292,7 @@ $(BatchCLRTestArgPrep)
       <_CLRTestExecutionScriptText>
   <![CDATA[
 @ECHO OFF
-setlocal
+setlocal ENABLEDELAYEDEXPANSION
 pushd %~dp0
 $(BatchCLRTestArgPrep)
 $(BatchCLRTestExitCodePrep)
@@ -282,6 +305,9 @@ $(BatchEnvironmentVariables)
 
 REM CrossGen Script (when /p:CrossGen=true)
 $(CrossgenBatchScript)
+
+REM IlasmRoundTrip Script
+$(IlasmRoundTripBatchScript)
 
 REM Precommands
 $(CLRTestBatchPreCommands)

--- a/tests/src/IL.targets
+++ b/tests/src/IL.targets
@@ -14,7 +14,6 @@
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Library'">/DLL</_OutputTypeArgument>
       <_OutputTypeArgument Condition="'$(OutputType)' == 'Exe'">/EXE</_OutputTypeArgument>
       <_IlasmSwitches>/QUIET /NOLOGO</_IlasmSwitches>
-      <_IlasmSwitches Condition="'$(KeyOriginatorFile)' != ''">$(_IlasmSwitches) /KEY=$(KeyOriginatorFile)</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(FoldIdenticalMethods)' == 'True'">$(_IlasmSwitches) /FOLD</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(SizeOfStackReserve)' != ''">$(_IlasmSwitches) /STACK=$(SizeOfStackReserve)</_IlasmSwitches>
       <_IlasmSwitches Condition="'$(DebugType)' == 'Full'">$(_IlasmSwitches) /DEBUG</_IlasmSwitches>

--- a/tests/src/JIT/BBT/Scenario4/Not-Int32.ilproj
+++ b/tests/src/JIT/BBT/Scenario4/Not-Int32.ilproj
@@ -14,6 +14,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/CodeGenBringUpTests/Add1.csproj
+++ b/tests/src/JIT/CodeGenBringUpTests/Add1.csproj
@@ -13,6 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Directed/array-il/_Arrayscomplex3.ilproj
+++ b/tests/src/JIT/Directed/array-il/_Arrayscomplex3.ilproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Generics/Exceptions/general_class_instance01.csproj
+++ b/tests/src/JIT/Generics/Exceptions/general_class_instance01.csproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/IL_Conformance/Old/directed/heap_ovf.ilproj
+++ b/tests/src/JIT/IL_Conformance/Old/directed/heap_ovf.ilproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Methodical/fp/apps/bouncingball_cs_d.csproj
+++ b/tests/src/JIT/Methodical/fp/apps/bouncingball_cs_d.csproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
 
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.csproj
@@ -13,6 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-M02/b00719/b00719.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-M02/b00719/b00719.csproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/SIMD/BitwiseOperations.csproj
+++ b/tests/src/JIT/SIMD/BitwiseOperations.csproj
@@ -13,6 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/jit64/eh/basics/loopEH.csproj
+++ b/tests/src/JIT/jit64/eh/basics/loopEH.csproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/opt/perf/doublealign/Locals.csproj
+++ b/tests/src/JIT/opt/perf/doublealign/Locals.csproj
@@ -15,6 +15,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This enables il{d}asm round-trip testing for Windows.
In order to test il{d}asm on xPlatforms, I injected il{d}asm running on the target binary before running it.
This means this step is a part of the runtest not the buildtest -- unlike runtest, currently buildtest is only on Windows.
1. Test batch file is extended to inject il{d}asm running
2. RunTest has now an optional flag "noasmgen" to fall back the original run without the round-tripping.
3. Test timeout is increased since the round-tripping is part of runtime.
4. Did some clean-up on CLRTest.Execute.Batch.targets
5. Bail out the round-tripping for the tests that are built against mscorlib instead of .Net Core.
6. Added /raweh to ildasm due to https://github.com/dotnet/coreclr/issues/2481

Most tests (>5K) are covered with this change.
The total test time is increased from 2287 to 2438 on debug build. Expecting the gap is smaller on release build/run.