### PR TITLE
CompareOptions.IgnoreSymbols only ignores punctuation on Unix, but not other symbols 

### DIFF
--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 project(System.Globalization.Native)
-include(CheckCXXSourceCompiles)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
@@ -29,27 +28,15 @@ if(NOT CLR_CMAKE_PLATFORM_DARWIN)
     endif()
 
     set(CMAKE_REQUIRED_INCLUDES ${ICU_HOMEBREW_INC_PATH})
-    CHECK_CXX_SOURCE_COMPILES("
-     #include <unicode/udat.h>
-     int main() { UDateFormatSymbolType e = UDAT_STANDALONE_SHORTER_WEEKDAYS; }
-    " HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
-
-    if(HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
-        add_definitions(-DHAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS=1)
-    endif(HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
-
 else()
-
     find_library(ICUCORE icucore)
     if(ICUI18N STREQUAL ICUCORE-NOTFOUND)
         message(FATAL_ERROR "Cannot find libicucore, skipping build for System.Globalization.Native. .NET globalization is not expected to function.")
         return()
     endif()
-
-    # libicucore supports UDAT_STANDALONE_SHORTER_WEEKDAYS
-    add_definitions(-DHAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS=1)
-
 endif()
+
+include(configure.cmake)
 
 add_compile_options(-fPIC)
 

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -26,8 +26,6 @@ if(NOT CLR_CMAKE_PLATFORM_DARWIN)
         message(FATAL_ERROR "Cannot find libicui18n, try installing libicu-dev (or the appropriate package for your platform)")
         return()
     endif()
-
-    set(CMAKE_REQUIRED_INCLUDES ${ICU_HOMEBREW_INC_PATH})
 else()
     find_library(ICUCORE icucore)
     if(ICUI18N STREQUAL ICUCORE-NOTFOUND)

--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <vector>
 
+#include "config.h"
 #include "locale.hpp"
 #include "holders.h"
 
@@ -577,8 +578,7 @@ extern "C" int32_t EnumCalendarInfo(EnumCalendarInfoCallback callback,
         case SuperShortDayNames:
             // UDAT_STANDALONE_SHORTER_WEEKDAYS was added in ICU 51, and CentOS 7 currently uses ICU 50.
             // fallback to UDAT_STANDALONE_NARROW_WEEKDAYS in that case.
-
-#ifdef HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS
+#if HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS
             return EnumSymbols(locale, calendarId, UDAT_STANDALONE_SHORTER_WEEKDAYS, 1, callback, context);
 #else
             return EnumSymbols(locale, calendarId, UDAT_STANDALONE_NARROW_WEEKDAYS, 1, callback, context);

--- a/src/corefx/System.Globalization.Native/config.h.in
+++ b/src/corefx/System.Globalization.Native/config.h.in
@@ -1,3 +1,4 @@
 #pragma once
 
 #cmakedefine01 HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS
+#cmakedefine01 HAVE_SET_MAX_VARIABLE

--- a/src/corefx/System.Globalization.Native/config.h.in
+++ b/src/corefx/System.Globalization.Native/config.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#cmakedefine01 HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS

--- a/src/corefx/System.Globalization.Native/configure.cmake
+++ b/src/corefx/System.Globalization.Native/configure.cmake
@@ -1,0 +1,10 @@
+include(CheckCXXSourceCompiles)
+
+CHECK_CXX_SOURCE_COMPILES("
+    #include <unicode/udat.h>
+    int main() { UDateFormatSymbolType e = UDAT_STANDALONE_SHORTER_WEEKDAYS; }
+" HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+    ${CMAKE_CURRENT_BINARY_DIR}/config.h)

--- a/src/corefx/System.Globalization.Native/configure.cmake
+++ b/src/corefx/System.Globalization.Native/configure.cmake
@@ -1,9 +1,19 @@
 include(CheckCXXSourceCompiles)
+include(CheckSymbolExists)
+
+set(CMAKE_REQUIRED_INCLUDES ${UTYPES_H} ${ICU_HOMEBREW_INC_PATH})
 
 CHECK_CXX_SOURCE_COMPILES("
     #include <unicode/udat.h>
     int main() { UDateFormatSymbolType e = UDAT_STANDALONE_SHORTER_WEEKDAYS; }
 " HAVE_UDAT_STANDALONE_SHORTER_WEEKDAYS)
+
+check_symbol_exists(
+    ucol_setMaxVariable
+    "unicode/ucol.h"
+    HAVE_SET_MAX_VARIABLE)
+
+unset(CMAKE_REQUIRED_INCLUDES)
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in


### PR DESCRIPTION
By default, ICU alternate shifted collation handling only ignores punctuation, not all symbols, so change the "variable top" to include all symbols and currency characters.

Fix http://github.com/dotnet/corefx/issues/4907

@ellismg @steveharter @stephentoub 