### PR TITLE
Add configureonly and skipconfigure to builds.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 usage()
 {
-    echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [coverage] [cross] [clangx.y] [ninja] [skipnative] [skipmscorlib] [skiptests]"
+    echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests]"
     echo "BuildArch can be: x64, x86, arm, arm64"
     echo "BuildType can be: Debug, Checked, Release"
     echo "clean - optional argument to force a clean build."
@@ -12,6 +12,8 @@ usage()
     echo "clangx.y - optional argument to build using clang version x.y."
     echo "cross - optional argument to signify cross compilation,"
     echo "      - will use ROOTFS_DIR environment variable if set."
+    echo "configureonly - do not perform any builds; just configure the build."
+    echo "skipconfigure - skip build configuration."
     echo "skipnative - do not build native components."
     echo "skipmscorlib - do not build mscorlib.dll even if mono is installed."
     echo "skiptests - skip the tests in the 'tests' subdirectory."
@@ -61,28 +63,25 @@ check_prereqs()
 
 build_coreclr()
 {
-    if [ $__SkipCoreCLR == 1 ]; then
-        echo "Skipping CoreCLR build."
-        return
-    fi
+    if [[ $__SkipCoreCLR == 0 || $__ConfigureOnly == 1 ]]; then
+        echo "Laying out dynamically generated files consumed by the build system "
+        python "$__ProjectRoot/src/scripts/genXplatEventing.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --exc "$__ProjectRoot/src/vm/ClrEtwAllMeta.lst" --inc "$__GeneratedIntermediatesDir/inc" --dummy "$__GeneratedIntermediatesDir/inc/etmdummy.h" --testdir "$__GeneratedIntermediatesDir/eventprovider_tests"
+        if  [[ $? != 0 ]]; then
+            exit
+        fi
 
-    echo "Laying out dynamically generated files consumed by the build system "
-    python "$__ProjectRoot/src/scripts/genXplatEventing.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --exc "$__ProjectRoot/src/vm/ClrEtwAllMeta.lst" --inc "$__GeneratedIntermediatesDir/inc" --dummy "$__GeneratedIntermediatesDir/inc/etmdummy.h" --testdir "$__GeneratedIntermediatesDir/eventprovider_tests"
-    if  [[ $? != 0 ]]; then
-        exit
+        #determine the logging system
+        case $__BuildOS in
+            Linux)
+                python "$__ProjectRoot/src/scripts/genXplatLttng.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__GeneratedIntermediatesDir/"
+                if  [[ $? != 0 ]]; then
+                    exit
+                fi
+                ;;
+            *)
+                ;;
+        esac
     fi
-
-    #determine the logging system
-    case $__BuildOS in
-        Linux)
-            python "$__ProjectRoot/src/scripts/genXplatLttng.py" --man "$__ProjectRoot/src/vm/ClrEtwAll.man" --intermediate "$__GeneratedIntermediatesDir/"
-            if  [[ $? != 0 ]]; then
-                exit
-            fi
-            ;;
-        *)
-            ;;
-    esac
 
     export __GeneratedIntermediatesDirPresent="$__IntermediatesDir/Generated" #do not use this variable, it is used below to support incremental build
     python -c "import sys;sys.path.insert(0,\"$__ProjectRoot/src/scripts\"); from Utilities import *;UpdateDirectory(\"$__GeneratedIntermediatesDirPresent\",\"$__GeneratedIntermediatesDir\")"
@@ -107,9 +106,16 @@ build_coreclr()
         buildTool="ninja"
     fi
 
-    # Regenerate the CMake solution
-    echo "Invoking \"$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh\" \"$__ProjectRoot\" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType $__CodeCoverage $__IncludeTests $generator"
-    "$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh" "$__ProjectRoot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType $__CodeCoverage $__IncludeTests $generator
+    if [ $__SkipConfigure == 0 ]; then
+        # Regenerate the CMake solution
+        echo "Invoking \"$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh\" \"$__ProjectRoot\" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType $__CodeCoverage $__IncludeTests $generator"
+        "$__ProjectRoot/src/pal/tools/gen-buildsys-clang.sh" "$__ProjectRoot" $__ClangMajorVersion $__ClangMinorVersion $__BuildArch $__BuildType $__CodeCoverage $__IncludeTests $generator
+    fi
+
+    if [ $__SkipCoreCLR == 1 ]; then
+        echo "Skipping CoreCLR build."
+        return
+    fi
 
     # Check that the makefiles were created.
 
@@ -291,6 +297,8 @@ __LogsDir="$__RootBinDir/Logs"
 __UnprocessedBuildArgs=
 __MSBCleanBuildArgs=
 __UseNinja=0
+__ConfigureOnly=0
+__SkipConfigure=0
 __SkipCoreCLR=0
 __SkipMSCorLib=0
 __CleanBuild=0
