### PR TITLE
NetBSD: Don't link with -ldl for dlopen(3) on NetBSD

### DIFF
--- a/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
@@ -12,12 +12,12 @@ add_executable(coreconsole
     ${CORECONSOLE_SOURCES}
 )
 
-# FreeBSD implements dlopen in libc
-if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+# FreeBSD and NetBSD implement dlopen(3) in libc
+if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
     target_link_libraries(coreconsole 
         dl
     )
-endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
 
 # Libc turns locks into no-ops if pthread was not loaded into process yet. Loading
 # pthread by the process executable ensures that all locks are initialized properly.

--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -12,12 +12,12 @@ add_executable(corerun
     ${CORERUN_SOURCES}
 )
 
-# FreeBSD implements dlopen in libc
-if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+# FreeBSD and NetBSD implement dlopen(3) in libc
+if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
     target_link_libraries(corerun 
         dl
     )
-endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
 
 # Libc turns locks into no-ops if pthread was not loaded into process yet. Loading
 # pthread by the process executable ensures that all locks are initialized properly.

--- a/src/ilasm/CMakeLists.txt
+++ b/src/ilasm/CMakeLists.txt
@@ -60,12 +60,12 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     palrt
   )
 
-  # FreeBSD implements dlopen in libc
-  if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  # FreeBSD and NetBSD implement dlopen(3) in libc
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
     target_link_libraries(ilasm
       dl
     )
-  endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
 
 else()
   target_link_libraries(ilasm

--- a/src/ildasm/exe/CMakeLists.txt
+++ b/src/ildasm/exe/CMakeLists.txt
@@ -54,12 +54,12 @@ if(CLR_CMAKE_PLATFORM_UNIX)
         palrt
     )
 
-    # FreeBSD implements dlopen in libc
-    if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    # FreeBSD and NetBSD implement dlopen(3) in libc
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
         target_link_libraries(ildasm
             dl
         )
-    endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+    endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
 else()
     target_link_libraries(ildasm
         ${ILDASM_LINK_LIBRARIES}


### PR DESCRIPTION
```
NAME
     dlopen, dlclose, dlsym, dlvsym, dladdr, dlctl, dlerror - dynamic link
     interface

LIBRARY
     (These functions are not in a library.  They are included in every
     dynamically linked program automatically.)

SYNOPSIS
     #include <dlfcn.h>

     void *
     dlopen(const char *path, int mode);
```