### PR TITLE
Fixing use case of incomplete Event Source payload

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Eventing/XplatEventLogger.cs
+++ b/src/mscorlib/src/System/Diagnostics/Eventing/XplatEventLogger.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics.Tracing
     internal  class XplatEventLogger : EventListener
     {
         public XplatEventLogger() {}
-        
+
         private static bool initializedPersistentListener = false;
 
         [System.Security.SecuritySafeCritical]
@@ -78,16 +78,17 @@ namespace System.Diagnostics.Tracing
             if (payloadName.Count == 0 || payload.Count == 0)
                 return String.Empty;
 
-            Contract.Assert(payloadName.Count == payload.Count);
+            int eventDataCount = payloadName.Count;
+
             if(payloadName.Count != payload.Count)
             {
-                return string.Empty;
+               eventDataCount = Math.Min(payloadName.Count, payload.Count);
             }
-            
+
             var sb = StringBuilderCache.Acquire();
 
             sb.Append('{');
-            for (int i = 0; i < payloadName.Count; i++)
+            for (int i = 0; i < eventDataCount; i++)
             {
                 var fieldstr = payloadName[i].ToString();
 
@@ -108,7 +109,7 @@ namespace System.Diagnostics.Tracing
                 {
                     sb.Append(payload[i].ToString());
                 }
-                
+
                 sb.Append(sep);
 
             }
@@ -135,7 +136,13 @@ namespace System.Diagnostics.Tracing
             string payload = "";
             if (eventData.Payload != null)
             {
-                payload = Serialize(eventData.PayloadNames, eventData.Payload);
+                try{
+                    payload = Serialize(eventData.PayloadNames, eventData.Payload);
+                }
+                catch (Exception ex)
+                {
+                    payload = "XplatEventLogger failed with Exception " + ex.ToString();
+                }
             }
 
             LogEventSource( eventData.EventId, eventData.EventName,eventData.EventSource.Name,payload);

--- a/src/mscorlib/src/System/Threading/Tasks/TPLETWProvider.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TPLETWProvider.cs
@@ -423,7 +423,7 @@ namespace System.Threading.Tasks
             {
                 unsafe
                 {
-                    EventData* eventPayload = stackalloc EventData[5];
+                    EventData* eventPayload = stackalloc EventData[6];
                     eventPayload[0].Size = sizeof(int);
                     eventPayload[0].DataPointer = ((IntPtr) (&OriginatingTaskSchedulerID));
                     eventPayload[1].Size = sizeof(int);
@@ -434,13 +434,15 @@ namespace System.Threading.Tasks
                     eventPayload[3].DataPointer = ((IntPtr) (&CreatingTaskID));
                     eventPayload[4].Size = sizeof(int);
                     eventPayload[4].DataPointer = ((IntPtr) (&TaskCreationOptions));
+                    eventPayload[5].Size = sizeof(int);
+                    eventPayload[5].DataPointer = ((IntPtr) (&appDomain));
                     if (TasksSetActivityIds)
                     {
                         Guid childActivityId = CreateGuidForTaskID(TaskID);
-                        WriteEventWithRelatedActivityIdCore(TASKSCHEDULED_ID, &childActivityId, 5, eventPayload);
+                        WriteEventWithRelatedActivityIdCore(TASKSCHEDULED_ID, &childActivityId, 6, eventPayload);
                     }
                     else 
-                        WriteEventCore(TASKSCHEDULED_ID, 5, eventPayload);
+                        WriteEventCore(TASKSCHEDULED_ID, 6, eventPayload);
                 }
             }
         }


### PR DESCRIPTION
This resolves #2233.

EventSource allows its providers to not specify all of its arguments through the  API  [WriteEventWithRelatedActivityIdCore](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs#L1145) within mscorlib . In this case payload and payloadNames do not match in size, I am not sure this is a documented feature, but that is the current behavior. If this is a bug I would like to fix populating the eventpayload names in  [PayLoadName getter](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs#L4827) to truncate it to the correct length of Min(PayLoad.Count,m_eventSource.m_eventData[EventId].Parameters.Count)

The incomplete Payload is accepted in [WriteToAllListeners] (https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Diagnostics/Eventing/EventSource.cs#L2127)
@brianrob @vancem @sergiy-k  PTAL