### PR TITLE
Several Stream.Read/WriteAsync improvements

### DIFF
--- a/src/mscorlib/src/System/IO/FileStream.cs
+++ b/src/mscorlib/src/System/IO/FileStream.cs
@@ -1778,9 +1778,6 @@ namespace System.IO {
             return;
         }
 
-#if FEATURE_CORECLR
-        internal override bool OverridesBeginEnd { get { return true; } }
-#endif
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [HostProtection(ExternalThreading = true)]

--- a/src/mscorlib/src/System/IO/FileStream.cs
+++ b/src/mscorlib/src/System/IO/FileStream.cs
@@ -1778,6 +1778,9 @@ namespace System.IO {
             return;
         }
 
+#if FEATURE_CORECLR
+        internal override bool OverridesBeginEnd { get { return true; } }
+#endif
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         [HostProtection(ExternalThreading = true)]

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -285,15 +285,29 @@ namespace System.IO {
             return new ManualResetEvent(false);
         }
 
-        [HostProtection(ExternalThreading=true)]
+        internal virtual bool OverridesBeginEnd 
+        { 
+            get 
+            {
+#if FEATURE_CORECLR
+                return false; // methods aren't exposed outside of mscorlib
+#else
+                return true; // have to assume they are overridden as they're exposed
+#endif
+            }
+        }
+
+            [HostProtection(ExternalThreading=true)]
         public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, Object state)
         {
             Contract.Ensures(Contract.Result<IAsyncResult>() != null);
-            return BeginReadInternal(buffer, offset, count, callback, state, serializeAsynchronously: false);
+            return BeginReadInternal(buffer, offset, count, callback, state, serializeAsynchronously: false, apm: true);
         }
 
         [HostProtection(ExternalThreading = true)]
