### PR TITLE
Allow all architectures for buildtest.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -427,11 +427,6 @@ if defined __SkipTestBuild (
     goto SkipTestBuild
 )
 
-if /i not "%__BuildArch%" == "x64" (
-    echo %__MsgPrefix%Skipping test build: architecture %__BuildArch% not supported for test build.
-    goto SkipTestBuild
-)
-
 echo %__MsgPrefix%Commencing build of tests for %__BuildOS%.%__BuildArch%.%__BuildType%
 
 REM Construct the arguments to pass to the test build script.

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -46,6 +46,9 @@ if /i "%1" == "/help" goto Usage
 if /i "%1" == "-help" goto Usage
 
 if /i "%1" == "x64"                 (set __BuildArch=x64&shift&goto Arg_Loop)
+if /i "%1" == "x86"                 (set __BuildArch=x86&shift&goto Arg_Loop)
+if /i "%1" == "arm"                 (set __BuildArch=arm&shift&goto Arg_Loop)
+if /i "%1" == "arm64"               (set __BuildArch=arm64&shift&goto Arg_Loop)
 
 if /i "%1" == "debug"               (set __BuildType=Debug&shift&goto Arg_Loop)
 if /i "%1" == "release"             (set __BuildType=Release&shift&goto Arg_Loop)


### PR DESCRIPTION
This fixes a failure in the CI system.
