### PR TITLE
Disable tests failing in Checked builds so automation will be green

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -5,7 +5,7 @@
              <Issue>1037</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M09.5-PDC\b14426\b14426\*" >
-	        <Issue>2235</Issue>
+            <Issue>2235</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b13621\b13621\*" >
             <Issue>2235</Issue>
@@ -37,266 +37,269 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b108129\b108129\*" >
             <Issue>2234</Issue>
         </ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
-	     <Issue>2329</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbgarrres\_il_dbgarrres.cmd" >
-	     <Issue>2330</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relarrres\_il_relarrres.cmd" >
-	     <Issue>2330</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\badldsfld_il_d\badldsfld_il_d.cmd" >
-	     <Issue>2405</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\badldsfld_il_r\badldsfld_il_r.cmd" >
-	     <Issue>2405</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_d\_simpleoddpower_il_d.cmd" >
-	     <Issue>2407</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_r\_simpleoddpower_il_r.cmd" >
-	     <Issue>2407</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\filter_il_d\filter_il_d.cmd" >
-	     <Issue>2411</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\filter_il_r\filter_il_r.cmd" >
-	     <Issue>2411</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_d\bleref_il_d.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_r\bleref_il_r.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i8_i\conv_ovf_i8_i.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\rem_r4\rem_r4.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_dynamic\verify01_dynamic.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_large\verify01_large.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_small\verify01_small.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ndpw\21220\b21220\b21220.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102754\test1\test1.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102754\test2\test2.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\tail_il_d\tail_il_d.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\tail_il_r\tail_il_r.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads3_il_d\threads3_il_d.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads3_il_r\threads3_il_r.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise3_il_d\precise3_il_d.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise3_il_r\precise3_il_r.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch1\switch1.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch10\switch10.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch11\switch11.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch2\switch2.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch3\switch3.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch4\switch4.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch5\switch5.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch6\switch6.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch7\switch7.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch8\switch8.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch9\switch9.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgrecurse_ep_void\_il_dbgrecurse_ep_void.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_void\_il_dbgtest_void.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relrecurse_ep_void\_il_relrecurse_ep_void.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_void\_il_reltest_void.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\fault_il_d\fault_il_d.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\fault_il_r\fault_il_r.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b65423\b65423\b65423.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b08046\b08046\b08046.cmd" >
-	     <Issue>2414</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_d\ldelemnullarr1_il_d.cmd" >
-	     <Issue>2416</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_r\ldelemnullarr1_il_r.cmd" >
-	     <Issue>2416</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_d\nonrefsdarr_il_d.cmd" >
-	     <Issue>2416</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_r\nonrefsdarr_il_r.cmd" >
-	     <Issue>2416</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic1\rva_rvastatic1.cmd" >
-	     <Issue>2433</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic2\rva_rvastatic2.cmd" >
-	     <Issue>2433</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic3\rva_rvastatic3.cmd" >
-	     <Issue>2433</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic4\rva_rvastatic4.cmd" >
-	     <Issue>2433</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\global_il_d\global_il_d.cmd" >
-	     <Issue>2433</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\global_il_r\global_il_r.cmd" >
-	     <Issue>2433</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\preemptive_cooperative\preemptive_cooperative.cmd" >
-	     <Issue>2434</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\extended\extended.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\overlap\overlap.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgpointer\_il_dbgpointer.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgpointer_i\_il_dbgpointer_i.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relpointer\_il_relpointer.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relpointer_i\_il_relpointer_i.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b49644\b49644\b49644.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b102637\b102637\b102637.cmd" >
-	     <Issue>2435</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tls\mutualrecurthd-tls\mutualrecurthd-tls.cmd" >
-	     <Issue>2441</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tls\test-tls\test-tls.cmd" >
-	     <Issue>2441</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\v1-m10\b07847\b07847\b07847.cmd" >
-	     <Issue>2441</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b03689\b03689\b03689.cmd" >
-	     <Issue>2441</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_il_cs\_dbgsin_il_cs.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_il_cs\_odbgsin_il_cs.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_il_cs\_orelsin_il_cs.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_relsin_il_cs\_relsin_il_cs.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_il_il\_dbgsin_il_il.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_il_il\_odbgsin_il_il.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_il_il\_orelsin_il_il.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_relsin_il_il\_relsin_il_il.cmd" >
-	     <Issue>2442</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbglocalloc\_il_dbglocalloc.cmd" >
-	     <Issue>2444</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_rellocalloc\_il_rellocalloc.cmd" >
-	     <Issue>2444</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfinally_d\badcodeafterfinally_d.cmd" >
-	     <Issue>2444</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfinally_r\badcodeafterfinally_r.cmd" >
-	     <Issue>2444</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev10_865840\dev10_865840\dev10_865840.cmd" >
-	     <Issue>2445</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic1\rvastatic1.cmd" >
-	     <Issue>2451</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic2\rvastatic2.cmd" >
-	     <Issue>2451</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic3\rvastatic3.cmd" >
-	     <Issue>2451</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic4\rvastatic4.cmd" >
-	     <Issue>2451</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic5\rvastatic5.cmd" >
-	     <Issue>2451</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b410474\b410474\b410474.cmd" >
-	     <Issue>2451</Issue>
-	</ExcludeList>
-	<ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinning\object-pin\object-pin\object-pin.cmd" >
-	     <Issue>2452</Issue>
-	</ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArgs\*" >
+            <Issue>2328</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
+             <Issue>2329</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbgarrres\_il_dbgarrres.cmd" >
+             <Issue>2330</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relarrres\_il_relarrres.cmd" >
+             <Issue>2330</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\badldsfld_il_d\badldsfld_il_d.cmd" >
+             <Issue>2405</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\badldsfld_il_r\badldsfld_il_r.cmd" >
+             <Issue>2405</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_d\_simpleoddpower_il_d.cmd" >
+             <Issue>2407</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\delegate\_simpleoddpower_il_r\_simpleoddpower_il_r.cmd" >
+             <Issue>2407</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\filter_il_d\filter_il_d.cmd" >
+             <Issue>2411</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\filter_il_r\filter_il_r.cmd" >
+             <Issue>2411</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_d\bleref_il_d.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_r\bleref_il_r.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i8_i\conv_ovf_i8_i.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\rem_r4\rem_r4.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_dynamic\verify01_dynamic.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_large\verify01_large.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_small\verify01_small.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ndpw\21220\b21220\b21220.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102754\test1\test1.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102754\test2\test2.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\tail_il_d\tail_il_d.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\tail_il_r\tail_il_r.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads3_il_d\threads3_il_d.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads3_il_r\threads3_il_r.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise3_il_d\precise3_il_d.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise3_il_r\precise3_il_r.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch1\switch1.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch10\switch10.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch11\switch11.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch2\switch2.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch3\switch3.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch4\switch4.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch5\switch5.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch6\switch6.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch7\switch7.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch8\switch8.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch9\switch9.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgrecurse_ep_void\_il_dbgrecurse_ep_void.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_void\_il_dbgtest_void.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relrecurse_ep_void\_il_relrecurse_ep_void.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_void\_il_reltest_void.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\fault_il_d\fault_il_d.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\fault_il_r\fault_il_r.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b65423\b65423\b65423.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b08046\b08046\b08046.cmd" >
+             <Issue>2414</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_d\ldelemnullarr1_il_d.cmd" >
+             <Issue>2416</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr1_il_r\ldelemnullarr1_il_r.cmd" >
+             <Issue>2416</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_d\nonrefsdarr_il_d.cmd" >
+             <Issue>2416</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nonrefsdarr_il_r\nonrefsdarr_il_r.cmd" >
+             <Issue>2416</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic1\rva_rvastatic1.cmd" >
+             <Issue>2433</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic2\rva_rvastatic2.cmd" >
+             <Issue>2433</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic3\rva_rvastatic3.cmd" >
+             <Issue>2433</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic4\rva_rvastatic4.cmd" >
+             <Issue>2433</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\global_il_d\global_il_d.cmd" >
+             <Issue>2433</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\global_il_r\global_il_r.cmd" >
+             <Issue>2433</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\preemptive_cooperative\preemptive_cooperative.cmd" >
+             <Issue>2434</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\extended\extended.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\overlap\overlap.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgpointer\_il_dbgpointer.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgpointer_i\_il_dbgpointer_i.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relpointer\_il_relpointer.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relpointer_i\_il_relpointer_i.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b49644\b49644\b49644.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b102637\b102637\b102637.cmd" >
+             <Issue>2435</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tls\mutualrecurthd-tls\mutualrecurthd-tls.cmd" >
+             <Issue>2441</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tls\test-tls\test-tls.cmd" >
+             <Issue>2441</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\v1-m10\b07847\b07847\b07847.cmd" >
+             <Issue>2441</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b03689\b03689\b03689.cmd" >
+             <Issue>2441</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_il_cs\_dbgsin_il_cs.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_il_cs\_odbgsin_il_cs.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_il_cs\_orelsin_il_cs.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_relsin_il_cs\_relsin_il_cs.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_il_il\_dbgsin_il_il.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_il_il\_odbgsin_il_il.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_il_il\_orelsin_il_il.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_relsin_il_il\_relsin_il_il.cmd" >
+             <Issue>2442</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbglocalloc\_il_dbglocalloc.cmd" >
+             <Issue>2444</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_rellocalloc\_il_rellocalloc.cmd" >
+             <Issue>2444</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfinally_d\badcodeafterfinally_d.cmd" >
+             <Issue>2444</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfinally_r\badcodeafterfinally_r.cmd" >
+             <Issue>2444</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev10_865840\dev10_865840\dev10_865840.cmd" >
+             <Issue>2445</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic1\rvastatic1.cmd" >
+             <Issue>2451</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic2\rvastatic2.cmd" >
+             <Issue>2451</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic3\rvastatic3.cmd" >
+             <Issue>2451</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic4\rvastatic4.cmd" >
+             <Issue>2451</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic5\rvastatic5.cmd" >
+             <Issue>2451</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b410474\b410474\b410474.cmd" >
+             <Issue>2451</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinning\object-pin\object-pin\object-pin.cmd" >
+             <Issue>2452</Issue>
+        </ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -110,8 +110,11 @@ JIT/opt/Tailcall/TailcallVerifyWithPrefix/TailcallVerifyWithPrefix.sh
 Loader/NativeLibs/FromNativePaths/FromNativePaths.sh
 JIT/jit64/gc/regress/vswhidbey/143837/143837.sh
 JIT/Methodical/Invoke/25params/25param1c_il_d/25param1c_il_d.sh
