### PR TITLE
Fix typo outter → outer

### DIFF
--- a/src/inc/corhlprpriv.cpp
+++ b/src/inc/corhlprpriv.cpp
@@ -275,7 +275,7 @@ HRESULT _GetFixedSigOfVarArg(           // S_OK or error.
     {
         _ASSERTE(cbCur < cbSigBlob);
 
-        // peak the outter most ELEMENT_TYPE_*
+        // peak the outer most ELEMENT_TYPE_*
         CorSigUncompressElementType (&pvSigBlob[cbCur], &ulElementType);
         if (ulElementType == ELEMENT_TYPE_SENTINEL)
             break;

--- a/src/mscorlib/src/System/Security/Cryptography/HMAC.cs
+++ b/src/mscorlib/src/System/Security/Cryptography/HMAC.cs
@@ -62,7 +62,7 @@ namespace System.Security.Cryptography {
         }
 
         internal void InitializeKey (byte[] key) {
-            // When we change the key value, we'll need to update the initial values of the inner and outter
+            // When we change the key value, we'll need to update the initial values of the inner and outer
             // computation buffers.  In the case of correct HMAC vs Whidbey HMAC, these buffers could get
             // generated to a different size than when we started.
             m_inner = null;

--- a/src/vm/fcall.h
+++ b/src/vm/fcall.h
@@ -884,9 +884,9 @@ void HCallAssert(void*& cache, void* target);
 // 
 // see code:ObjectNative::GetClass for an example
 //
-#define FC_INNER_PROLOG(outterfuncname)                         \
+#define FC_INNER_PROLOG(outerfuncname)                          \
     LPVOID __me;                                                \
-    __me = GetEEFuncEntryPointMacro(outterfuncname);            \
+    __me = GetEEFuncEntryPointMacro(outerfuncname);             \
     FC_CAN_TRIGGER_GC();                                        \
     INCONTRACT(FCallCheck __fCallCheck(__FILE__, __LINE__));
 

--- a/tests/src/baseservices/exceptions/simple/finally.cs
+++ b/tests/src/baseservices/exceptions/simple/finally.cs
@@ -40,7 +40,7 @@ public class Finally
 		bool retVal = true;
 		int  stage  = 0;
 
-		TestLibrary.TestFramework.LogInformation("PosTest1: Outter finally");
+		TestLibrary.TestFramework.LogInformation("PosTest1: Outer finally");
 
 		try
 		{


### PR DESCRIPTION
Some comments, a test's logged statement, and a macro parameter name.