### PR TITLE
Reenable VectorArgs after SIMD change

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -37,9 +37,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b108129\b108129\*" >
             <Issue>2234</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArgs\*" >
-            <Issue>2328</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd" >
              <Issue>2329</Issue>
         </ExcludeList>


### PR DESCRIPTION
@CarolEidt's PR #2545 fixed JIT\SIMD\VectorArgs.  Re-enabling the test case.

Closes #2328

@dotnet/jit-contrib 