### PR TITLE
Add ready to run support to unix crossgen

### DIFF
--- a/crossgen.cmake
+++ b/crossgen.cmake
@@ -19,10 +19,11 @@ remove_definitions(
 
 if(WIN32)
     add_definitions(-MT)
-    if(FEATURE_READYTORUN)
-        add_definitions(-DFEATURE_READYTORUN_COMPILER)
-    endif(FEATURE_READYTORUN)
 endif(WIN32)
+
+if(FEATURE_READYTORUN)
+    add_definitions(-DFEATURE_READYTORUN_COMPILER)
+endif(FEATURE_READYTORUN)
 
 if(CLR_CMAKE_PLATFORM_LINUX)
     add_definitions(-DFEATURE_PERFMAP)

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -685,6 +685,8 @@ enum CORCOMPILE_GCREFMAP_TOKENS
 // Tags for fixup blobs
 enum CORCOMPILE_FIXUP_BLOB_KIND
 {
+    ENCODE_NONE                 = 0,
+    
     ENCODE_MODULE_OVERRIDE      = 0x80,             /* When the high bit is set, override of the module immediately follows */
 
     ENCODE_TYPE_HANDLE          = 0x10,             /* Type handle */

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -2543,12 +2543,12 @@ CORCOMPILE_FIXUP_BLOB_KIND CEECompileInfo::GetFieldBaseOffset(
 
     if (pMT->IsValueType())
     {
-        return (CORCOMPILE_FIXUP_BLOB_KIND)0;
+        return ENCODE_NONE;
     }
 
     if (pMT->GetParentMethodTable()->IsInheritanceChainLayoutFixedInCurrentVersionBubble())
     {
-        return (CORCOMPILE_FIXUP_BLOB_KIND)0;
+        return ENCODE_NONE;
     }
 
     if (pMT->HasLayout())

--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2615,7 +2615,7 @@ extern "C" SIZE_T STDCALL DynamicHelperWorker(TransitionBlock * pTransitionBlock
     TypeHandle th;
     MethodDesc * pMD = NULL;
     FieldDesc * pFD = NULL;
-    CORCOMPILE_FIXUP_BLOB_KIND kind = (CORCOMPILE_FIXUP_BLOB_KIND)0;
+    CORCOMPILE_FIXUP_BLOB_KIND kind = ENCODE_NONE;
 
     {
         GCX_PREEMP_THREAD_EXISTS(CURRENT_THREAD);

--- a/src/zap/crossgen/CMakeLists.txt
+++ b/src/zap/crossgen/CMakeLists.txt
@@ -17,12 +17,12 @@ set(ZAP_SOURCES
     ../nativeformatwriter.cpp
 )
 
-if (WIN32 AND FEATURE_READYTORUN)
+if (FEATURE_READYTORUN)
     list(APPEND ZAP_SOURCES
         ../zapreadytorun.cpp
         ../nativeformatwriter.cpp
     )
-endif (WIN32 AND FEATURE_READYTORUN)
+endif (FEATURE_READYTORUN)
 
 add_precompiled_header(common.h ../common.cpp ZAP_SOURCES)
 add_library(corzap_crossgen STATIC ${ZAP_SOURCES})

--- a/src/zap/zapimport.cpp
+++ b/src/zap/zapimport.cpp
@@ -677,7 +677,7 @@ void ZapImportSectionSignatures::PlaceStubDispatchCell(ZapImport * pImport)
     {
         // Create the delay load helper
         ReadyToRunHelper helper = (ReadyToRunHelper)(READYTORUN_HELPER_DelayLoad_MethodCall | READYTORUN_HELPER_FLAG_VSD);
-        ZapNode * pDelayLoadHelper = m_pImage->GetImportTable()->GetPlacedIndirectHelperThunk(helper, (PVOID)m_dwIndex);
+        ZapNode * pDelayLoadHelper = m_pImage->GetImportTable()->GetPlacedIndirectHelperThunk(helper, (PVOID)(SIZE_T)m_dwIndex);
         pCell->SetDelayLoadHelper(pDelayLoadHelper);
     }
     else
@@ -778,7 +778,7 @@ void ZapImportSectionSignatures::PlaceExternalMethodCell(ZapImport * pImport)
     if (IsReadyToRunCompilation())
     {
         // Create the delay load helper
-        ZapNode * pDelayLoadHelper = m_pImage->GetImportTable()->GetPlacedIndirectHelperThunk(READYTORUN_HELPER_DelayLoad_MethodCall, (PVOID)m_dwIndex);
+        ZapNode * pDelayLoadHelper = m_pImage->GetImportTable()->GetPlacedIndirectHelperThunk(READYTORUN_HELPER_DelayLoad_MethodCall, (PVOID)(SIZE_T)m_dwIndex);
         pCell->SetDelayLoadHelper(pDelayLoadHelper);
     }
     else
@@ -1777,7 +1777,7 @@ void ZapImportSectionSignatures::PlaceDynamicHelperCell(ZapImport * pImport)
     ReadyToRunHelper helperNum = GetDelayLoadHelperForDynamicHelper(
         (CORCOMPILE_FIXUP_BLOB_KIND)(pCell->GetKind() & ~CORINFO_HELP_READYTORUN_ATYPICAL_CALLSITE));
 
-    ZapNode * pDelayLoadHelper = m_pImage->GetImportTable()->GetPlacedIndirectHelperThunk(helperNum, (PVOID)m_dwIndex, 
+    ZapNode * pDelayLoadHelper = m_pImage->GetImportTable()->GetPlacedIndirectHelperThunk(helperNum, (PVOID)(SIZE_T)m_dwIndex, 
         (pCell->GetKind() & CORINFO_HELP_READYTORUN_ATYPICAL_CALLSITE) ? pCell : NULL);
 
     pCell->SetDelayLoadHelper(pDelayLoadHelper);
@@ -1901,6 +1901,7 @@ public:
     }
 };
 
+#ifdef _TARGET_ARM_
 static void MovRegImm(BYTE* p, int reg)
 {
     *(WORD *)(p + 0) = 0xF240;
@@ -1908,6 +1909,7 @@ static void MovRegImm(BYTE* p, int reg)
     *(WORD *)(p + 4) = 0xF2C0;
     *(WORD *)(p + 6) = (UINT16)(reg << 8);
 }
+#endif // _TARGET_ARM_
 
 DWORD ZapIndirectHelperThunk::SaveWorker(ZapWriter * pZapWriter)
 {

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3680,7 +3680,7 @@ void ZapInfo::getFieldInfo (CORINFO_RESOLVED_TOKEN * pResolvedToken,
                     }
                     break;
 
-                case (CORCOMPILE_FIXUP_BLOB_KIND)0:
+                case ENCODE_NONE:
                     break;
 
                 default:

--- a/src/zap/zapreadytorun.cpp
+++ b/src/zap/zapreadytorun.cpp
@@ -343,71 +343,71 @@ void ZapImage::OutputDebugInfoForReadyToRun()
 //
 static_assert_no_msg(sizeof(READYTORUN_IMPORT_SECTION)          == sizeof(CORCOMPILE_IMPORT_SECTION));
 
-static_assert_no_msg(READYTORUN_IMPORT_SECTION_TYPE_UNKNOWN     == CORCOMPILE_IMPORT_TYPE_UNKNOWN);
+static_assert_no_msg((int)READYTORUN_IMPORT_SECTION_TYPE_UNKNOWN     == (int)CORCOMPILE_IMPORT_TYPE_UNKNOWN);
 
-static_assert_no_msg(READYTORUN_IMPORT_SECTION_FLAGS_EAGER      == CORCOMPILE_IMPORT_FLAGS_EAGER);
+static_assert_no_msg((int)READYTORUN_IMPORT_SECTION_FLAGS_EAGER      == (int)CORCOMPILE_IMPORT_FLAGS_EAGER);
 
 //
 // READYTORUN_METHOD_SIG
 //
-static_assert_no_msg(READYTORUN_METHOD_SIG_UnboxingStub         == ENCODE_METHOD_SIG_UnboxingStub);
-static_assert_no_msg(READYTORUN_METHOD_SIG_InstantiatingStub    == ENCODE_METHOD_SIG_InstantiatingStub);
-static_assert_no_msg(READYTORUN_METHOD_SIG_MethodInstantiation  == ENCODE_METHOD_SIG_MethodInstantiation);
-static_assert_no_msg(READYTORUN_METHOD_SIG_SlotInsteadOfToken   == ENCODE_METHOD_SIG_SlotInsteadOfToken);
-static_assert_no_msg(READYTORUN_METHOD_SIG_MemberRefToken       == ENCODE_METHOD_SIG_MemberRefToken);
-static_assert_no_msg(READYTORUN_METHOD_SIG_Constrained          == ENCODE_METHOD_SIG_Constrained);
-static_assert_no_msg(READYTORUN_METHOD_SIG_OwnerType            == ENCODE_METHOD_SIG_OwnerType);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_UnboxingStub         == (int)ENCODE_METHOD_SIG_UnboxingStub);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_InstantiatingStub    == (int)ENCODE_METHOD_SIG_InstantiatingStub);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_MethodInstantiation  == (int)ENCODE_METHOD_SIG_MethodInstantiation);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_SlotInsteadOfToken   == (int)ENCODE_METHOD_SIG_SlotInsteadOfToken);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_MemberRefToken       == (int)ENCODE_METHOD_SIG_MemberRefToken);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_Constrained          == (int)ENCODE_METHOD_SIG_Constrained);
+static_assert_no_msg((int)READYTORUN_METHOD_SIG_OwnerType            == (int)ENCODE_METHOD_SIG_OwnerType);
 
 //
 // READYTORUN_FIELD_SIG
 //
