### PR TITLE
Fix Unix stack overflow detection

### DIFF
--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -685,6 +685,8 @@ inline T* InterlockedCompareExchangePointerT(
 
 #include "volatile.h"
 
+const char StackOverflowMessage[] = "Process is terminated due to StackOverflowException.\n";
+
 #endif // __cplusplus
 
 #endif /* _PAL_INTERNAL_H_ */

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -673,17 +673,31 @@ namespace CorUnix
             void
             );
 
-        // Get base address of this thread's stack
-        // Can be called only for the current thread.
+        // Get base address of the current thread's stack
+        static
         void *
         GetStackBase(
             void
             );
 
-        // Get limit address of this thread's stack
+        // Get cached base address of this thread's stack
         // Can be called only for the current thread.
         void *
+        GetCachedStackBase(
+            void
+            );
+
+        // Get limit address of the current thread's stack
+        static
+        void *
         GetStackLimit(
+            void
+            );
+
+        // Get cached limit address of this thread's stack
+        // Can be called only for the current thread.
+        void *
+        GetCachedStackLimit(
             void
             );
         


### PR DESCRIPTION
On Linux (and other non-OSX Unix systems), we were not distinguishing a stack overflow detected
using a probe from a general access violation. So instead of aborting the process,
we were sending it a managed access violation exception.
This change checks for the case when the access violation happens in the page
below the stack limit and aborts right in the sigsegv_handler if it does.