### PR TITLE
Fix compilation of Object.GetType intrinsic in ReadyToRun mode

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6073,6 +6073,9 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
         case GT_INTRINSIC:
             copy = new (this, GT_INTRINSIC) GenTreeIntrinsic(tree->TypeGet(), tree->gtOp.gtOp1, tree->gtOp.gtOp2, tree->gtIntrinsic.gtIntrinsicId,
                                                    tree->gtIntrinsic.gtMethodHandle);
+#ifdef FEATURE_READYTORUN_COMPILER
+            copy->gtIntrinsic.gtEntryPoint = tree->gtIntrinsic.gtEntryPoint;
+#endif
             break;
 
         case GT_COPYOBJ:

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2568,6 +2568,11 @@ struct GenTreeIntrinsic: public GenTreeOp
     CorInfoIntrinsics     gtIntrinsicId;
     CORINFO_METHOD_HANDLE gtMethodHandle;    // Method handle of the method which is treated as an intrinsic.
 
+#ifdef FEATURE_READYTORUN_COMPILER
+    // Call target lookup info for method call from a Ready To Run module
+    CORINFO_CONST_LOOKUP gtEntryPoint;
+#endif
+
     GenTreeIntrinsic(var_types type, GenTreePtr op1, CorInfoIntrinsics intrinsicId, CORINFO_METHOD_HANDLE methodHandle) :
         GenTreeOp(GT_INTRINSIC, type, op1, NULL),
         gtIntrinsicId(intrinsicId),

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1739,7 +1739,7 @@ GenTreePtr Compiler::impMethodPointer(CORINFO_RESOLVED_TOKEN * pResolvedToken, C
             info.compCompHnd->getReadyToRunHelper(pResolvedToken, CORINFO_HELP_READYTORUN_DELEGATE_CTOR, &op1->gtFptrVal.gtDelegateCtor);
         }
         else
-            op1->gtFptrVal.gtEntryPoint.addr = NULL;
+            op1->gtFptrVal.gtEntryPoint.addr = nullptr;
 #endif
         break;
 
@@ -5844,6 +5844,22 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
                 assert(!(mflags & CORINFO_FLG_VIRTUAL) ||
                        (mflags & CORINFO_FLG_FINAL) ||
                        (clsFlags & CORINFO_FLG_FINAL));
+
+#ifdef FEATURE_READYTORUN_COMPILER
+                if (call->OperGet() == GT_INTRINSIC)
+                {
+                    if (opts.IsReadyToRun())
+                    {
+                        assert(callInfo->kind == CORINFO_CALL);
+                        call->gtIntrinsic.gtEntryPoint = callInfo->codePointerLookup.constLookup;
+                    }
+                    else
+                    {
+                        call->gtIntrinsic.gtEntryPoint.addr = nullptr;
+                    }
+                }
+#endif
+
                 bIntrinsicImported = true;
                 goto DONE_CALL;
             }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7137,7 +7137,7 @@ GenTreePtr          Compiler::fgMorphLeaf(GenTreePtr tree)
         CORINFO_CONST_LOOKUP addrInfo;
 
 #ifdef FEATURE_READYTORUN_COMPILER
-        if (tree->gtFptrVal.gtEntryPoint.addr != NULL)
+        if (tree->gtFptrVal.gtEntryPoint.addr != nullptr)
         {
             addrInfo = tree->gtFptrVal.gtEntryPoint;
         }

--- a/src/jit/rationalize.h
+++ b/src/jit/rationalize.h
@@ -174,7 +174,12 @@ private:
     static void RewriteInitBlk(GenTreePtr* ppTree, Compiler::fgWalkData* data);
 
     // Intrinsic related    
-    static void RewriteNodeAsCall(GenTreePtr* ppTree, Compiler::fgWalkData* data, CORINFO_METHOD_HANDLE callHnd, GenTreeArgList* args);
+    static void RewriteNodeAsCall(GenTreePtr* ppTree, Compiler::fgWalkData* data,
+        CORINFO_METHOD_HANDLE callHnd,
+#ifdef FEATURE_READYTORUN_COMPILER
+        CORINFO_CONST_LOOKUP entryPoint,
+#endif
+        GenTreeArgList* args);
     static void RewriteIntrinsicAsUserCall(GenTreePtr* ppTree, Compiler::fgWalkData* data);    
 };
 

--- a/tests/src/readytorun/main.cs
+++ b/tests/src/readytorun/main.cs
@@ -234,6 +234,12 @@ class Program
         MyChangingHFAStruct.Check(s);
     }
 
+    [MethodImplAttribute(MethodImplOptions.NoInlining)]
+    static void TestGetType()
+    {
+        new MyClass().GetType().ToString();
+    }
+
 #if CORECLR
     class MyLoadContext : AssemblyLoadContext
     {
@@ -308,6 +314,8 @@ class Program
         TestGrowingStruct();
         TestChangingStruct();
         TestChangingHFAStruct();
+
+        TestGetType();
 
 #if CORECLR
         TestMultipleLoads();


### PR DESCRIPTION
In ReadyToRun mode, the method entrypoint to call is always given to the JIT via getCallInfo. GenTreeIntrinsic was dropping this entrypoint that caused methods that use Object.GetType intrinsics to fail to compile in ReadyToRun mode. It is a fatal error in CoreRT because of there is no fallback to JIT at runtime.

The fix is to pass this entrypoint around in GenTreeIntrinsic.

Added a test case in the ReadyToRun unit test.