### PR TITLE
Fix exception in Burgers on AVX-capable HW

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/Burgers/Burgers.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Burgers/Burgers.cs
@@ -139,7 +139,7 @@ public class Burgers
 
         for (int tStep = 0; tStep < nt; tStep++)
         {
-            for (int i = 1; i < nx2 - 1; i += Vector<double>.Count)
+            for (int i = 1; i < nx2 - Vector<double>.Count + 1; i += Vector<double>.Count)
             {
                 var vectorIn0 = new Vector<double>(un, i);
                 var vectorInPrev = new Vector<double>(un, i - 1);


### PR DESCRIPTION
Original code was implicitly assuming Vector<>.Count == 2, which isn't true once AVX kicks in.

Closes #2679.