### PR TITLE
Enable AVX SIMD support for Unix systems.

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -8,9 +8,7 @@ include_directories("../inc")
 
 if (CLR_CMAKE_PLATFORM_ARCH_AMD64)
   add_definitions(-DFEATURE_SIMD) 
-if (WIN32) 
   add_definitions(-DFEATURE_AVX_SUPPORT) 
-endif (WIN32)
 endif (CLR_CMAKE_PLATFORM_ARCH_AMD64)
 
 set( JIT_SOURCES

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -360,12 +360,12 @@ public:
     // than the one it was spilled from
     void            insertCopyOrReload(GenTreePtr tree, RefPosition* refPosition);
 
-#ifdef FEATURE_SIMD
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     // Insert code to save and restore the upper half of a vector that lives
     // in a callee-save register at the point of a call (the upper half is
     // not preserved).
     void            insertUpperVectorSaveAndReload(GenTreePtr tree, RefPosition* refPosition, BasicBlock* block);
-#endif // FEATURE_SIMD
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
     // resolve along one block-block edge
     enum ResolveType { ResolveSplit, ResolveJoin, ResolveCritical, ResolveSharedCritical, ResolveTypeCount };
@@ -569,10 +569,10 @@ private:
                                              ArrayStack<LocationInfo> *stack,
                                              LsraLocation loc);
 
-#ifdef FEATURE_SIMD
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
     VARSET_VALRET_TP buildUpperVectorSaveRefPositions(GenTree *tree, LsraLocation currentLoc);
     void             buildUpperVectorRestoreRefPositions(GenTree *tree, LsraLocation currentLoc, VARSET_VALARG_TP liveLargeVectors);
-#endif //FEATURE_SIMD
+#endif //FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
     // For AMD64 on SystemV machines. This method 
@@ -990,7 +990,7 @@ private:
     VARSET_TP           currentLiveVars;
     // Set of floating point variables to consider for callee-save registers.
     VARSET_TP           fpCalleeSaveCandidateVars;
-#ifdef FEATURE_SIMD
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 #if defined(_TARGET_AMD64_)
     static const var_types     LargeVectorType = TYP_SIMD32;
     static const var_types     LargeVectorSaveType = TYP_SIMD16;
@@ -1005,7 +1005,7 @@ private:
     VARSET_TP           largeVectorVars;
     // Set of large vector (TYP_SIMD32 on AVX) variables to consider for callee-save registers.
     VARSET_TP           largeVectorCalleeSaveCandidateVars;
-#endif // FEATURE_SIMD
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
 };
 
 /*XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -1262,9 +1262,9 @@ public:
     bool            RequiresRegister()
     {
         return (refType == RefTypeDef || refType == RefTypeUse
-#ifdef FEATURE_SIMD
+#if FEATURE_PARTIAL_SIMD_CALLEE_SAVE
                || refType == RefTypeUpperVectorSaveDef || refType == RefTypeUpperVectorSaveUse
-#endif // FEATURE_SIMD
+#endif // FEATURE_PARTIAL_SIMD_CALLEE_SAVE
                );
     }
 

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -681,6 +681,11 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 
 #ifdef FEATURE_SIMD
   #define ALIGN_SIMD_TYPES         1       // whether SIMD type locals are to be aligned
+#if defined(UNIX_AMD64_ABI) || !defined(FEATURE_AVX_SUPPORT)
+  #define FEATURE_PARTIAL_SIMD_CALLEE_SAVE 0 // Whether SIMD registers are partially saved at calls
+#else // !UNIX_AMD64_ABI && !FEATURE_AVX_SUPPORT
+  #define FEATURE_PARTIAL_SIMD_CALLEE_SAVE 1 // Whether SIMD registers are partially saved at calls
+#endif // !UNIX_AMD64_ABI
 #endif
   #define FEATURE_WRITE_BARRIER    1       // Generate the WriteBarrier calls for GC (currently not the x86-style register-customized barriers)
   #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog


### PR DESCRIPTION
The existing code was assuming that there would be callee-save
registers for SIMD, but with the Unix ABI there are none.

Fix #983