@@ -304,103 +312,119 @@ __MSBuildPath="$__PackagesDir/$__MSBuildPackageId.$__MSBuildPackageVersion/lib/M
 __NuGetPath="$__PackagesDir/NuGet.exe"
 
 for i in "$@"
-    do
-        lowerI="$(echo $i | awk '{print tolower($0)}')"
-        case $lowerI in
-            -\?|-h|--help)
-                usage
-                exit 1
-                ;;
+do
+    lowerI="$(echo $i | awk '{print tolower($0)}')"
+    case $lowerI in
+        -\?|-h|--help)
+            usage
+            exit 1
+            ;;
 
-            x86)
-                __BuildArch=x86
-                ;;
+        x86)
+            __BuildArch=x86
+            ;;
 
-            x64)
-                __BuildArch=x64
-                ;;
+        x64)
+            __BuildArch=x64
+            ;;
 
-            arm)
-                __BuildArch=arm
-                ;;
+        arm)
+            __BuildArch=arm
+            ;;
 
-            arm64)
-                __BuildArch=arm64
-                ;;
+        arm64)
+            __BuildArch=arm64
+            ;;
 
-            debug)
-                __BuildType=Debug
-                ;;
+        debug)
+            __BuildType=Debug
+            ;;
 
-            checked)
-                __BuildType=Checked
-                ;;
+        checked)
+            __BuildType=Checked
+            ;;
 
-            release)
-                __BuildType=Release
-                ;;
+        release)
+            __BuildType=Release
+            ;;
 
-            coverage)
-                __CodeCoverage=Coverage
-                ;;
+        coverage)
+            __CodeCoverage=Coverage
+            ;;
 
-            clean)
-                __CleanBuild=1
-                ;;
+        clean)
+            __CleanBuild=1
+            ;;
 
-            verbose)
-                __VerboseBuild=1
-                ;;
+        verbose)
+            __VerboseBuild=1
+            ;;
 
-            cross)
-                __CrossBuild=1
-                ;;
+        cross)
+            __CrossBuild=1
+            ;;
 
-            clang3.5)
-                __ClangMajorVersion=3
-                __ClangMinorVersion=5
-                ;;
+        clang3.5)
+            __ClangMajorVersion=3
+            __ClangMinorVersion=5
+            ;;
 
-            clang3.6)
-                __ClangMajorVersion=3
-                __ClangMinorVersion=6
-                ;;
+        clang3.6)
+            __ClangMajorVersion=3
+            __ClangMinorVersion=6
+            ;;
 
-            clang3.7)
-                __ClangMajorVersion=3
-                __ClangMinorVersion=7
-                ;;
+        clang3.7)
+            __ClangMajorVersion=3
+            __ClangMinorVersion=7
+            ;;
 
-            ninja)
-                __UseNinja=1
-                ;;
+        ninja)
+            __UseNinja=1
+            ;;
 
-            skipnative)
-                # Use "skipnative" to use the same option name as build.cmd.
-                __SkipCoreCLR=1
-                ;;
+        configureonly)
+            __ConfigureOnly=1
+            __SkipCoreCLR=1
+            __SkipMSCorLib=1
+            __IncludeTests=
+            ;;
 
-            skipcoreclr)
-                # Accept "skipcoreclr" for backwards-compatibility.
-                __SkipCoreCLR=1
-                ;;
+        skipconfigure)
+            __SkipConfigure=1
+            ;;
 
-            skipmscorlib)
-                __SkipMSCorLib=1
-                ;;
+        skipnative)
+            # Use "skipnative" to use the same option name as build.cmd.
+            __SkipCoreCLR=1
+            ;;
 
-            includetests)
-                ;;
+        skipcoreclr)
+            # Accept "skipcoreclr" for backwards-compatibility.
+            __SkipCoreCLR=1
+            ;;
 
-            skiptests)
-                __IncludeTests=
-                ;;
+        skipmscorlib)
+            __SkipMSCorLib=1
+            ;;
 
-            *)
-                __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
-                ;;
-        esac
-    done
+        includetests)
+            ;;
+
+        skiptests)
+            __IncludeTests=
+            ;;
+
+        *)
+            __UnprocessedBuildArgs="$__UnprocessedBuildArgs $i"
+            ;;
+    esac
+done
+
+if [[ $__ConfigureOnly == 1 && $__SkipConfigure == 1 ]]; then
+    echo "configureonly and skipconfigure are mutually exclusive!"
+    exit 1
+fi
 
 # Set the remaining variables based upon the determined build configuration
 __BinDir="$__RootBinDir/Product/$__BuildOS.$__BuildArch.$__BuildType"


### PR DESCRIPTION
These options allow the developer to either:
1. Run build configuration without actually running the build, or
2. Skip build configuration when running the build.

CMake already adds the various CMakeLists.txt files as build
dependencies s.t. it will be automatically re-run when necessary.