### PR TITLE
NetBSD: Add support for retrieving the number of available CPUs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -129,6 +129,8 @@ build_coreclr()
     # processors available to a single process.
     if [ `uname` = "FreeBSD" ]; then
         NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
+    elif [ `uname` = "NetBSD" ]; then
+        NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
     else
         NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
     fi

--- a/run-cppcheck.sh
+++ b/run-cppcheck.sh
@@ -41,6 +41,8 @@ SloccountOutput="sloccount.sc"
 # processors available to a single process.
 if [ `uname` = "FreeBSD" ]; then
 NumProc=`sysctl hw.ncpu | awk '{ print $2+1 }'`
+elif [ `uname` = "NetBSD" ]; then
+NumProc=$(($(getconf NPROCESSORS_ONLN)+1))
 else
 NumProc=$(($(getconf _NPROCESSORS_ONLN)+1))
 fi


### PR DESCRIPTION
```
$ uname
NetBSD
$ getconf NPROCESSORS_ONLN
2
$ getconf _NPROCESSORS_ONLN
getconf: _NPROCESSORS_ONLN: unknown variable
```