### PR TITLE
Add support for GCStress 0xC

### DIFF
--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -1046,7 +1046,13 @@ MemoryRange Debugger::s_hijackFunction[kMaxHijackFunctions] =
      GetMemoryRangeForFunction(RedirectedHandledJITCaseForUserSuspend_Stub,
                                RedirectedHandledJITCaseForUserSuspend_StubEnd),
      GetMemoryRangeForFunction(RedirectedHandledJITCaseForYieldTask_Stub,
-                               RedirectedHandledJITCaseForYieldTask_StubEnd)};
+                               RedirectedHandledJITCaseForYieldTask_StubEnd)
+#ifdef HAVE_GCCOVER
+     ,
+     GetMemoryRangeForFunction(RedirectedHandledJITCaseForGCStress_Stub,
+                               RedirectedHandledJITCaseForGCStress_StubEnd)
+#endif // HAVE_GCCOVER
+    };
 #endif // FEATURE_HIJACK && !PLATFORM_UNIX
 
 // Save the necessary information for the debugger to recognize an IP in one of the thread redirection 

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -2884,6 +2884,9 @@ private:
         kRedirectedForDbgThreadControl,
         kRedirectedForUserSuspend,
         kRedirectedForYieldTask,
+#ifdef HAVE_GCCOVER
+        kRedirectedForGCStress,
+#endif // HAVE_GCCOVER
         kMaxHijackFunctions,
     };
 
@@ -2972,6 +2975,10 @@ void RedirectedHandledJITCaseForUserSuspend_StubEnd();
 
 void RedirectedHandledJITCaseForYieldTask_Stub();
 void RedirectedHandledJITCaseForYieldTask_StubEnd();
+#ifdef HAVE_GCCOVER
+void RedirectedHandledJITCaseForGCStress_Stub();
+void RedirectedHandledJITCaseForGCStress_StubEnd();
+#endif // HAVE_GCCOVER
 };
 
 

--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -141,7 +141,7 @@
 #endif
 
 // GCCoverage has a dependency on msvcdisXXX.dll, which is not available for CoreSystem. Hence, it is disabled for CoreSystem builds.
-#if defined(STRESS_HEAP) && defined(_DEBUG) && defined(FEATURE_HIJACK) && !(defined(FEATURE_CORESYSTEM) && (defined(_TARGET_X86_) || defined(_TARGET_AMD64_)))
+#if defined(STRESS_HEAP) && defined(_DEBUG) && defined(FEATURE_HIJACK) && (!defined(FEATURE_CORECLR) || (defined(WIN32) || defined(__LINUX__)) && defined(_TARGET_AMD64_))
 #define HAVE_GCCOVER
 #endif
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6763,12 +6763,19 @@ public:
 };
 
 typedef VOID (PALAPI *PHARDWARE_EXCEPTION_HANDLER)(PAL_SEHException* ex);
+typedef DWORD (PALAPI *PGET_GCMARKER_EXCEPTION_CODE)(LPVOID ip);
 
 PALIMPORT
 VOID
 PALAPI
 PAL_SetHardwareExceptionHandler(
     IN PHARDWARE_EXCEPTION_HANDLER exceptionHandler);
+
+PALIMPORT
+VOID
+PALAPI
+PAL_SetGetGcMarkerExceptionCode(
+    IN PGET_GCMARKER_EXCEPTION_CODE getGcMarkerExceptionCode);
 
 //
 // This holder is used to indicate that a hardware

