### PR TITLE
Remove StringBuilder allocation/usage from DateTimeFormat

### DIFF
--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -287,9 +287,10 @@ namespace System {
     
         //
         // The pos should point to a quote character. This method will
-        // get the string encloed by the quote character.
+        // get the length, including beginning and ending quote, of the
+        // quoted string.
         //
-        internal static int ParseQuoteString(String format, int pos, StringBuilder result)
+        internal static int ParseQuoteString(String format, int pos)
         {
             //
             // NOTE : pos will be the index of the quote character in the 'format' string.
@@ -314,15 +315,13 @@ namespace System {
                     //  minute: 45"
                     // because the second double quote is escaped.
                     if (pos < formatLen) {
-                        result.Append(format[pos++]);
+                        pos++;
                     } else {
                             //
                             // This means that '\' is at the end of the formatting string.
                             //
                             throw new FormatException(Environment.GetResourceString("Format_InvalidString"));
                     }                    
-                } else {
-                    result.Append(ch);
                 }
             }
             
@@ -334,7 +333,7 @@ namespace System {
                             CultureInfo.CurrentCulture,
                             Environment.GetResourceString("Format_BadQuote"), quoteChar));
             }
-            
+
             //
             // Return the character count including the begin/end quote characters and enclosed string.
             //
@@ -629,9 +628,8 @@ namespace System {
                         break;
                     case '\'':
                     case '\"':
-                        StringBuilder enquotedString = new StringBuilder();
-                        tokenLen = ParseQuoteString(format, i, enquotedString); 
-                        result.Append(enquotedString);
+                        tokenLen = ParseQuoteString(format, i);
+                        result.Append(format, i + 1, tokenLen - 2);
                         break;
                     case '%':
                         // Optional format character.

--- a/src/mscorlib/src/System/Globalization/TimeSpanFormat.cs
+++ b/src/mscorlib/src/System/Globalization/TimeSpanFormat.cs
@@ -231,9 +231,8 @@ namespace System.Globalization {
                         break;
                     case '\'':
                     case '\"':
-                        StringBuilder enquotedString = new StringBuilder();
-                        tokenLen = DateTimeFormat.ParseQuoteString(format, i, enquotedString); 
-                        result.Append(enquotedString);
+                        tokenLen = DateTimeFormat.ParseQuoteString(format, i); 
+                        result.Append(format, i + 1, tokenLen - 2);
                         break;
                     case '%':
                         // Optional format character.


### PR DESCRIPTION
ASP.NET uses DateTimeOffset.ToString("r") to format in accordance with RFC1123.  The implementation of "r", for which the format includes quotes, ends up allocating a StringBuilder and parsing into it, just to get the quoted contents.  With a minor transformation, this is unnecessary, allowing the StringBuilder and associated allocations and work to be removed.

cc: @jkotas, @ellismg