### PR TITLE
Enabling profiling on Unix/OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -609,6 +609,7 @@ add_definitions(-D_BLD_CLR)
 add_definitions(-DWINVER=0x0602)
 add_definitions(-DWIN32_LEAN_AND_MEAN=1)
 add_definitions(-DDEBUGGING_SUPPORTED)
+add_definitions(-DPROFILING_SUPPORTED)
 
 if(WIN32)
   if(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_I386)
@@ -616,8 +617,7 @@ if(WIN32)
     # Only enable edit and continue on windows x86 and x64
     # exclude Linux, arm & arm64
     add_definitions(-DEnC_SUPPORTED)
-  endif(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_I386)
-  add_definitions(-DPROFILING_SUPPORTED)
+  endif(CLR_CMAKE_PLATFORM_ARCH_AMD64 OR CLR_CMAKE_PLATFORM_ARCH_I386)  
 endif(WIN32)
 
 # Features - please keep them alphabetically sorted

--- a/dac.cmake
+++ b/dac.cmake
@@ -2,8 +2,8 @@
 
 add_definitions(-DDACCESS_COMPILE)
 add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
-if(WIN32)
-    remove_definitions(-DPROFILING_SUPPORTED)
-    add_definitions(-DPROFILING_SUPPORTED_DATA)
+if(WIN32)    
     add_definitions(-MT)
 endif(WIN32)
+remove_definitions(-DPROFILING_SUPPORTED)
+add_definitions(-DPROFILING_SUPPORTED_DATA)

--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -23769,13 +23769,11 @@ void gc_heap::walk_plug (uint8_t* plug, size_t size, BOOL check_last_object_p, w
 
     STRESS_LOG_PLUG_MOVE(plug, (plug + size), -last_plug_relocation);
 
-#ifdef FEATURE_EVENT_TRACE
     ETW::GCLog::MovedReference(plug,
                                (plug + size),
                                reloc,
                                profiling_context,
                                settings.compaction);
-#endif
 
     if (check_last_object_p)
     {

--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -502,12 +502,14 @@ void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForE
 #endif //MULTIPLE_HEAPS
         }
 
+#ifdef FEATURE_EVENT_TRACE
         // **** Done! Indicate to ETW helpers that the heap walk is done, so any buffers
         // should be flushed into the ETW stream
         if (fShouldWalkHeapObjectsForEtw || fShouldWalkHeapRootsForEtw)
         {
             ETW::GCLog::EndHeapDump(&profilerWalkHeapContext);
         }
+#endif // FEATURE_EVENT_TRACE
     }
 }
 #endif // defined(GC_PROFILING)

--- a/src/gc/objecthandle.cpp
+++ b/src/gc/objecthandle.cpp
@@ -517,6 +517,7 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, uintpt
     }
 #endif // GC_PROFILING
 
+#if defined(FEATURE_EVENT_TRACE)
     // Notify ETW of the handle
     if (ETW::GCLog::ShouldWalkHeapRootsForEtw())
     {
@@ -535,6 +536,7 @@ void CALLBACK ScanPointerForProfilerAndETW(_UNCHECKED_OBJECTREF *pObjRef, uintpt
             0,              // dwGCFlags,
             rootFlags);     // ETW handle flags
     }
+#endif // defined(FEATURE_EVENT_TRACE) 
 }
 #endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 

--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -79,3 +79,4 @@ install (FILES cor.h
                gcinfoencoder.h
                gcinfotypes.h
                DESTINATION inc)
+install (TARGETS corguids DESTINATION lib)

--- a/src/inc/eventtrace.h
+++ b/src/inc/eventtrace.h
@@ -329,9 +329,16 @@ namespace ETW
         static BOOL ShouldWalkStaticsAndCOMForEtw();
         static VOID WalkStaticsAndCOMForETW();
         static VOID EndHeapDump(ProfilerWalkHeapContext * profilerWalkHeapContext);
+#ifdef FEATURE_EVENT_TRACE        
         static VOID BeginMovedReferences(size_t * pProfilingContext);
         static VOID MovedReference(BYTE * pbMemBlockStart, BYTE * pbMemBlockEnd, ptrdiff_t cbRelocDistance, size_t profilingContext, BOOL fCompacting, BOOL fAllowProfApiNotification = TRUE);
         static VOID EndMovedReferences(size_t profilingContext, BOOL fAllowProfApiNotification = TRUE);
