### PR TITLE
Fix for Bug 2652 [JitStress=2] JIT/Directed/Arrays/Complex2/Complex2.…

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -4461,7 +4461,7 @@ void                Compiler::fgMoveOpsLeft(GenTreePtr tree)
 
         new_op1->gtOp.gtOp1     = op1;
         new_op1->gtOp.gtOp2     = ad1;
-
+        
         /* Change the flags. */
 
         // Make sure we arent throwing away any flags
@@ -4489,6 +4489,20 @@ void                Compiler::fgMoveOpsLeft(GenTreePtr tree)
             // Neither ad1 nor op1 are GC. So new_op1 isnt either
             noway_assert(op1->gtType == TYP_I_IMPL && ad1->gtType == TYP_I_IMPL);
             new_op1->gtType = TYP_I_IMPL;
+        }
+
+        // If new_op1 is a new expression. Assign it a new unique value number.
+        // vnStore is null before the ValueNumber phase has run
+        if (vnStore != nullptr)
+        {
+            assert(op1->gtVNPair.GetLiberal() != ValueNumStore::NoVN);
+            assert(ad2->gtVNPair.GetLiberal() != ValueNumStore::NoVN);
+
+            // Since op is commutative, comparing only ad2 and op1 is enough.
+            if (ad2->gtVNPair.GetLiberal() != op1->gtVNPair.GetLiberal())
+            {
+                new_op1->gtVNPair.SetBoth(vnStore->VNForExpr(new_op1->TypeGet()));
+            }
         }
 
         tree->gtOp.gtOp1 = new_op1;


### PR DESCRIPTION
…exe fails

The bug is caused by calling fgMorph in optPerformHoistExpr:

Before
 N043 ( 1, 1) [000806] ------------ /--* lclVar int V04 loc3 u:7 $380
 N044 ( 3, 3) [000805] ------------ /--* + int $348
 N042 ( 1, 1) [000807] ------------ | --* lclVar int V05 loc4 u:7 $381
 N045 ( 5, 5) [000804] ------------ /--* + int $349
 N041 ( 1, 1) [000808] ------------ | --* lclVar int V06 loc5 u:7 $382
 N046 ( 7, 7) [000803] ------------ /--* + int $34a
 N040 ( 1, 1) [000809] ------------ | --* lclVar int V07 loc6 u:7 $383
 N047 ( 9, 9) [000802] ------------ /--* + int $34b
 N039 ( 1, 1) [000810] ------------ | --* lclVar int V08 loc7 u:7 $384
 N048 ( 11, 11) [000801] ------------ * + int $34c
 N038 ( 1, 1) [000811] ------------ --* lclVar int V09 loc8 u:7 $385

After
 ( 1, 1) [001747] -------H---- | /--* lclVar int V04 loc3 u:7 $380
 ( 11, 11) [001737] -------H---- --* + int $34c
 ( 1, 1) [001746] -------H---- | /--* lclVar int V05 loc4 u:7 $381
 ( 9, 9) [001739] ------------ --* + int $34b
 ( 1, 1) [001744] -------H---- | /--* lclVar int V06 loc5 u:7 $382
 ( 7, 7) [001741] ------------ --* + int $34a
 ( 1, 1) [001742] -------H---- | /--* lclVar int V07 loc6 u:7 $383
 ( 5, 5) [001743] ------------ --* + int $349
 ( 1, 1) [001740] -------H---- | /--* lclVar int V08 loc7 u:7 $384
 ( 3, 3) [001745] ------------ --* + int $348
 ( 1, 1) [001738] -------H---- --* lclVar int V09 loc8 u:7 $385

See the value number $34b doesn't reflect the same expressions before and after.

When fgMorph is called after value numbering, we have to ensure that a correct or a new value number is assigned to the resulting tree.