### PR TITLE
Allow some ITaskCompletionActions to always run synchronously

### DIFF
--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -685,6 +685,8 @@ namespace System.IO {
                     using(context) ExecutionContext.Run(context, invokeAsyncCallback, this, true);
                 }
             }
+
+            bool ITaskCompletionAction.InvokeMayRunArbitraryCode { get { return true; } }
         }
 #endif
 

--- a/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/TaskFactory.cs
@@ -1668,6 +1668,8 @@ namespace System.Threading.Tasks
                 Contract.Assert(_count >= 0, "Count should never go below 0");
             }
 
+            public bool InvokeMayRunArbitraryCode { get { return true; } }
+
             /// <summary>
             /// Returns whether we should notify the debugger of a wait completion.  This returns 
             /// true iff at least one constituent task has its bit set.
@@ -1745,6 +1747,8 @@ namespace System.Threading.Tasks
                 }
                 Contract.Assert(_count >= 0, "Count should never go below 0");
             }
+
+            public bool InvokeMayRunArbitraryCode { get { return true; } }
 
             /// <summary>
             /// Returns whether we should notify the debugger of a wait completion.  This returns 
@@ -2462,6 +2466,8 @@ namespace System.Threading.Tasks
 
                 }
             }
+
+            public bool InvokeMayRunArbitraryCode { get { return true; } }
         }
         // Common ContinueWhenAny logic
         // If the tasks list is not an array, it must be an internal defensive copy so that 


### PR DESCRIPTION
A few internal Task completion actions do a known and small quantity of work, without any potential to run arbitrary code, e.g. a completion action used in Task.Wait to set a ManualResetEventSlim.  Such actions used to typically run synchronously, but after https://github.com/dotnet/coreclr/pull/2026 can be forced to run asynchronously.  These few actions are considered purely internal implementation details of TPL, need not be subject to forcing continuations to run asynchronously, and have perf benefits to always being run synchronously, e.g. calling Wait on a RunContinuationsAsynchronously task shouldn't require a work item to be queued to unblock the task.

This commit adds a property to ITaskCompletionAction that we can check to determine whether it's ok to force the continuation to run synchronously even if the system says we should be running all continuations asynchronously.  Only those actions which are safe are annotated as such.  We only invoke this interface property getter in cases where we're about to fall back to allocating and queueing a work item, so the cost of the extra interface call is acceptable for the benefits it provides.  As all of this is internal, it can also be tweaked further in the future.

Fixes https://github.com/dotnet/coreclr/issues/2712
cc: @AlfredoMS, @mellinoe 