### PR TITLE
Daylight transitions are not correct on Unix.

### DIFF
--- a/src/mscorlib/src/System/TimeZoneInfo.cs
+++ b/src/mscorlib/src/System/TimeZoneInfo.cs
@@ -1900,10 +1900,12 @@ namespace System {
         }
 
 
-        static private Boolean CheckIsDst(DateTime startTime, DateTime time, DateTime endTime,bool ignoreYearAdjustment, AdjustmentRule rule) {
+        static private Boolean CheckIsDst(DateTime startTime, DateTime time, DateTime endTime, bool ignoreYearAdjustment, AdjustmentRule rule) {
             Boolean isDst;
 
-            if (!ignoreYearAdjustment) {
+            // NoDaylightTransitions AdjustmentRules should never get their year adjusted since they adjust the offset for the
+            // entire time period - which may be for multiple years
+            if (!ignoreYearAdjustment && !rule.NoDaylightTransitions) {
                 int startTimeYear = startTime.Year;
                 int endTimeYear = endTime.Year;
 


### PR DESCRIPTION
When checking whether a DateTime is daylight savings time, TimeZoneInfo gets it wrong when the AdjustmentRule spans multiple years. This is because CheckIsDst will adjust the DateTime's Year to be the same as the AdjustmentRule.StartTime.Year. On Unix, this is incorrect because the AdjustmentRules are fixed for the whole time; the offset doesn't change at all during the AdjustmentRule.

This is a fix for the last 2 issues noted in #2185.

@tarekgh @jskeet