### PR TITLE
NetBSD: CHAR_BIT as defined by POSIX in limits.h

### DIFF
--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -96,7 +96,7 @@ check_type_size(off_t SIZEOF_OFF_T)
 
 check_cxx_symbol_exists(SYS_yield sys/syscall.h HAVE_YIELD_SYSCALL)
 check_cxx_symbol_exists(INFTIM poll.h HAVE_INFTIM)
-check_cxx_symbol_exists(CHAR_BIT sys/limits.h HAVE_CHAR_BIT)
+check_cxx_symbol_exists(CHAR_BIT limits.h HAVE_CHAR_BIT)
 check_cxx_symbol_exists(_DEBUG sys/user.h USER_H_DEFINES_DEBUG)
 check_cxx_symbol_exists(_SC_PHYS_PAGES unistd.h HAVE__SC_PHYS_PAGES)
 check_cxx_symbol_exists(_SC_AVPHYS_PAGES unistd.h HAVE__SC_AVPHYS_PAGES)


### PR DESCRIPTION
Reference:

    limits.h - implementation-defined constants

    Numerical Limits
        {CHAR_BIT} Number of bits in a type char.

--- http://pubs.opengroup.org/onlinepubs/009695399/basedefs/limits.h.html

There is no such file as sys/limits.h in NetBSD.