### PR TITLE
Add syntax highlighting to the build instructions

### DIFF
--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -8,15 +8,21 @@ Requirements
 
 You need a Debian based host and the following packages needs to be installed:
 
-    ben@ubuntu ~/git/coreclr/ $ sudo apt-get install qemu qemu-user-static binfmt-support debootstrap
+```sh
+ben@ubuntu ~/git/coreclr/ $ sudo apt-get install qemu qemu-user-static binfmt-support debootstrap
+```
 
 In addition, to cross compile CoreCLR the binutils for the target are required. So for arm you need:
 
-    ben@ubuntu ~/git/coreclr/ $ sudo apt-get install binutils-arm-linux-gnueabihf
+```sh
+ben@ubuntu ~/git/coreclr/ $ sudo apt-get install binutils-arm-linux-gnueabihf
+```
 
 and conversely for arm64:
 
-    ben@ubuntu ~/git/coreclr/ $ sudo apt-get install binutils-aarch64-linux-gnu
+```sh
+ben@ubuntu ~/git/coreclr/ $ sudo apt-get install binutils-aarch64-linux-gnu
+```
 
 
 Generating the rootfs
@@ -30,11 +36,15 @@ The `build-rootfs.sh` script must be run as root as it has to make some symlinks
 
 For example, to generate an arm rootfs:
 
-    ben@ubuntu ~/git/coreclr/ $ sudo ./cross/build-rootfs.sh arm
+```sh
+ben@ubuntu ~/git/coreclr/ $ sudo ./cross/build-rootfs.sh arm
+```
 
 and if you wanted to generate the rootfs elsewhere:
 
-    ben@ubuntu ~/git/coreclr/ $ sudo ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build-rootfs.sh arm
+```sh
+ben@ubuntu ~/git/coreclr/ $ sudo ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build-rootfs.sh arm
+```
 
 Patching Urcu
 -------------
@@ -67,11 +77,15 @@ Once the rootfs has been generated, it will be possible to cross compile CoreCLR
 
 So, without `ROOTFS_DIR`:
 
-    ben@ubuntu ~/git/coreclr/ $ ./build.sh arm debug verbose clean cross
+```sh
+ben@ubuntu ~/git/coreclr/ $ ./build.sh arm debug verbose clean cross
+```
 
 And with:
 
-    ben@ubuntu ~/git/coreclr/ $ ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build.sh arm debug verbose clean cross
+```sh
+ben@ubuntu ~/git/coreclr/ $ ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build.sh arm debug verbose clean cross
+```
 
 As usual the resulting binaries will be found in `bin/Product/BuildOS.BuildArch.BuildType/`
 
@@ -96,7 +110,7 @@ The output is at bin\Product\<BuildOS>.x64.Debug\mscorlib.dll.
 
 The CoreCLR native components need to be built on the target platform.  This can be done with the following command:
 
-```
+```sh
 ellismg@linux:~/git/coreclr$ ./build.sh skipmscorlib
 ```
 
@@ -116,6 +130,6 @@ The output is at bin\<BuildOS>.AnyCPU.Debug.
 
 The CoreFX native components need to be built on the target platform.  This can be done with the following command:
 
-```
+```sh
 ellismg@linux:~/git/corefx$ ./build.sh native
 ```

--- a/Documentation/building/linux-instructions.md
+++ b/Documentation/building/linux-instructions.md
@@ -33,7 +33,7 @@ Install the following packages for the toolchain:
 
 In order to get lldb-3.6 on Ubuntu 14.04, we need to add an additional package source:
 
-```
+```sh
 ellismg@linux:~$ echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.6 main" | sudo tee /etc/apt/sources.list.d/llvm.list
 ellismg@linux:~$ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
 ellismg@linux:~$ sudo apt-get update
@@ -41,7 +41,7 @@ ellismg@linux:~$ sudo apt-get update
 
 Then install the packages you need:
 
