### PR TITLE
Fix issue with unlimited stack setting

### DIFF
--- a/src/gc/gc.h
+++ b/src/gc/gc.h
@@ -204,6 +204,7 @@ struct ScanContext
 {
     Thread* thread_under_crawl;
     int thread_number;
+    uintptr_t stack_limit; // Lowest point on the thread stack that the scanning logic is permitted to read
     BOOL promotion; //TRUE: Promotion, FALSE: Relocation.
     BOOL concurrent; //TRUE: concurrent scanning 
 #if CHECK_APP_DOMAIN_LEAKS || defined (FEATURE_APPDOMAIN_RESOURCE_MONITORING) || defined (DACCESS_COMPILE)
@@ -225,6 +226,7 @@ struct ScanContext
 
         thread_under_crawl = 0;
         thread_number = -1;
+        stack_limit = 0;
         promotion = FALSE;
         concurrent = FALSE;
 #ifdef GC_PROFILING


### PR DESCRIPTION
This change fixes a problem when a process stack size is set to unlimited.
In such case, the main thread stack memory range can shrink during the
process run time. But CoreCLR caches the initial stack limit value and
uses it to detect whether an object is on stack. Since the stack range is
not correct and there can be allocations in the original range of the stack,
this check sometimes fails and can cause issues.

The fix is to remember the stack top at the beginning of the scan in the
ScanContext and use it to check the object address too.