### PR TITLE
Ensure floating point context pointer has been initialized

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -419,7 +419,7 @@ void CONTEXTToNativeContext(CONST CONTEXT *lpContext, native_context_t *native)
     }
 #undef ASSIGN_REG
 
-    if ((lpContext->ContextFlags & CONTEXT_FLOATING_POINT) == CONTEXT_FLOATING_POINT)
+    if ((lpContext->ContextFlags & CONTEXT_FLOATING_POINT) == CONTEXT_FLOATING_POINT && native->uc_mcontext.fpregs != nullptr)
     {
 #ifdef _AMD64_
         FPREG_ControlWord(native) = lpContext->FltSave.ControlWord;
@@ -478,7 +478,7 @@ void CONTEXTFromNativeContext(const native_context_t *native, LPCONTEXT lpContex
     }
 #undef ASSIGN_REG
     
-    if ((contextFlags & CONTEXT_FLOATING_POINT) == CONTEXT_FLOATING_POINT)
+    if ((contextFlags & CONTEXT_FLOATING_POINT) == CONTEXT_FLOATING_POINT && native->uc_mcontext.fpregs != nullptr)
     {
 #ifdef _AMD64_
         lpContext->FltSave.ControlWord = FPREG_ControlWord(native);


### PR DESCRIPTION
We shouldn't try to read from or write to the floating point context passed in to a signal handler if the thread hasn't done any floating point operations yet. #2631 exposed this bug because now, we try to dereference a pointer to get to the FP state (which the kernel will not populate unless needed so we crash).

@janvorli @sergiy-k 