### PR TITLE
Add back COMPlus_DbgWaitForDebuggerAttach env var for mdbg tests

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -2111,6 +2111,14 @@ HRESULT Debugger::Startup(void)
     #ifdef FEATURE_PAL
         PAL_SetShutdownCallback(AbortTransport);
     #endif // FEATURE_PAL
+
+         bool waitForAttach = CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_DbgWaitForDebuggerAttach) != 0;
+         if (waitForAttach)
+         {
+             // Mark this process as launched by the debugger and the debugger as attached.
+             g_CORDebuggerControlFlags |= DBCF_GENERATE_DEBUG_CODE;
+             MarkDebuggerAttachedInternal();
+         }
     #endif // FEATURE_DBGIPC_TRANSPORT_VM
 
         RaiseStartupNotification();


### PR DESCRIPTION
Needed to keep the mdbg debugger tests going until they are switched to the new dbgshim API.