### PR TITLE
Fix for bug 2294 [JitStress=2] Assertion failed 'curArgTabEntry->regN…

### DIFF
--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -726,7 +726,12 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define REG_FP_FIRST             REG_XMM0
   #define REG_FP_LAST              REG_XMM15
   #define FIRST_FP_ARGREG          REG_XMM0
-  #define LAST_FP_ARGREG           REG_XMM3
+
+#ifdef    UNIX_AMD64_ABI
+  #define LAST_FP_ARGREG        REG_XMM7
+#else // !UNIX_AMD64_ABI
+  #define LAST_FP_ARGREG        REG_XMM3
+#endif // !UNIX_AMD64_ABI
 
   #define REGNUM_BITS              6       // number of bits in a REG_*
   #define TINY_REGNUM_BITS         6       // number used in a tiny instrdesc (same)


### PR DESCRIPTION
…um == regNum' in 'BringUpTest Main() in morph.cpp

The bug is due to a misproper definition of LAST_FP_ARGREG for Unix. On Windows, we set LAST_FP_ARGREG to XMM3. On UNix, the value should be XMM7.