### PR TITLE
IdnMapping GetUnicode conformance tests fail

### DIFF
--- a/src/corefx/System.Globalization.Native/idna.cpp
+++ b/src/corefx/System.Globalization.Native/idna.cpp
@@ -12,7 +12,8 @@ const uint32_t UseStd3AsciiRules = 0x2;
 
 uint32_t GetOptions(uint32_t flags)
 {
-    uint32_t options = UIDNA_DEFAULT;
+    // Using Nontransitional to Unicode and Check ContextJ to match the current behavior of .NET on Windows
+    uint32_t options = UIDNA_NONTRANSITIONAL_TO_UNICODE | UIDNA_CHECK_CONTEXTJ;
 
     if ((flags & AllowUnassigned) == AllowUnassigned)
     {


### PR DESCRIPTION
The IdnaConformanceTests fail on Unix because \u00DF, \u200C and \u200D characters are not being handled as specified in the http://www.unicode.org/Public/idna/6.0.0/IdnaTest.txt file.

The fix is to use UIDNA_NONTRANSITIONAL_TO_UNICODE and UIDNA_CHECK_CONTEXTJ options when calling uidna_openUTS46.

Partial fix for https://github.com/dotnet/corefx/issues/3406.

@tarekgh @ellismg 