### PR TITLE
Fix "call to 'sqrt' is ambiguous" error when building on SunOS

### DIFF
--- a/src/pal/src/cruntime/finite.cpp
+++ b/src/pal/src/cruntime/finite.cpp
@@ -28,9 +28,9 @@ Abstract:
 #endif  // HAVE_IEEEFP_H
 #include <errno.h>
 
-#define PAL_NAN sqrt(-1)
-#define PAL_POSINF -log(0)
-#define PAL_NEGINF log(0)
+#define PAL_NAN sqrt(-1.0)
+#define PAL_POSINF -log(0.0)
+#define PAL_NEGINF log(0.0)
 
 SET_DEFAULT_DEBUG_CHANNEL(CRT);
 


### PR DESCRIPTION
Building on SunOS will fail with the message of "call to 'sqrt' is
ambiguous" because it can't determine the type of the constant value
passed to it. This change adds a cast to a double because every usage
uses this data type