### PR TITLE
Fixed issue #5109.  Console stops echoing typed keys after running coreclr.

### DIFF
--- a/src/debug/debug-pal/unix/twowaypipe.cpp
+++ b/src/debug/debug-pal/unix/twowaypipe.cpp
@@ -178,13 +178,13 @@ int TwoWayPipe::Write(const void *data, DWORD dataSize)
 bool TwoWayPipe::Disconnect()
 {
 
-    if (m_outboundPipe != INVALID_PIPE)
+    if (m_outboundPipe != INVALID_PIPE && m_outboundPipe != 0)
     {
         close(m_outboundPipe);
         m_outboundPipe = INVALID_PIPE;
     }
 
-    if (m_inboundPipe != INVALID_PIPE)
+    if (m_inboundPipe != INVALID_PIPE && m_inboundPipe != 0)
     {
         close(m_inboundPipe);
         m_inboundPipe = INVALID_PIPE;

--- a/src/debug/shared/dbgtransportsession.cpp
+++ b/src/debug/shared/dbgtransportsession.cpp
@@ -57,6 +57,11 @@ HRESULT DbgTransportSession::Init(DebuggerIPCControlBlock *pDCB, AppDomainEnumer
     // cleanup necessary.
     memset(this, 0, sizeof(*this));
 
+    // Because of the above memset the embeded classes/structs need to be reinitialized especially
+    // the two way pipe; it expects the in/out handles to be -1 instead of 0.
+    m_pipe = TwoWayPipe();
+    m_sStateLock = DbgTransportLock();
+
     // Initialize all per-session state variables.
     InitSessionState();
 


### PR DESCRIPTION
The DbgTransportSession/TwoWayPipe code was closing handle 0 (stdout) because the DbgTransportSession class wasn't being zero init'ed via a memset. The TwoWayPipe code initialized the pipe handles to -1.  The fix is to reinitialized the TwoWayPipe by calling the constructor. Even though it is overkill also checked for 0 in the Disconnect code that closes the pipes.