### PR TITLE
Override AggregateException.Message to include more detail

### DIFF
--- a/src/mscorlib/src/System/AggregateException.cs
+++ b/src/mscorlib/src/System/AggregateException.cs
@@ -17,6 +17,7 @@ using System.Globalization;
 using System.Runtime.ExceptionServices;
 using System.Runtime.Serialization;
 using System.Security;
+using System.Text;
 using System.Threading;
 
 namespace System
@@ -429,6 +430,30 @@ namespace System
 
 
             return new AggregateException(Message, flattenedExceptions);
+        }
+
+        /// <summary>Gets a message that describes the exception.</summary>
+        public override string Message
+        {
+            get
+            {
+                if (m_innerExceptions.Count == 0)
+                {
+                    return base.Message;
+                }
+
+                StringBuilder sb = StringBuilderCache.Acquire();
+                sb.Append(base.Message);
+                sb.Append(' ');
+                for (int i = 0; i < m_innerExceptions.Count; i++)
+                {
+                    sb.Append('(');
+                    sb.Append(m_innerExceptions[i].Message);
+                    sb.Append(") ");
+                }
+                sb.Length -= 1;
+                return StringBuilderCache.GetStringAndRelease(sb);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
ToString() includes details on inner exceptions, but Message does not, with the default message just saying "One or more errors occurred."  This commit overrides Message to append the messages of the inner exceptions as well.

cc: @yishaigalatzer, @jkotas 
Fixes https://github.com/dotnet/corefx/issues/5364