### PR TITLE
Don't use Turkish casing for en-US-POSIX.

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/TextInfo.Unix.cs
@@ -88,7 +88,8 @@ namespace System.Globalization
         private bool NeedsTurkishCasing(string localeName)
         {
             Contract.Assert(localeName != null);
-            return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("i", "I", CompareOptions.IgnoreCase) != 0;
+
+            return CultureInfo.GetCultureInfo(localeName).CompareInfo.Compare("\u0131", "I", CompareOptions.IgnoreCase) == 0;
         }
 
         private bool IsInvariant { get { return m_cultureName.Length == 0; } }


### PR DESCRIPTION
Previously, we were using a comparision between "i" and "I" to (while
ignoring case) to figure out if we needed to do Turkish casing (on the
assumption that locales which compared i and I as non equal when
ignoring case were doing Turkish casing).

ICU Does tailoring of the en-US-POSIX locale and assigns different
primary wights to 'i' and 'I'. You can see this in the ICU Collation
Demo by looking at the raw collation elements. Different primary weights
mean they different letters, not the same letter with a difference in
casing (which is a trinary weight).

This changes the check to compare using an actual Turkish i when doing
our detection to not get confused by these cases.

Fixes #2531