### PR TITLE
Fix issue 2295.

### DIFF
--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -474,6 +474,9 @@ void Compiler::gsParamsToShadows()
             dst = gtNewOperNode(GT_ADDR, TYP_BYREF, dst);
 
             opAssign = gtNewCpObjNode(dst, src, clsHnd, false);
+#if FEATURE_MULTIREG_STRUCTS
+            lvaTable[shadowVar].lvDontPromote = lvaTable[lclNum].lvDontPromote;
+#endif // FEATURE_MULTIREG_STRUCTS
         }
         else
         {


### PR DESCRIPTION
When creating shadow variables, if the type is struct (and it is
multiregister struct) the lvDontPromote flag was not set. The flag needs
to be set to avoid promoting the struct to registers.