### PR TITLE
Ensure CreateAdjustmentRule is compiled into mscorlib.

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8152,6 +8152,10 @@
       <Member MemberType="Property" Name="Local" />
       <Member MemberType="Property" Name="Utc" />
     </Type>
+    <Type Name="System.TimeZoneInfo+AdjustmentRule">
+      <!-- CreateAdjustmentRule doesn't have a public contract, but tests and other callers can use Reflection to invoke it, so ensure it is left in mscorlib. -->
+      <Member Name="CreateAdjustmentRule(System.DateTime,System.DateTime,System.TimeSpan,System.TimeZoneInfo+TransitionTime,System.TimeZoneInfo+TransitionTime)" />
+    </Type>
     <Type Name="System.Tuple">
       <Member Name="Create&lt;T1&gt;(T1)" />
       <Member Name="Create&lt;T1,T2&gt;(T1,T2)" />


### PR DESCRIPTION
Legacy SelfTest/SelfHost tests are currently calling CreateAdjustmentRule using reflection. When changes were made to no longer have an upstream caller of this method, the tests started failing because BclWriter was removing the method from mscorlib.

To fix the tests, and in case other external callers are invoking this method using reflection, add this member to model.xml to ensure BclWriter leaves it in mscorlib.

This fixes devdiv bug https://devdiv.visualstudio.com/web/wi.aspx?pcguid=011b8bdf-6d56-4f87-be0d-0092136884d9&id=132217

@weshaggard @tarekgh @AlexGhiondea 