-        internal IAsyncResult BeginReadInternal(byte[] buffer, int offset, int count, AsyncCallback callback, Object state, bool serializeAsynchronously)
+        internal IAsyncResult BeginReadInternal(
+            byte[] buffer, int offset, int count, AsyncCallback callback, Object state, 
+            bool serializeAsynchronously, bool apm)
         {
             Contract.Ensures(Contract.Result<IAsyncResult>() != null);
             if (!CanRead) __Error.ReadNotSupported();
@@ -326,7 +340,7 @@ namespace System.IO {
 
             // Create the task to asynchronously do a Read.  This task serves both
             // as the asynchronous work item and as the IAsyncResult returned to the user.
-            var asyncResult = new ReadWriteTask(true /*isRead*/, delegate
+            var asyncResult = new ReadWriteTask(true /*isRead*/, apm, delegate
             {
                 // The ReadWriteTask stores all of the parameters to pass to Read.
                 // As we're currently inside of it, we can get the current task
@@ -334,10 +348,23 @@ namespace System.IO {
                 var thisTask = Task.InternalCurrent as ReadWriteTask;
                 Contract.Assert(thisTask != null, "Inside ReadWriteTask, InternalCurrent should be the ReadWriteTask");
 
-                // Do the Read and return the number of bytes read
-                var bytesRead = thisTask._stream.Read(thisTask._buffer, thisTask._offset, thisTask._count);
-                thisTask.ClearBeginState(); // just to help alleviate some memory pressure
-                return bytesRead;
+                try
+                {
+                    // Do the Read and return the number of bytes read
+                    return thisTask._stream.Read(thisTask._buffer, thisTask._offset, thisTask._count);
+                }
+                finally
+                {
+                    // If this implementation is part of Begin/EndXx, then the EndXx method will handle
+                    // finishing the async operation.  However, if this is part of XxAsync, then there won't
+                    // be an end method, and this task is responsible for cleaning up.
+                    if (!thisTask._apm)
+                    {
+                        thisTask._stream.FinishTrackingAsyncOperation();
+                    }
+      
+                    thisTask.ClearBeginState(); // just to help alleviate some memory pressure
+                }
             }, state, this, buffer, offset, count, callback);
 
             // Schedule it
@@ -388,9 +415,7 @@ namespace System.IO {
             }
             finally
             {
-                _activeReadWriteTask = null;
-                Contract.Assert(_asyncActiveSemaphore != null, "Must have been initialized in order to get here.");
-                _asyncActiveSemaphore.Release();
+                FinishTrackingAsyncOperation();
             }
 #endif
         }
@@ -414,7 +439,12 @@ namespace System.IO {
         }
 
         private Task<Int32> BeginEndReadAsync(Byte[] buffer, Int32 offset, Int32 count)
-        {            
+        {
+            if (!OverridesBeginEnd)
+            {
+                return (Task<Int32>)BeginReadInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+            }
+
             return TaskFactory<Int32>.FromAsyncTrim(
                         this, new ReadWriteParameters { Buffer = buffer, Offset = offset, Count = count },
                         (stream, args, callback, state) => stream.BeginRead(args.Buffer, args.Offset, args.Count, callback, state), // cached by compiler
@@ -434,11 +464,13 @@ namespace System.IO {
         public virtual IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, Object state)
         {
             Contract.Ensures(Contract.Result<IAsyncResult>() != null);
-            return BeginWriteInternal(buffer, offset, count, callback, state, serializeAsynchronously: false);
+            return BeginWriteInternal(buffer, offset, count, callback, state, serializeAsynchronously: false, apm: true);
         }
 
         [HostProtection(ExternalThreading = true)]
-        internal IAsyncResult BeginWriteInternal(byte[] buffer, int offset, int count, AsyncCallback callback, Object state, bool serializeAsynchronously)
+        internal IAsyncResult BeginWriteInternal(
+            byte[] buffer, int offset, int count, AsyncCallback callback, Object state, 
+            bool serializeAsynchronously, bool apm)
         {
             Contract.Ensures(Contract.Result<IAsyncResult>() != null);
             if (!CanWrite) __Error.WriteNotSupported();
@@ -470,7 +502,7 @@ namespace System.IO {
 
             // Create the task to asynchronously do a Write.  This task serves both
             // as the asynchronous work item and as the IAsyncResult returned to the user.
-            var asyncResult = new ReadWriteTask(false /*isRead*/, delegate
+            var asyncResult = new ReadWriteTask(false /*isRead*/, apm, delegate
             {
                 // The ReadWriteTask stores all of the parameters to pass to Write.
                 // As we're currently inside of it, we can get the current task
@@ -478,10 +510,24 @@ namespace System.IO {
                 var thisTask = Task.InternalCurrent as ReadWriteTask;
                 Contract.Assert(thisTask != null, "Inside ReadWriteTask, InternalCurrent should be the ReadWriteTask");
 
-                // Do the Write
-                thisTask._stream.Write(thisTask._buffer, thisTask._offset, thisTask._count);  
-                thisTask.ClearBeginState(); // just to help alleviate some memory pressure
-                return 0; // not used, but signature requires a value be returned
+                try
+                {
+                    // Do the Write
+                    thisTask._stream.Write(thisTask._buffer, thisTask._offset, thisTask._count);  
+                    return 0; // not used, but signature requires a value be returned
+                }
+                finally
+                {
+                    // If this implementation is part of Begin/EndXx, then the EndXx method will handle
+                    // finishing the async operation.  However, if this is part of XxAsync, then there won't
+                    // be an end method, and this task is responsible for cleaning up.
+                    if (!thisTask._apm)
+                    {
+                        thisTask._stream.FinishTrackingAsyncOperation();
+                    }
+
+                    thisTask.ClearBeginState(); // just to help alleviate some memory pressure
+                }
             }, state, this, buffer, offset, count, callback);
 
             // Schedule it
@@ -534,6 +580,13 @@ namespace System.IO {
             readWriteTask.m_taskScheduler = TaskScheduler.Default;
             readWriteTask.ScheduleAndStart(needsProtection: false);
         }
+
+        private void FinishTrackingAsyncOperation()
+        {
+             _activeReadWriteTask = null;
+            Contract.Assert(_asyncActiveSemaphore != null, "Must have been initialized in order to get here.");
+            _asyncActiveSemaphore.Release();
+        }
 #endif
 
         public virtual void EndWrite(IAsyncResult asyncResult)
@@ -574,9 +627,7 @@ namespace System.IO {
             }
             finally
             {
-                _activeReadWriteTask = null;
-                Contract.Assert(_asyncActiveSemaphore != null, "Must have been initialized in order to get here.");
-                _asyncActiveSemaphore.Release();
+                FinishTrackingAsyncOperation();
             }
 #endif
         }
@@ -600,7 +651,8 @@ namespace System.IO {
         // with a single allocation.
         private sealed class ReadWriteTask : Task<int>, ITaskCompletionAction
         {
-            internal readonly bool _isRead;
+            internal readonly bool _isRead; 
+            internal readonly bool _apm; // true if this is from Begin/EndXx; false if it's from XxAsync
             internal Stream _stream;
             internal byte [] _buffer;
             internal int _offset;
@@ -618,6 +670,7 @@ namespace System.IO {
             [MethodImpl(MethodImplOptions.NoInlining)]
             public ReadWriteTask(
                 bool isRead,
+                bool apm,
                 Func<object,int> function, object state,
                 Stream stream, byte[] buffer, int offset, int count, AsyncCallback callback) :
                 base(function, state, CancellationToken.None, TaskCreationOptions.DenyChildAttach)
@@ -631,6 +684,7 @@ namespace System.IO {
 
                 // Store the arguments
                 _isRead = isRead;
+                _apm = apm;
                 _stream = stream;
                 _buffer = buffer;
                 _offset = offset;
@@ -710,7 +764,12 @@ namespace System.IO {
 
 
         private Task BeginEndWriteAsync(Byte[] buffer, Int32 offset, Int32 count)
-        {            
+        {
+            if (!OverridesBeginEnd)
+            {
+                return (Task)BeginWriteInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
+            }
+
             return TaskFactory<VoidTaskResult>.FromAsyncTrim(
                         this, new ReadWriteParameters { Buffer=buffer, Offset=offset, Count=count },
                         (stream, args, callback, state) => stream.BeginWrite(args.Buffer, args.Offset, args.Count, callback, state), // cached by compiler
@@ -1222,7 +1281,7 @@ namespace System.IO {
                     // _stream due to this call blocked while holding the lock.
                     return _overridesBeginRead.Value ?
                         _stream.BeginRead(buffer, offset, count, callback, state) :
-                        _stream.BeginReadInternal(buffer, offset, count, callback, state, serializeAsynchronously: true);
+                        _stream.BeginReadInternal(buffer, offset, count, callback, state, serializeAsynchronously: true, apm: true);
                 }
             }
         
@@ -1280,7 +1339,7 @@ namespace System.IO {
                     // _stream due to this call blocked while holding the lock.
                     return _overridesBeginWrite.Value ?
                         _stream.BeginWrite(buffer, offset, count, callback, state) :
-                        _stream.BeginWriteInternal(buffer, offset, count, callback, state, serializeAsynchronously: true);
+                        _stream.BeginWriteInternal(buffer, offset, count, callback, state, serializeAsynchronously: true, apm: true);
                 }
             }
             

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -285,19 +285,7 @@ namespace System.IO {
             return new ManualResetEvent(false);
         }
 
-        internal virtual bool OverridesBeginEnd 
-        { 
-            get 
-            {
-#if FEATURE_CORECLR
-                return false; // methods aren't exposed outside of mscorlib
-#else
-                return true; // have to assume they are overridden as they're exposed
-#endif
-            }
-        }
-
-            [HostProtection(ExternalThreading=true)]
+        [HostProtection(ExternalThreading=true)]
         public virtual IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, Object state)
         {
             Contract.Ensures(Contract.Result<IAsyncResult>() != null);
@@ -438,9 +426,13 @@ namespace System.IO {
                         : BeginEndReadAsync(buffer, offset, count);
         }
 
+        [System.Security.SecuritySafeCritical]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private extern bool HasOverridenBeginEndRead();
+
         private Task<Int32> BeginEndReadAsync(Byte[] buffer, Int32 offset, Int32 count)
         {
-            if (!OverridesBeginEnd)
+            if (!HasOverridenBeginEndRead())
             {
                 return (Task<Int32>)BeginReadInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
             }
@@ -751,6 +743,8 @@ namespace System.IO {
             return WriteAsync(buffer, offset, count, CancellationToken.None);
         }
 
+
+
         [HostProtection(ExternalThreading = true)]
         [ComVisible(false)]
         public virtual Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
@@ -762,10 +756,13 @@ namespace System.IO {
                         : BeginEndWriteAsync(buffer, offset, count);
         }
 
+        [System.Security.SecuritySafeCritical]
+        [MethodImplAttribute(MethodImplOptions.InternalCall)]
+        private extern bool HasOverridenBeginEndWrite();
 
         private Task BeginEndWriteAsync(Byte[] buffer, Int32 offset, Int32 count)
         {
-            if (!OverridesBeginEnd)
+            if (!HasOverridenBeginEndWrite())
             {
                 return (Task)BeginWriteInternal(buffer, offset, count, null, null, serializeAsynchronously: true, apm: false);
             }

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -3164,7 +3164,7 @@ static MethodTable * g_pStreamMT;
 static WORD g_slotBeginRead, g_slotEndRead;
 static WORD g_slotBeginWrite, g_slotEndWrite;
 
-FCIMPL1(FC_BOOL_RET, StreamNative::HasOverridenBeginEndRead, Object *stream)
+FCIMPL1(FC_BOOL_RET, StreamNative::HasOverriddenBeginEndRead, Object *stream)
 {
     FCALL_CONTRACT;
 
@@ -3189,7 +3189,7 @@ FCIMPL1(FC_BOOL_RET, StreamNative::HasOverridenBeginEndRead, Object *stream)
 }
 FCIMPLEND
 
-FCIMPL1(FC_BOOL_RET, StreamNative::HasOverridenBeginEndWrite, Object *stream)
+FCIMPL1(FC_BOOL_RET, StreamNative::HasOverriddenBeginEndWrite, Object *stream)
 {
     FCALL_CONTRACT;
 

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -3159,3 +3159,57 @@ INT32 QCALLTYPE CoreFxGlobalization::HashSortKey(PCBYTE pSortKey, INT32 cbSortKe
     return retVal;
 }
 #endif //FEATURE_COREFX_GLOBALIZATION
+
+static MethodTable * g_pStreamMT;
+static WORD g_slotBeginRead, g_slotEndRead;
+static WORD g_slotBeginWrite, g_slotEndWrite;
+
+FCIMPL1(FC_BOOL_RET, StreamNative::HasOverridenBeginEndRead, Object *stream)
+{
+    FCALL_CONTRACT;
+
+    if (stream == NULL)
+        FC_RETURN_BOOL(TRUE);
+
+    if (g_pStreamMT == NULL || g_slotBeginRead == 0 || g_slotEndRead == 0)
+    {
+        HELPER_METHOD_FRAME_BEGIN_RET_1(stream);
+        g_pStreamMT = MscorlibBinder::GetClass(CLASS__STREAM);
+        g_slotBeginRead = MscorlibBinder::GetMethod(METHOD__STREAM__BEGIN_READ)->GetSlot();
+        g_slotEndRead = MscorlibBinder::GetMethod(METHOD__STREAM__END_READ)->GetSlot();
+        HELPER_METHOD_FRAME_END();
+    }
+
+    MethodTable * pMT = stream->GetMethodTable();
+
+    FC_RETURN_BOOL(
+        pMT->GetRestoredSlot(g_slotBeginRead) != g_pStreamMT->GetRestoredSlot(g_slotBeginRead) ||
+        pMT->GetRestoredSlot(g_slotEndRead) != g_pStreamMT->GetRestoredSlot(g_slotEndRead)
+    );
+}
+FCIMPLEND
+
+FCIMPL1(FC_BOOL_RET, StreamNative::HasOverridenBeginEndWrite, Object *stream)
+{
+    FCALL_CONTRACT;
+
+    if (stream == NULL) 
+        FC_RETURN_BOOL(TRUE);
+
+    if (g_pStreamMT == NULL || g_slotBeginWrite == 0 || g_slotEndWrite == 0)
+    {
+        HELPER_METHOD_FRAME_BEGIN_RET_1(stream);
+        g_pStreamMT = MscorlibBinder::GetClass(CLASS__STREAM);
+        g_slotBeginWrite = MscorlibBinder::GetMethod(METHOD__STREAM__BEGIN_WRITE)->GetSlot();
+        g_slotEndWrite = MscorlibBinder::GetMethod(METHOD__STREAM__END_WRITE)->GetSlot();
+        HELPER_METHOD_FRAME_END();
+    }
+
+    MethodTable * pMT = stream->GetMethodTable();
+
+    FC_RETURN_BOOL(
+        pMT->GetRestoredSlot(g_slotBeginWrite) != g_pStreamMT->GetRestoredSlot(g_slotBeginWrite) ||
+        pMT->GetRestoredSlot(g_slotEndWrite) != g_pStreamMT->GetRestoredSlot(g_slotEndWrite)
+    );
+}
+FCIMPLEND

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -316,4 +316,10 @@ public:
 };
 #endif // FEATURE_COREFX_GLOBALIZATION
 
+class StreamNative {
+public:
+    static FCDECL1(FC_BOOL_RET, HasOverridenBeginEndRead, Object *stream);
+    static FCDECL1(FC_BOOL_RET, HasOverridenBeginEndWrite, Object *stream);
+};
+
 #endif // _COMUTILNATIVE_H_

--- a/src/vm/comutilnative.h
+++ b/src/vm/comutilnative.h
@@ -318,8 +318,8 @@ public:
 
 class StreamNative {
 public:
-    static FCDECL1(FC_BOOL_RET, HasOverridenBeginEndRead, Object *stream);
-    static FCDECL1(FC_BOOL_RET, HasOverridenBeginEndWrite, Object *stream);
+    static FCDECL1(FC_BOOL_RET, HasOverriddenBeginEndRead, Object *stream);
+    static FCDECL1(FC_BOOL_RET, HasOverriddenBeginEndWrite, Object *stream);
 };
 
 #endif // _COMUTILNATIVE_H_

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -2070,8 +2070,8 @@ FCFuncStart(gVersioningHelperFuncs)
 FCFuncEnd()
 
 FCFuncStart(gStreamFuncs)
-    FCFuncElement("HasOverridenBeginEndRead", StreamNative::HasOverridenBeginEndRead)
-    FCFuncElement("HasOverridenBeginEndWrite", StreamNative::HasOverridenBeginEndWrite)
+    FCFuncElement("HasOverriddenBeginEndRead", StreamNative::HasOverriddenBeginEndRead)
+    FCFuncElement("HasOverriddenBeginEndWrite", StreamNative::HasOverriddenBeginEndWrite)
 FCFuncEnd()
 
 #ifndef FEATURE_CORECLR

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -2069,6 +2069,11 @@ FCFuncStart(gVersioningHelperFuncs)
     FCFuncElement("GetRuntimeId", GetRuntimeId_Wrapper)
 FCFuncEnd()
 
+FCFuncStart(gStreamFuncs)
+    FCFuncElement("HasOverridenBeginEndRead", StreamNative::HasOverridenBeginEndRead)
+    FCFuncElement("HasOverridenBeginEndWrite", StreamNative::HasOverridenBeginEndWrite)
+FCFuncEnd()
+
 #ifndef FEATURE_CORECLR
 FCFuncStart(gConsoleStreamFuncs)
     FCFuncElement("WaitForAvailableConsoleInput", ConsoleStreamHelper::WaitForAvailableConsoleInput)
@@ -2420,6 +2425,7 @@ FCClassElement("SizedReference", "System", gSizedRefHandleFuncs)
 FCClassElement("StackBuilderSink", "System.Runtime.Remoting.Messaging", gStackBuilderSinkFuncs)
 #endif    
 FCClassElement("StackTrace", "System.Diagnostics", gDiagnosticsStackTrace)
+FCClassElement("Stream", "System.IO", gStreamFuncs)
 FCClassElement("String", "System", gStringFuncs)
 FCClassElement("StringBuilder", "System.Text", gStringBufferFuncs)
 FCClassElement("StringExpressionSet", "System.Security.Util", gCOMStringExpressionSetFuncs)

--- a/src/vm/metasig.h
+++ b/src/vm/metasig.h
@@ -679,6 +679,10 @@ DEFINE_METASIG_T(SM(RefCleanupWorkList_SafeHandle_RetIntPtr, r(C(CLEANUP_WORK_LI
 DEFINE_METASIG_T(IM(RuntimeTypeHandle_RefException_RetBool, g(RT_TYPE_HANDLE) r(C(EXCEPTION)), F))
 DEFINE_METASIG_T(IM(RuntimeTypeHandle_RetRuntimeTypeHandle, g(RT_TYPE_HANDLE), g(RT_TYPE_HANDLE)))
 
+DEFINE_METASIG_T(IM(ArrByte_Int_Int_AsyncCallback_Object_RetIAsyncResult, a(b) i i C(ASYNCCALLBACK) j, C(IASYNCRESULT)))
+DEFINE_METASIG_T(IM(IAsyncResult_RetInt, C(IASYNCRESULT), i))
+DEFINE_METASIG_T(IM(IAsyncResult_RetVoid, C(IASYNCRESULT), v))
+
 // Undefine macros in case we include the file again in the compilation unit
 
 #undef  DEFINE_METASIG

--- a/src/vm/mscorlib.h
+++ b/src/vm/mscorlib.h
@@ -1495,6 +1495,10 @@ DEFINE_CLASS(STACK_TRACE,           Diagnostics,            StackTrace)
 DEFINE_METHOD(STACK_TRACE,          GET_MANAGED_STACK_TRACE_HELPER, GetManagedStackTraceStringHelper, SM_Bool_RetStr)
 
 DEFINE_CLASS(STREAM,                IO,                     Stream)
+DEFINE_METHOD(STREAM,               BEGIN_READ,             BeginRead,  IM_ArrByte_Int_Int_AsyncCallback_Object_RetIAsyncResult)
+DEFINE_METHOD(STREAM,               END_READ,               EndRead,    IM_IAsyncResult_RetInt)
+DEFINE_METHOD(STREAM,               BEGIN_WRITE,            BeginWrite, IM_ArrByte_Int_Int_AsyncCallback_Object_RetIAsyncResult)
+DEFINE_METHOD(STREAM,               END_WRITE,              EndWrite,   IM_IAsyncResult_RetVoid)
 
 // Defined as element type alias
 // DEFINE_CLASS(INTPTR,                System,                 IntPtr)


### PR DESCRIPTION
Stream.XxAsync are currently implemented as wrappers around Stream.Begin/EndXx.  When a derived class overrides XxAsync to do its own async implementation, there's no issue (its derived XxAsync implementation will be used).  When a derived class overrides Begin/EndXx but not XxAsync, there's no issue (the base implementation does what it needs to do, wrapping Begin/EndXx).  However, if the derived implementation doesn't override either XxAsync or Begin/EndXx, there are a few issues.

First, there's unnecessary cost.  The base Begin/EndXx methods queue a Task to call the corresponding Read/Write method.  But then the XxAsync methods create another Task to wrap the Begin/End methods invocation.  This means we're allocating and completing two tasks, when we only needed to do one.

Second, task wait inlining is affected.  Because Read/WriteAsync aren't returning the original queued delegate-backed task but rather a promise task, Wait()'ing on the returned task blocks until the operation completes on another thread.  If the original delegate-backed task were returned, then Wait()'ing on the task could potentially "inline" its execution onto the current thread.

Third, there's unnecessary blocking if there are other outstanding async operations on the instance.  Since the Begin/EndXx methods were introduced, they've tracked whether an operation is in progress, and subsequent calls to BeginXx while an operation is in progress blocks synchronously (this is because most Read/Write methods on most Streams are not safe to be called concurrently).  Since Read/WriteAsync just wrap the virtual Begin/End methods, they inherit this behavior.

This commit addresses all three issues for CoreCLR.  The Begin/EndXx methods aren't exposed from Stream in the new contracts, and as a result outside of mscorlib we don't need to be concerned about these methods being overridden.  Thus, the commit adds an optimized path that simply returns the original delegate-backed task rather than wrapping it.  This avoids the unnecessary task overheads and duplication, and it enables wait inlining if someone happens to wait on it.  Further, since we're no longer subject to the behaviors of Begin/End, we can change the serialization to be done asynchronously rather than synchronously. Override detection is done via a new FCall added for this purpose by @jkotas (thanks!)

On a microbenchmark that measures the overhead of Stream.XxAsync when Begin/EndXx are not overridden, this change improves single-threaded throughput by ~25% and cuts allocations by ~50%.

cc: @jkotas, @janvorli, @ericstj, @ellismg, @AlfredoMS 
Related to https://github.com/dotnet/coreclr/issues/2712, https://github.com/dotnet/corefx/issues/5077