### PR TITLE
Port https://github.com/dotnet/coreclr/pull/2758 to rc2

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -1001,11 +1001,18 @@ namespace System.Collections.Generic {
             }
         }
 
-        // ToArray returns a new Object array containing the contents of the List.
+        // ToArray returns an array containing the contents of the List.
         // This requires copying the List, which is an O(n) operation.
         public T[] ToArray() {
             Contract.Ensures(Contract.Result<T[]>() != null);
             Contract.Ensures(Contract.Result<T[]>().Length == Count);
+
+#if FEATURE_CORECLR
+            if (_size == 0)
+            {
+                return _emptyArray;
+            }
+#endif
 
             T[] array = new T[_size];
             Array.Copy(_items, 0, array, 0, _size);


### PR DESCRIPTION
ToArray() calls in our collections and in LINQ allocate a new array even if the collection/enumerable is empty.  This is unnecessary garbage, which can result in extra GCs, extra overhead, etc.