### PR TITLE
Enable tailcallopt for CoreRT

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6087,24 +6087,13 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
                 if (opts.IsReadyToRun())
                 {
                     call->gtCall.gtEntryPoint = callInfo->codePointerLookup.constLookup;
-                    if (canTailCall)
-                    {
-                        canTailCall = false;
-                        szCanTailCallFailReason = "Ready To Run";
-                    }
                 }
 #endif
                 break;
             }
 
         case CORINFO_CALL_CODE_POINTER:
-            {     
-                if (compIsForInlining())
-                {
-                    inlineFailReason = "Inlinee calls through code pointer";
-                    goto ABORT_THIS_INLINE_ONLY;
-                }
-                                
+            {
                 // The EE has asked us to call by computing a code pointer and then doing an 
                 // indirect call.  This is because a runtime lookup is required to get the code entry point.
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1545,12 +1545,6 @@ void Lowering::LowerCall(GenTree* node)
                 break;
             }
 #endif
-#if defined(_TARGET_AMD64_) && defined(FEATURE_READYTORUN_COMPILER)
-            if (call->gtEntryPoint.addr != nullptr)
-            {
-                break;
-            }
-#endif
             if  (call->gtCallType == CT_INDIRECT)
             {
                 result = LowerIndirectNonvirtCall(call);

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -4497,6 +4497,12 @@ bool ZapInfo::canTailCall(CORINFO_METHOD_HANDLE caller,
                                          CORINFO_METHOD_HANDLE exactCallee,
                                          bool fIsTailPrefix)
 {
+#ifdef FEATURE_READYTORUN_COMPILER
+    // READYTORUN: FUTURE: Delay load fixups for tailcalls
+    if (IsReadyToRunCompilation())
+        return false;
+#endif
+
     return m_pEEJitInfo->canTailCall(caller, declaredCallee, exactCallee, fIsTailPrefix);
 }
 


### PR DESCRIPTION
tailcallopt was disabled for ReadyToRun compilation mode because of zapper limitation. Moved the block to the zapper so that CoreRT can take advantage of it.