### PR TITLE
Use output redirection in BuildRyuJitPackage.

### DIFF
--- a/src/.nuget/BuildRyuJitPackage.ps1
+++ b/src/.nuget/BuildRyuJitPackage.ps1
@@ -67,7 +67,9 @@ $json = ""
 $blobs = @()
 try
 {
-    $json = (azure storage blob list -a $storageAccount -k $storageKey $storageContainer --json) -join ""
+    $tmpFileName = [System.IO.Path]::GetTempFileName()
+    azure storage blob list -a $storageAccount -k $storageKey $storageContainer --json > $tmpFileName
+    $json = [System.IO.File]::ReadAllText($tmpFileName)
     $blobs = ConvertFrom-Json $json
 }
 catch


### PR DESCRIPTION
Command capture was producing unexpected results on the build
machines.