### PR TITLE
Improve and clean-up build.cmd

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [coverage] [cross] [clangx.y] [ninja] [skipcoreclr] [skipmscorlib] [skiptests]"
+    echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [coverage] [cross] [clangx.y] [ninja] [skipnative] [skipmscorlib] [skiptests]"
     echo "BuildArch can be: x64, x86, arm, arm64"
     echo "BuildType can be: Debug, Checked, Release"
     echo "clean - optional argument to force a clean build."
@@ -12,7 +12,7 @@ usage()
     echo "clangx.y - optional argument to build using clang version x.y."
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
-    echo "skipcoreclr - do not build CoreCLR."
+    echo "skipnative - do not build native components."
     echo "skipmscorlib - do not build mscorlib.dll even if mono is installed."
     echo "skiptests - skip the tests in the 'tests' subdirectory."
 
@@ -358,7 +358,12 @@ for i in "$@"
         ninja)
         __UseNinja=1
         ;;
+        skipnative)
+        # Use "skipnative" to use the same option name as build.cmd.
+        __SkipCoreCLR=1
+        ;;
         skipcoreclr)
+        # Accept "skipcoreclr" for backwards-compatibility.
         __SkipCoreCLR=1
         ;;
         skipmscorlib)


### PR DESCRIPTION
1. Change logging verbosity so there is much, much less noise on the screen. All the build output is still logged to a .log file.
2. Add separate .wrn and .err log files to capture warning and error output.
3. Add "skipmscorlibbuild" option to skip the mscorlib build steps.
4. Add "skipnativebuild" option to skip the native components build steps.
5. Add "msbuildargs" option to pass all remaining arguments directly to msbuild.
6. Add "sequential" option to build sequentially (disable parallel builds). One use: this simplifies reading the build logs.
7. Update the Usage output to be correct, and easier to understand.
8. Regularize script output; most lines now have a "BUILD:" prefix, so you know where they are coming from.
9. Restructure and simplified the script to be more readable and easier to modify in the future.
10. Added support for setting __echo=1 to see what the script is doing, line-by-line.
11. Added additional ways to view the usage screen (-? /h -h /help -help)