### PR TITLE
Initial round of jit inliner refactoring

### DIFF
--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1576,10 +1576,7 @@ inline unsigned     Compiler::lvaGrabTemp(bool shortLifetime
         {
             // Don't create more LclVar with inlining 
             JITLOG((LL_INFO1000000, INLINER_FAILED "Inlining requires new LclVars and we already have too many locals."));
-
-            JitInlineResult result(INLINE_FAIL, impInlineInfo->inlineCandidateInfo->ilCallerHandle,
-                                   info.compMethodHnd, "Inlining requires new LclVars and we already have too many locals.");
-            compSetInlineResult(result);  // Only fail for this inline attempt.
+            compInlineResult->setFailure("Inlining requires new LclVars and we already have too many locals.");
         }
 
         unsigned tmpNum = pComp->lvaGrabTemp(shortLifetime DEBUGARG(reason));
@@ -4282,31 +4279,17 @@ bool                Compiler::compIsForInlining()
 
 /*****************************************************************************
  *
- *  Set the inline result in the compiler.
- */
-
-inline
-void                Compiler::compSetInlineResult(const JitInlineResult& result)
-{
-    assert(compIsForInlining());
-    assert(dontInline(result.result()));     // Should only set to a failure state.
-   
-    compInlineResult = result;    
-}
-
-/*****************************************************************************
- *
  *  Check the inline result field in the compiler to see if inlining failed or not.
  */
 
 inline
 bool                Compiler::compDonotInline()
 {
-    if (dontInline(compInlineResult.result()))
+    if (compIsForInlining())
     {
-        assert(compIsForInlining());
-        return true;
-    }    
+       assert(compInlineResult != nullptr);
+       return compInlineResult->isFailure();
+    }
     else
     {
         return false;


### PR DESCRIPTION
In the jit, a particular inline decision is the aggregate result of checks
in many different parts of the code. The primary goal of this refactoring
is to establity a single object instance that will accumulate the necessary
information, and to ensure there are a small number of places in the code
where the final outcome is known.

That object is the `JitInlineResult`. I've updated it so it is no longer
copyable or assignable. Instead each root instance is passed down stack
by reference to helper methods that update the instance as the inline decision
making process evolves. Methods on the JitInlineResult can be used to advance
the state of what's known. The allowable state transitions are limited and the
code verifies that (when appropriate) a decision was actually made.

There are 4 such root instances:
* the main check done in the inlining pass.
* the candidate identification pass done in the importer.
* a pre-jit viability scan also done in the importer.
* another pre-jit viability scan done in the importer.

(These latter two identify un-inlinable methods at pre-jit time, so
subsequent jit invocations don't expend any cycles considering them).

I've updated various APIs to try and avoid introducing aliased copies or
projections of the inline result, for instance passing it via argument to
a helper that already has access to it via a member variable, or returning
a bool result from one of the various 'canInline' methods. More work is possible
here -- for example the compiler instance probably doesn't need an inline
result member of its own, since whenever it is inlining it has an inline
instance that has an inline result. I've added a few asserts in places to ensure
that if there is more than one plausible path to the result that they all refer
to the same object.

I've also started streamlining a bit of the goto-heavy case analysis in favor
of early returns, which I find more readable. The reporting obligation
is now held by the JitInlineResult destructor. Future work may go further in this
direction, and make the JitInlineResult responsible for never attribute flagging,
logging and dump messages, and perhaps even responsibility for undoing some of
the speculative state modification done when preparing for inlining (eg cleaning up
the locals in `fgMorphCallInlineHelper`).

At this stage the various candidate and failure reasons are still strings.
I added some new strings for in-progress checks so the dumps now show the
"success reason" for an inline. This is an area that will undergo
further refinement. Success reasons and failures and failure reasons
are still not captured in the inline tree; that too is forthcoming.

There are likely a bunch of coding conventions that I've either introduced or
are highlighting with this change.

This change should be no diff. I've verified this by hand on some simple
examples and will do further testing of it before merging.