+JIT/Methodical/Invoke/25params/25param1c_il_r/25param1c_il_r.sh
 JIT/Methodical/Invoke/25params/25param3c_il_d/25param3c_il_d.sh
+JIT/Methodical/Invoke/25params/25param3c_il_r/25param3c_il_r.sh
 JIT/Methodical/Invoke/25params/25paramMixed_il_d/25paramMixed_il_d.sh
+JIT/Methodical/Invoke/25params/25paramMixed_il_r/25paramMixed_il_r.sh
 JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b79250/b79250/b79250.sh
 JIT/Directed/coverage/importer/Desktop/badldsfld_il_d/badldsfld_il_d.sh
 JIT/Directed/coverage/importer/Desktop/badldsfld_il_r/badldsfld_il_r.sh

--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -20,10 +20,14 @@ JIT/Generics/pinvoke/instance02/instance02.sh
 JIT/Generics/pinvoke/instance03/instance03.sh
 JIT/Generics/pinvoke/static01/static01.sh
 JIT/Generics/pinvoke/static02/static02.sh
+JIT/Methodical/Arrays/misc/_il_dbgarrres/_il_dbgarrres.sh
+JIT/Methodical/Arrays/misc/_il_relarrres/_il_relarrres.sh
 JIT/Methodical/cctor/xassem/xprecise3_cs_d/xprecise3_cs_d.sh
 JIT/Methodical/cctor/xassem/xprecise3_cs_do/xprecise3_cs_do.sh
 JIT/Methodical/cctor/xassem/xprecise3_cs_r/xprecise3_cs_r.sh
 JIT/Methodical/cctor/xassem/xprecise3_cs_ro/xprecise3_cs_ro.sh
