### PR TITLE
Revert old change for floating point context alignment issue

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -2768,13 +2768,10 @@ typedef struct _CONTEXT {
 #define CONTEXT_EXCEPTION_REQUEST 0x40000000
 #define CONTEXT_EXCEPTION_REPORTING 0x80000000
 
-typedef struct _M128U {
+typedef struct DECLSPEC_ALIGN(16) _M128A {
     ULONGLONG Low;
     LONGLONG High;
-} M128U, *PM128U;
-
-// Same as _M128U but aligned to a 16-byte boundary
-typedef DECLSPEC_ALIGN(16) M128U M128A, *PM128A;
+} M128A, *PM128A;
 
 typedef struct _XMM_SAVE_AREA32 {
     WORD   ControlWord;

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -67,9 +67,9 @@ typedef ucontext_t native_context_t;
 #define MCREG_R14(mc)       ((mc).gregs[REG_R14])
 #define MCREG_R15(mc)       ((mc).gregs[REG_R15])
 
-#define FPREG_Xmm(uc, index) *(M128U*)&((uc)->uc_mcontext.fpregs->_xmm[index])
+#define FPREG_Xmm(uc, index) *(M128A*)&((uc)->uc_mcontext.fpregs->_xmm[index])
 
-#define FPREG_St(uc, index) *(M128U*)&((uc)->uc_mcontext.fpregs->_st[index])
+#define FPREG_St(uc, index) *(M128A*)&((uc)->uc_mcontext.fpregs->_st[index])
 
 #define FPREG_ControlWord(uc) ((uc)->uc_mcontext.fpregs->cwd)
 #define FPREG_StatusWord(uc) ((uc)->uc_mcontext.fpregs->swd)

--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -434,12 +434,12 @@ void CONTEXTToNativeContext(CONST CONTEXT *lpContext, native_context_t *native)
 
         for (int i = 0; i < 8; i++)
         {
-            FPREG_St(native, i) = ((M128U*)lpContext->FltSave.FloatRegisters)[i];
+            FPREG_St(native, i) = lpContext->FltSave.FloatRegisters[i];
         }
 
         for (int i = 0; i < 16; i++)
         {
-            FPREG_Xmm(native, i) = ((M128U*)lpContext->FltSave.XmmRegisters)[i];
+            FPREG_Xmm(native, i) = lpContext->FltSave.XmmRegisters[i];
         }
 #endif
     }
@@ -493,12 +493,12 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
 
         for (int i = 0; i < 8; i++)
         {
-            ((M128U*)lpContext->FltSave.FloatRegisters)[i] = FPREG_St(native, i);
+            lpContext->FltSave.FloatRegisters[i] = FPREG_St(native, i);
         }
 
         for (int i = 0; i < 16; i++)
         {
-            ((M128U*)lpContext->FltSave.XmmRegisters)[i] = FPREG_Xmm(native, i);
+            lpContext->FltSave.XmmRegisters[i] = FPREG_Xmm(native, i);
         }
 #endif
     }


### PR DESCRIPTION
We added a fix in #1263 to solve a crash that was occurring in optimized builds wherein the `movaps` instruction was being used to copy some floating point register values to/from a context that was passed in to a signal handler. The problem was that the offset in the context struct that we thought represented the floating point registers was not aligned to a 16-byte boundary so the `movaps` would segfault. The fix in #1263 prevents us from using `movaps` by removing the alignment specification on our 128-bit struct.

Turns out that we shouldn't have been accessing the FP regs from that location (`__fpregs_mem`) anyway, and instead should use the pointer to a `_libc_fpstate` that's available in the `uc_mcontext` to get at the correct location where the kernel puts the FP state. This was fixed in #2631.

This change reverts the fix we made earlier since this corrected location _is_ aligned to a 16-byte boundary and so we can use `movaps` after all.

@janvorli @sergiy-k 