### PR TITLE
Actually lock the project.lock.json

### DIFF
--- a/tests/src/JIT/config/benchmark+serialize/project.lock.json
+++ b/tests/src/JIT/config/benchmark+serialize/project.lock.json
@@ -1,5 +1,5 @@
 {
-  "locked": false,
+  "locked": true,
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -214,3 +214,6 @@ JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexcept_r/throwincascade
 JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexceptnofin_d/throwincascadedexceptnofin_d.sh
 JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexceptnofin_r/throwincascadedexceptnofin_r.sh
 JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621/b13621.sh
+JIT/Performance/CodeQuality/Serialization/Serialize/Serialize.sh
+JIT/Performance/CodeQuality/Serialization/Deserialize/Deserialize.sh
+


### PR DESCRIPTION
Hopefully this clears up some test issues on ubuntu with the serialization benchmarks.