### PR TITLE
Fix missing disassembler.cpp in .targets files

### DIFF
--- a/src/vm/dac/dacwks.targets
+++ b/src/vm/dac/dacwks.targets
@@ -25,6 +25,7 @@
         <CppCompile Include="$(ClrSrcDirectory)\vm\debugdebugger.cpp" />
         <CppCompile Include="$(ClrSrcDirectory)\vm\debugHelp.cpp" />
         <CppCompile Include="$(ClrSrcDirectory)\vm\debuginfostore.cpp" />
+        <CppCompile Include="$(ClrSrcDirectory)\vm\disassembler.cpp" />
         <CppCompile Include="$(ClrSrcDirectory)\vm\DllImport.cpp" />
         <CppCompile Include="$(ClrSrcDirectory)\vm\domainfile.cpp" />
         <CppCompile Include="$(ClrSrcDirectory)\vm\dynamicmethod.cpp" />

--- a/src/vm/wks/wks.targets
+++ b/src/vm/wks/wks.targets
@@ -72,6 +72,7 @@
     <CppCompile Include="$(VmSourcesDir)\decodeMD.cpp" />
     <CppCompile Include="$(VmSourcesDir)\DebugDebugger.cpp" />
     <CppCompile Include="$(VmSourcesDir)\DebugInfoStore.cpp" />
+    <CppCompile Include="$(VmSourcesDir)\disassembler.cpp" />
     <CppCompile Include="$(VmSourcesDir)\DynamicMethod.cpp" />
     <CppCompile Include="$(VmSourcesDir)\ecall.cpp" />
     <CppCompile Include="$(VmSourcesDir)\eeconfig.cpp" />


### PR DESCRIPTION
This change adds missing disassembler.cpp to wks.targets and dacwks.targets files.