### PR TITLE
Fix usage of floating point state from native contexts.

### DIFF
--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -67,19 +67,19 @@ typedef ucontext_t native_context_t;
 #define MCREG_R14(mc)       ((mc).gregs[REG_R14])
 #define MCREG_R15(mc)       ((mc).gregs[REG_R15])
 
-#define FPREG_Xmm(uc, index) *(M128U*)&((uc)->__fpregs_mem._xmm[index])
+#define FPREG_Xmm(uc, index) *(M128U*)&((uc)->uc_mcontext.fpregs->_xmm[index])
 
-#define FPREG_St(uc, index) *(M128U*)&((uc)->__fpregs_mem._st[index])
+#define FPREG_St(uc, index) *(M128U*)&((uc)->uc_mcontext.fpregs->_st[index])
 
-#define FPREG_ControlWord(uc) ((uc)->__fpregs_mem.cwd)
-#define FPREG_StatusWord(uc) ((uc)->__fpregs_mem.swd)
-#define FPREG_TagWord(uc) ((uc)->__fpregs_mem.ftw)
-#define FPREG_ErrorOffset(uc) *(DWORD*)&((uc)->__fpregs_mem.rip)
-#define FPREG_ErrorSelector(uc) *(((WORD*)&((uc)->__fpregs_mem.rip)) + 2)
-#define FPREG_DataOffset(uc) *(DWORD*)&((uc)->__fpregs_mem.rdp)
-#define FPREG_DataSelector(uc) *(((WORD*)&((uc)->__fpregs_mem.rdp)) + 2)
-#define FPREG_MxCsr(uc) ((uc)->__fpregs_mem.mxcsr)
-#define FPREG_MxCsr_Mask(uc) ((uc)->__fpregs_mem.mxcr_mask)
+#define FPREG_ControlWord(uc) ((uc)->uc_mcontext.fpregs->cwd)
+#define FPREG_StatusWord(uc) ((uc)->uc_mcontext.fpregs->swd)
+#define FPREG_TagWord(uc) ((uc)->uc_mcontext.fpregs->ftw)
+#define FPREG_ErrorOffset(uc) *(DWORD*)&((uc)->uc_mcontext.fpregs->rip)
+#define FPREG_ErrorSelector(uc) *(((WORD*)&((uc)->uc_mcontext.fpregs->rip)) + 2)
+#define FPREG_DataOffset(uc) *(DWORD*)&((uc)->uc_mcontext.fpregs->rdp)
+#define FPREG_DataSelector(uc) *(((WORD*)&((uc)->uc_mcontext.fpregs->rdp)) + 2)
+#define FPREG_MxCsr(uc) ((uc)->uc_mcontext.fpregs->mxcsr)
+#define FPREG_MxCsr_Mask(uc) ((uc)->uc_mcontext.fpregs->mxcr_mask)
 
 #else // BIT64
 


### PR DESCRIPTION
We access floating point registers from native context structs by using the set of `FPREG_` macros. These macros were accessing the FP registers by using the `__fpregs_mem` field in the `ucontext_t`. This was problematic because the kernel defines some types like `sigset_t` differently than the libc headers, which meant the floating point registers in the contexts passed in to our signal handlers were at different memory locations than where we were looking.

The solution is to stop using `__fpregs_mem` and instead use the `fpregs` pointer in the `uc_mcontext` member of the `ucontext_t`. This pointer is set to the correct location where the `_libc_fpstate` begins, so we can avoid reading bogus values.