+#else
+        // TODO: Need to be implemented for PROFILING_SUPPORTED.
+        static VOID BeginMovedReferences(size_t * pProfilingContext) {};
+        static VOID MovedReference(BYTE * pbMemBlockStart, BYTE * pbMemBlockEnd, ptrdiff_t cbRelocDistance, size_t profilingContext, BOOL fCompacting, BOOL fAllowProfApiNotification = TRUE) {};
+        static VOID EndMovedReferences(size_t profilingContext, BOOL fAllowProfApiNotification = TRUE) {};
+#endif // FEATURE_EVENT_TRACE        
         static VOID SendFinalizeObjectEvent(MethodTable * pMT, Object * pObj);
     };
 };

--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -133,7 +133,6 @@ enum EtwThreadFlags
 #endif // FEATURE_EVENT_TRACE
 
 #endif // FEATURE_REDHAWK
-#ifdef FEATURE_EVENT_TRACE
 
 // During a heap walk, this is the storage for keeping track of all the nodes and edges
 // being batched up by ETW, and for remembering whether we're also supposed to call into
@@ -151,6 +150,8 @@ public:
     BOOL fProfilerPinned;
     LPVOID pvEtwContext;
 };
+
+#ifdef FEATURE_EVENT_TRACE
 
 class Object;
 #if !defined(FEATURE_PAL)
@@ -1068,7 +1069,6 @@ McGenEventProviderEnabled(
 
 
 struct ProfilingScanContext;
-struct ProfilerWalkHeapContext;
 class Object;
 
 namespace ETW

--- a/src/pal/prebuilt/inc/CMakeLists.txt
+++ b/src/pal/prebuilt/inc/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 2.8.12.2)
 
 project(COREPAL)
 
