### PR TITLE
Fix for bug 2353 Assertion Failure 'nextStmtExpr->gtOper == GT_RETURN…

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21804,7 +21804,7 @@ Compiler::fgWalkResult      Compiler::fgUpdateInlineReturnExpressionPlaceHolder(
             else
             {
                 // Just assign the inlinee to a variable to keep it simple.
-                tree = comp->fgAssignStructInlineeToVar(tree, retClsHnd);
+                tree->CopyFrom(comp->fgAssignStructInlineeToVar(tree, retClsHnd), comp);
             }
         }
 #endif // defined(_TARGET_ARM_) || defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21804,7 +21804,7 @@ Compiler::fgWalkResult      Compiler::fgUpdateInlineReturnExpressionPlaceHolder(
             else
             {
                 // Just assign the inlinee to a variable to keep it simple.
-                tree->CopyFrom(comp->fgAssignStructInlineeToVar(tree, retClsHnd), comp);
+                tree = comp->fgAssignStructInlineeToVar(tree, retClsHnd);
             }
         }
 #endif // defined(_TARGET_ARM_) || defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6669,17 +6669,10 @@ GenTreePtr          Compiler::fgMorphCall(GenTreeCall* call)
         }
         else if ((stmtExpr->gtOper == GT_ASG) && (fgMorphStmt->gtNext != nullptr))
         {
-            GenTreePtr nextStmtExpr = fgMorphStmt->gtNext->gtStmt.gtStmtExpr;
-            noway_assert(nextStmtExpr->gtOper == GT_RETURN);
-            // In this case we have an assignment of the result of the call, and then a return of the  result of the assignment.
-            // This can occur if impSpillStackEnsure() has introduced an assignment to a temp.
-            noway_assert(stmtExpr->gtGetOp1()->OperIsLocal() &&
-                         nextStmtExpr->OperGet() == GT_RETURN &&
-                         nextStmtExpr->gtGetOp1() != nullptr &&
-                         nextStmtExpr->gtGetOp1()->OperIsLocal() &&
-                         stmtExpr->gtGetOp1()->AsLclVarCommon()->gtLclNum == nextStmtExpr->gtGetOp1()->AsLclVarCommon()->gtLclNum);
+            noway_assert(fgMorphStmt->gtNext->gtStmt.gtStmtExpr->gtOper == GT_RETURN);
             deleteReturn = true;
         }
+
         if (deleteReturn)
         {
             fgRemoveStmt(compCurBB, fgMorphStmt->gtNext);


### PR DESCRIPTION
…' in RetBufferBug:Tailaller() in morph.cpp line 6671.

The change fixes a bug in importing POP instruction where a copy between a tempvar and the return value of a tail call is misgenerated for Unix with enregisterable struct return values.

The change also fixes a bug of using GenTree::CopyFrom in fMorphInline where the dst node is a child of the src node.