### PR TITLE
Changed tests that were causing build failure from pri 1 to pri 2

### DIFF
--- a/tests/src/Loader/classloader/nesting/coreclr/VSW491577.csproj
+++ b/tests/src/Loader/classloader/nesting/coreclr/VSW491577.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/Loader/classloader/nesting/coreclr/VSW491577_1.csproj
+++ b/tests/src/Loader/classloader/nesting/coreclr/VSW491577_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>VSW491577.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/Loader/classloader/nesting/coreclr/VSW491577_2.csproj
+++ b/tests/src/Loader/classloader/nesting/coreclr/VSW491577_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>VSW491577.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddInt.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddInt_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddInt_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:0 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddInt_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddInt_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:2147483647 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddLong.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddLong_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddLong_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:-922337203685477 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddLong_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddLong_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:922337203685477 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:214748</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_4.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_4.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:-214748</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:-922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:-1</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:12345</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_4.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_4.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:-922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeTClass.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>"hello world"</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeTClass.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>null</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>null "This is a string"</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>empty "This is a long string that I am trying to test to be sure that the Exchange can handle this long of a string.  If it can't then that's bad and we will have to fix it."</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartBool.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>true</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartBool.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>false</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartCast.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartCast.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartCast.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>k</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>1234</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_4.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_4.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDecimal.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDecimal.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDecimal.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDelegate.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDelegate.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDelegate.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDouble.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDouble.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDouble.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartFloat.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartFloat.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartFloat.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartGenerics.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartGenerics.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartGenerics.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartObject.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>MyObject</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartObject.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>""</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartOperations.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartOperations.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartOperations.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartSByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartSByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartSByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>" "</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>""</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>null</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_4.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_4.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>MyStringHere</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartULong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartULong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartULong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_1.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_2.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_3.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>2</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>


### PR DESCRIPTION
This is a workaround while I try to fix https://github.com/dotnet/coreclr/issues/2713. By changing these tests from Pri 1 to Pri 2, we can stop the build from breaking in the CI, which allows all pri 1 tests to be run there overnight (as it is now, these tests break the build and stop all other pri 1 tests from being run in CI).