### PR TITLE
Improve stack limit checking precision

### DIFF
--- a/src/vm/frames.h
+++ b/src/vm/frames.h
@@ -3837,7 +3837,7 @@ class FrameWithCookieHolder
 #endif // #ifndef DACCESS_COMPILE
 
 
-#define ASSERT_ADDRESS_IN_STACK(address) _ASSERTE (GetThread () && GetThread ()->IsAddressInStack (address));
+#define ASSERT_ADDRESS_IN_STACK(address) _ASSERTE (Thread::IsAddressInCurrentStack (address));
 
 #if defined (_DEBUG) && !defined (DACCESS_COMPILE)
 #define ASSUME_BYREF_FROM_JIT_STACK_BEGIN(__objRef)                                      \

--- a/src/vm/qcall.h
+++ b/src/vm/qcall.h
@@ -187,7 +187,7 @@ public:
             CONTRACTL_END;
 
             // The space for the return value has to be on the stack
-            _ASSERTE(GetThread()->IsAddressInStack(m_ppStringObject));
+            _ASSERTE(Thread::IsAddressInCurrentStack(m_ppStringObject));
 
             *m_ppStringObject = STRINGREFToObject(s);
         }
@@ -214,7 +214,7 @@ public:
             LIMITED_METHOD_CONTRACT;
 
             // The space for the return value has to be on the stack
-            _ASSERTE(GetThread()->IsAddressInStack(m_ppObject));
+            _ASSERTE(Thread::IsAddressInCurrentStack(m_ppObject));
 
             *m_ppObject = OBJECTREFToObject(o);
         }

--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -2989,7 +2989,7 @@ FCIMPLEND
 FCIMPL1(FC_BOOL_RET, ReflectionInvocation::IsAddressInStack, void * ptr)
 {
     FCALL_CONTRACT;
-    FC_RETURN_BOOL(GetThread()->IsAddressInStack(ptr));
+    FC_RETURN_BOOL(Thread::IsAddressInCurrentStack(ptr));
 }
 FCIMPLEND
 #endif

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -7924,7 +7924,6 @@ BOOL Thread::CanResetStackTo(LPCVOID stackPointer)
         return FALSE;
     }
 }
-#endif // FEATURE_STACK_PROBE
 
 /*
  * IsStackSpaceAvailable
@@ -7974,6 +7973,8 @@ BOOL Thread::IsStackSpaceAvailable(float numPages)
 
     return TRUE;
 }
+
+#endif // FEATURE_STACK_PROBE
 
 /*
  * GetStackGuarantee

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -198,6 +198,7 @@ class Thread
 
 public:
     BOOL IsAddressInStack (PTR_VOID addr) const { return TRUE; }
+    static BOOL IsAddressInCurrentStack (PTR_VOID addr) { return TRUE; }
 
     Frame *IsRunningIn(AppDomain* pDomain, int *count) { return NULL; }
 
@@ -3853,6 +3854,21 @@ public:
         return m_CacheStackLimit < addr && addr <= m_CacheStackBase;
     }
 
+    static BOOL IsAddressInCurrentStack (PTR_VOID addr)
+    {
+        LIMITED_METHOD_DAC_CONTRACT;
+        Thread* currentThread = GetThread();
+        if (currentThread == NULL)
+        {
+            return FALSE;
+        }
+
+        PTR_VOID sp = dac_cast<PTR_VOID>(GetCurrentSP());
+        _ASSERTE(currentThread->m_CacheStackBase != NULL);
+        _ASSERTE(sp < currentThread->m_CacheStackBase);
+        return sp < addr && addr <= currentThread->m_CacheStackBase;
+    }
+
     // DetermineIfGuardPagePresent returns TRUE if the thread's stack contains a proper guard page. This function
     // makes a physical check of the stack, rather than relying on whether or not the CLR is currently processing a
     // stack overflow exception.
@@ -3862,10 +3878,11 @@ public:
     // CanResetStackTo will return TRUE if the given stack pointer is far enough away from the guard page to proper
     // restore the guard page with RestoreGuardPage.
     BOOL CanResetStackTo(LPCVOID stackPointer);
-#endif
 
     // IsStackSpaceAvailable will return true if there are the given number of stack pages available on the stack.
     BOOL IsStackSpaceAvailable(float numPages);
+
+#endif
     
     // Returns the amount of stack available after an SO but before the OS rips the process.
     static UINT_PTR GetStackGuarantee();


### PR DESCRIPTION
This change improves the precision of checking whether an address is in stack limits
for cases where ulimit -s is set to unlimited and the stack limit is checked for the
current thread. It uses current SP instead of the cached stack limit, since the OS
is free to move the stack limit up during the process runtime and the cached value
reflects the initial stack limit.
There is a new static Thread::IsAddressInCurrentStack function that performs that check.
I have also modified the UnwindManagedExceptionPassX functions to use the new
range checking function.