### PR TITLE
NetBSD: Set proper shortAsciiName for NetBSD's libc

### DIFF
--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -1621,6 +1621,8 @@ static HMODULE LOADLoadLibrary(LPCSTR shortAsciiName, BOOL fDynamic)
         shortAsciiName = "libc.dylib";
 #elif defined(__FreeBSD__)
         shortAsciiName = FREEBSD_LIBC;
+#elif defined(__NetBSD__)
+        shortAsciiName = "libc.so";
 #else
         shortAsciiName = LIBC_SO;
 #endif


### PR DESCRIPTION
There is no need for the `LIBC_SO`-like solution on NetBSD.