### PR TITLE
Array.Sort<T>: Remove unnecessary GetLowerBound(0) call

### DIFF
--- a/src/mscorlib/src/System/Array.cs
+++ b/src/mscorlib/src/System/Array.cs
@@ -1753,7 +1753,7 @@ namespace System {
             if (array==null)
                 throw new ArgumentNullException("array");
             Contract.EndContractBlock();
-            Sort<T>(array, array.GetLowerBound(0), array.Length, null);
+            Sort<T>(array, 0, array.Length, null);
         }
 
         [ReliabilityContract(Consistency.MayCorruptInstance, Cer.MayFail)]


### PR DESCRIPTION
The lower bound of `T[]` is `0`, so there's no need to call `GetLowerBound(0)`.