### PR TITLE
python3-ize the ETW setup scripts

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -33,7 +33,8 @@ The CoreCLR build relies on CMake for the build. We are currently using CMake 3.
 
 Python
 ---------
-Python is used in the build system. We are currently using python 2.7.9.
+Python is used in the build system. We are currently using python 2.7.9, although
+any recent (2.4+) version of Python should work, including Python 3.
 - Install [Python](https://www.python.org/downloads/) for Windows.
 - Add it to the PATH environment variable.
 

--- a/src/scripts/Utilities.py
+++ b/src/scripts/Utilities.py
@@ -7,7 +7,7 @@ def walk_recursively_and_update(dcmp):
     for name in dcmp.diff_files:
         srcpath = dcmp.right + "/" + name
         destpath = dcmp.left + "/" + name
-        print "Updating %s" % (destpath)
+        print("Updating %s" % (destpath))
         if  os.path.isfile(srcpath):
             shutil.copyfile(srcpath, destpath)
         else :
@@ -17,7 +17,7 @@ def walk_recursively_and_update(dcmp):
     for name in dcmp.right_only:
         srcpath = dcmp.right + "/" + name
         destpath = dcmp.left + "/" + name
-        print "Updating %s" % (destpath)
+        print("Updating %s" % (destpath))
         if  os.path.isfile(srcpath):
             shutil.copyfile(srcpath, destpath)
         elif  os.path.isdir(srcpath):
@@ -28,7 +28,7 @@ def walk_recursively_and_update(dcmp):
     #delete left only files
     for name in dcmp.left_only:
         path = dcmp.left + "/" + name
-        print "Deleting " % (path)
+        print("Deleting " % (path))
         if  os.path.isfile(path):
             os.remove(path)
         elif  os.path.isdir(path):

--- a/src/scripts/genWinEtw.py
+++ b/src/scripts/genWinEtw.py
@@ -37,12 +37,12 @@ def generateEtwMacroHeader(sClrEtwAllMan, sExcludeFile,macroHeader,inHeader):
         os.makedirs(incDir)
     
     outHeader    = open(macroHeader,'w')
-    print >>outHeader, stdprolog
-    
-    print >>outHeader, "#include \"" + os.path.basename(inHeader) + '"'
-    print >>outHeader, "#define NO_OF_ETW_PROVIDERS " + str(numOfProviders)
-    print >>outHeader, "#define MAX_BYTES_PER_ETW_PROVIDER " + str(nMaxEventBytesPerProvider)
-    print >>outHeader, "EXTERN_C __declspec(selectany) const BYTE etwStackSupportedEvents[NO_OF_ETW_PROVIDERS][MAX_BYTES_PER_ETW_PROVIDER] = \n{"
+    outHeader.write(stdprolog + "\n")
+
+    outHeader.write("#include \"" + os.path.basename(inHeader) + '"\n')
+    outHeader.write("#define NO_OF_ETW_PROVIDERS " + str(numOfProviders) + "\n")
+    outHeader.write("#define MAX_BYTES_PER_ETW_PROVIDER " + str(nMaxEventBytesPerProvider) + "\n")
+    outHeader.write("EXTERN_C __declspec(selectany) const BYTE etwStackSupportedEvents[NO_OF_ETW_PROVIDERS][MAX_BYTES_PER_ETW_PROVIDER] = \n{\n")
 
     for providerNode in tree.getElementsByTagName('provider'):
         stackSupportedEvents = [0]*nMaxEventBytesPerProvider
@@ -55,8 +55,8 @@ def generateEtwMacroHeader(sClrEtwAllMan, sExcludeFile,macroHeader,inHeader):
             eventTemplate           = eventNode.getAttribute('template')
             eventTemplate           = eventNode.getAttribute('template')
             eventValue              = int(eventNode.getAttribute('value'))
-            eventIndex              = eventValue/8
-            eventBitPositionInIndex = eventValue%8
+            eventIndex              = eventValue // 8
+            eventBitPositionInIndex = eventValue % 8
             
             eventStackBitFromNoStackList       = int(getStackWalkBit(eventProvider, taskName, eventSymbol, exclusionInfo.nostack))
             eventStackBitFromExplicitStackList = int(getStackWalkBit(eventProvider, taskName, eventSymbol, exclusionInfo.explicitstack))
@@ -80,8 +80,8 @@ def generateEtwMacroHeader(sClrEtwAllMan, sExcludeFile,macroHeader,inHeader):
         
         del line[-1]
         line.append("},")
-        print >>outHeader,''.join(line)
-    print >>outHeader, "};"
+        outHeader.write(''.join(line) + "\n")
+    outHeader.write("};\n")
     
     outHeader.close()
 

--- a/src/scripts/genXplatEventing.py
+++ b/src/scripts/genXplatEventing.py
@@ -10,7 +10,6 @@
 
 import os 
 import xml.dom.minidom as DOM
-from sets import Set
 
 stdprolog="""
 //
@@ -179,8 +178,8 @@ def bucketizeAbstractTemplates(template,fnPrototypes,var_Dependecies):
 
     return templateProp
 
-ignoredXmlTemplateAttribes = Set(["map","outType"])
-usedXmlTemplateAttribes    = Set(["name","inType","count", "length"])
+ignoredXmlTemplateAttribes = frozenset(["map","outType"])
+usedXmlTemplateAttribes    = frozenset(["name","inType","count", "length"])
 
 def parseTemplateNodes(templateNodes):
 
@@ -608,14 +607,14 @@ def generateEtmDummyHeader(sClrEtwAllMan,clretwdummy):
     if not os.path.exists(incDir):
         os.makedirs(incDir)
     Clretwdummy    = open(clretwdummy,'w')
-    print >>Clretwdummy, stdprolog
+    Clretwdummy.write(stdprolog + "\n")
 
     for providerNode in tree.getElementsByTagName('provider'):
         templateNodes = providerNode.getElementsByTagName('template')
         allTemplates  = parseTemplateNodes(templateNodes)
         eventNodes = providerNode.getElementsByTagName('event')
         #pal: create etmdummy.h
-        print >>Clretwdummy,generateclrEtwDummy(eventNodes,allTemplates)
+        Clretwdummy.write(generateclrEtwDummy(eventNodes, allTemplates) + "\n")
     
     Clretwdummy.close()
 
@@ -632,20 +631,20 @@ def generatePlformIndependentFiles(sClrEtwAllMan,incDir,etmDummyFile, testDir):
     Clrallevents   = open(clrallevents,'w')
     Clrxplatevents = open(clrxplatevents,'w')
 
-    print >>Clrallevents, stdprolog
-    print >>Clrxplatevents, stdprolog
+    Clrallevents.write(stdprolog + "\n")
+    Clrxplatevents.write(stdprolog + "\n")
 
-    print >>Clrallevents, "\n#include \"clrxplatevents.h\"\n"
+    Clrallevents.write("\n#include \"clrxplatevents.h\"\n\n")
 
     for providerNode in tree.getElementsByTagName('provider'):
         templateNodes = providerNode.getElementsByTagName('template')
         allTemplates  = parseTemplateNodes(templateNodes)
         eventNodes = providerNode.getElementsByTagName('event')
         #vm header: 
-        print >>Clrallevents,generateClrallEvents(eventNodes,allTemplates)
+        Clrallevents.write(generateClrallEvents(eventNodes, allTemplates) + "\n")
 
         #pal: create clrallevents.h
-        print >>Clrxplatevents, generateClrXplatEvents(eventNodes,allTemplates)
+        Clrxplatevents.write(generateClrXplatEvents(eventNodes, allTemplates) + "\n")
 
 
     Clrxplatevents.close()
@@ -653,9 +652,9 @@ def generatePlformIndependentFiles(sClrEtwAllMan,incDir,etmDummyFile, testDir):
 
 class EventExclusions:
     def __init__(self):
-        self.nostack         = Set()
-        self.explicitstack   = Set()
-        self.noclrinstance   = Set()
+        self.nostack         = set()
+        self.explicitstack   = set()
+        self.noclrinstance   = set()
 
 def parseExclusionList(exclusionListFile):
     ExclusionFile   = open(exclusionListFile,'r')

--- a/src/scripts/genXplatLttng.py
+++ b/src/scripts/genXplatLttng.py
@@ -428,8 +428,8 @@ def generateLttngFiles(etwmanifest,intermediate):
 
 #Top level Cmake
     topCmake          = open(eventprovider_directory + "/CMakeLists.txt", 'w')
-    print >>topCmake, stdprolog_cmake
-    print >>topCmake, """cmake_minimum_required(VERSION 2.8.12.2)
+    topCmake.write(stdprolog_cmake + "\n")
+    topCmake.write("""cmake_minimum_required(VERSION 2.8.12.2)
 
     project(eventprovider)
 
@@ -441,7 +441,7 @@ def generateLttngFiles(etwmanifest,intermediate):
 
     add_library(eventprovider
         STATIC
-"""
+""")
 
     for providerNode in tree.getElementsByTagName('provider'):
         providerName = providerNode.getAttribute('name')
@@ -451,21 +451,22 @@ def generateLttngFiles(etwmanifest,intermediate):
         providerName_File = providerName.replace('-','')
         providerName_File = providerName_File.lower()
         
-        print >>topCmake,'        "'+ lttngevntprovPre + providerName_File + ".cpp" + '"'
+        topCmake.write('        "'+ lttngevntprovPre + providerName_File + ".cpp" + '"\n')
 
-    print >>topCmake, """)
+    topCmake.write(""")
     add_subdirectory(tracepointprovider)
     
     # Install the static eventprovider library 
-    install (TARGETS eventprovider DESTINATION lib)"""
+    install (TARGETS eventprovider DESTINATION lib)
+    """)
     topCmake.close()
 
 #TracepointProvider  Cmake
     
     tracepointprovider_Cmake          = open(tracepointprovider_directory + "/CMakeLists.txt", 'w')
     
-    print >>tracepointprovider_Cmake, stdprolog_cmake
-    print >>tracepointprovider_Cmake, """cmake_minimum_required(VERSION 2.8.12.2)
+    tracepointprovider_Cmake.write(stdprolog_cmake + "\n")
+    tracepointprovider_Cmake.write("""cmake_minimum_required(VERSION 2.8.12.2)
     
     project(coreclrtraceptprovider)
     
@@ -477,7 +478,8 @@ def generateLttngFiles(etwmanifest,intermediate):
     add_compile_options(-fPIC)
     
     add_library(coreclrtraceptprovider
-        SHARED"""
+        SHARED
+    """)
     
     for providerNode in tree.getElementsByTagName('provider'):
         providerName = providerNode.getAttribute('name')
@@ -487,16 +489,17 @@ def generateLttngFiles(etwmanifest,intermediate):
         providerName_File = providerName.replace('-','')
         providerName_File = providerName_File.lower()
         
-        print >>tracepointprovider_Cmake,'        "'+ lttngevntprovTpPre + providerName_File +".cpp" + '"'
+        tracepointprovider_Cmake.write('        "'+ lttngevntprovTpPre + providerName_File +".cpp" + '"\n')
 
-    print >>tracepointprovider_Cmake, """    )
+    tracepointprovider_Cmake.write("""    )
     
     target_link_libraries(coreclrtraceptprovider
                          -llttng-ust
     )
             
    #Install the static coreclrtraceptprovider library
-   install (TARGETS coreclrtraceptprovider DESTINATION .)"""
+   install (TARGETS coreclrtraceptprovider DESTINATION .)
+   """)
     tracepointprovider_Cmake.close()
 
 # Generate Lttng specific instrumentation
@@ -520,40 +523,43 @@ def generateLttngFiles(etwmanifest,intermediate):
         lTTngImpl         = open(lttngevntprov, 'w')
         lTTngTpImpl       = open(lttngevntprovTp, 'w')
 
-        print >>lTTngHdr, stdprolog
-        print >>lTTngImpl, stdprolog
-        print >>lTTngTpImpl, stdprolog
+        lTTngHdr.write(stdprolog + "\n")
+        lTTngImpl.write(stdprolog + "\n")
+        lTTngTpImpl.write(stdprolog + "\n")
 
-        print >>lTTngTpImpl,"\n#define TRACEPOINT_CREATE_PROBES\n"
+        lTTngTpImpl.write("\n#define TRACEPOINT_CREATE_PROBES\n")
         
        
-        print >>lTTngTpImpl,"#include \"./"+lttngevntheadershortname + "\""
+        lTTngTpImpl.write("#include \"./"+lttngevntheadershortname + "\"\n")
         
-        print >>lTTngHdr, """
+        lTTngHdr.write("""
 #include "palrt.h"
 #include "pal.h"
 
 #undef TRACEPOINT_PROVIDER
-"""
+
+""")
 
 
-        print >>lTTngHdr, "#define TRACEPOINT_PROVIDER " + providerName
-        print >>lTTngHdr,"""
+        lTTngHdr.write("#define TRACEPOINT_PROVIDER " + providerName + "\n")
+        lTTngHdr.write("""
 
-#undef TRACEPOINT_INCLUDE"""
+#undef TRACEPOINT_INCLUDE
+""")
 
-        print >>lTTngHdr,"#define TRACEPOINT_INCLUDE \"./" + lttngevntheadershortname + "\"\n"
+        lTTngHdr.write("#define TRACEPOINT_INCLUDE \"./" + lttngevntheadershortname + "\"\n\n")
 
 
-        print >>lTTngHdr, "#if !defined(LTTNG_CORECLR_H" + providerName + ") || defined(TRACEPOINT_HEADER_MULTI_READ)\n"
-        print >>lTTngHdr, "#define LTTNG_CORECLR_H" + providerName
+        lTTngHdr.write("#if !defined(LTTNG_CORECLR_H" + providerName + ") || defined(TRACEPOINT_HEADER_MULTI_READ)\n\n")
+        lTTngHdr.write("#define LTTNG_CORECLR_H" + providerName + "\n")
 
-        print >>lTTngHdr, "\n#include <lttng/tracepoint.h>\n"
+        lTTngHdr.write("\n#include <lttng/tracepoint.h>\n\n")
 
-        print >>lTTngImpl, """
+        lTTngImpl.write("""
 #define TRACEPOINT_DEFINE
-#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE"""
-        print >>lTTngImpl,"#include \"" + lttngevntheadershortname + "\"\n"
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+""")
+        lTTngImpl.write("#include \"" + lttngevntheadershortname + "\"\n\n")
         
 
 
@@ -562,10 +568,10 @@ def generateLttngFiles(etwmanifest,intermediate):
 
         allTemplates  = parseTemplateNodes(templateNodes)
         #generate the header
-        print >>lTTngHdr,generateLttngHeader(providerName,allTemplates,eventNodes)
+        lTTngHdr.write(generateLttngHeader(providerName,allTemplates,eventNodes) + "\n")
 
         #create the implementation of eventing functions : lttngeventprov*.cp
-        print >>lTTngImpl,generateLttngTpProvider(providerName,eventNodes,allTemplates)
+        lTTngImpl.write(generateLttngTpProvider(providerName,eventNodes,allTemplates) + "\n")
         
         lTTngHdr.close()
         lTTngImpl.close()


### PR DESCRIPTION
This PR enables the coreclr build to work with Python3+ in addition to the Python 2 family that was supported. There are three categories of changes in this PR:

1. The removal of `sets.Set`, which has been [deprecated as of Python 2.6](https://docs.python.org/2/library/sets.html) and removed in Python 3, and replacement with `set` and `frozenset`, which is present in Python 2.4+ and Python 3+.
2. Using the floor division operator `//` instead of the "true" division operator `/`, since [PEP238](https://docs.python.org/release/2.2.3/whatsnew/node7.html) changed the meaning of the division operator in Python 3. `//` performs identically across all versions of python greater than 2.2.
3. Manual desuraging of the "print chevron" into calls to the `write` function and changing bare `print` statements into calls to the `print` function

With these changes, these scripts can run identically under Python 2.7+ and Python 3+. I tested this on my machine with Python 2.7.9 and Python 3.5.0 and both of them worked fine.