### PR TITLE
Perf tweaks/cleanup to AppDomain.Setup

### DIFF
--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -3675,96 +3675,17 @@ namespace System {
                         nSetNativeDllSearchDirectories(paths);
                     }
                     else
-                    if(propertyNames[i]=="TRUSTED_PLATFORM_ASSEMBLIES")
+                    if (propertyNames[i]=="TRUSTED_PLATFORM_ASSEMBLIES" ||
+                        propertyNames[i]=="PLATFORM_RESOURCE_ROOTS" ||
+                        propertyNames[i]=="APP_PATHS" ||
+                        propertyNames[i]=="APP_NI_PATHS")
                     {
                         if(propertyValues[i]==null)
-                            throw new ArgumentNullException("TRUSTED_PLATFORM_ASSEMBLIES");
+                            throw new ArgumentNullException(propertyNames[i]);
 
                         StringBuilder normalisedAppPathList = new StringBuilder();
                         foreach(string path in propertyValues[i].Split(Path.PathSeparator))
                         {
-
-                            if( path.Length==0 )                  // skip empty dirs
-                                continue;
-                               
-                            if (Path.IsRelative(path))
-                                throw new ArgumentException( Environment.GetResourceString( "Argument_AbsolutePathRequired" ) );
-
-                            string appPath=Path.NormalizePath(path,true);
-                            normalisedAppPathList.Append(appPath);
-                            normalisedAppPathList.Append(Path.PathSeparator);
-                        }
-                        // Strip the last separator
-                        if (normalisedAppPathList.Length > 0)
-                        {
-                            normalisedAppPathList.Remove(normalisedAppPathList.Length - 1, 1);
-                        }
-                        ad.SetDataHelper(propertyNames[i],normalisedAppPathList.ToString(),null);        // not supported by fusion, so set explicitly                
-                    }
-                    else
-                    if(propertyNames[i]=="PLATFORM_RESOURCE_ROOTS")
-                    {
-                        if(propertyValues[i]==null)
-                            throw new ArgumentNullException("PLATFORM_RESOURCE_ROOTS");
-
-                        StringBuilder normalisedAppPathList = new StringBuilder();
-                        foreach(string path in propertyValues[i].Split(Path.PathSeparator))
-                        {
-
-                            if( path.Length==0 )                  // skip empty dirs
-                                continue;
-                               
-                            if (Path.IsRelative(path))
-                                throw new ArgumentException( Environment.GetResourceString( "Argument_AbsolutePathRequired" ) );
-
-                            string appPath=Path.NormalizePath(path,true);
-                            normalisedAppPathList.Append(appPath);
-                            normalisedAppPathList.Append(Path.PathSeparator);
-                        }
-                        // Strip the last separator
-                        if (normalisedAppPathList.Length > 0)
-                        {
-                            normalisedAppPathList.Remove(normalisedAppPathList.Length - 1, 1);
-                        }
-                        ad.SetDataHelper(propertyNames[i],normalisedAppPathList.ToString(),null);        // not supported by fusion, so set explicitly                
-                    }
-                    else
-                    if(propertyNames[i]=="APP_PATHS")
-                    {
-                        if(propertyValues[i]==null)
-                            throw new ArgumentNullException("APP_PATHS");
-
-                        StringBuilder normalisedAppPathList = new StringBuilder();
-                        foreach(string path in propertyValues[i].Split(Path.PathSeparator))
-                        {
-
-                            if( path.Length==0 )                  // skip empty dirs
-                                continue;
-                               
-                            if (Path.IsRelative(path))
-                                throw new ArgumentException( Environment.GetResourceString( "Argument_AbsolutePathRequired" ) );
-
-                            string appPath=Path.NormalizePath(path,true);
-                            normalisedAppPathList.Append(appPath);
-                            normalisedAppPathList.Append(Path.PathSeparator);
-                        }
-                        // Strip the last separator
-                        if (normalisedAppPathList.Length > 0)
-                        {
-                            normalisedAppPathList.Remove(normalisedAppPathList.Length - 1, 1);
-                        }
-                        ad.SetDataHelper(propertyNames[i],normalisedAppPathList.ToString(),null);        // not supported by fusion, so set explicitly                
-                    }
-                    else
-                    if(propertyNames[i]=="APP_NI_PATHS")
-                    {
-                        if(propertyValues[i]==null)
-                            throw new ArgumentNullException("APP_NI_PATHS");
-
-                        StringBuilder normalisedAppPathList = new StringBuilder();
-                        foreach(string path in propertyValues[i].Split(Path.PathSeparator))
-                        {
-
                             if( path.Length==0 )                  // skip empty dirs
                                 continue;
                                

--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -3623,11 +3623,9 @@ namespace System {
 
             if(propertyNames!=null && propertyValues != null)
             {
-                char[] pathSeparators = null;
                 StringBuilder normalisedAppPathList = null;
                 for (int i=0; i<propertyNames.Length; i++)
                 {
-                    
                     if(propertyNames[i]=="APPBASE") // make sure in sync with Fusion
                     {
                         if(propertyValues[i]==null)
@@ -3682,10 +3680,11 @@ namespace System {
                        propertyNames[i]=="APP_PATHS" ||
                        propertyNames[i]=="APP_NI_PATHS")
                     {
-                        if(propertyValues[i]==null)
+                        string values = propertyValues[i];
+                        if(values==null)
                             throw new ArgumentNullException(propertyNames[i]);
 
-                        int estimatedLength = propertyValues[i].Length + 1; // +1 for extra separator temporarily added at end
+                        int estimatedLength = values.Length + 1; // +1 for extra separator temporarily added at end
                         if (normalisedAppPathList == null) {
                             normalisedAppPathList = new StringBuilder(estimatedLength);
                         }
@@ -3695,11 +3694,22 @@ namespace System {
                                 normalisedAppPathList.Capacity = estimatedLength;
                         }
 
-                        if (pathSeparators == null)
-                            pathSeparators = new[] { Path.PathSeparator };
-
-                        foreach(string path in propertyValues[i].Split(pathSeparators))
+                        for (int pos = 0; pos < values.Length; pos++)
                         {
+                            string path;
+
+                            int nextPos = values.IndexOf(Path.PathSeparator, pos);
+                            if (nextPos == -1)
+                            {
+                                path = values.Substring(pos);
+                                pos = values.Length - 1;
+                            }
+                            else
+                            {
+                                path = values.Substring(pos, nextPos - pos);
+                                pos = nextPos;
+                            }
+
                             if( path.Length==0 )                  // skip empty dirs
                                 continue;
 

--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -3623,6 +3623,8 @@ namespace System {
 
             if(propertyNames!=null && propertyValues != null)
             {
+                char[] pathSeparators = null;
+                StringBuilder normalisedAppPathList = null;
                 for (int i=0; i<propertyNames.Length; i++)
                 {
                     
@@ -3675,20 +3677,32 @@ namespace System {
                         nSetNativeDllSearchDirectories(paths);
                     }
                     else
-                    if (propertyNames[i]=="TRUSTED_PLATFORM_ASSEMBLIES" ||
-                        propertyNames[i]=="PLATFORM_RESOURCE_ROOTS" ||
-                        propertyNames[i]=="APP_PATHS" ||
-                        propertyNames[i]=="APP_NI_PATHS")
+                    if(propertyNames[i]=="TRUSTED_PLATFORM_ASSEMBLIES" ||
+                       propertyNames[i]=="PLATFORM_RESOURCE_ROOTS" ||
+                       propertyNames[i]=="APP_PATHS" ||
+                       propertyNames[i]=="APP_NI_PATHS")
                     {
                         if(propertyValues[i]==null)
                             throw new ArgumentNullException(propertyNames[i]);
 
-                        StringBuilder normalisedAppPathList = new StringBuilder();
-                        foreach(string path in propertyValues[i].Split(Path.PathSeparator))
+                        int estimatedLength = propertyValues[i].Length + 1; // +1 for extra separator temporarily added at end
+                        if (normalisedAppPathList == null) {
+                            normalisedAppPathList = new StringBuilder(estimatedLength);
+                        }
+                        else {
+                            normalisedAppPathList.Clear();
+                            if (normalisedAppPathList.Capacity < estimatedLength)
+                                normalisedAppPathList.Capacity = estimatedLength;
+                        }
+
+                        if (pathSeparators == null)
+                            pathSeparators = new[] { Path.PathSeparator };
+
+                        foreach(string path in propertyValues[i].Split(pathSeparators))
                         {
                             if( path.Length==0 )                  // skip empty dirs
                                 continue;
-                               
+
                             if (Path.IsRelative(path))
                                 throw new ArgumentException( Environment.GetResourceString( "Argument_AbsolutePathRequired" ) );
 


### PR DESCRIPTION
- AppDomain.Setup currently has the same code repeated four times for handling four different properties.  Condense those down to a single block.
- Then make a few tweaks to avoid some unnecessary allocation: reuse the StringBuilder and char[] allocations across all four properties, and size the StringBuilder correctly rather than having it grow repeatedly.

cc: @jkotas, @ellismg 