### PR TITLE
Make CORCOMPILE_HEADER backward compatible

### DIFF
--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -249,7 +249,9 @@ enum CorCompileHeaderFlags
 struct CORCOMPILE_HEADER
 {
     // For backward compatibility reasons, VersionInfo field must be at offset 40, ManifestMetaData
-    // must be at 88, size of CORCOMPILE_HEADER must be 164/168 bytes.  Be careful when you modify this struct.  See code:PEDecoder::GetMetaDataHelper.
+    // must be at 88, PEKind must be at 112/116 bytes, Machine must be at 120/124 bytes, and
+    // size of CORCOMPILE_HEADER must be 164/168 bytes.  Be careful when you modify this struct.
+    // See code:PEDecoder::GetMetaDataHelper.
     DWORD                   Signature;
     USHORT                  MajorVersion;
     USHORT                  MinorVersion;
@@ -274,7 +276,6 @@ struct CORCOMPILE_HEADER
                                                 // training data. They can also be used to have better nidump support for
                                                 // decoding virtual section information ( start - end ranges for each
                                                 // virtual section )
-    IMAGE_DATA_DIRECTORY    EEInfoTable;    // points to a code:CORCOMPILE_EE_INFO_TABLE
 
     TADDR                   ImageBase;      // Actual image base address (ASLR fakes the image base in PE header while applying relocations in kernel)
     DWORD                   Flags;          // Flags, see CorCompileHeaderFlags above
@@ -284,6 +285,8 @@ struct CORCOMPILE_HEADER
     ULONG                   COR20Flags;     // Cached value of code:IMAGE_COR20_HEADER.Flags from original IL image
     WORD                    Machine;        // Cached value of _IMAGE_FILE_HEADER.Machine from original IL image
     WORD                    Characteristics;// Cached value of _IMAGE_FILE_HEADER.Characteristics from original IL image
+
+    IMAGE_DATA_DIRECTORY    EEInfoTable;    // points to a code:CORCOMPILE_EE_INFO_TABLE
 
     // For backward compatibility (see above)
     IMAGE_DATA_DIRECTORY    Dummy1;

--- a/src/utilcode/pedecoder.cpp
+++ b/src/utilcode/pedecoder.cpp
@@ -1226,9 +1226,12 @@ IMAGE_DATA_DIRECTORY *PEDecoder::GetMetaDataHelper(METADATA_SECTION_TYPE type) c
 
     // Visual Studio took dependency on crossgen /CreatePDB returning COR_E_NI_AND_RUNTIME_VERSION_MISMATCH
     // when crossgen and the native image come from different runtimes. In order to reach error path that returns
-    // COR_E_NI_AND_RUNTIME_VERSION_MISMATCH in this case, size of CORCOMPILE_HEADER has to remain constant to pass earlier 
+    // COR_E_NI_AND_RUNTIME_VERSION_MISMATCH in this case, size of CORCOMPILE_HEADER has to remain constant,
+    // and the offset of PEKind and Machine fields inside CORCOMPILE_HEADER also have to remain constant, to pass earlier
     // checks that lead to different error codes. See Windows Phone Blue Bug #45406 for details.
     _ASSERTE(sizeof(CORCOMPILE_HEADER) == 160 + sizeof(TADDR));
+    _ASSERTE(offsetof(CORCOMPILE_HEADER, PEKind) == 108 + sizeof(TADDR));
+    _ASSERTE(offsetof(CORCOMPILE_HEADER, Machine) == 116 + sizeof(TADDR));
 
     // Handle NGEN format; otherwise, there is only one MetaData section in the
     // COR_HEADER and so the value of pDirRet is correct


### PR DESCRIPTION
Resolve issue #2348 by reordering fields in CORCOMPILE_HEADER,
so that PEKind and Machines fields are in the same location as
in older versions of this struct.