### PR TITLE
Make time measurement in PAL threading tests more precise

### DIFF
--- a/src/pal/tests/palsuite/common/palsuite.h
+++ b/src/pal/tests/palsuite/common/palsuite.h
@@ -165,6 +165,17 @@ char* convertC(WCHAR * wString)
     return MultiBuffer;
 }
 
+UINT64 GetHighPrecisionTimeStamp(LARGE_INTEGER performanceFrequency)
+{
+    LARGE_INTEGER ts;
+    if (!QueryPerformanceCounter(&ts))
+    {
+        Fail("ERROR: Unable to query performance counter!\n");      
+    }
+    
+    return ts.QuadPart / (performanceFrequency.QuadPart / 1000);    
+}
+
 #endif
 
 

--- a/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.c
+++ b/src/pal/tests/palsuite/threading/Sleep/test1/Sleep.c
@@ -34,8 +34,8 @@ DWORD AcceptableTimeError = 150;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    DWORD OldTickCount;
-    DWORD NewTickCount;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     DWORD MaxDelta;
     DWORD TimeDelta;
     DWORD i;
@@ -45,21 +45,19 @@ int __cdecl main( int argc, char **argv )
         return ( FAIL );
     }
 
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        return FAIL;
+    }
+
     for( i = 0; i < sizeof(SleepTimes) / sizeof(DWORD); i++)
     {
-        OldTickCount = GetTickCount();
+        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
         Sleep(SleepTimes[i]);
-        NewTickCount = GetTickCount();
+        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
-        /* 
-         * Check for DWORD wraparound
-         */
-        if (OldTickCount>NewTickCount)
-        {
-            OldTickCount -= NewTickCount+1;
-            NewTickCount  = 0xFFFFFFFF;
-        }
-        TimeDelta = NewTickCount-OldTickCount;
+        TimeDelta = NewTimeStamp - OldTimeStamp;
 
         /* For longer intervals use a 10 percent tolerance */
         if ((SleepTimes[i] * 0.1) > AcceptableTimeError)

--- a/src/pal/tests/palsuite/threading/Sleep/test2/sleep.c
+++ b/src/pal/tests/palsuite/threading/Sleep/test2/sleep.c
@@ -35,8 +35,8 @@ DWORD AcceptableTimeError = 150;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    DWORD OldTickCount;
-    DWORD NewTickCount;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     DWORD MaxDelta;
     DWORD TimeDelta;
     DWORD i;
@@ -46,21 +46,19 @@ int __cdecl main( int argc, char **argv )
         return ( FAIL );
     }
 
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        return FAIL;
+    }
+
     for( i = 0; i < sizeof(SleepTimes) / sizeof(DWORD); i++)
     {
-        OldTickCount = GetTickCount();
+        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
         Sleep(SleepTimes[i]);
-        NewTickCount = GetTickCount();
+        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
-        /* 
-         * Check for DWORD wraparound
-         */
-        if (OldTickCount>NewTickCount)
-        {
-            OldTickCount -= NewTickCount+1;
-            NewTickCount  = 0xFFFFFFFF;
-        }
-        TimeDelta = NewTickCount-OldTickCount;
+        TimeDelta = NewTimeStamp - OldTimeStamp;
 
         MaxDelta = SleepTimes[i] + AcceptableTimeError;
 

--- a/src/pal/tests/palsuite/threading/SleepEx/test1/test1.c
+++ b/src/pal/tests/palsuite/threading/SleepEx/test1/test1.c
@@ -41,8 +41,8 @@ DWORD AcceptableTimeError = 150;
 
 int __cdecl main( int argc, char **argv ) 
 {
-    DWORD OldTickCount;
-    DWORD NewTickCount;
+    UINT64 OldTimeStamp;
+    UINT64 NewTimeStamp;
     DWORD MaxDelta;
     DWORD TimeDelta;
     DWORD i;
@@ -52,24 +52,21 @@ int __cdecl main( int argc, char **argv )
         return FAIL;
     }
 
+    LARGE_INTEGER performanceFrequency;
+    if (!QueryPerformanceFrequency(&performanceFrequency))
+    {
+        return FAIL;
+    }
+
     for (i = 0; i<sizeof(testCases) / sizeof(testCases[0]); i++)
     {
-        OldTickCount = GetTickCount();
+        OldTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
         SleepEx(testCases[i].SleepTime, testCases[i].Alertable);
 
-        NewTickCount = GetTickCount();
+        NewTimeStamp = GetHighPrecisionTimeStamp(performanceFrequency);
 
-        /* 
-         * Check for DWORD wraparound
-         */
-        if (OldTickCount>NewTickCount)
-        {
-            OldTickCount -= NewTickCount+1;
-            NewTickCount  = 0xFFFFFFFF;
-        }
-
-        TimeDelta = NewTickCount - OldTickCount;
+        TimeDelta = NewTimeStamp - OldTimeStamp;
 
         /* For longer intervals use a 10 percent tolerance */
         if ((testCases[i].SleepTime * 0.1) > AcceptableTimeError)


### PR DESCRIPTION
This change replaces GetTickCount by measurement using QueryPerformanceCounter.
This is an attempt to fix stability of bunch of threading tests that were
failing randomly due to large error margin of the GetTickCount on Debian.