### PR TITLE
Use _emptyArray in List<T>.ToArray

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1001,11 +1001,18 @@ namespace System.Collections.Generic {
             }
         }
 
-        // ToArray returns a new Object array containing the contents of the List.
+        // ToArray returns an array containing the contents of the List.
         // This requires copying the List, which is an O(n) operation.
         public T[] ToArray() {
             Contract.Ensures(Contract.Result<T[]>() != null);
             Contract.Ensures(Contract.Result<T[]>().Length == Count);
+
+#if FEATURE_CORECLR
+            if (_size == 0)
+            {
+                return _emptyArray;
+            }
+#endif
 
             T[] array = new T[_size];
             Array.Copy(_items, 0, array, 0, _size);


### PR DESCRIPTION
I've only added this to ```List<T>``` in mscorlib as it's the only one of the collections with a ToArray that's exposed out (I've not touched legacy collections like ArrayList).  The other changes for the other collections are in corefx in https://github.com/dotnet/corefx/pull/5562.

cc: @jkotas, @ellismg 
https://github.com/dotnet/corefx/issues/2363