### PR TITLE
Fix ARM build break (Issue 2362).

### DIFF
--- a/tests/src/JIT/jit64/mcc/interop/native_i0c.cpp
+++ b/tests/src/JIT/jit64/mcc/interop/native_i0c.cpp
@@ -5,7 +5,7 @@
 #include "native.h"
 
 
-MCC_API VType0 __cdecl sum(unsigned __int64 first, ...) {
+MCC_API VType0 sum(unsigned __int64 first, ...) {
     VType0 result;
 
     int count = 0;


### PR DESCRIPTION
Remove unnecessary __cdecl modifier.