### PR TITLE
Fix for issue 2380.

### DIFF
--- a/src/jit/codegenlinear.h
+++ b/src/jit/codegenlinear.h
@@ -42,6 +42,10 @@
     void                genPutArgStk(GenTreePtr treeNode);
     unsigned            getBaseVarForPutArgStk(GenTreePtr treeNode);
 
+#ifdef _TARGET_XARCH_
+    unsigned            getFirstArgWithStackSlot();
+#endif // !_TARGET_XARCH_
+
     void                genCompareFloat(GenTreePtr treeNode);
 
     void                genCompareInt(GenTreePtr treeNode);

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7863,6 +7863,59 @@ CodeGen::genIntrinsic(GenTreePtr treeNode)
     genProduceReg(treeNode);
 }
 
+//------------------------------------------------------------------------------------------------ //
+// getFirstArgWithStackSlot - returns the first argument with stack slot on the caller's frame.
+//
+// Return value:
+//    The number of the first argument with stack slot on the caller's frame.
+//
+// Note:
+//    On Windows the caller always allocates stack slots (homing space) in its frame for the 
+//    first 4 arguments of a calee (register passed args). So, the baseVarNum is always 0.
+//    For System V systems there is no such calling convention requirement, and the code needs to find
+//    the first stack passed argument from the caller. This is done by iterating over 
+//    all the lvParam variables and finding the first with lvArgReg equals to REG_STK.
+//    
+unsigned
+CodeGen::getFirstArgWithStackSlot()
+{
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    unsigned baseVarNum = compiler->lvaFirstStackIncomingArgNum;
+
+    if (compiler->lvaFirstStackIncomingArgNum != BAD_VAR_NUM)
+    {
+        baseVarNum = compiler->lvaFirstStackIncomingArgNum;
+    }
+    else
+    {
+        // Iterate over all the local variables in the lclvartable. 
+        // They contain all the implicit argumets - thisPtr, retBuf, 
+        // generic context, PInvoke cookie, var arg cookie,no-standard args, etc.
+        for (unsigned i = 0; i < compiler->lvaCount; i++)
+        {
+            LclVarDsc* varDsc = &(compiler->lvaTable[i]);
+
+            // We are iterating over the arguments only.
+            assert(varDsc->lvIsParam);
+
+            if (varDsc->lvArgReg == REG_STK)
+            {
+                baseVarNum = compiler->lvaFirstStackIncomingArgNum = i;
+                break;
+            }
+        }
+    }
+
+    return baseVarNum;
+#elif _TARGET_AMD64_
+    return 0;
+#else
+    // Not implemented for x86.
+    unreached();
+    return BAD_VAR_NUM;
+#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+}
+
 //-------------------------------------------------------------------------- //
 // getBaseVarForPutArgStk - returns the baseVarNum for passing a stack arg.
 //
@@ -7872,25 +7925,38 @@ CodeGen::genIntrinsic(GenTreePtr treeNode)
 // Return value:
 //    The number of the base variable.
 //
+// Note:
+//    If tail call the outgoing args are placed in the callers incomig stack space.
+//    Otherwise, they go in the outgoing arg area on the current frame.
+//    
+//    On Windows the caller always creates slots (homing space) in its frame for the 
+//    first 4 arguments of a callee (register passed args). So, the baseVarNum is always 0.
+//    For System V systems there is no such calling convention requirement, and the code needs to find
+//    the first stack passed argument from the caller. This is done by iterating over 
+//    all the lvParam variables and finding the first with lvArgReg equals to REG_STK.
+//    
 unsigned
 CodeGen::getBaseVarForPutArgStk(GenTreePtr treeNode)
 {
     assert(treeNode->OperGet() == GT_PUTARG_STK);
 
     unsigned baseVarNum;
+
 #if FEATURE_FASTTAILCALL
     bool putInIncomingArgArea = treeNode->AsPutArgStk()->putInIncomingArgArea;
 #else
     const bool putInIncomingArgArea = false;
 #endif
+
     // Whether to setup stk arg in incoming or out-going arg area?
     // Fast tail calls implemented as epilog+jmp = stk arg is setup in incoming arg area.
     // All other calls - stk arg is setup in out-going arg area.
     if (putInIncomingArgArea)
     {
-        // The first baseVarNum is guaranteed to be the first incoming arg of the method being compiled.
-        // See lvaInitTypeRef() for the order in which lvaTable entries are initialized.
-        baseVarNum = 0;
+        // See the note in the function header re: finding the first stack passed argument.
+        baseVarNum = getFirstArgWithStackSlot();
+        assert(baseVarNum != BAD_VAR_NUM);
+
 #ifdef DEBUG
         // This must be a fast tail call.
         assert(treeNode->AsPutArgStk()->gtCall->AsCall()->IsFastTailCall());
@@ -7898,10 +7964,16 @@ CodeGen::getBaseVarForPutArgStk(GenTreePtr treeNode)
         // Since it is a fast tail call, the existence of first incoming arg is guaranteed
         // because fast tail call requires that in-coming arg area of caller is >= out-going
         // arg area required for tail call.
-        LclVarDsc* varDsc = compiler->lvaTable;
+        LclVarDsc* varDsc = &(compiler->lvaTable[baseVarNum]);
         assert(varDsc != nullptr);
-        assert(varDsc->lvIsRegArg && ((varDsc->lvArgReg == REG_ARG_0) || (varDsc->lvArgReg == REG_FLTARG_0)));
-#endif
+
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+        assert(!varDsc->lvIsRegArg && varDsc->lvArgReg == REG_STK);
+#else // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+        // On Windows this assert is always true. The first argument will always be in REG_ARG_0 or REG_FLTARG_0.
+        assert(varDsc->lvIsRegArg && (varDsc->lvArgReg == REG_ARG_0 || varDsc->lvArgReg == REG_FLTARG_0));
+#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+#endif // !DEBUG
     }
     else
     {

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2276,6 +2276,11 @@ public :
     unsigned short      lvaTrackedCount;    // actual # of locals being tracked
     unsigned            lvaTrackedCountInSizeTUnits;  // min # of size_t's sufficient to hold a bit for all the locals being tracked
 
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    // Only for AMD64 System V cache the first caller stack homed argument.
+    unsigned            lvaFirstStackIncomingArgNum;  // First argument with stack slot in the caller.
+#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
+
 #ifdef DEBUG
     VARSET_TP           lvaTrackedVars;     // set of tracked variables
 #endif
@@ -8816,6 +8821,13 @@ void * CompAllocator::ArrayAlloc(size_t elems, size_t elemSize)
 inline
 LclVarDsc::LclVarDsc(Compiler* comp)
     :
+    // Initialize the ArgRegs to REG_STK.
+    // The morph will do the right thing to change 
+    // to the right register if passed in register.
+    _lvArgReg(REG_STK),
+#if FEATURE_MULTIREG_STRUCT_ARGS
+    _lvOtherArgReg(REG_STK),
+#endif // FEATURE_MULTIREG_STRUCT_ARGS
 #if ASSERTION_PROP
     lvRefBlks(BlockSetOps::UninitVal()),
 #endif // ASSERTION_PROP

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -77,6 +77,9 @@ void                Compiler::lvaInit()
     lvaSIMDInitTempVarNum = BAD_VAR_NUM;
 #endif // FEATURE_SIMD
     lvaCurEpoch = 0;
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    lvaFirstStackIncomingArgNum = BAD_VAR_NUM;
+#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
The problem here is that when calculating the first caller frame stack
homed in argument
when preparing for a tail call, the code used the Windows convention
(arg0)
- on Windows the first 4 args always get slots on the caller stack when a
  call is made.
  For System V the first stack passed arg needs to be calculated.

 Needed to initialize the uninitialized lvArgReg and lvOtherArgReg to
 REG_STK, so these var can be used to detect first caller stack homed
 argument istead of iterating over the types of the args.

 Also caching the value of the first caller stack homed arg number to
 avoid calculating it multiple times.