### PR TITLE
Fix bad codegen for comparing 16-bit unsigned values

### DIFF
--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -2884,40 +2884,27 @@ void Lowering::LowerCmp(GenTreePtr tree)
             }
         }
     }
-    else if (op2->isMemoryOp())
-    {
-        if (op1Type == op2Type)
-        {
-            MakeSrcContained(tree, op2);
+	else if (op1Type == op2Type)
+	{
+		if (op2->isMemoryOp())
+		{
+			MakeSrcContained(tree, op2);
+		}
+		else if (op1->isMemoryOp() && IsSafeToContainMem(tree, op1))
+		{
+			MakeSrcContained(tree, op1);
+		}
 
-            // Mark the tree as doing unsigned comparison if
-            // both the operands are small and unsigned types.
-            // Otherwise we will end up performing a signed comparison
-            // of two small unsigned values without zero extending them to
-            // TYP_INT size and which is incorrect.
-            if (varTypeIsSmall(op1Type) && varTypeIsUnsigned(op1Type))
-            {
-                tree->gtFlags |= GTF_UNSIGNED;
-            }
-        }
-    }
-    else if (op1->isMemoryOp()) 
-    {
-        if ((op1Type == op2Type) && IsSafeToContainMem(tree, op1))
-        {
-            MakeSrcContained(tree, op1);
-
-            // Mark the tree as doing unsigned comparison if
-            // both the operands are small and unsigned types.
-            // Otherwise we will end up performing a signed comparison
-            // of two small unsigned values without zero extending them to
-            // TYP_INT size and which is incorrect.
-            if (varTypeIsSmall(op1Type) && varTypeIsUnsigned(op1Type))
-            {
-                tree->gtFlags |= GTF_UNSIGNED;
-            }
-        }
-    }
+		if (varTypeIsSmall(op1Type) && varTypeIsUnsigned(op1Type))
+		{
+			// Mark the tree as doing unsigned comparison if
+			// both the operands are small and unsigned types.
+			// Otherwise we will end up performing a signed comparison
+			// of two small unsigned values without zero extending them to
+			// TYP_INT size and which is incorrect.
+			tree->gtFlags |= GTF_UNSIGNED;
+		}
+	}
 }
 
 /* Lower GT_CAST(srcType, DstType) nodes. 


### PR DESCRIPTION
The changes fix a bug generating 16-bit signed comparison code to
compare unsigned 16-bit values.

int c = GT(ushort a, ushort b)

Give the comparison above, RyuJIT generates 16-bit cmp instruction and its signed-ness should be properly handled.

Code generated by RyuJIT:

```
movzx    rcx, word  ptr [rdi+8] ; load a 
movzx    rax, word  ptr [rsi+8] ; load b
cmp      cx, ax                   ; compare only 16 bits
setg     cl                       ; set if greater (signed comparison)
```

After fix:
```
movzx    rcx, word  ptr [rdi+8] ; load a
movzx    rax, word  ptr [rsi+8] ; load b
cmp      cx, ax                 ; compare only 16 bits
seta     cl                     ; set if above (unsigned comparison)  <-- Fixed instruction
```