-static_assert_no_msg(READYTORUN_FIELD_SIG_IndexInsteadOfToken   == ENCODE_FIELD_SIG_IndexInsteadOfToken);
-static_assert_no_msg(READYTORUN_FIELD_SIG_MemberRefToken        == ENCODE_FIELD_SIG_MemberRefToken);
-static_assert_no_msg(READYTORUN_FIELD_SIG_OwnerType             == ENCODE_FIELD_SIG_OwnerType);
+static_assert_no_msg((int)READYTORUN_FIELD_SIG_IndexInsteadOfToken   == (int)ENCODE_FIELD_SIG_IndexInsteadOfToken);
+static_assert_no_msg((int)READYTORUN_FIELD_SIG_MemberRefToken        == (int)ENCODE_FIELD_SIG_MemberRefToken);
+static_assert_no_msg((int)READYTORUN_FIELD_SIG_OwnerType             == (int)ENCODE_FIELD_SIG_OwnerType);
 
 //
 // READYTORUN_FIXUP
 //
-static_assert_no_msg(READYTORUN_FIXUP_TypeHandle                == ENCODE_TYPE_HANDLE);
-static_assert_no_msg(READYTORUN_FIXUP_MethodHandle              == ENCODE_METHOD_HANDLE);
-static_assert_no_msg(READYTORUN_FIXUP_FieldHandle               == ENCODE_FIELD_HANDLE);
+static_assert_no_msg((int)READYTORUN_FIXUP_TypeHandle                == (int)ENCODE_TYPE_HANDLE);
+static_assert_no_msg((int)READYTORUN_FIXUP_MethodHandle              == (int)ENCODE_METHOD_HANDLE);
+static_assert_no_msg((int)READYTORUN_FIXUP_FieldHandle               == (int)ENCODE_FIELD_HANDLE);
 