-```
+```sh
 ellismg@linux:~$ sudo apt-get install cmake llvm-3.5 clang-3.5 lldb-3.6 lldb-3.6-dev libunwind8 libunwind8-dev gettext libicu-dev liblttng-ust-dev libcurl4-openssl-dev libssl-dev uuid-dev
 ```
 
@@ -59,7 +59,7 @@ If you don't already have Mono installed on your system, use the [installation i
 
 At a high level, you do the following:
 
-```
+```sh
 ellismg@linux:~$ sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 ellismg@linux:~$ echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
 ellismg@linux:~$ sudo apt-get update
@@ -76,7 +76,7 @@ Build the Runtime and Microsoft Core Library
 
 To build the runtime on Linux, run build.sh from the root of the coreclr repository:
 
-```
+```sh
 ellismg@linux:~/git/coreclr$ ./build.sh
 ```
 
@@ -88,7 +88,7 @@ After the build is completed, there should some files placed in `bin/Product/Lin
 
 In order to keep everything tidy, let's create a new directory for the runtime and copy the runtime and corerun into it.
 
-```
+```sh
 ellismg@linux:~/git/coreclr$ mkdir -p ~/coreclr-demo/runtime
 ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/corerun ~/coreclr-demo/runtime
 ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/libcoreclr.so ~/coreclr-demo/runtime
@@ -99,13 +99,13 @@ ellismg@linux:~/git/coreclr$ cp bin/Product/Linux.x64.Debug/System.Globalization
 Build the Framework
 ===================
 
-```
+```sh
 ellismg@linux:~/git/corefx$ ./build.sh
 ```
 
 For the purposes of Hello World, you need to copy a few required files to the demo folder.
 
