### PR TITLE
Remove redundant internal Array.FunctorComparer<T> type

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -9742,9 +9742,6 @@
       <Member Name="ReleaseAllData" />
       <Member Name="GetEventProvider(System.RuntimeType)" />
     </Type>
-    <Type Status="ImplRoot" Name="System.Array+FunctorComparer&lt;T&gt;">
-      <Member Name="Compare(T,T)" />
-    </Type>
     <Type Status="ImplRoot" Name="System.BCLDebug">
       <Member Name="GetRegistryLoggingValues(System.Boolean@,System.Boolean@,System.Int32@,System.Boolean@,System.Boolean@,System.Boolean@)" /> <!-- EE -->
     </Type>

--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1864,7 +1864,7 @@ namespace System {
             }
             Contract.EndContractBlock();
 
-            IComparer<T> comparer = new FunctorComparer<T>(comparison);
+            IComparer<T> comparer = Comparer<T>.Create(comparison);
             Array.Sort(array, comparer);
         }
 
@@ -1884,18 +1884,6 @@ namespace System {
                 }
             }
             return true;
-        }
-
-        internal sealed class FunctorComparer<T> : IComparer<T> {
-            Comparison<T> comparison;
-
-            public FunctorComparer(Comparison<T> comparison) {
-                this.comparison = comparison;
-            }
-
-            public int Compare(T x, T y) {
-                return comparison(x, y);
-            }
         }
 
 

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -996,7 +996,7 @@ namespace System.Collections.Generic {
             Contract.EndContractBlock();
 
             if( _size > 0) {
-                IComparer<T> comparer = new Array.FunctorComparer<T>(comparison);
+                IComparer<T> comparer = Comparer<T>.Create(comparison);
                 Array.Sort(_items, 0, _size, comparer);
             }
         }


### PR DESCRIPTION
Instead, use the public [`Comparer<T>.Create`](https://github.com/dotnet/coreclr/blob/e6538fcbd554009d7edb5f378bf2763652905af4/src/mscorlib/src/System/Collections/Generic/Comparer.cs#L34) API, which already has an [internal type](https://github.com/dotnet/coreclr/blob/e6538fcbd554009d7edb5f378bf2763652905af4/src/mscorlib/src/System/Collections/Generic/Comparer.cs#L154-L165) to adapt a `Comparison<T>` delegate as `IComparer<T>`.