--- a/src/pal/src/exception/machexception.cpp
+++ b/src/pal/src/exception/machexception.cpp
@@ -612,8 +612,9 @@ static DWORD exception_from_trap_code(
 
         return EXCEPTION_ACCESS_VIOLATION; 
 
-    // Instruction failed. Illegal or undefined instruction or operand. 
-    case EXC_BAD_INSTRUCTION :
+    // Instruction failed. Illegal, privileged, or undefined instruction or operand.
+    case EXC_BAD_INSTRUCTION:
+        // TODO: Identify privileged instruction. Need to get the thread state and read the machine code. May be better to do this in the place that calls SEHProcessException, similar to how it's done on Linux.
         return EXCEPTION_ILLEGAL_INSTRUCTION; 
 
     // Arithmetic exception; exact nature of exception is in subcode field. 

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -57,6 +57,7 @@ const UINT RESERVED_SEH_BIT = 0x800000;
 /* Internal variables definitions **********************************************/
 
 PHARDWARE_EXCEPTION_HANDLER g_hardwareExceptionHandler = NULL;
+PGET_GCMARKER_EXCEPTION_CODE g_getGcMarkerExceptionCode = NULL;
 
 /* Internal function definitions **********************************************/
 
@@ -131,6 +132,26 @@ PAL_SetHardwareExceptionHandler(
     IN PHARDWARE_EXCEPTION_HANDLER exceptionHandler)
 {
     g_hardwareExceptionHandler = exceptionHandler;
+}
+
+/*++
+Function:
+    PAL_SetGetGcMarkerExceptionCode
+
+    Register a function that determines if the specified IP has code that is a GC marker for GCCover.
+
+Parameters:
+    getGcMarkerExceptionCode - the function to register
+
+Return value:
+    None
+--*/
+VOID
+PALAPI 
+PAL_SetGetGcMarkerExceptionCode(
+    IN PGET_GCMARKER_EXCEPTION_CODE getGcMarkerExceptionCode)
+{
+    g_getGcMarkerExceptionCode = getGcMarkerExceptionCode;
 }
 
 /*++

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -626,7 +626,7 @@ static void common_signal_handler(PEXCEPTION_POINTERS pointers, int code,
     // Fill context record with required information. from pal.h :
     // On non-Win32 platforms, the CONTEXT pointer in the
     // PEXCEPTION_POINTERS will contain at least the CONTEXT_CONTROL registers.
-    CONTEXTFromNativeContext(ucontext, &context, CONTEXT_CONTROL | CONTEXT_INTEGER);
+    CONTEXTFromNativeContext(ucontext, &context, CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
 
     pointers->ContextRecord = &context;
 

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -74,6 +74,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     debughelp.cpp
     debuginfostore.cpp
     decodemd.cpp
+    disassembler.cpp
     dllimport.cpp
     domainfile.cpp
     dynamicmethod.cpp

--- a/src/vm/amd64/cgencpu.h
+++ b/src/vm/amd64/cgencpu.h
@@ -82,7 +82,9 @@ EXTERN_C void FastCallFinalizeWorker(Object *obj, PCODE funcPtr);
 #define INSTRFMT_K64SMALL
 #define INSTRFMT_K64
 
+#ifndef FEATURE_PAL
 #define USE_REDIRECT_FOR_GCSTRESS
+#endif // FEATURE_PAL
 
 //
 // REX prefix byte

--- a/src/vm/disassembler.cpp
+++ b/src/vm/disassembler.cpp
@@ -1,0 +1,308 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#include "common.h"
+
+#include "disassembler.h"
+#include "dllimport.h"
+
+#if USE_DISASSEMBLER
+
+// TODO: Which contracts should be used where? Currently, everything is using LIMITED_METHOD_CONTRACT.
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+HMODULE Disassembler::s_libraryHandle = nullptr;
+
+Disassembler::CorDisasm *(*Disassembler::External_InitDisasm)(enum TargetArch Target) = nullptr;
+SIZE_T(*Disassembler::External_DisasmInstruction)(const Disassembler::CorDisasm *Disasm, size_t Address,
+                                  const uint8_t *Bytes, size_t Maxlength,
+                                  bool PrintAssembly) = nullptr;
+void(*Disassembler::External_FinishDisasm)(const Disassembler::CorDisasm *Disasm) = nullptr;
+#endif // USE_COREDISTOOLS_DISASSEMBLER
+
+Disassembler::ExternalDisassembler *Disassembler::s_availableExternalDisassembler = nullptr;
+
+#if defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+// static
+bool Disassembler::IsRexPrefix(UINT8 potentialRexByte)
+{
+    LIMITED_METHOD_CONTRACT;
+
+#ifdef _TARGET_AMD64_
+    return (potentialRexByte & 0xf0) == REX_PREFIX_BASE;
+#else // !_TARGET_AMD64_
+    return false;
+#endif // _TARGET_AMD64_
+}
+
+// static
+UINT8 Disassembler::DecodeModFromModRm(UINT8 modRm)
+{
+    LIMITED_METHOD_CONTRACT;
+    return modRm >> 6;
+}
+
+// static
+UINT8 Disassembler::DecodeRegOrOpCodeFromModRm(UINT8 modRm)
+{
+    LIMITED_METHOD_CONTRACT;
+    return (modRm >> 3) & 0x7;
+}
+
+// static
+UINT8 Disassembler::DecodeRmFromModRm(UINT8 modRm)
+{
+    LIMITED_METHOD_CONTRACT;
+    return modRm & 0x7;
+}
+#endif // defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+
+// static
+bool Disassembler::IsAvailable()
+{
+    LIMITED_METHOD_CONTRACT;
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+    return s_libraryHandle != nullptr;
+#else // !USE_COREDISTOOLS_DISASSEMBLER
+    return true;
+#endif // USE_COREDISTOOLS_DISASSEMBLER
+}
+
+// static
+void Disassembler::StaticInitialize()
+{
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(!IsAvailable());
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+    // TODO: The 'coredistools' library will eventually be part of a NuGet package, need to be able to load
+    // that using appropriate search paths
+    LPCWSTR libraryName = MAKEDLLNAME(W("coredistools"));
+    HMODULE libraryHandle = CLRLoadLibrary(libraryName);
+    do
+    {
+        if (libraryHandle == nullptr)
+        {
+        #ifdef _DEBUG
+            wprintf(W("LoadLibrary failed for '%s': error %u\n"), libraryName, GetLastError());
+        #endif // _DEBUG
+            break;
+        }
+
+        External_InitDisasm =
+            reinterpret_cast<decltype(External_InitDisasm)>(GetProcAddress(libraryHandle, "InitDisasm"));
+        if (External_InitDisasm == nullptr)
+        {
+        #ifdef _DEBUG
+            wprintf(
+                W("GetProcAddress failed for library '%s', function 'InitDisasm': error %u\n"),
+                libraryName,
+                GetLastError());
+        #endif // _DEBUG
+            break;
+        }
+
+        External_DisasmInstruction =
+            reinterpret_cast<decltype(External_DisasmInstruction)>(GetProcAddress(libraryHandle, "DisasmInstruction"));
+        if (External_DisasmInstruction == nullptr)
+        {
+        #ifdef _DEBUG
+            wprintf(
+                W("GetProcAddress failed for library '%s', function 'DisasmInstruction': error %u\n"),
+                libraryName,
+                GetLastError());
+        #endif // _DEBUG
+            break;
+        }
+
+        External_FinishDisasm =
+            reinterpret_cast<decltype(External_FinishDisasm)>(GetProcAddress(libraryHandle, "FinishDisasm"));
+        if (External_FinishDisasm == nullptr)
+        {
+        #ifdef _DEBUG
+            wprintf(
+                W("GetProcAddress failed for library '%s', function 'FinishDisasm': error %u\n"),
+                libraryName,
+                GetLastError());
+        #endif // _DEBUG
+            break;
+        }
+
+        // Set this last to indicate successful load of the library and all exports
+        s_libraryHandle = libraryHandle;
+        _ASSERTE(IsAvailable());
+        return;
+    } while (false);
+
+    CLRFreeLibrary(libraryHandle);
+    _ASSERTE(!IsAvailable());
+#endif // USE_COREDISTOOLS_DISASSEMBLER
+}
+
+// static
+void Disassembler::StaticClose()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    if (!IsAvailable())
+    {
+        return;
+    }
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+    CLRFreeLibrary(s_libraryHandle);
+    s_libraryHandle = nullptr;
+#endif
+}
+
+Disassembler::Disassembler()
+{
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(IsAvailable());
+
+    // TODO: Is it ok to save and reuse an instance of the LLVM-based disassembler? It may later be used from a different
+    // thread, and it may be deleted from a different thread than the one from which it was created.
+
+    // Try to get an external disassembler that is already available for use before creating one
+    ExternalDisassembler *externalDisassembler =
+        FastInterlockExchangePointer(&s_availableExternalDisassembler, static_cast<ExternalDisassembler *>(nullptr));
+    if (externalDisassembler == nullptr)
+    {
+    #if USE_COREDISTOOLS_DISASSEMBLER
+        // First parameter:
+        // - Empty string for the current architecture
+        // - A string of the form "x86_64-pc-win32"
+        externalDisassembler = External_InitDisasm(Target_Host);
+    #elif USE_MSVC_DISASSEMBLER
+    #ifdef _TARGET_X86_
+        externalDisassembler = ExternalDisassembler::PdisNew(ExternalDisassembler::distX86);
+    #elif defined(_TARGET_AMD64_)
+        externalDisassembler = ExternalDisassembler::PdisNew(ExternalDisassembler::distX8664);
+    #endif // defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
+    #endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+    }
+
+    _ASSERTE(externalDisassembler != nullptr);
+    m_externalDisassembler = externalDisassembler;
+}
+
+Disassembler::~Disassembler()
+{
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(IsAvailable());
+
+    // Save the external disassembler for future use. We only save one instance, so delete a previously saved one.
+    ExternalDisassembler *externalDisassemblerToDelete =
+        FastInterlockExchangePointer(&s_availableExternalDisassembler, m_externalDisassembler);
+    if (externalDisassemblerToDelete == nullptr)
+    {
+        return;
+    }
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+    External_FinishDisasm(externalDisassemblerToDelete);
+#elif USE_MSVC_DISASSEMBLER
+    delete externalDisassemblerToDelete;
+#endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+}
+
+SIZE_T Disassembler::DisassembleInstruction(const UINT8 *code, SIZE_T codeLength, InstructionType *instructionTypeRef) const
+{
+    LIMITED_METHOD_CONTRACT;
+    _ASSERTE(IsAvailable());
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+    SIZE_T instructionLength = External_DisasmInstruction(m_externalDisassembler, reinterpret_cast<SIZE_T>(code), code, codeLength, false /* PrintAssembly */);
+#elif USE_MSVC_DISASSEMBLER
+    SIZE_T instructionLength =
+        m_externalDisassembler->CbDisassemble(reinterpret_cast<ExternalDisassembler::ADDR>(code), code, codeLength);
+#endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+    _ASSERTE(instructionLength <= codeLength);
+
+    if (instructionTypeRef != nullptr)
+    {
+        if (instructionLength == 0)
+        {
+            *instructionTypeRef = InstructionType::Unknown;
+        }
+        else
+        {
+        #if USE_COREDISTOOLS_DISASSEMBLER
+            *instructionTypeRef = DetermineInstructionType(code, instructionLength);
+        #elif USE_MSVC_DISASSEMBLER
+            *instructionTypeRef = DetermineInstructionType(m_externalDisassembler->Trmt());
+        #endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+        }
+    }
+
+    return instructionLength;
+}
+
+// static
+InstructionType Disassembler::DetermineInstructionType(
+#if USE_COREDISTOOLS_DISASSEMBLER
+    const UINT8 *instructionCode, SIZE_T instructionCodeLength
+#elif USE_MSVC_DISASSEMBLER
+    ExternalDisassembler::TRMT terminationType
+#endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+    )
+{
+    LIMITED_METHOD_CONTRACT;
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+    _ASSERTE(instructionCodeLength != 0);
+
+    SIZE_T i = 0;
+    if (Disassembler::IsRexPrefix(instructionCode[i]))
+    {
+        ++i;
+    }
+
+    switch (instructionCode[i])
+    {
+        case 0xe8: // call near rel
+        #ifdef _TARGET_X86_
+        case 0x9a: // call far ptr
+        #endif // _TARGET_X86_
+            return InstructionType::Call_DirectUnconditional;
+
+        case 0xff:
+            ++i;
+            if (i >= instructionCodeLength)
+            {
+                break;
+            }
+
+            switch (Disassembler::DecodeRegOrOpCodeFromModRm(instructionCode[i]))
+            {
+                case 2: // call near r/m
+                case 3: // call far m
+                    return InstructionType::Call_IndirectUnconditional;
+
+                case 4: // jmp near r/m
+                case 5: // jmp far m
+                    return InstructionType::Branch_IndirectUnconditional;
+            }
+            break;
+    }
+#elif USE_MSVC_DISASSEMBLER
+    switch (terminationType)
+    {
+        case ExternalDisassembler::trmtCall:
+            return InstructionType::Call_DirectUnconditional;
+
+        case ExternalDisassembler::trmtCallInd:
+            return InstructionType::Call_IndirectUnconditional;
+
+        case ExternalDisassembler::trmtBraInd:
+            return InstructionType::Branch_IndirectUnconditional;
+    }
+#endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+
+    return InstructionType::Unknown;
+}
+
+#endif // USE_DISASSEMBLER

--- a/src/vm/disassembler.h
+++ b/src/vm/disassembler.h
@@ -1,0 +1,122 @@
+//
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+#ifndef __DISASSEMBLER_H__
+#define __DISASSEMBLER_H__
+
+#include "switches.h"
+
+#define USE_COREDISTOOLS_DISASSEMBLER 0
+#define USE_MSVC_DISASSEMBLER 0
+#ifdef HAVE_GCCOVER
+    #ifdef FEATURE_CORECLR
+        #undef USE_COREDISTOOLS_DISASSEMBLER
+        #define USE_COREDISTOOLS_DISASSEMBLER 1
+    #elif defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+        #undef USE_MSVC_DISASSEMBLER
+        #define USE_MSVC_DISASSEMBLER 1
+    #endif // defined(FEATURE_CORECLR) || defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+#endif // HAVE_GCCOVER
+
+#if USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+    #define USE_DISASSEMBLER 1
+#else
+    #define USE_DISASSEMBLER 0
+#endif
+
+#if USE_DISASSEMBLER
+
+#if USE_MSVC_DISASSEMBLER
+#undef free
+
+// This pragma is needed because public\vc\inc\xiosbase contains
+// a static local variable
+#pragma warning(disable : 4640)
+#include "msvcdis.h"
+#pragma warning(default : 4640)
+
+#include "disx86.h"
+
+#define free(memblock) Use_free(memblock)
+#endif // USE_MSVC_DISASSEMBLER
+
+enum class InstructionType : UINT8
+{
+    Unknown,
+    Call_DirectUnconditional,
+    Call_IndirectUnconditional,
+    Branch_IndirectUnconditional
+};
+
+class InstructionInfo;
+
+// Wraps the MSVC disassembler or the coredistools disassembler
+class Disassembler
+{
+#if USE_COREDISTOOLS_DISASSEMBLER
+private:
+    class CorDisasm;
+    typedef CorDisasm ExternalDisassembler;
+#elif USE_MSVC_DISASSEMBLER
+private:
+    typedef DIS ExternalDisassembler;
+#endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+
+#if defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+public:
+    static bool IsRexPrefix(UINT8 potentialRexByte);
+    static UINT8 DecodeModFromModRm(UINT8 modRm);
+    static UINT8 DecodeRegOrOpCodeFromModRm(UINT8 modRm);
+    static UINT8 DecodeRmFromModRm(UINT8 modRm);
+#endif // defined(_TARGET_AMD64_) || defined(_TARGET_X86_)
+
+public:
+    static bool IsAvailable();
+    static void StaticInitialize();
+    static void StaticClose();
+
+public:
+    Disassembler();
+    ~Disassembler();
+
+public:
+    SIZE_T DisassembleInstruction(const UINT8 *code, SIZE_T codeLength, InstructionType *instructionTypeRef) const;
+    static InstructionType DetermineInstructionType(
+    #if USE_COREDISTOOLS_DISASSEMBLER
+        const UINT8 *instructionCode, SIZE_T instructionCodeLength
+    #elif USE_MSVC_DISASSEMBLER
+        ExternalDisassembler::TRMT terminationType
+    #endif // USE_COREDISTOOLS_DISASSEMBLER || USE_MSVC_DISASSEMBLER
+        );
+
+#if USE_COREDISTOOLS_DISASSEMBLER
+private:
+    static HMODULE s_libraryHandle;
+
+    // 'coredistools' library exports
+private:
+
+    enum TargetArch {
+      Target_Host, // Target is the same as host architecture
+      Target_X86,
+      Target_X64,
+      Target_Thumb,
+      Target_Arm64
+    };
+
+    static CorDisasm *(*External_InitDisasm)(enum TargetArch Target);
+    static SIZE_T (*External_DisasmInstruction)(const CorDisasm *Disasm, size_t Address,
+                                  const uint8_t *Bytes, size_t Maxlength,
+                                  bool PrintAssembly);
+    static void (*External_FinishDisasm)(const CorDisasm *Disasm);
+#endif // USE_COREDISTOOLS_DISASSEMBLER
+
+private:
+    static ExternalDisassembler *s_availableExternalDisassembler;
+    ExternalDisassembler *m_externalDisassembler;
+};
+
+#endif // USE_DISASSEMBLER
+#endif // __DISASSEMBLER_H__

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -7097,7 +7097,24 @@ bool IsInterceptableException(Thread *pThread)
             );
 }
 
