### PR TITLE
Fix SOS DumpLog

### DIFF
--- a/src/ToolBox/SOS/Strike/stressLogDump.cpp
+++ b/src/ToolBox/SOS/Strike/stressLogDump.cpp
@@ -432,7 +432,7 @@ HRESULT StressLog::Dump(ULONG64 outProcLog, const char* fileName, struct IDebugD
         threadCtr++;
     }
 
-    if (!bDoGcHist && ((file = fopen(fileName, "w")) != NULL))
+    if (!bDoGcHist && ((file = fopen(fileName, "w")) == NULL))
     {
         hr = GetLastError();
         goto FREE_MEM;


### PR DESCRIPTION
Apparently, SOS DumpLog has been broken for a while. Turns out there's a check that was changed from using fopen_s (which returns 0 on success) to fopen (which returns a FILE pointer), but it was still treating a non-zero return value as failure so we were bailing out when we got a valid pointer.

`sos DumpLog` works after this change.

@mikem8361 