### PR TITLE
Eliminate array allocations in CustomAttribute.IsDefined() overloads

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -39,8 +39,10 @@ namespace System {
             }
             Contract.Ensures(Contract.Result<ReadOnlyCollection<T>>() != null);
 
+            // If the array is empty, return the cached, empty ReadOnlyCollection<T>
+            // instance to avoid allocating an unnecessary object.
             // T[] implements IList<T>.
-            return new ReadOnlyCollection<T>(array);
+            return array.Length == 0 ? EmptyReadOnlyCollection<T>.Value : new ReadOnlyCollection<T>(array);
         }
 
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]

--- a/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/mscorlib/src/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -228,4 +228,11 @@ namespace System.Collections.ObjectModel
             ThrowHelper.ThrowNotSupportedException(ExceptionResource.NotSupported_ReadOnlyCollection);
         }    
     }
+
+    // Useful in number of places that return an empty ReadOnlyCollection<T> to avoid unnecessary memory allocation.
+    internal static class EmptyReadOnlyCollection<T>
+    {
+        public static readonly ReadOnlyCollection<T> Value =
+            new ReadOnlyCollection<T>(Array.Empty<T>());
+    }
 }

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -304,11 +304,11 @@ namespace System.Reflection
         [System.Security.SecurityCritical]  // auto-generated
         private static IList<CustomAttributeData> GetCustomAttributes(RuntimeModule module, int tkTarget)
         {
-            var records = GetCustomAttributeRecordCollection(module, tkTarget);
+            CustomAttributeRecordCollection records = GetCustomAttributeRecordCollection(module, tkTarget);
 
             CustomAttributeData[] customAttributes = null;
-            var recordIndex = 0;
-            foreach (var record in records)
+            int recordIndex = 0;
+            foreach (CustomAttributeRecord record in records)
             {
                 // Create the customAttributes array only if it's going to be non-empty.
                 if (customAttributes == null)
@@ -1714,7 +1714,8 @@ namespace System.Reflection
                 throw new InvalidOperationException(Environment.GetResourceString("Arg_ReflectionOnlyCA"));
             Contract.EndContractBlock();
 
-            var cars = CustomAttributeData.GetCustomAttributeRecordCollection(decoratedModule, decoratedMetadataToken);
+            CustomAttributeData.CustomAttributeRecordCollection cars =
+                CustomAttributeData.GetCustomAttributeRecordCollection(decoratedModule, decoratedMetadataToken);
 
             if (attributeFilterType != null)
             {
@@ -1729,7 +1730,7 @@ namespace System.Reflection
                 // we can cache the successful APTCA check between the decorated and the declared assembly.
                 Assembly lastAptcaOkAssembly = null;
 
-                foreach (var caRecord in cars)
+                foreach (CustomAttributeRecord caRecord in cars)
                 {
                     if (FilterCustomAttributeRecord(caRecord, scope, ref lastAptcaOkAssembly,
                         decoratedModule, decoratedMetadataToken, attributeFilterType, mustBeInheritable, null, null,
@@ -1742,7 +1743,7 @@ namespace System.Reflection
                 Contract.Assert(attributeFilterType == null);
                 Contract.Assert(!MetadataToken.IsNullToken(attributeCtorToken));
 
-                foreach (var caRecord in cars)
+                foreach (CustomAttributeRecord caRecord in cars)
                 {
                     if (caRecord.tkCtor == attributeCtorToken)
                         return true;
@@ -1769,16 +1770,16 @@ namespace System.Reflection
             Contract.EndContractBlock();
 
             MetadataImport scope = decoratedModule.MetadataImport;
-            var cars = CustomAttributeData.GetCustomAttributeRecordCollection(decoratedModule, decoratedMetadataToken);
-            var carCount = cars.Count;  // Relatively expensive, so call this once and reuse it.
+            CustomAttributeData.CustomAttributeRecordCollection cars =
+                CustomAttributeData.GetCustomAttributeRecordCollection(decoratedModule, decoratedMetadataToken);
 
             bool useObjectArray = (attributeFilterType == null || attributeFilterType.IsValueType || attributeFilterType.ContainsGenericParameters);
             Type arrayType = useObjectArray ? typeof(object) : attributeFilterType;
 
-            if (attributeFilterType == null && carCount == 0)
+            if (attributeFilterType == null && cars.Count == 0)
                 return CreateAttributeArrayHelper(arrayType, 0);
 
-            object[] attributes = CreateAttributeArrayHelper(arrayType, carCount);
+            object[] attributes = CreateAttributeArrayHelper(arrayType, cars.Count);
             int cAttributes = 0;
 
             // Custom attribute security checks are done with respect to the assembly *decorated* with the 
@@ -1795,7 +1796,7 @@ namespace System.Reflection
             // we can cache the successful APTCA check between the decorated and the declared assembly.
             Assembly lastAptcaOkAssembly = null;
 
-            foreach (var caRecord in cars)
+            foreach (CustomAttributeRecord caRecord in cars)
             {
                 object attribute = null;
 
@@ -1943,7 +1944,7 @@ namespace System.Reflection
             // finally or CERs here.
             frame.Pop();
 
-            if (cAttributes == carCount && pcaCount == 0)
+            if (cAttributes == cars.Count && pcaCount == 0)
                 return attributes;
 
             object[] result = CreateAttributeArrayHelper(arrayType, cAttributes + pcaCount);
@@ -2121,11 +2122,12 @@ namespace System.Reflection
         {
             RuntimeModule decoratedModule = decoratedAttribute.GetRuntimeModule();
             MetadataImport scope = decoratedModule.MetadataImport;
-            var cars = CustomAttributeData.GetCustomAttributeRecordCollection(decoratedModule, decoratedAttribute.MetadataToken);
+            CustomAttributeData.CustomAttributeRecordCollection cars =
+                CustomAttributeData.GetCustomAttributeRecordCollection(decoratedModule, decoratedAttribute.MetadataToken);
 
             AttributeUsageAttribute attributeUsageAttribute = null;
 
-            foreach (var caRecord in cars)
+            foreach (CustomAttributeRecord caRecord in cars)
             {
                 RuntimeType attributeType = decoratedModule.ResolveType(scope.GetParentToken(caRecord.tkCtor), null, null) as RuntimeType;
 

--- a/src/mscorlib/src/System/Reflection/CustomAttribute.cs
+++ b/src/mscorlib/src/System/Reflection/CustomAttribute.cs
@@ -321,7 +321,9 @@ namespace System.Reflection
 
             // If there weren't any custom attributes, return the empty array instance
             // instead of allocating a new empty array.
-            return customAttributes == null ? Array.Empty<CustomAttributeData>() : (IList<CustomAttributeData>)Array.AsReadOnly(customAttributes);
+            // Array.AsReadOnly() returns a cached instance for an empty input array
+            // so won't cause an allocation in that case.
+            return Array.AsReadOnly(customAttributes ?? Array.Empty<CustomAttributeData>());
         }
         #endregion
 


### PR DESCRIPTION
Implemented struct enumerable and corresponding enumerator wrapping ``MetadataImport`` and ``MetadataEnumResult``.

Replaced ``CustomAttributeData.GetCustomAttributeRecords(RuntimeModule, int)`` with a new method returning a value of the new struct enumerable type (``CustomAttributeRecordCollection``); modified call sites of the old method to use the new method and structs instead.

These changes eliminate the short-lived ``CustomAttributeRecord[]`` allocations which currently result from calling any of the ``CustomAttribute.IsDefined()`` overloads.