-static_assert_no_msg(READYTORUN_FIXUP_MethodEntry               == ENCODE_METHOD_ENTRY);
-static_assert_no_msg(READYTORUN_FIXUP_MethodEntry_DefToken      == ENCODE_METHOD_ENTRY_DEF_TOKEN);
-static_assert_no_msg(READYTORUN_FIXUP_MethodEntry_RefToken      == ENCODE_METHOD_ENTRY_REF_TOKEN);
+static_assert_no_msg((int)READYTORUN_FIXUP_MethodEntry               == (int)ENCODE_METHOD_ENTRY);
+static_assert_no_msg((int)READYTORUN_FIXUP_MethodEntry_DefToken      == (int)ENCODE_METHOD_ENTRY_DEF_TOKEN);
+static_assert_no_msg((int)READYTORUN_FIXUP_MethodEntry_RefToken      == (int)ENCODE_METHOD_ENTRY_REF_TOKEN);
 
-static_assert_no_msg(READYTORUN_FIXUP_VirtualEntry              == ENCODE_VIRTUAL_ENTRY);
-static_assert_no_msg(READYTORUN_FIXUP_VirtualEntry_DefToken     == ENCODE_VIRTUAL_ENTRY_DEF_TOKEN);
-static_assert_no_msg(READYTORUN_FIXUP_VirtualEntry_RefToken     == ENCODE_VIRTUAL_ENTRY_REF_TOKEN);
-static_assert_no_msg(READYTORUN_FIXUP_VirtualEntry_Slot         == ENCODE_VIRTUAL_ENTRY_SLOT);
+static_assert_no_msg((int)READYTORUN_FIXUP_VirtualEntry              == (int)ENCODE_VIRTUAL_ENTRY);
+static_assert_no_msg((int)READYTORUN_FIXUP_VirtualEntry_DefToken     == (int)ENCODE_VIRTUAL_ENTRY_DEF_TOKEN);
+static_assert_no_msg((int)READYTORUN_FIXUP_VirtualEntry_RefToken     == (int)ENCODE_VIRTUAL_ENTRY_REF_TOKEN);
+static_assert_no_msg((int)READYTORUN_FIXUP_VirtualEntry_Slot         == (int)ENCODE_VIRTUAL_ENTRY_SLOT);
 
-static_assert_no_msg(READYTORUN_FIXUP_Helper                    == ENCODE_READYTORUN_HELPER);
-static_assert_no_msg(READYTORUN_FIXUP_StringHandle              == ENCODE_STRING_HANDLE);
+static_assert_no_msg((int)READYTORUN_FIXUP_Helper                    == (int)ENCODE_READYTORUN_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_StringHandle              == (int)ENCODE_STRING_HANDLE);
 