+JIT/Methodical/delegate/_simpleoddpower_il_d/_simpleoddpower_il_d.sh
+JIT/Methodical/delegate/_simpleoddpower_il_r/_simpleoddpower_il_r.sh
 JIT/Methodical/delegate/_XModuledeleg1_d/_XModuledeleg1_d.sh
 JIT/Methodical/delegate/_XModuledeleg1_do/_XModuledeleg1_do.sh
 JIT/Methodical/delegate/_XModuledeleg1_r/_XModuledeleg1_r.sh


### PR DESCRIPTION
#2328
 JIT\SIMD\VectorArgs\VectorArgs.cmd

#2330 
 JIT/Methodical/Arrays/misc/_il_dbgarrres/_il_dbgarrres.sh
 JIT/Methodical/Arrays/misc/_il_relarrres/_il_relarrres.sh

#2380
 JIT/Methodical/Invoke/25params/25param1c_il_r/25param1c_il_r.sh
 JIT/Methodical/Invoke/25params/25param3c_il_r/25param3c_il_r.sh
 JIT/Methodical/Invoke/25params/25paramMixed_il_r/25paramMixed_il_r.sh

#2407
 JIT/Methodical/delegate/_simpleoddpower_il_d/_simpleoddpower_il_d.sh
 JIT/Methodical/delegate/_simpleoddpower_il_r/_simpleoddpower_il_r.sh

I also took the liberty of fixing the whitespace in issues.targets on the
assumption that all modern differs can ignore whitespace diffs.  If this
is unacceptable and should be separated, let me know.

@dotnet/jit-contrib @mmitche