### PR TITLE
Add ifdef to suppress non-coreclr warning

### DIFF
--- a/src/mscorlib/src/System/AppDomain.cs
+++ b/src/mscorlib/src/System/AppDomain.cs
@@ -3623,7 +3623,9 @@ namespace System {
 
             if(propertyNames!=null && propertyValues != null)
             {
+#if FEATURE_CORECLR
                 StringBuilder normalisedAppPathList = null;
+#endif // FEATURE_CORECLR
                 for (int i=0; i<propertyNames.Length; i++)
                 {
                     if(propertyNames[i]=="APPBASE") // make sure in sync with Fusion


### PR DESCRIPTION
My change to optimize AppDomain.Setup included moving a variable out of a loop, which also ended up moving it out of an ifdef.  That then causes an unused variable warning on some builds.

cc: @adiaaida, @jkotas 