### PR TITLE
Fix to issue #2349 - Assertion failed '!foundDiff' in 'Node[__Canon][System.__Canon]:Search(ref,ref):ref:this' in lsra.cpp

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -6602,9 +6602,18 @@ GenTreePtr          Compiler::fgMorphCall(GenTreeCall* call)
 #if FEATURE_TAILCALL_OPT
         // TODO-CQ: enable the transformation when the method has a struct parameter that can be passed in a register
         // or return type is a struct that can be passed in a register.
+        //
+        // TODO-CQ: if the method being compiled requires generic context reported in gc-info (either through
+        // hidden generic context param or through keep alive thisptr), then while transforming a recursive
+        // call to such a method requires that the generic context stored on stack slot be updated.  Right now,
+        // fgMorphRecursiveFastTailCallIntoLoop() is not handling update of generic context while transforming
+        // a recursive call into a loop.  Another option is to modify gtIsRecursiveCall() to check that the
+        // generic type parameters of both caller and callee generic method are the same.
         if (opts.compTailCallLoopOpt &&
             canFastTailCall &&
             gtIsRecursiveCall(call) &&
+            !lvaReportParamTypeArg() &&
+            !lvaKeepAliveAndReportThis() &&
             !call->IsVirtual() &&
             !hasStructParam &&
             !varTypeIsStruct(call->TypeGet()))

--- a/tests/src/JIT/CodeGenBringUpTests/RecursiveTailCall.cs
+++ b/tests/src/JIT/CodeGenBringUpTests/RecursiveTailCall.cs
@@ -25,6 +25,11 @@ public struct Struct8
     }
 }
 
+class GenericClass<T> { }
+class GenericException<T> : Exception
+{
+}
+
 public class Test
 {
     // Test a recursive tail call with a 1-byte struct parameter.
@@ -92,6 +97,24 @@ public class Test
         }
     }
 
+    // Test a recursive tail call to a method with hidden generic context param.
+    // This test will make sure that when a recursive call is converte to a loop
+    // there is no mismatch of generic context reported to VM and the one used
+    // within the method.
+    public static int TestGenericContext<T>(int x)
+    {
+        try
+        {
+            if (x == 1) throw new GenericException<T>();
+        }
+        catch (GenericException<T>)
+        {            
+            return 1;
+        }
+
+        return x * TestGenericContext<GenericClass<T>>(x - 1);
+    }
+
     // Test a recursive tail call to a method that has a 'this' parameter
     // and a parameter passed on the stack.
     bool TestStackParam(int i1, int i2, int i3, int i4)
@@ -136,6 +159,11 @@ public class Test
         if (!test.TestStackParam(1, 0, 5, 7))
         {
             return Fail;
+        }
+
+        if (TestGenericContext<GenericClass<int>>(5) != 120)
+        {
+           return Fail;
         }
 
         return Pass;


### PR DESCRIPTION
The repro is a case of generic method whose generic context is derived from thisptr.  
For this reason JIT is asked to keep thisptr alive and report in gc-info.  For such
methods JIT, caches thisptr to a stack slot in prolog and that stack slot gets 
reported in gc-info.

Due to tail call loop optimization, the recursive method call at the end
is converted into a loop.  This transformation assigns all the arguments
to temps and temps back to incoming parameters of the method and finally
branches to the first basic block (see fgMorphRecursiveFastTailCallIntoLoop()).
This will leads to the following basic block

tmp = GT_INDIR(thisptr+24)
thisptr = tmp

That is thisptr is changing while looping.  But the thisptr stored in
cached stack slot is not updated.  So potentially there is a mismatch
in generic context reported in gc-info to VM and the one used within
the method body.  

The same issue exists in case of methods that have generic context
passed in a hidden argument instead of derived from thisptr.  

Fix:
For now disabling tail call loop optimization for methods that need generic
context till we address the above mentioned issues. Issue #2658 tracks
enabling this optimization again by doing the required work.

Fix #2349 