### PR TITLE
Eliminate a bunch of AppDomain.Setup string path allocations

### DIFF
--- a/src/mscorlib/src/System/IO/Path.cs
+++ b/src/mscorlib/src/System/IO/Path.cs
@@ -783,13 +783,7 @@ namespace System.IO {
                 return null;  // Unreachable - silence a compiler error.
             }
 
-            String returnVal = newBuffer.ToString();
-            if (String.Equals(returnVal, path, StringComparison.Ordinal))
-            {
-                returnVal = path;
-            }
-            return returnVal;
-
+            return newBuffer.ToStringOrExisting(path);
         }
         internal const int MaxLongPath = 32000;
 

--- a/src/mscorlib/src/System/IO/PathHelper.cs
+++ b/src/mscorlib/src/System/IO/PathHelper.cs
@@ -379,6 +379,24 @@ namespace System.IO {
             }
         }
 
+        [System.Security.SecurityCritical]
+        private unsafe bool OrdinalEqualsStackAlloc(String compareTo)
+        {
+            Contract.Requires(useStackAlloc, "Currently no efficient implementation for StringBuilder.OrdinalEquals(String)");
+
+            if (Length != compareTo.Length) {
+                return false;
+            }
+
+            for (int i = 0; i < compareTo.Length; i++) {
+                if (m_arrayPtr[i] != compareTo[i]) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         [System.Security.SecuritySafeCritical]
         public override String ToString() {
             if (useStackAlloc) {
@@ -386,6 +404,22 @@ namespace System.IO {
             }
             else {
                 return m_sb.ToString();
+            }
+        }
+
+        [System.Security.SecuritySafeCritical]
+        internal String ToStringOrExisting(String existingString)
+        {
+            if (useStackAlloc) {
+                return OrdinalEqualsStackAlloc(existingString) ?
+                    existingString : 
+                    new String(m_arrayPtr, 0, Length);
+            }
+            else {
+                string newString = m_sb.ToString(); // currently no good StringBuilder.OrdinalEquals(string)
+                return String.Equals(newString, existingString, StringComparison.Ordinal) ?
+                    existingString :
+                    newString;
             }
         }
 


### PR DESCRIPTION
A simple "Hello, World" CoreCLR app involves several hundred K of allocations.  A large percentage of this is in AppDomain.Setup.  At least for my configuration, 30% of all allocations are strings coming from AppDomain.Setup calling Path.NormalizePath (using CoreRun to run a "Hello, World" app in a folder containing the runtime and a bunch of framework libraries).  NormalizePath already checks to see whether the generated string is the same one that was supplied, but it does so after generating the string rather than before; changing to do it before-hand eliminates those allocations (given the right circumstances).

cc: @jkotas, @ellismg