### PR TITLE
Cleanup code in fgPerStatementLiveness and fgPerBlockLocalVarLiveness

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3611,9 +3611,9 @@ public :
     void                fgLocalVarLiveness();
 
     void                fgLocalVarLivenessInit();
-    GenTreePtr          fgPerStatementLocalVarLiveness(GenTreePtr startNode,
-                                                       GenTreePtr relopNode,
-                                                       GenTreePtr lshNode);
+
+    void                fgPerStatementLocalVarLiveness(GenTreePtr startNode, GenTreePtr asgdLclVar);
+
     void                fgPerBlockLocalVarLiveness();
 
     VARSET_VALRET_TP    fgGetHandlerLiveVars(BasicBlock *block);


### PR DESCRIPTION
Removed the <BUGNUM> comment about GT_QMARK that preceded the fgPerStatementLiveness method.
Added method header comment for fgPerStatementLiveness.
Changed return type of fgPerStatementLiveness to void.
Renamed the lhsNode argument to asgnLclVar.
Removed all the code that handles GT_QMARK/GT_COLON nodes,
 as those node are no longer used by the RyuJit codebase.
In fgPerStatementLiveness, renamed lhsNode to asgnLclVar.