-```
+```sh
 ellismg@linux:~/git/corefx$ cp bin/Linux.x64.Debug/Native/*.so ~/coreclr-demo/runtime
 ellismg@linux:~/git/corefx$ cp bin/Linux.AnyCPU.Debug/System.Console/System.Console.dll ~/coreclr-demo/runtime
 ellismg@linux:~/git/corefx$ cp bin/Linux.AnyCPU.Debug/System.Diagnostics.Debug/System.Diagnostics.Debug.dll ~/coreclr-demo/runtime
@@ -113,7 +113,7 @@ ellismg@linux:~/git/corefx$ cp bin/Linux.AnyCPU.Debug/System.Diagnostics.Debug/S
 
 The runtime directory should now look like the following:
 
-```
+```sh
 matell@linux:~$ ls ~/coreclr-demo/runtime/
 corerun                       System.Globalization.Native.so
 libcoreclr.so                 System.Native.so
@@ -129,7 +129,7 @@ The rest of the assemblies you need to run are presently just facades that point
 
 Create a folder for the packages:
 
-```
+```sh
 ellismg@linux:~$ mkdir ~/coreclr-demo/packages
 ellismg@linux:~$ cd ~/coreclr-demo/packages
 ```
@@ -139,7 +139,7 @@ Download the NuGet Client
 
 Grab NuGet (if you don't have it already)
 
-```
+```sh
 ellismg@linux:~/coreclr-demo/packages$ curl -L -O https://nuget.org/nuget.exe
 ```
 Download NuGet Packages
@@ -149,7 +149,7 @@ With Mono and NuGet in hand, you can use NuGet to get the required dependencies.
 
 Make a `packages.config` file with the following text. These are the required dependencies of this particular app. Different apps will have different dependencies and require a different `packages.config` - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
 
-```
+```xml
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="System.Console" version="4.0.0-beta-22703" />
@@ -175,7 +175,7 @@ Make a `packages.config` file with the following text. These are the required de
 
 And restore your packages.config file:
 
-```
+```sh
 ellismg@linux:~/coreclr-demo/packages$ mono nuget.exe restore -Source https://www.myget.org/F/dotnet-corefx/ -PackagesDirectory .
 ```
 
@@ -183,7 +183,7 @@ NOTE: This assumes you installed Mono from the mono-project.com packages. If you
 
 Finally, you need to copy over the assemblies to the runtime folder.  You don't want to copy over System.Console.dll or System.Diagnostics.Debug however, since the version from NuGet is the Windows version.  The easiest way to do this is with a little find magic:
 
-```
+```sh
 ellismg@linux:~/coreclr-demo/packages$ find . -wholename '*/aspnetcore50/*.dll' -exec cp -n {} ~/coreclr-demo/runtime \;
 ```
 
@@ -192,14 +192,14 @@ Compile an App
 
 Now you need a Hello World application to run.  You can write your own, if you'd like.  Personally, I'm partial to the one on corefxlab which will draw Tux for us.
 
-```
+```sh
 ellismg@linux:~$ cd ~/coreclr-demo/runtime
 ellismg@linux:~/coreclr-demo/runtime$ curl -O https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs
 ```
 
 Then you just need to build it, with `mcs`, the Mono C# compiler. FYI: The Roslyn C# compiler will soon be available on Linux.  Because you need to compile the app against the .NET Core surface area, you need to pass references to the contract assemblies you restored using NuGet:
 
-```
+```sh
 ellismg@linux:~/coreclr-demo/runtime$ mcs /nostdlib /noconfig /r:../packages/System.Console.4.0.0-beta-22703/lib/contract/System.Console.dll /r:../packages/System.Runtime.4.0.20-beta-22703/lib/contract/System.Runtime.dll HelloWorld.cs
 ```
 
@@ -208,7 +208,7 @@ Run your App
 
 You're ready to run Hello World!  To do that, run corerun, passing the path to the managed exe, plus any arguments.  The HelloWorld from corefxlab will print Tux if you pass "linux" as an argument, so:
 
-```
+```sh
 ellismg@linux:~/coreclr-demo/runtime$ ./corerun HelloWorld.exe linux
 ```
 

--- a/Documentation/building/osx-instructions.md
+++ b/Documentation/building/osx-instructions.md
@@ -42,7 +42,9 @@ CoreCLR has a dependency on CMake for the build. You can download it from [CMake
 
 Alternatively, you can install CMake from [Homebrew](http://brew.sh/).
 
-    dotnet-mbp:~ richlander$ brew install cmake
+```sh
+dotnet-mbp:~ richlander$ brew install cmake
+```
 
 Mono
 ----
@@ -51,7 +53,9 @@ Mono
 
 In order to build mscorlib (directions follow) you will need to raise the limit on the number of open files allowed otherwise you may see an error. To do this execute the following command from the shell:
 
-    ulimit -n 2048
+```sh
+ulimit -n 2048
+```
 
 ICU
 ---
@@ -61,24 +65,28 @@ OpenSSL
 -------
 The CoreFX cryptography libraries are built on OpenSSL. The version of OpenSSL included on OS X (0.9.8) has gone out of support, and a newer version is required. A supported version can be obtained via [Homebrew](http://brew.sh).
 
-    brew install openssl
-    brew link --force openssl
+```sh
+brew install openssl
+brew link --force openssl
+```
 
 Demo directory
 --------------
 
 In order to keep everything tidy, create a new directory for all the files that you will build or acquire.
 
-    dotnet-mbp:~ richlander$ mkdir -p ~/coreclr-demo/runtime
-    dotnet-mbp:~ richlander$ mkdir -p ~/coreclr-demo/packages
-    dotnet-mbp:~ richlander$ cd ~/coreclr-demo/
+```sh
+dotnet-mbp:~ richlander$ mkdir -p ~/coreclr-demo/runtime
+dotnet-mbp:~ richlander$ mkdir -p ~/coreclr-demo/packages
+dotnet-mbp:~ richlander$ cd ~/coreclr-demo/
+```
 
 NuGet
 -----
 
 NuGet is required to acquire any .NET assembly dependency that is not built by these instructions.
 
-    dotnet-mbp:coreclr-demo richlander$ curl -L -O https://nuget.org/nuget.exe
+dotnet-mbp:coreclr-demo richlander$ curl -L -O https://nuget.org/nuget.exe
 
 Build the Runtime and Microsoft Core Library
 ============================================
@@ -97,7 +105,9 @@ Type `./build.sh -?` to see the full set of build options.
 
 Check the build output.
 
-    dotnet-mbp:coreclr richlander$ ls bin/Product/OSX.x64.Debug/
+```sh
+dotnet-mbp:coreclr richlander$ ls bin/Product/OSX.x64.Debug/
+```
 
 You will see several files. The interesting ones are:
 
@@ -107,21 +117,27 @@ You will see several files. The interesting ones are:
 
 Copy the runtime and corerun into the demo directory.
 
-    dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/corerun ~/coreclr-demo/runtime/
-    dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/libcoreclr.dylib ~/coreclr-demo/runtime/
-	dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/mscorlib.dll ~/coreclr-demo/runtime/
-	dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/System.Globalization.Native.dylib ~/coreclr-demo/runtime/
+```sh
+dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/corerun ~/coreclr-demo/runtime/
+dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/libcoreclr.dylib ~/coreclr-demo/runtime/
+dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/mscorlib.dll ~/coreclr-demo/runtime/
+dotnet-mbp:coreclr richlander$ cp bin/Product/OSX.x64.Debug/System.Globalization.Native.dylib ~/coreclr-demo/runtime/
+```
 
 Build the Framework
 ===================
 
-    dotnet-mbp:corefx richlander$ ./build.sh
+```sh
+dotnet-mbp:corefx richlander$ ./build.sh
+```
 
 For the purposes of this demo, you need to copy a few required files to the demo folder.
 
-	dotnet-mbp:corefx richlander$ cp bin/OSX.x64.Debug/Native/*.dylib ~/coreclr-demo/runtime
-    dotnet-mbp:corefx richlander$ cp bin/OSX.AnyCPU.Debug/System.Console/System.Console.dll ~/coreclr-demo/runtime
-    dotnet-mbp:corefx richlander$ cp bin/OSX.AnyCPU.Debug/System.Diagnostics.Debug/System.Diagnostics.Debug.dll ~/coreclr-demo/runtime
+```sh
+dotnet-mbp:corefx richlander$ cp bin/OSX.x64.Debug/Native/*.dylib ~/coreclr-demo/runtime
+dotnet-mbp:corefx richlander$ cp bin/OSX.AnyCPU.Debug/System.Console/System.Console.dll ~/coreclr-demo/runtime
+dotnet-mbp:corefx richlander$ cp bin/OSX.AnyCPU.Debug/System.Diagnostics.Debug/System.Diagnostics.Debug.dll ~/coreclr-demo/runtime
+```
 
 The runtime directory should now look like the following:
 
@@ -139,68 +155,81 @@ The rest of the assemblies you need to run are presently just facades that point
 
 Make a `packages/packages.config` file with the following text. These are the required dependencies of this particular app. Different apps will have different dependencies and require a different `packages.config` - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
 
-    <?xml version="1.0" encoding="utf-8"?>
-    <packages>
-      <package id="System.Console" version="4.0.0-beta-22703" />
-      <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
-      <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
-      <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
-      <package id="System.Globalization" version="4.0.10-beta-22703" />
-      <package id="System.IO" version="4.0.10-beta-22703" />
-      <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
-      <package id="System.Reflection" version="4.0.10-beta-22703" />
-      <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
-      <package id="System.Runtime" version="4.0.20-beta-22703" />
-      <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
-      <package id="System.Runtime.Handles" version="4.0.0-beta-22703" />
-      <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
-      <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
-      <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22703" />
-      <package id="System.Threading" version="4.0.10-beta-22703" />
-      <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
-    </packages>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Console" version="4.0.0-beta-22703" />
+  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
+  <package id="System.Globalization" version="4.0.10-beta-22703" />
+  <package id="System.IO" version="4.0.10-beta-22703" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Threading" version="4.0.10-beta-22703" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
+</packages>
+```
 
 And restore your packages.config file:
 
-    dotnet-mbp:~ richlander$ cd ~/coreclr-demo
-    dotnet-mbp:coreclr-demo richlander$ mono nuget.exe restore packages/packages.config -Source https://www.myget.org/F/dotnet-corefx/ -PackagesDirectory packages
+```sh
+dotnet-mbp:~ richlander$ cd ~/coreclr-demo
+dotnet-mbp:coreclr-demo richlander$ mono nuget.exe restore packages/packages.config -Source https://www.myget.org/F/dotnet-corefx/ -PackagesDirectory packages
+```
 
 Finally, you need to copy the assemblies over to the runtime folder.  You don't want to copy over System.Console.dll or System.Diagnostics.Debug however, since the version from NuGet is the Windows version.  The easiest way to do this is with a little find magic:
 
-    dotnet-mbp:coreclr-demo richlander$ find . -wholename '*/aspnetcore50/*.dll' -exec cp -n {} ~/coreclr-demo/runtime \;
+```sh
+dotnet-mbp:coreclr-demo richlander$ find . -wholename '*/aspnetcore50/*.dll' -exec cp -n {} ~/coreclr-demo/runtime \;
+```
 
 Compile an App
 ==============
 
 Now you need a Hello World application to run.  You can write your own, if you'd like. Here's a very simple one:
 
-    using System;
+```csharp
+using System;
 
-    public class Program
+public class Program
+{
+    public static void Main (string[] args)
     {
-        public static void Main (string[] args)
-        {
-            Console.WriteLine("Hello, OS X");
-            Console.WriteLine("Love from CoreCLR.");
-        }   
-    } 
+        Console.WriteLine("Hello, OS X");
+        Console.WriteLine("Love from CoreCLR.");
+    }   
+} 
+```
 
-Personally, I'm partial to the one on corefxlab which will print a  picture for you.
+Personally, I'm partial to the one on corefxlab which will print a picture for you.
 
-    dotnet-mbp:coreclr-demo richlander$ curl -O https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs
-
+```sh
+dotnet-mbp:coreclr-demo richlander$ curl -O https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs
+```
 
 Then you just need to build it, with `mcs`, the Mono C# compiler. FYI: The Roslyn C# compiler will soon be available on OS X.  Because you need to compile the app against the .NET Core surface area, you need to pass references to the contract assemblies you restored using NuGet:
 
-    dotnet-mbp:coreclr-demo richlander$ mcs /nostdlib /noconfig /r:packages/System.Console.4.0.0-beta-22703/lib/contract/System.Console.dll /r:packages/System.Runtime.4.0.20-beta-22703/lib/contract/System.Runtime.dll -out:runtime/HelloWorld.exe HelloWorld.cs 
+```sh
+dotnet-mbp:coreclr-demo richlander$ mcs /nostdlib /noconfig /r:packages/System.Console.4.0.0-beta-22703/lib/contract/System.Console.dll /r:packages/System.Runtime.4.0.20-beta-22703/lib/contract/System.Runtime.dll -out:runtime/HelloWorld.exe HelloWorld.cs 
+```
 
 Run your App
 ============
 
 You're ready to run Hello World!  To do that, run corerun, passing the path to the managed exe, plus any arguments.  The HelloWorld from corefxlab will print a special fruit if you pass "mac" as an argument, so:
 
-    dotnet-mbp:coreclr-demo richlander$ cd runtime/
-    dotnet-mbp:runtime richlander$ ./corerun HelloWorld.exe mac
+```sh
+dotnet-mbp:coreclr-demo richlander$ cd runtime/
+dotnet-mbp:runtime richlander$ ./corerun HelloWorld.exe mac
+```
 
 
 Over time, this process will get easier. We will remove the dependency on having to compile managed code on Windows. For example, we are working to get our NuGet packages to include  Windows, Linux and OS X versions of an assembly, so you can simply nuget restore the dependencies. 

--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -145,26 +145,28 @@ You need to restore/download the rest of the demo dependencies via NuGet, as the
 
 Make a packages/packages.config file with the following XML. These packages are the required dependencies of this particular app. Different apps will have different dependencies and require different packages.config - see [Issue #480](https://github.com/dotnet/coreclr/issues/480).
 
-	<?xml version="1.0" encoding="utf-8"?>
-	<packages>
-	  <package id="System.Console" version="4.0.0-beta-22703" />
-	  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
-	  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
-	  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
-	  <package id="System.Globalization" version="4.0.10-beta-22703" />
-	  <package id="System.IO" version="4.0.10-beta-22703" />
-	  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
-	  <package id="System.Reflection" version="4.0.10-beta-22703" />
-	  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
-	  <package id="System.Runtime" version="4.0.20-beta-22703" />
-	  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
-	  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" />
-	  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
-	  <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
-	  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22703" />
-	  <package id="System.Threading" version="4.0.10-beta-22703" />
-	  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
-	</packages>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Console" version="4.0.0-beta-22703" />
+  <package id="System.Diagnostics.Contracts" version="4.0.0-beta-22703" />
+  <package id="System.Diagnostics.Debug" version="4.0.10-beta-22703" />
+  <package id="System.Diagnostics.Tools" version="4.0.0-beta-22703" />
+  <package id="System.Globalization" version="4.0.10-beta-22703" />
+  <package id="System.IO" version="4.0.10-beta-22703" />
+  <package id="System.IO.FileSystem.Primitives" version="4.0.0-beta-22703" />
+  <package id="System.Reflection" version="4.0.10-beta-22703" />
+  <package id="System.Resources.ResourceManager" version="4.0.0-beta-22703" />
+  <package id="System.Runtime" version="4.0.20-beta-22703" />
+  <package id="System.Runtime.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Runtime.Handles" version="4.0.0-beta-22703" />
+  <package id="System.Runtime.InteropServices" version="4.0.20-beta-22703" />
+  <package id="System.Text.Encoding" version="4.0.10-beta-22703" />
+  <package id="System.Text.Encoding.Extensions" version="4.0.10-beta-22703" />
+  <package id="System.Threading" version="4.0.10-beta-22703" />
+  <package id="System.Threading.Tasks" version="4.0.10-beta-22703" />
+</packages>
+```
 
 And restore the packages with the packages.config:
 
@@ -175,16 +177,18 @@ Compile the Demo
 
 Now you need a Hello World application to run. You can write your own, if you'd like. Here's a very simple one:
 
-	using System;
+```csharp
+using System;
 
-	public class Program
-	{
-	    public static void Main (string[] args)
-	    {
-	        Console.WriteLine("Hello, Windows");
-	        Console.WriteLine("Love from CoreCLR.");
-	    }   
-	} 
+public class Program
+{
+    public static void Main (string[] args)
+    {
+        Console.WriteLine("Hello, Windows");
+        Console.WriteLine("Love from CoreCLR.");
+    }   
+} 
+```
 
 Personally, I'm partial to the one on corefxlab which will print a picture for you. Download the [corefxlab demo](https://raw.githubusercontent.com/dotnet/corefxlab/master/demos/CoreClrConsoleApplications/HelloWorld/HelloWorld.cs) to `\coreclr-demo`.
 


### PR DESCRIPTION
Adds GFM syntax highlighting to the build instructions so they're colorized. Admittedly a pretty trivial change.