### PR TITLE
Fix issues on ARM64 with lvOtherArgReg being initialized to REG_STK

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -429,6 +429,9 @@ void                Compiler::lvaInitThisPtr(InitVarDscInfo *       varDscInfo)
         noway_assert(varDscInfo->intRegArgNum == 0);
 
         varDsc->lvArgReg  = genMapRegArgNumToRegNum(varDscInfo->allocRegArg(TYP_INT), varDsc->TypeGet());
+#if FEATURE_MULTIREG_STRUCT_ARGS
+        varDsc->lvOtherArgReg = REG_NA;
+#endif
         varDsc->setPrefReg(varDsc->lvArgReg, this);
         varDsc->lvOnFrame = true; // The final home for this incoming register might be our local stack frame
 
@@ -471,6 +474,9 @@ void                Compiler::lvaInitRetBuffArg(InitVarDscInfo *    varDscInfo)
         varDsc->lvSingleDef = 1;
 #endif
         varDsc->lvArgReg  = genMapRegArgNumToRegNum(varDscInfo->allocRegArg(TYP_INT), varDsc->TypeGet());
+#if FEATURE_MULTIREG_STRUCT_ARGS
+        varDsc->lvOtherArgReg = REG_NA;
+#endif
         varDsc->setPrefReg(varDsc->lvArgReg, this);
         varDsc->lvOnFrame = true; // The final home for this incoming register might be our local stack frame
 
@@ -971,6 +977,9 @@ void                Compiler::lvaInitGenericsCtxt(InitVarDscInfo *  varDscInfo)
 
             varDsc->lvIsRegArg = 1;
             varDsc->lvArgReg   = genMapRegArgNumToRegNum(varDscInfo->regArgNum(TYP_INT), varDsc->TypeGet());
+#if FEATURE_MULTIREG_STRUCT_ARGS
+            varDsc->lvOtherArgReg = REG_NA;
+#endif
             varDsc->setPrefReg(varDsc->lvArgReg, this);
             varDsc->lvOnFrame = true; // The final home for this incoming register might be our local stack frame
 
@@ -1026,6 +1035,9 @@ void                Compiler::lvaInitVarArgsHandle(InitVarDscInfo * varDscInfo)
 
             varDsc->lvIsRegArg = 1;
             varDsc->lvArgReg   = genMapRegArgNumToRegNum(varArgHndArgNum, TYP_I_IMPL);
+#if FEATURE_MULTIREG_STRUCT_ARGS
+            varDsc->lvOtherArgReg = REG_NA;
+#endif
             varDsc->setPrefReg(varDsc->lvArgReg, this);
             varDsc->lvOnFrame = true; // The final home for this incoming register might be our local stack frame
 #ifdef _TARGET_ARM_

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -678,7 +678,7 @@ regNumber     Compiler::raUpdateRegStateForArg(RegState *regState, LclVarDsc *ar
 
 #if FEATURE_MULTIREG_STRUCT_ARGS
 #ifdef _TARGET_ARM64_
-    if (argDsc->lvOtherArgReg != REG_NA)
+    if ((argDsc->lvOtherArgReg != REG_STK) && (argDsc->lvOtherArgReg != REG_NA))
     {
         regNumber secondArgReg = argDsc->lvOtherArgReg;
 


### PR DESCRIPTION
Recently the field lvOtherArgReg was changed to be initialized to REG_STK and this caused the ARM64 tesing to fail.  This change relaxes the ARM64 specific check in Compiler::raUpdateRegStateForArg to allow for both REG_NA or REG_STK.
 (Note that a very similar check is performed by unixAmd64UpdateRegStateForArg in lsra.cpp) 

Additionally for the places in LclVar.cpp where we were setting lvArgReg to 1 (true) and the argument only uses one register, I set the value of lvOtherArgReg to a better value of REG_NA rather than leaving it as REG_STK.

@LLITCHEV PTAL
@CarolEidt PTAL as well