### PR TITLE
Untangle FEATURE_EVENT_TRACE and GC_PROFILING for coreclr

### DIFF
--- a/src/gc/gcee.cpp
+++ b/src/gc/gcee.cpp
@@ -386,10 +386,9 @@ size_t GCHeap::GetNow()
     return GetHighPrecisionTimeStamp();
 }
 
-#if defined(GC_PROFILING) //UNIXTODO: Enable this for FEATURE_EVENT_TRACE
 void ProfScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
 {
-#if  defined(FEATURE_EVENT_TRACE)
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
     Object *pObj = *ppObject;
 #ifdef INTERIOR_POINTERS
     if (dwFlags & GC_CALL_INTERIOR)
@@ -405,7 +404,41 @@ void ProfScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
     }
 #endif //INTERIOR_POINTERS
     ScanRootsHelper(&pObj, pSC, dwFlags);
-#endif //  defined(FEATURE_EVENT_TRACE)
+#endif //  defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+}
+
+// TODO - at some point we would like to completely decouple profiling
+// from ETW tracing using a pattern similar to this, where the
+// ProfilingScanContext has flags about whether or not certain things
+// should be tracked, and each one of these ProfilerShouldXYZ functions
+// will check these flags and determine what to do based upon that.
+// GCProfileWalkHeapWorker can, in turn, call those methods without fear
+// of things being ifdef'd out.
+
+// Returns TRUE if GC profiling is enabled and the profiler
+// should scan dependent handles, FALSE otherwise.
+BOOL ProfilerShouldTrackConditionalWeakTableElements() {
+#if defined(GC_PROFILING)
+    return CORProfilerTrackConditionalWeakTableElements();
+#else
+        return FALSE;
+#endif // defined (GC_PROFILING)
+}
+
+// If GC profiling is enabled, informs the profiler that we are done
+// tracing dependent handles.
+void ProfilerEndConditionalWeakTableElementReferences(void* heapId) {
+#if defined (GC_PROFILING)
+    g_profControlBlock.pProfInterface->EndConditionalWeakTableElementReferences(heapId);
+#endif // defined (GC_PROFILING)
+}
+
+// If GC profiling is enabled, informs the profiler that we are done
+// tracing root references.
+void ProfilerEndRootReferences2(void* heapId) {
+#if defined (GC_PROFILING)
+    g_profControlBlock.pProfInterface->EndRootReferences2(heapId);
+#endif // defined (GC_PROFILING)
 }
 
 // This is called only if we've determined that either:
@@ -416,6 +449,7 @@ void ProfScanRootsHelper(Object** ppObject, ScanContext *pSC, uint32_t dwFlags)
 //     objects, or both.
 // This can also be called to do a single walk for BOTH a) and b) simultaneously.  Since
 // ETW can ask for roots, but not objects
+#if defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForEtw, BOOL fShouldWalkHeapObjectsForEtw)
 {
     {
@@ -457,16 +491,14 @@ void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForE
             // indicate that regular handle scanning is over, so we can flush the buffered roots
             // to the profiler.  (This is for profapi only.  ETW will flush after the
             // entire heap was is complete, via ETW::GCLog::EndHeapDump.)
-#if defined (GC_PROFILING)
             if (fProfilerPinned)
             {
-                g_profControlBlock.pProfInterface->EndRootReferences2(&SC.pHeapId);
+                ProfilerEndRootReferences2(&SC.pHeapId);
             }
-#endif // defined (GC_PROFILING)
         }
 
         // **** Scan dependent handles: only if the profiler supports it or ETW wants roots
-        if ((fProfilerPinned && CORProfilerTrackConditionalWeakTableElements()) ||
+        if ((fProfilerPinned && ProfilerShouldTrackConditionalWeakTableElements()) ||
             fShouldWalkHeapRootsForEtw)
         {
             // GcScanDependentHandlesForProfiler double-checks
@@ -477,9 +509,9 @@ void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForE
             // indicate that dependent handle scanning is over, so we can flush the buffered roots
             // to the profiler.  (This is for profapi only.  ETW will flush after the
             // entire heap was is complete, via ETW::GCLog::EndHeapDump.)
-            if (fProfilerPinned && CORProfilerTrackConditionalWeakTableElements())
+            if (fProfilerPinned && ProfilerShouldTrackConditionalWeakTableElements())
             {
-                g_profControlBlock.pProfInterface->EndConditionalWeakTableElementReferences(&SC.pHeapId);
+                ProfilerEndConditionalWeakTableElementReferences(&SC.pHeapId);
             }
         }
 
@@ -510,7 +542,7 @@ void GCProfileWalkHeapWorker(BOOL fProfilerPinned, BOOL fShouldWalkHeapRootsForE
         }
     }
 }
-#endif // defined(GC_PROFILING)
+#endif // defined(GC_PROFILING) || defined(FEATURE_EVENT_TRACE) 
 
 void GCProfileWalkHeap()
 {
@@ -536,15 +568,15 @@ void GCProfileWalkHeap()
     }
 #endif // defined (GC_PROFILING)
 
-#if  defined (GC_PROFILING)//UNIXTODO: Enable this for FEATURE_EVENT_TRACE
-    // If the profiling API didn't want us to walk the heap but ETW does, then do the
-    // walk here
+#if defined (GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
+    // we need to walk the heap if one of GC_PROFILING or FEATURE_EVENT_TRACE
+    // is defined, since both of them make use of the walk heap worker.
     if (!fWalkedHeapForProfiler && 
         (fShouldWalkHeapRootsForEtw || fShouldWalkHeapObjectsForEtw))
     {
         GCProfileWalkHeapWorker(FALSE /* fProfilerPinned */, fShouldWalkHeapRootsForEtw, fShouldWalkHeapObjectsForEtw);
     }
-#endif // FEATURE_EVENT_TRACE
+#endif // defined (GC_PROFILING) || defined(FEATURE_EVENT_TRACE)
 }
 
 BOOL GCHeap::IsGCInProgressHelper (BOOL bConsiderGCStart)


### PR DESCRIPTION
This PR attempts to separate the functionalities of GC_PROFILING and FEATURE_EVENT_TRACE, so that when one of the two is defined the mechanism by which the heap is walked for tracing purposes is defined. This fixes a problem in CoreRT that causes some event tracing to not work on Windows when it should - this PR should be applied to CoreRT as well if the CI is clean.