### PR TITLE
Fix bad-codegen from ilasm

### DIFF
--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -2105,7 +2105,7 @@ void Assembler::EmitInstrSwitch(Instr* instr, Labels* targets)
     Labels  *pLbls;
     int     NumLabels;
     Label   *pLabel;
-    long    offset;
+    UINT    offset;
 
     EmitOpcode(instr);
 
@@ -2134,10 +2134,10 @@ void Assembler::EmitInstrSwitch(Instr* instr, Labels* targets)
         }
         else
         {
-            offset = (long)(UINT_PTR)pLbls->Label;
+            offset = (UINT)(UINT_PTR)pLbls->Label;
             if (m_fDisplayTraceOutput) report->msg("%d\n", offset);
         }
-        EmitBytes((BYTE *)&offset, sizeof(long));
+        EmitBytes((BYTE *)&offset, sizeof(UINT));
     }
     delete targets;
 }


### PR DESCRIPTION
Switch target should be 4 byte instead of 8 byte.
In Windows, size of long is same as size of int which is 4 byte, but this is 8 byte in Unix.