-// Did we hit an DO_A_GC_HERE marker in JITTed code?
+// Determines whether we hit an DO_A_GC_HERE marker in JITted code, and returns the 
+// appropriate exception code, or zero if the code is not a GC marker.
+DWORD GetGcMarkerExceptionCode(LPVOID ip)
+{
+#if defined(HAVE_GCCOVER) && defined(FEATURE_CORECLR)
+    WRAPPER_NO_CONTRACT;
+
+    if (GCStress<cfg_any>::IsEnabled() && IsGcCoverageInterrupt(ip))
+    {
+        return STATUS_CLR_GCCOVER_CODE;
+    }
+#else // !(defined(HAVE_GCCOVER) && defined(FEATURE_CORECLR))
+    LIMITED_METHOD_CONTRACT;
+#endif // defined(HAVE_GCCOVER) && defined(FEATURE_CORECLR)
+    return 0;
+}
+
+// Did we hit an DO_A_GC_HERE marker in JITted code?
 bool IsGcMarker(DWORD exceptionCode, CONTEXT *pContext)
 {
 #ifdef HAVE_GCCOVER

--- a/src/vm/excep.h
+++ b/src/vm/excep.h
@@ -769,6 +769,7 @@ LONG NotifyDebuggerLastChance(Thread *pThread,
 void CPFH_AdjustContextForThreadSuspensionRace(T_CONTEXT *pContext, Thread *pThread);
 #endif // _TARGET_X86_
 
+DWORD GetGcMarkerExceptionCode(LPVOID ip);
 bool IsGcMarker(DWORD exceptionCode, T_CONTEXT *pContext);
 
 void InitSavedExceptionInfo();

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -14404,15 +14404,23 @@ LPVOID                EECodeInfo::findNextFunclet (LPVOID pvFuncletStart, SIZE_T
 
     while (cbCode > 0)
     {
+        PRUNTIME_FUNCTION   pFunctionEntry;
+        ULONGLONG           uImageBase;
+#ifdef FEATURE_PAL
+        EECodeInfo codeInfo;
+        codeInfo.Init((PCODE)pvFuncletStart);
+        pFunctionEntry = codeInfo.GetFunctionEntry();
+        uImageBase = (ULONGLONG)codeInfo.GetModuleBase();
+#else // !FEATURE_PAL
         //
         // This is GCStress debug only - use the slow OS APIs to enumerate funclets
         //
 
-        ULONGLONG           uImageBase;
-        PRUNTIME_FUNCTION pFunctionEntry = (PRUNTIME_FUNCTION) RtlLookupFunctionEntry((ULONGLONG)pvFuncletStart,
-                                                &uImageBase
-                                                AMD64_ARG(NULL)
-                                                );
+        pFunctionEntry = (PRUNTIME_FUNCTION) RtlLookupFunctionEntry((ULONGLONG)pvFuncletStart,
+                              &uImageBase
+                              AMD64_ARG(NULL)
+                              );
+#endif
 
         if (pFunctionEntry != NULL)
         {

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -1614,6 +1614,7 @@ void *GenFastGetSharedStaticBase(bool bCheckCCtor);
 #ifdef HAVE_GCCOVER
 void SetupGcCoverage(MethodDesc* pMD, BYTE* nativeCode);
 void SetupGcCoverageForNativeImage(Module* module);
+bool IsGcCoverageInterrupt(LPVOID ip);
 BOOL OnGcCoverageInterrupt(PT_CONTEXT regs);
 void DoGcStress (PT_CONTEXT regs, MethodDesc *pMD);
 #endif //HAVE_GCCOVER


### PR DESCRIPTION
This change addresses #2583 and enables us to run GCStress 0xC (GC on every allowable JITted or NGEN'd instruction) on Windows and Linux.
 
Note that it depends on a disassembler library that will be delivered by the JIT team but has not yet been published on GitHub.

This work is still being tested, so please do not merge it yet.