-install (FILES corerror.h DESTINATION inc)
+install (FILES corerror.h corprof.h DESTINATION inc)
 

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -230,6 +230,7 @@ set(VM_SOURCES_WKS
     profattachclient.cpp
     profattachserver.cpp
     profdetach.cpp
+    profilermetadataemitvalidator.cpp
     profilingenumerators.cpp
     profilinghelper.cpp
     proftoeeinterfaceimpl.cpp
@@ -304,8 +305,7 @@ list(APPEND VM_SOURCES_WKS
     microsoft.comservices_i.c
     mngstdinterfaces.cpp
     notifyexternals.cpp
-    olecontexthelpers.cpp
-    profilermetadataemitvalidator.cpp
+    olecontexthelpers.cpp    
     rcwrefcache.cpp
     rtlfunctions.cpp
     runtimecallablewrapper.cpp

--- a/src/vm/amd64/unixstubs.cpp
+++ b/src/vm/amd64/unixstubs.cpp
@@ -27,6 +27,21 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
+    void ProfileEnterNaked(FunctionIDOrClientID functionIDOrClientID)    
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
+
+    void ProfileLeaveNaked(FunctionIDOrClientID functionIDOrClientID)
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
+
+    void ProfileTailcallNaked(FunctionIDOrClientID functionIDOrClientID)
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
+
     DWORD getcpuid(DWORD arg, unsigned char result[16])
     {
         DWORD eax;

--- a/src/vm/eetoprofinterfaceimpl.cpp
+++ b/src/vm/eetoprofinterfaceimpl.cpp
@@ -370,6 +370,11 @@ EEToProfInterfaceImpl::CHashTableImpl::CHashTableImpl(ULONG iBuckets)
     WRAPPER_NO_CONTRACT;
 }
 
+EEToProfInterfaceImpl::CHashTableImpl::~CHashTableImpl()
+{
+    WRAPPER_NO_CONTRACT;
+}
+
 //---------------------------------------------------------------------------------------
 //
 // Comparison function for hash table of ClassIDs

--- a/src/vm/eetoprofinterfaceimpl.h
+++ b/src/vm/eetoprofinterfaceimpl.h
@@ -488,7 +488,8 @@ private:
     {
     public:
         CHashTableImpl(ULONG iBuckets);
-
+        virtual ~CHashTableImpl();
+        
     protected:
         virtual BOOL Cmp(SIZE_T k1, const HASHENTRY * pc2);
     };

--- a/src/vm/profilermetadataemitvalidator.cpp
+++ b/src/vm/profilermetadataemitvalidator.cpp
@@ -35,6 +35,11 @@ m_cRefCount(0)
     maxInitialGenericParam = TokenFromRid(m_pInnerInternalImport->GetCountWithTokenKind(mdtGenericParam), mdtGenericParam);
 }
 
+ProfilerMetadataEmitValidator::~ProfilerMetadataEmitValidator()
+{
+    LIMITED_METHOD_CONTRACT;
+}
+
   //IUnknown
 HRESULT ProfilerMetadataEmitValidator::QueryInterface(REFIID riid, void** ppInterface)
 {

--- a/src/vm/profilermetadataemitvalidator.h
+++ b/src/vm/profilermetadataemitvalidator.h
@@ -15,7 +15,8 @@ class ProfilerMetadataEmitValidator : public IMetaDataEmit2, public IMetaDataAss
 {
 public:
     ProfilerMetadataEmitValidator(IMetaDataEmit* pInnerEmit);
-
+    virtual ~ProfilerMetadataEmitValidator();
+    
     //IUnknown
     virtual HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppInterface);
     virtual ULONG   STDMETHODCALLTYPE AddRef();

--- a/src/vm/profilingenumerators.h
+++ b/src/vm/profilingenumerators.h
@@ -29,17 +29,14 @@
 //                       (e.g., ICorProfilerObjectEnum)
 //      Element -- the type of the objects this enumerator returns.
 //
-//      pEnumInterfaceIID -- pointer to the class ID for this interface
-//          (you probably don't need to use this)
 //
-//
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID = &__uuidof(EnumInterface) >
+template< typename EnumInterface, typename Element >
 class ProfilerEnum : public EnumInterface
 {
 public:
     ProfilerEnum(CDynArray< Element >* elements);
     ProfilerEnum();
-    ~ProfilerEnum();
+    virtual ~ProfilerEnum();
 
     // IUnknown functions
 
@@ -67,7 +64,13 @@ protected:
     CDynArray< Element > m_elements;
 
     LONG m_refCount;
+    
+private:
+    static const IID& m_pEnumInterfaceIID;
 };
+
+template< typename EnumInterface, typename Element >
+const IID& ProfilerEnum< EnumInterface, Element >::m_pEnumInterfaceIID = __uuidof(EnumInterface);
 
 //
 //
@@ -98,8 +101,8 @@ protected:
 // </TODO>
 //
 //
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::ProfilerEnum(CDynArray< Element >* elements) :
+template< typename EnumInterface, typename Element >
+ProfilerEnum< EnumInterface, Element >::ProfilerEnum(CDynArray< Element >* elements) :
     m_currentElement(0),
     m_refCount(1)
 {
@@ -120,8 +123,8 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::ProfilerEnum(CDynArra
     }
 }
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::ProfilerEnum() :
+template< typename EnumInterface, typename Element >
+ProfilerEnum< EnumInterface, Element >::ProfilerEnum() :
     m_currentElement(0),
     m_refCount(1)
 {
@@ -140,8 +143,8 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::ProfilerEnum() :
 // Returns
 //      None
 //
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::~ProfilerEnum()
+template< typename EnumInterface, typename Element >
+ProfilerEnum< EnumInterface, Element >::~ProfilerEnum()
 {
 }
 
@@ -160,11 +163,11 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::~ProfilerEnum()
 //      E_NOINTERFACE   -- if the enumerator does not implement the requested interface
 //
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 HRESULT
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::QueryInterface(REFIID id, void** pInterface)
+ProfilerEnum< EnumInterface, Element >::QueryInterface(REFIID id, void** pInterface)
 {
-    if (*pEnumInterfaceIID == id)
+    if (m_pEnumInterfaceIID == id)
     {
         *pInterface = static_cast< EnumInterface* >(this);
     }
@@ -182,16 +185,16 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::QueryInterface(REFIID
     return S_OK;
 }
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 ULONG
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::AddRef()
+ProfilerEnum< EnumInterface, Element >::AddRef()
 {
     return InterlockedIncrement(&m_refCount);
 }
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 ULONG
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Release()
+ProfilerEnum< EnumInterface, Element >::Release()
 {
     ULONG refCount = InterlockedDecrement(&m_refCount);
 
@@ -225,9 +228,9 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Release()
 //    try to advance 1 item and return S_OK if it is successful
 //
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 HRESULT
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Next(ULONG elementsRequested,
+ProfilerEnum< EnumInterface, Element >::Next(ULONG elementsRequested,
                                                                 Element elements[],
                                                                 ULONG* elementsFetched)
 {
@@ -307,9 +310,9 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Next(ULONG elementsRe
 //
 //
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 HRESULT
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::GetCount(ULONG* count)
+ProfilerEnum< EnumInterface, Element >::GetCount(ULONG* count)
 {
     CONTRACTL
     {
@@ -352,9 +355,9 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::GetCount(ULONG* count
 // before and after calling Skip()
 //
 //
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 HRESULT
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Skip(ULONG count)
+ProfilerEnum< EnumInterface, Element >::Skip(ULONG count)
 {
     CONTRACTL
     {
@@ -392,9 +395,9 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Skip(ULONG count)
 //
 //
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 HRESULT
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Reset()
+ProfilerEnum< EnumInterface, Element >::Reset()
 {
     CONTRACTL
     {
@@ -424,9 +427,9 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Reset()
 //   E_INVALIDARG   -- if pInterface is an invalid pointer
 //
 
-template< typename EnumInterface, typename Element, const IID* pEnumInterfaceIID >
+template< typename EnumInterface, typename Element >
 HRESULT
-ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Clone(EnumInterface** pInterface)
+ProfilerEnum< EnumInterface, Element >::Clone(EnumInterface** pInterface)
 {
     CONTRACTL
     {
@@ -446,7 +449,7 @@ ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >::Clone(EnumInterface**
     HRESULT hr = S_OK;
     EX_TRY
     {
-        *pInterface = new ProfilerEnum< EnumInterface, Element, pEnumInterfaceIID >(&m_elements);
+        *pInterface = new ProfilerEnum< EnumInterface, Element >(&m_elements);
     }
     EX_CATCH
     {

--- a/src/vm/profilinghelper.cpp
+++ b/src/vm/profilinghelper.cpp
@@ -289,7 +289,6 @@ void CurrentProfilerStatus::Set(ProfilerStatus newProfStatus)
 // See code:#LoadUnloadCallbackSynchronization.
 CRITSEC_COOKIE ProfilingAPIUtility::s_csStatus = NULL;
 
-#ifndef FEATURE_PAL
 
 SidBuffer * ProfilingAPIUtility::s_pSidBuffer = NULL;
 
@@ -337,8 +336,6 @@ void ProfilingAPIUtility::AppendSupplementaryInformation(int iStringResource, SS
         GetCurrentProcessId(),
         iStringResource);
 }
-
-#endif // !FEATURE_PAL
 
 //---------------------------------------------------------------------------------------
 //

--- a/src/vm/profilinghelper.h
+++ b/src/vm/profilinghelper.h
@@ -38,9 +38,7 @@ enum ProfAPIFaultFlags
 };
 #endif // _DEBUG
 
-#ifndef FEATURE_PAL
 class SidBuffer;
-#endif // !FEATURE_PAL
 
 //---------------------------------------------------------------------------------------
 // Static-only class to coordinate initialization of the various profiling API
@@ -83,11 +81,9 @@ private:
         kAttachLoad,
     };
 
-#ifndef FEATURE_PAL
     // Allocated lazily the first time it's needed, and then remains allocated until the
     // process exits.
     static SidBuffer * s_pSidBuffer;
-#endif // !FEATURE_PAL
 
     // See code:ProfilingAPIUtility::InitializeProfiling#LoadUnloadCallbackSynchronization
     static CRITSEC_COOKIE s_csStatus;
@@ -107,9 +103,7 @@ private:
     static HRESULT ProfilerCLSIDFromString(__inout_z LPWSTR wszClsid, CLSID * pClsid);
     static HRESULT AttemptLoadProfilerForStartup();
 
-#ifndef FEATURE_PAL
     static void AppendSupplementaryInformation(int iStringResource, SString * pString);
-#endif // !FEATURE_PAL
 
     static void LogProfEventVA(
         int iStringResourceID, 

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -1157,6 +1157,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
             (ObjectID *) arrObjRef);
     }
 
+#ifdef FEATURE_EVENT_TRACE
     if (s_forcedGCInProgress &&
         ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, 
                                      TRACE_LEVEL_INFORMATION, 
@@ -1170,6 +1171,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
             (Object **) arrObjRef);
 
     }
+#endif // FEATURE_EVENT_TRACE
 
     // If the data was not allocated on the stack, need to clean it up.
     if ((arrObjRef != NULL) && !bOnStack)
@@ -1298,6 +1300,7 @@ void ScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
             RootReference2((BYTE *)*ppObject, pPSC->dwEtwRootKind, (EtwGCRootFlags)dwEtwRootFlags, (BYTE *)rootID, &((pPSC)->pHeapId));
     }
 
+#ifdef FEATURE_EVENT_TRACE
     // Notify ETW of the root
     if (s_forcedGCInProgress &&
         ETW_TRACING_CATEGORY_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, 
@@ -1313,6 +1316,7 @@ void ScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
             dwFlags,        // dwGCFlags
             dwEtwRootFlags);
     }
+#endif // FEATURE_EVENT_TRACE
 }
 
 
@@ -4792,11 +4796,15 @@ HRESULT ProfToEEInterfaceImpl::ForceGC()
         LL_INFO1000, 
         "**PROF: ForceGC.\n"));        
 
+#ifdef FEATURE_EVENT_TRACE
     // This helper, used by ETW and profAPI ensures a managed thread gets created for
     // this thread before forcing the GC (to work around Jupiter issues where it's
     // expected this thread is already managed before starting the GC).
     HRESULT hr = ETW::GCLog::ForceGCForDiagnostics();
-
+#else // !FEATURE_EVENT_TRACE
+    HRESULT hr = E_FAIL;
+#endif // FEATURE_EVENT_TRACE
+ 
     // If a Thread object was just created for this thread, remember the fact that it
     // was a ForceGC() thread, so we can be more lenient when doing
     // COR_PRF_CALLBACKSTATE_INCALLBACK later on from other APIs
@@ -6799,6 +6807,8 @@ StackWalkAction ProfilerStackWalkCallback(CrawlFrame *pCf, PROFILER_STACK_WALK_D
     return SWA_ABORT;
 }
 
+#ifdef _TARGET_X86_
+
 //---------------------------------------------------------------------------------------
 // Normally, calling GetFunction() on the frame is sufficient to ensure
 // HelperMethodFrames are intialized. However, sometimes we need to be able to specify
@@ -6859,8 +6869,6 @@ static BOOL EnsureFrameInitialized(Frame * pFrame)
     return FALSE;
 }
 
-
-#ifdef _TARGET_X86_
 //---------------------------------------------------------------------------------------
 //
 // Implements the COR_PRF_SNAPSHOT_X86_OPTIMIZED algorithm called by DoStackSnapshot. 
@@ -7212,13 +7220,13 @@ HRESULT ProfToEEInterfaceImpl::DoStackSnapshot(ThreadID thread,
     return E_NOTIMPL;
 #endif
 
-#ifndef FEATURE_HIJACK
+#if !defined(FEATURE_HIJACK) || !defined(PLATFORM_SUPPORTS_SAFE_THREADSUSPEND)
 
     // DoStackSnapshot needs Thread::Suspend/ResumeThread functionality.
     // On platforms w/o support for these APIs return E_NOTIMPL.
     return E_NOTIMPL;
 
-#else // FEATURE_HIJACK
+#else // !defined(FEATURE_HIJACK) || !defined(PLATFORM_SUPPORTS_SAFE_THREADSUSPEND)
 
     CONTRACTL
     {
@@ -7405,7 +7413,7 @@ HRESULT ProfToEEInterfaceImpl::DoStackSnapshot(ThreadID thread,
             _ASSERTE(!"Profiler trying to walk destroyed thread");
             EEPOLICY_HANDLE_FATAL_ERROR(CORPROF_E_STACKSNAPSHOT_INVALID_TGT_THREAD);
         }
-        
+
         // Thread::SuspendThread() ensures that no one else should try to suspend us
         // while we're suspending pThreadToSnapshot.
         //
@@ -7656,7 +7664,7 @@ Cleanup:
 
     return hr;
 
-#endif //  FEATURE_HIJACK
+#endif // !defined(FEATURE_HIJACK) || !defined(PLATFORM_SUPPORTS_SAFE_THREADSUSPEND)
 }
 
 
@@ -9053,8 +9061,6 @@ HRESULT ProfToEEInterfaceImpl::EnumNgenModuleMethodsInliningThisMethod(
     CONTRACTL_END;
 
     PROFILER_TO_CLR_ENTRYPOINT_SYNC_EX(kP2EETriggers, (LF_CORPROF, LL_INFO1000,  "**PROF: EnumNgenModuleMethodsInliningThisMethod.\n"));
-
-    typedef DPTR(class MethodDesc)   PTR_MethodDesc;
 
     if (ppEnum == NULL)
     {

--- a/src/vm/proftoeeinterfaceimpl.h
+++ b/src/vm/proftoeeinterfaceimpl.h
@@ -144,7 +144,7 @@ public:
     static void ObjectRefCallback(void* context, void* objectRefUNSAFE);
 
     ProfToEEInterfaceImpl();
-    ~ProfToEEInterfaceImpl();
+    virtual ~ProfToEEInterfaceImpl();
     HRESULT Init();
 
     // IUnknown


### PR DESCRIPTION
Building with PROFILING_SUPPORTED. #2519 

Some functionality is still missing.
* MovedReferences, MovedReferences2, SurvivingReferences and SurvivingReferences2 will only
  be called when FEATURE_EVENT_TRACE is defined.
* Enter, Leave and Tailcall function hooks is not implemented for Unix.
* DoStackSnapshot is not implemented when PLATFORM_SUPPORTS_SAFE_THREADSUSPEND is
  not defined.