### PR TITLE
Refactor duplicate code in mscorlib primitives

### DIFF
--- a/src/mscorlib/src/System/Boolean.cs
+++ b/src/mscorlib/src/System/Boolean.cs
@@ -83,10 +83,7 @@ namespace System {
       ==============================================================================*/
       // Converts the boolean value of this instance to a String.
       public override String ToString() {
-        if (false == m_value) {
-          return FalseLiteral;
-        }
-        return TrueLiteral;
+        return ToString(null);
       }
 
       public String ToString(IFormatProvider provider) {
@@ -103,7 +100,7 @@ namespace System {
           return false;
         }
     
-        return (m_value==((Boolean)obj).m_value);
+        return Equals((Boolean)obj);
       }
 
       [System.Runtime.Versioning.NonVersionable]
@@ -126,13 +123,8 @@ namespace System {
             if (!(obj is Boolean)) {
                 throw new ArgumentException (Environment.GetResourceString("Arg_MustBeBoolean"));
             }
-             
-            if (m_value==((Boolean)obj).m_value) {
-                return 0;
-            } else if (m_value==false) {
-                return -1;
-            }
-            return 1;
+            
+            return CompareTo((Boolean)obj);
         }
 
         public int CompareTo(Boolean value) {

--- a/src/mscorlib/src/System/Byte.cs
+++ b/src/mscorlib/src/System/Byte.cs
@@ -51,7 +51,7 @@ namespace System {
                 throw new ArgumentException(Environment.GetResourceString("Arg_MustBeByte"));
             }
     
-            return m_value - (((Byte)value).m_value);
+            return CompareTo((Byte)value);
         }
 
         public int CompareTo(Byte value) {
@@ -63,7 +63,7 @@ namespace System {
             if (!(obj is Byte)) {
                 return false;
             }
-            return m_value == ((Byte)obj).m_value;
+            return Equals((Byte)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -142,7 +142,14 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
+        }
+
+        [Pure]
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        public String ToString(IFormatProvider provider) {
+            Contract.Ensures(Contract.Result<String>() != null);
+            return ToString(null, provider);
         }
 
         [Pure]
@@ -150,13 +157,6 @@ namespace System {
         public String ToString(String format) {
             Contract.Ensures(Contract.Result<String>() != null);
             return Number.FormatInt32(m_value, format, NumberFormatInfo.CurrentInfo);
-        }
-
-        [Pure]
-        [System.Security.SecuritySafeCritical]  // auto-generated
-        public String ToString(IFormatProvider provider) {
-            Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
         }
 
         [Pure]

--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -109,7 +109,7 @@ namespace System {
         if (!(obj is Char)) {
           return false;
         }
-        return (m_value==((Char)obj).m_value);
+        return Equals((Char)obj);
       }
 
       [System.Runtime.Versioning.NonVersionable]
@@ -132,8 +132,7 @@ namespace System {
           if (!(value is Char)) {
               throw new ArgumentException (Environment.GetResourceString("Arg_MustBeChar"));
           }
-    
-          return (m_value-((Char)value).m_value);
+          return CompareTo((Char)value);
       }
 
       [Pure]
@@ -145,7 +144,7 @@ namespace System {
       [Pure]
       public override String ToString() {
           Contract.Ensures(Contract.Result<String>() != null);
-          return Char.ToString(m_value);
+          return ToString(null);
       }
 
       [Pure]

--- a/src/mscorlib/src/System/Guid.cs
+++ b/src/mscorlib/src/System/Guid.cs
@@ -925,42 +925,16 @@ namespace System {
         //  by o is the same as this instance.
         public override bool Equals(Object o)
         {
-            Guid g;
             // Check that o is a Guid first
-            if(o == null || !(o is Guid))
-                return false;
-            else g = (Guid) o;
-
-            // Now compare each of the elements
-            if(g._a != _a)
-                return false;
-            if(g._b != _b)
-                return false;
-            if(g._c != _c)
-                return false;
-            if (g._d != _d)
-                return false;
-            if (g._e != _e)
-                return false;
-            if (g._f != _f)
-                return false;
-            if (g._g != _g)
-                return false;
-            if (g._h != _h)
-                return false;
-            if (g._i != _i)
-                return false;
-            if (g._j != _j)
-                return false;
-            if (g._k != _k)
+            if(!(o is Guid))
                 return false;
 
-            return true;
+            return Equals((Guid)o);
         }
 
         public bool Equals(Guid g)
         {
-            // Now compare each of the elements
+            // Compare each of the elements
             if(g._a != _a)
                 return false;
             if(g._b != _b)
@@ -998,56 +972,11 @@ namespace System {
             if (value == null) {
                 return 1;
             }
+            
             if (!(value is Guid)) {
                 throw new ArgumentException(Environment.GetResourceString("Arg_MustBeGuid"));
             }
-            Guid g = (Guid)value;
-
-            if (g._a!=this._a) {
-                return GetResult((uint)this._a, (uint)g._a);
-            }
-
-            if (g._b!=this._b) {
-                return GetResult((uint)this._b, (uint)g._b);
-            }
-
-            if (g._c!=this._c) {
-                return GetResult((uint)this._c, (uint)g._c);
-            }
-
-            if (g._d!=this._d) {
-                return GetResult((uint)this._d, (uint)g._d);
-            }
-
-            if (g._e!=this._e) {
-                return GetResult((uint)this._e, (uint)g._e);
-            }
-
-            if (g._f!=this._f) {
-                return GetResult((uint)this._f, (uint)g._f);
-            }
-
-            if (g._g!=this._g) {
-                return GetResult((uint)this._g, (uint)g._g);
-            }
-
-            if (g._h!=this._h) {
-                return GetResult((uint)this._h, (uint)g._h);
-            }
-
-            if (g._i!=this._i) {
-                return GetResult((uint)this._i, (uint)g._i);
-            }
-
-            if (g._j!=this._j) {
-                return GetResult((uint)this._j, (uint)g._j);
-            }
-
-            if (g._k!=this._k) {
-                return GetResult((uint)this._k, (uint)g._k);
-            }
-
-            return 0;
+            return CompareTo((Guid)value);
         }
 
         public int CompareTo(Guid value)
@@ -1101,31 +1030,7 @@ namespace System {
 
         public static bool operator ==(Guid a, Guid b)
         {
-            // Now compare each of the elements
-            if(a._a != b._a)
-                return false;
-            if(a._b != b._b)
-                return false;
-            if(a._c != b._c)
-                return false;
-            if(a._d != b._d)
-                return false;
-            if(a._e != b._e)
-                return false;
-            if(a._f != b._f)
-                return false;
-            if(a._g != b._g)
-                return false;
-            if(a._h != b._h)
-                return false;
-            if(a._i != b._i)
-                return false;
-            if(a._j != b._j)
-                return false;
-            if(a._k != b._k)
-                return false;
-
-            return true;
+            return a.Equals(b);
         }
 
         public static bool operator !=(Guid a, Guid b)
@@ -1187,7 +1092,7 @@ namespace System {
         [System.Security.SecuritySafeCritical]
         public String ToString(String format, IFormatProvider provider)
         {
-            if (format == null || format.Length == 0)
+            if (string.IsNullOrEmpty(format))
                 format = "D";
 
             string guidString;

--- a/src/mscorlib/src/System/Int16.cs
+++ b/src/mscorlib/src/System/Int16.cs
@@ -41,11 +41,10 @@ namespace System {
                 return 1;
             }
     
-            if (value is Int16) {
-                return m_value - ((Int16)value).m_value;
+            if (!(value is Int16)) {
+                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeInt16"));
             }
-    
-            throw new ArgumentException(Environment.GetResourceString("Arg_MustBeInt16"));
+            return CompareTo((Int16)value);
         }
 
         public int CompareTo(Int16 value) {
@@ -56,7 +55,7 @@ namespace System {
             if (!(obj is Int16)) {
                 return false;
             }
-            return m_value == ((Int16)obj).m_value;
+            return Equals((Int16)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -74,19 +73,19 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
-        
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
-        }        
+            return ToString(null, provider);
+        }
 
         public String ToString(String format) {
             Contract.Ensures(Contract.Result<String>() != null);
             return ToString(format, NumberFormatInfo.CurrentInfo);
-        }        
+        }
     
         public String ToString(String format, IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);

--- a/src/mscorlib/src/System/Int32.cs
+++ b/src/mscorlib/src/System/Int32.cs
@@ -40,15 +40,10 @@ namespace System {
             if (value == null) {
                 return 1;
             }
-            if (value is Int32) {
-                // Need to use compare because subtraction will wrap
-                // to positive for very large neg numbers, etc.
-                int i = (int)value;
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+            if (!(value is Int32)) {
+                throw new ArgumentException (Environment.GetResourceString("Arg_MustBeInt32"));
             }
-            throw new ArgumentException (Environment.GetResourceString("Arg_MustBeInt32"));
+            return CompareTo((Int32)value);
         }
 
         public int CompareTo(int value) {
@@ -63,7 +58,7 @@ namespace System {
             if (!(obj is Int32)) {
                 return false;
             }
-            return m_value == ((Int32)obj).m_value;
+            return Equals((Int32)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -81,21 +76,21 @@ namespace System {
         [Pure]
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
-        }
-
-        [System.Security.SecuritySafeCritical]  // auto-generated
-        [Pure]
-        public String ToString(String format) {
-            Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, format, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated
         [Pure]
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return ToString(null, provider);
+        }
+        
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        [Pure]
+        public String ToString(String format) {
+            Contract.Ensures(Contract.Result<String>() != null);
+            return Number.FormatInt32(m_value, format, NumberFormatInfo.CurrentInfo);
         }
 
         [Pure]

--- a/src/mscorlib/src/System/Int64.cs
+++ b/src/mscorlib/src/System/Int64.cs
@@ -39,15 +39,10 @@ namespace System {
             if (value == null) {
                 return 1;
             }
-            if (value is Int64) {
-                // Need to use compare because subtraction will wrap
-                // to positive for very large neg numbers, etc.
-                long i = (long)value;
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+            if (!(value is Int64)) {
+                throw new ArgumentException (Environment.GetResourceString("Arg_MustBeInt64"));
             }
-            throw new ArgumentException (Environment.GetResourceString("Arg_MustBeInt64"));
+            return CompareTo((Int64)value);
         }
 
         public int CompareTo(Int64 value) {
@@ -62,7 +57,7 @@ namespace System {
             if (!(obj is Int64)) {
                 return false;
             }
-            return m_value == ((Int64)obj).m_value;
+            return Equals((Int64)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -79,15 +74,15 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt64(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt64(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return ToString(null, provider);
         }
-    
+        
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(String format) {
             Contract.Ensures(Contract.Result<String>() != null);

--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -101,12 +101,12 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override bool Equals(Object obj) {
-            if (obj is IntPtr) {
-                return (m_value == ((IntPtr)obj).m_value);
+            if (!(obj is IntPtr)) {
+                return false;
             }
-            return false;
+            return (m_value == ((IntPtr)obj).m_value);
         }
-    
+        
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
             return unchecked((int)((long)m_value));

--- a/src/mscorlib/src/System/SByte.cs
+++ b/src/mscorlib/src/System/SByte.cs
@@ -45,7 +45,7 @@ namespace System {
             if (!(obj is SByte)) {
                 throw new ArgumentException (Environment.GetResourceString("Arg_MustBeSByte"));
             }
-            return m_value - ((SByte)obj).m_value;
+            return CompareTo((SByte)obj);
         }
 
         public int CompareTo(SByte value) {
@@ -57,7 +57,7 @@ namespace System {
             if (!(obj is SByte)) {
                 return false;
             }
-            return m_value == ((SByte)obj).m_value;
+            return Equals((SByte)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -76,13 +76,13 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return ToString(null, provider);
         }
     
         public String ToString(String format) {

--- a/src/mscorlib/src/System/UInt16.cs
+++ b/src/mscorlib/src/System/UInt16.cs
@@ -39,10 +39,10 @@ namespace System {
             if (value == null) {
                 return 1;
             }
-            if (value is UInt16) {
-                return ((int)m_value - (int)(((UInt16)value).m_value));
+            if (!(value is UInt16)) {
+                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeUInt16"));
             }
-            throw new ArgumentException(Environment.GetResourceString("Arg_MustBeUInt16"));
+            return CompareTo((UInt16)value);
         }
 
         public int CompareTo(UInt16 value) {
@@ -53,7 +53,7 @@ namespace System {
             if (!(obj is UInt16)) {
                 return false;
             }
-            return m_value == ((UInt16)obj).m_value;
+            return Equals((UInt16)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -71,13 +71,13 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return ToString(null, provider);
         }
 
 

--- a/src/mscorlib/src/System/UInt32.cs
+++ b/src/mscorlib/src/System/UInt32.cs
@@ -41,15 +41,10 @@ namespace System {
             if (value == null) {
                 return 1;
             }
-            if (value is UInt32) {
-                // Need to use compare because subtraction will wrap
-                // to positive for very large neg numbers, etc.
-                uint i = (uint)value;
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+            if (!(value is UInt32)) {
+                throw new ArgumentException(Environment.GetResourceString("Arg_MustBeUInt32"));
             }
-            throw new ArgumentException(Environment.GetResourceString("Arg_MustBeUInt32"));
+            return CompareTo((UInt32)value);
         }
 
         public int CompareTo(UInt32 value) {
@@ -64,7 +59,7 @@ namespace System {
             if (!(obj is UInt32)) {
                 return false;
             }
-            return m_value == ((UInt32)obj).m_value;
+            return Equals((UInt32)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -82,13 +77,13 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatUInt32(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return ToString(null, provider);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/UInt64.cs
+++ b/src/mscorlib/src/System/UInt64.cs
@@ -38,15 +38,10 @@ namespace System {
             if (value == null) {
                 return 1;
             }
-            if (value is UInt64) {
-                // Need to use compare because subtraction will wrap
-                // to positive for very large neg numbers, etc.
-                ulong i = (ulong)value;
-                if (m_value < i) return -1;
-                if (m_value > i) return 1;
-                return 0;
+            if (!(value is UInt64)) {
+                throw new ArgumentException (Environment.GetResourceString("Arg_MustBeUInt64"));
             }
-            throw new ArgumentException (Environment.GetResourceString("Arg_MustBeUInt64"));
+            return CompareTo((UInt64)value);
         }
 
         public int CompareTo(UInt64 value) {
@@ -61,7 +56,7 @@ namespace System {
             if (!(obj is UInt64)) {
                 return false;
             }
-            return m_value == ((UInt64)obj).m_value;
+            return Equals((UInt64)obj);
         }
 
         [System.Runtime.Versioning.NonVersionable]
@@ -78,13 +73,13 @@ namespace System {
         [System.Security.SecuritySafeCritical]  // auto-generated
         public override String ToString() {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatUInt64(m_value, null, NumberFormatInfo.CurrentInfo);
+            return ToString((String)null);
         }
         
         [System.Security.SecuritySafeCritical]  // auto-generated
         public String ToString(IFormatProvider provider) {
             Contract.Ensures(Contract.Result<String>() != null);
-            return Number.FormatUInt64(m_value, null, NumberFormatInfo.GetInstance(provider));
+            return ToString(null, provider);
         }        
     
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -81,10 +81,10 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override bool Equals(Object obj) {
-            if (obj is UIntPtr) {
-                return (m_value == ((UIntPtr)obj).m_value);
+            if (!(obj is UIntPtr)) {
+                return false;
             }
-            return false;
+            return (m_value == ((UIntPtr)obj).m_value);
         }
     
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/Version.cs
+++ b/src/mscorlib/src/System/Version.cs
@@ -165,31 +165,7 @@ namespace System {
 #endif                
             }
 
-            if (this._Major != v._Major)
-                if (this._Major > v._Major)
-                    return 1;
-                else
-                    return -1;
-
-            if (this._Minor != v._Minor)
-                if (this._Minor > v._Minor)
-                    return 1;
-                else
-                    return -1;
-
-            if (this._Build != v._Build)
-                if (this._Build > v._Build)
-                    return 1;
-                else
-                    return -1;
-
-            if (this._Revision != v._Revision)
-                if (this._Revision > v._Revision)
-                    return 1;
-                else
-                    return -1;
-
-            return 0;
+            return CompareTo(v);
         }
 
         public int CompareTo(Version value)
@@ -229,14 +205,7 @@ namespace System {
             if (v == null)
                 return false;
 
-            // check that major, minor, build & revision numbers match
-            if ((this._Major != v._Major) || 
-                (this._Minor != v._Minor) || 
-                (this._Build != v._Build) ||
-                (this._Revision != v._Revision))
-                return false;
-
-            return true;
+            return Equals(v);
         }
 
         public bool Equals(Version obj)


### PR DESCRIPTION
Remove duplicate code
Make the code more readable
Mainly in ToString, CompareTo and Equals methods