### PR TITLE
Make JIT's fgWalk*Rec functions static

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4363,12 +4363,12 @@ public:
     };
 
     template<bool computeStack>
-    fgWalkResult        fgWalkTreePreRec  (GenTreePtr  *pTree, fgWalkData *fgWalkPre);
+    static fgWalkResult fgWalkTreePreRec  (GenTreePtr  *pTree, fgWalkData *fgWalkPre);
 
     // general purpose tree-walker that is capable of doing pre- and post- order
     // callbacks at the same time
     template<bool doPreOrder, bool doPostOrder>
-    fgWalkResult        fgWalkTreeRec  (GenTreePtr  *pTree, fgWalkData *fgWalkPre);
+    static fgWalkResult fgWalkTreeRec  (GenTreePtr  *pTree, fgWalkData *fgWalkPre);
 
     fgWalkResult        fgWalkTreePre     (GenTreePtr  *pTree,
                                            fgWalkPreFn *visitor,
@@ -4387,7 +4387,7 @@ public:
     //----- Postorder
 
     template<bool computeStack>
-    fgWalkResult        fgWalkTreePostRec (GenTreePtr  *pTree, fgWalkData *fgWalkPre);
+    static fgWalkResult fgWalkTreePostRec (GenTreePtr  *pTree, fgWalkData *fgWalkPre);
 
     fgWalkResult        fgWalkTreePost    (GenTreePtr   *pTree,
                                            fgWalkPostFn  *visitor,

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -404,6 +404,7 @@ template Compiler::fgWalkResult Compiler::fgWalkTreeRec<false,true> (GenTreePtr 
 //                    a stack of ancestor nodes which can be viewed in the callback.
 //
 template<bool computeStack>
+// static
 Compiler::fgWalkResult      Compiler::fgWalkTreePreRec(GenTreePtr *pTree, fgWalkData *fgWalkData)
 {
     fgWalkResult    result        = WALK_CONTINUE;
@@ -608,7 +609,7 @@ Compiler::fgWalkResult      Compiler::fgWalkTreePreRec(GenTreePtr *pTree, fgWalk
 
         default:
 #ifdef  DEBUG
-            gtDispTree(tree);
+            fgWalkData->compiler->gtDispTree(tree);
 #endif
             assert(!"unexpected operator");
         }
@@ -660,6 +661,7 @@ void                    Compiler::fgWalkAllTreesPre(fgWalkPreFn * visitor,
 //                     a stack of ancestor nodes which can be viewed in the callback.
 //
 template<bool computeStack> 
+// static
 Compiler::fgWalkResult Compiler::fgWalkTreePostRec(GenTreePtr *pTree, fgWalkData *fgWalkData)
 {
     fgWalkResult    result;
@@ -821,7 +823,7 @@ Compiler::fgWalkResult Compiler::fgWalkTreePostRec(GenTreePtr *pTree, fgWalkData
 
     default:
 #ifdef  DEBUG
-        gtDispTree(tree);
+        fgWalkData->compiler->gtDispTree(tree);
 #endif
         assert(!"unexpected operator");
     }
@@ -843,6 +845,7 @@ DONE:
 // walk tree doing callbacks in both pre- and post- order (both optional)
 
 template<bool doPreOrder, bool doPostOrder>
+// static
 Compiler::fgWalkResult      
 Compiler::fgWalkTreeRec(GenTreePtr *pTree, fgWalkData *fgWalkData)
 {
@@ -1019,7 +1022,7 @@ Compiler::fgWalkTreeRec(GenTreePtr *pTree, fgWalkData *fgWalkData)
 
     default:
 #ifdef  DEBUG
-        gtDispTree(tree);
+        fgWalkData->compiler->gtDispTree(tree);
 #endif
         assert(!"unexpected operator");
     }


### PR DESCRIPTION
The compiler object is already available via `fgWalkData` and is only needed in debug builds to call `gtDispTree`. Given that these are recursive functions and have many callsites it seems useful to minimize the number of function parameters.