### PR TITLE
Clang sanitizer fixes to remove incorrect function type 'void *(*)()'

### DIFF
--- a/src/inc/clrhost.h
+++ b/src/inc/clrhost.h
@@ -82,12 +82,8 @@ extern int RFS_HashStack();
 
 void ClrFlsAssociateCallback(DWORD slot, PTLS_CALLBACK_FUNCTION callback);
 
-// Function pointer for fast TLS fetch - do not use directly
-typedef LPVOID (*POPTIMIZEDTLSGETTER)();
-
 typedef LPVOID* (*CLRFLSGETBLOCK)();
-
-extern POPTIMIZEDTLSGETTER __ClrFlsGetBlock;
+extern CLRFLSGETBLOCK __ClrFlsGetBlock;
 
 #ifndef CLR_STANDALONE_BINDER
 // Combining getter/setter into a single call
@@ -101,8 +97,7 @@ inline void ClrFlsIncrementValue(DWORD slot, int increment)
 
     _ASSERTE(increment != 0);
     
-    CLRFLSGETBLOCK clrFlsGetBlockFn = (CLRFLSGETBLOCK)__ClrFlsGetBlock;
-    void **block = (*clrFlsGetBlockFn)();
+    void **block = (*__ClrFlsGetBlock)();
     size_t value;
 
     if (block != NULL)
@@ -137,9 +132,8 @@ inline void * ClrFlsGetValue (DWORD slot)
     STATIC_CONTRACT_CANNOT_TAKE_LOCK;
     STATIC_CONTRACT_SO_TOLERANT;
 
-    CLRFLSGETBLOCK clrFlsGetBlockFn = (CLRFLSGETBLOCK)__ClrFlsGetBlock;
-    void **block = (*clrFlsGetBlockFn)();
-    if (block != NULL)
+	void **block = (*__ClrFlsGetBlock)();
+	if (block != NULL)
     {
         return block[slot];
     }
@@ -163,9 +157,8 @@ inline BOOL ClrFlsCheckValue(DWORD slot, void ** pValue)
 #ifdef _DEBUG
     *pValue = ULongToPtr(0xcccccccc);
 #endif //_DEBUG 
-    CLRFLSGETBLOCK clrFlsGetBlockFn = (CLRFLSGETBLOCK)__ClrFlsGetBlock;
-    void **block = (*clrFlsGetBlockFn)();
-    if (block != NULL)
+	void **block = (*__ClrFlsGetBlock)();
+	if (block != NULL)
     {
         *pValue = block[slot];
         return TRUE;    
@@ -186,9 +179,8 @@ inline void ClrFlsSetValue(DWORD slot, void *pData)
     STATIC_CONTRACT_CANNOT_TAKE_LOCK;
     STATIC_CONTRACT_SO_TOLERANT;
 
-    CLRFLSGETBLOCK clrFlsGetBlockFn = (CLRFLSGETBLOCK)__ClrFlsGetBlock;
-    void **block = (*clrFlsGetBlockFn)();
-    if (block != NULL)
+	void **block = (*__ClrFlsGetBlock)();
+	if (block != NULL)
     {
         block[slot] = pData;
     }

--- a/src/utilcode/clrhost_nodependencies.cpp
+++ b/src/utilcode/clrhost_nodependencies.cpp
@@ -746,15 +746,15 @@ void ClrFlsAssociateCallback(DWORD slot, PTLS_CALLBACK_FUNCTION callback)
     GetExecutionEngine()->TLS_AssociateCallback(slot, callback);
 }
 
-void * __stdcall ClrFlsGetBlockGeneric()
+void ** __stdcall ClrFlsGetBlockGeneric()
 {
     WRAPPER_NO_CONTRACT;
     STATIC_CONTRACT_SO_TOLERANT;
 
-    return GetExecutionEngine()->TLS_GetDataBlock();
+    return (void **) GetExecutionEngine()->TLS_GetDataBlock();
 }
 
-POPTIMIZEDTLSGETTER __ClrFlsGetBlock = (POPTIMIZEDTLSGETTER)ClrFlsGetBlockGeneric;
+CLRFLSGETBLOCK __ClrFlsGetBlock = ClrFlsGetBlockGeneric;
 
 CRITSEC_COOKIE ClrCreateCriticalSection(CrstType crstType, CrstFlags flags)
 {

--- a/src/utilcode/hostimpl.cpp
+++ b/src/utilcode/hostimpl.cpp
@@ -32,14 +32,14 @@ static PTLS_CALLBACK_FUNCTION Callbacks[MAX_PREDEFINED_TLS_SLOT];
 HANDLE (*g_fnGetExecutableHeapHandle)();
 #endif
 
-extern LPVOID (*__ClrFlsGetBlock)();
+extern LPVOID* (*__ClrFlsGetBlock)();
 
 //
 // FLS getter to avoid unnecessary indirection via execution engine.
 //
-VOID * ClrFlsGetBlockDirect()
+LPVOID* ClrFlsGetBlockDirect()
 {
-    return UnsafeTlsGetValue(TlsIndex);
+    return (LPVOID*)UnsafeTlsGetValue(TlsIndex);
 }
 
 //

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -1526,11 +1526,11 @@ AppDomain* STDCALL GetAppDomainGeneric()
 // FLS getter to avoid unnecessary indirection via execution engine. It will be used if we get high TLS slot
 // from the OS where we cannot use the fast optimized assembly helpers. (It happens pretty often in hosted scenarios).
 //
-VOID * ClrFlsGetBlockDirect()
+LPVOID* ClrFlsGetBlockDirect()
 {
     LIMITED_METHOD_CONTRACT;
 
-    return UnsafeTlsGetValue(CExecutionEngine::GetTlsIndex());
+    return (LPVOID*)UnsafeTlsGetValue(CExecutionEngine::GetTlsIndex());
 }
 
 extern "C" void * ClrFlsGetBlock();
@@ -1660,10 +1660,10 @@ void InitThreadManager()
     CExecutionEngine::CheckThreadState(0, FALSE);
 
     DWORD masterSlotIndex = CExecutionEngine::GetTlsIndex();
-    POPTIMIZEDTLSGETTER pGetter = MakeOptimizedTlsGetter(masterSlotIndex, (PVOID)ClrFlsGetBlock, TLS_GETTER_MAX_SIZE);
+    CLRFLSGETBLOCK pGetter = (CLRFLSGETBLOCK)MakeOptimizedTlsGetter(masterSlotIndex, (PVOID)ClrFlsGetBlock, TLS_GETTER_MAX_SIZE);
     __ClrFlsGetBlock = pGetter ? pGetter : ClrFlsGetBlockDirect;
 #else
-    __ClrFlsGetBlock = (POPTIMIZEDTLSGETTER) CExecutionEngine::GetTlsData;
+    __ClrFlsGetBlock = CExecutionEngine::GetTlsData;
 #endif // FEATURE_IMPLICIT_TLS
 
     IfFailThrow(Thread::CLRSetThreadStackGuarantee(Thread::STSGuarantee_Force));


### PR DESCRIPTION
As part of part of dotnet/corefx#4804, fix address sanitizer errors relating to invoking late bound clr functions including ClrFlsGetBlockGeneric and CExecutionEngine::GetTlsData(). The address sanitizer requires the pointer definition match the corresponding method being invoked.

The fix is to declare both the function pointer definition and the corresponding implementation as void** instead of using void* in some cases, as at runtime void** is how the pointer is used.