-static_assert_no_msg(READYTORUN_FIXUP_NewObject                  == ENCODE_NEW_HELPER);
-static_assert_no_msg(READYTORUN_FIXUP_NewArray                   == ENCODE_NEW_ARRAY_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_NewObject                  == (int)ENCODE_NEW_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_NewArray                   == (int)ENCODE_NEW_ARRAY_HELPER);
 
-static_assert_no_msg(READYTORUN_FIXUP_IsInstanceOf               == ENCODE_ISINSTANCEOF_HELPER);
-static_assert_no_msg(READYTORUN_FIXUP_ChkCast                    == ENCODE_CHKCAST_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_IsInstanceOf               == (int)ENCODE_ISINSTANCEOF_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_ChkCast                    == (int)ENCODE_CHKCAST_HELPER);
 
-static_assert_no_msg(READYTORUN_FIXUP_FieldAddress               == ENCODE_FIELD_ADDRESS);
-static_assert_no_msg(READYTORUN_FIXUP_CctorTrigger               == ENCODE_CCTOR_TRIGGER);
+static_assert_no_msg((int)READYTORUN_FIXUP_FieldAddress               == (int)ENCODE_FIELD_ADDRESS);
+static_assert_no_msg((int)READYTORUN_FIXUP_CctorTrigger               == (int)ENCODE_CCTOR_TRIGGER);
 
-static_assert_no_msg(READYTORUN_FIXUP_StaticBaseNonGC            == ENCODE_STATIC_BASE_NONGC_HELPER);
-static_assert_no_msg(READYTORUN_FIXUP_StaticBaseGC               == ENCODE_STATIC_BASE_GC_HELPER);
-static_assert_no_msg(READYTORUN_FIXUP_ThreadStaticBaseNonGC      == ENCODE_THREAD_STATIC_BASE_NONGC_HELPER);
-static_assert_no_msg(READYTORUN_FIXUP_ThreadStaticBaseGC         == ENCODE_THREAD_STATIC_BASE_GC_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_StaticBaseNonGC            == (int)ENCODE_STATIC_BASE_NONGC_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_StaticBaseGC               == (int)ENCODE_STATIC_BASE_GC_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_ThreadStaticBaseNonGC      == (int)ENCODE_THREAD_STATIC_BASE_NONGC_HELPER);
+static_assert_no_msg((int)READYTORUN_FIXUP_ThreadStaticBaseGC         == (int)ENCODE_THREAD_STATIC_BASE_GC_HELPER);
 
-static_assert_no_msg(READYTORUN_FIXUP_FieldBaseOffset            == ENCODE_FIELD_BASE_OFFSET);
-static_assert_no_msg(READYTORUN_FIXUP_FieldOffset                == ENCODE_FIELD_OFFSET);
+static_assert_no_msg((int)READYTORUN_FIXUP_FieldBaseOffset            == (int)ENCODE_FIELD_BASE_OFFSET);
+static_assert_no_msg((int)READYTORUN_FIXUP_FieldOffset                == (int)ENCODE_FIELD_OFFSET);
 
-static_assert_no_msg(READYTORUN_FIXUP_TypeDictionary             == ENCODE_TYPE_DICTIONARY);
-static_assert_no_msg(READYTORUN_FIXUP_MethodDictionary           == ENCODE_METHOD_DICTIONARY);
+static_assert_no_msg((int)READYTORUN_FIXUP_TypeDictionary             == (int)ENCODE_TYPE_DICTIONARY);
+static_assert_no_msg((int)READYTORUN_FIXUP_MethodDictionary           == (int)ENCODE_METHOD_DICTIONARY);
 
-static_assert_no_msg(READYTORUN_FIXUP_Check_TypeLayout           == ENCODE_CHECK_TYPE_LAYOUT);
-static_assert_no_msg(READYTORUN_FIXUP_Check_FieldOffset          == ENCODE_CHECK_FIELD_OFFSET);
+static_assert_no_msg((int)READYTORUN_FIXUP_Check_TypeLayout           == (int)ENCODE_CHECK_TYPE_LAYOUT);
+static_assert_no_msg((int)READYTORUN_FIXUP_Check_FieldOffset          == (int)ENCODE_CHECK_FIELD_OFFSET);
 
-static_assert_no_msg(READYTORUN_FIXUP_DelegateCtor               == ENCODE_DELEGATE_CTOR);
+static_assert_no_msg((int)READYTORUN_FIXUP_DelegateCtor               == (int)ENCODE_DELEGATE_CTOR);
 
 //
 // READYTORUN_EXCEPTION


### PR DESCRIPTION
This change enables ready to run support in the unix crossgen that was accidentally
not enabled when adding ready to run support for Unix in the past. Only the
FEATURE_READYTORUN was set, but not the FEATURE_READYTORUN_COMPILER.