### PR TITLE
Fix OSX bps for PC-relative instructions.

### DIFF
--- a/src/pal/src/arch/i386/dispatchexceptionwrapper.S
+++ b/src/pal/src/arch/i386/dispatchexceptionwrapper.S
@@ -18,9 +18,9 @@
 #include "unixasmmacros.inc"
 
 #if defined(__x86_64__)
-#define PAL_DISPATCHEXCEPTION __Z21PAL_DispatchExceptionmmmmmmP8_CONTEXTP17_EXCEPTION_RECORD
+#define PAL_DISPATCHEXCEPTION __Z21PAL_DispatchExceptionmmmmmmP8_CONTEXTP17_EXCEPTION_RECORDP11MachMessage
 #else //!defined(_AMD64_)
-#define PAL_DISPATCHEXCEPTION __Z21PAL_DispatchExceptionP8_CONTEXTP17_EXCEPTION_RECORD
+#define PAL_DISPATCHEXCEPTION __Z21PAL_DispatchExceptionP8_CONTEXTP17_EXCEPTION_RECORDP11MachMessage
 #endif // defined(_AMD64_)
 
 // Offset of the return address from the PAL_DISPATCHEXCEPTION in the PAL_DispatchExceptionWrapper
@@ -34,13 +34,14 @@ C_FUNC(PAL_DispatchExceptionReturnOffset):
 // unwinding behavior is equivalent to any standard function having
 // an ebp frame. It is analogous to the following source file.
 // 
-// void PAL_DispatchException(CONTEXT *pContext, EXCEPTION_RECORD *pExceptionRecord);
+// void PAL_DispatchException(CONTEXT *pContext, EXCEPTION_RECORD *pExceptionRecord, MachMessage *pMessage);
 // 
 // extern "C" void PAL_DispatchExceptionWrapper()
 // {
 //     CONTEXT Context;
 //     EXCEPTION_RECORD ExceptionRecord;
-//     PAL_DispatchException(&Context, &ExceptionRecord);
+//     MachMessage Message;
+//     PAL_DispatchException(&Context, &ExceptionRecord, &Message);
 // }
 //
 

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -425,8 +425,8 @@ Function:
 --*/
 kern_return_t
 CONTEXT_GetThreadContextFromPort(
-        mach_port_t Port,
-        LPCONTEXT lpContext);
+    mach_port_t Port,
+    LPCONTEXT lpContext);
 
 /*++
 Function:
@@ -436,9 +436,20 @@ Function:
 --*/
 kern_return_t
 CONTEXT_SetThreadContextOnPort(
-           mach_port_t Port,
-           IN CONST CONTEXT *lpContext);
+   mach_port_t Port,
+   IN CONST CONTEXT *lpContext);
 
+/*++
+Function:
+  GetThreadContextFromThreadState
+
+  Helper for mach exception support
+--*/
+void
+CONTEXT_GetThreadContextFromThreadState(
+    thread_state_flavor_t stateFlavor,
+    thread_state_t threadState,
+    LPCONTEXT lpContext);
 
 #else // HAVE_MACH_EXCEPTIONS
 /*++

--- a/src/pal/src/include/pal/process.h
+++ b/src/pal/src/include/pal/process.h
@@ -153,19 +153,6 @@ Return
 --*/
 BOOL InitializeFlushProcessWriteBuffers();
 
-#if HAVE_MACH_EXCEPTIONS
-/*++
-Function:
-  PROCThreadFromMachPort
-  
-  Given a Mach thread port, return the CPalThread associated with it.
-
-Return
-    CPalThread*
---*/
-CorUnix::CPalThread *PROCThreadFromMachPort(mach_port_t hThread);
-#endif // HAVE_MACH_EXCEPTIONS
-
 #ifdef __cplusplus
 }
 #endif // __cplusplus

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -159,7 +159,7 @@ namespace CorUnix
         // Returns a pointer to the handler node that should be initialized next. The first time this is
         // called for a thread the bottom node will be returned. Thereafter the top node will be returned.
         // Also returns the Mach exception port that should be registered.
-        CThreadMachExceptionHandlerNode *GetNodeForInitialization(mach_port_t *pExceptionPort);
+        CThreadMachExceptionHandlerNode *GetNodeForInitialization();
 
         // Returns a pointer to the handler node for cleanup. This will always be the bottom node. This isn't
         // really the right algorithm (because there isn't one). There are lots of reasonable scenarios where
@@ -167,22 +167,18 @@ namespace CorUnix
         // can support a lot more chaining scenarios but we can't pull the same sort of trick when
         // unregistering, in particular we have two sets of chain back handlers and no way to reach into other
         // components and alter what their chain-back information is).
-        CThreadMachExceptionHandlerNode *GetNodeForCleanup() { return &m_bottom; }
+        CThreadMachExceptionHandlerNode *GetNodeForCleanup() { return &m_node; }
 
         // Get handler details for a given type of exception. If successful the structure pointed at by
-        // pHandler is filled in and true is returned. Otherwise false is returned. The fTopException argument
-        // indicates whether the handlers found at the time of a call to ICLRRuntimeHost2::RegisterMacEHPort()
-        // should be searched (if not, or a handler is not found there, we'll fallback to looking at the
-        // handlers discovered at the point when the CLR first saw this thread).
-        bool GetHandler(exception_type_t eException, bool fTopException, MachExceptionHandler *pHandler);
+        // pHandler is filled in and true is returned. Otherwise false is returned.
+        bool GetHandler(exception_type_t eException, MachExceptionHandler *pHandler);
 
     private:
         // Look for a handler for the given exception within the given handler node. Return its index if
         // successful or -1 otherwise.
         int GetIndexOfHandler(exception_mask_t bmExceptionMask, CThreadMachExceptionHandlerNode *pNode);
 
-        CThreadMachExceptionHandlerNode m_top;
-        CThreadMachExceptionHandlerNode m_bottom;
+        CThreadMachExceptionHandlerNode m_node;
     };
 #endif // HAVE_MACH_EXCEPTIONS
 #endif // FEATURE_PAL_SXS

--- a/src/pal/src/memory/heap.cpp
+++ b/src/pal/src/memory/heap.cpp
@@ -39,24 +39,6 @@ SET_DEFAULT_DEBUG_CHANNEL(MEM);
 #define DUMMY_HEAP 0x01020304
 #endif // __APPLE__
 
-#ifdef __APPLE__
-#define CACHE_HEAP_ZONE
-#endif // __APPLE__
-
-#ifdef CACHE_HEAP_ZONE
-/* This is a kludge.
- *
- * We need to know whether an instruction pointer fault is in our executable
- * heap, but the intersection between the HeapX functions on Windows and the
- * malloc_zone functions on Mac OS X are somewhat at odds and we'd have to 
- * implement an unnecessarily complicated HeapWalk. Instead, we cache the only
- * "heap" we create, knowing it's the executable heap, and use that instead
- * with the much simpler malloc_zone_from_ptr.
- */
-extern malloc_zone_t *s_pExecutableHeap;
-malloc_zone_t *s_pExecutableHeap = NULL;
-#endif // CACHE_HEAP_ZONE
-
 /*++
 Function:
   RtlMoveMemory
@@ -172,13 +154,6 @@ GetProcessHeap(
 #else
     malloc_zone_t *pZone = malloc_default_zone();
     ret = (HANDLE)pZone;
-#ifdef CACHE_HEAP_ZONE
-    if (s_pExecutableHeap == NULL)
-    {
-        s_pExecutableHeap = pZone;
-        TRACE("s_pExecutableHeap is %p (process heap).\n", s_pExecutableHeap);
-    }
-#endif // CACHE_HEAP_ZONE
 #endif // HEAP_HANDLES_ARE_REAL_HANDLES
 #else
     ret = (HANDLE) DUMMY_HEAP;

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -4290,38 +4290,6 @@ getPath(
     return FALSE;
 }
 
-#if HAVE_MACH_EXCEPTIONS
-/*++
-Function:
-  PROCThreadFromMachPort
-  
-  Given a Mach thread port, return the CPalThread associated with it.
-
-Return
-    CPalThread*
---*/
-CorUnix::CPalThread *PROCThreadFromMachPort(mach_port_t hTargetThread)
-{
-    CorUnix::CPalThread *pThread;
-
-    PROCProcessLock();
-
-    pThread = pGThreadList;
-    while (pThread)
-    {
-        mach_port_t hThread = pThread->GetMachPortSelf();
-        if (hThread == hTargetThread)
-            break;
-
-        pThread = pThread->GetNext();
-    }
-    
-    PROCProcessUnlock();
-
-    return pThread;
-}
-#endif // HAVE_MACH_EXCEPTIONS
-
 /*++
 Function:
     ~CProcProcessLocalData

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
@@ -31,7 +31,7 @@ int DllTest1()
 
     PAL_TRY(VOID*, unused, NULL)
     {
-        volatile int* p = 0x00000000;   /* NULL pointer */
+        volatile int* p = (volatile int *)0x11; /* invalid pointer */
 
         bTry = TRUE;    /* indicate we hit the PAL_TRY block */
         *p = 13;        /* causes an access violation exception */

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
@@ -31,7 +31,7 @@ int DllTest2()
 
     PAL_TRY(VOID*, unused, NULL)
     {
-        volatile int* p = 0x00000000;   /* NULL pointer */
+        volatile int* p = (volatile int *)0x22; /* invalid pointer */
 
         bTry = TRUE;    /* indicate we hit the PAL_TRY block */
         *p = 13;        /* causes an access violation exception */


### PR DESCRIPTION
Changed the mach exception handling to always hijack/send the exception back to the faulting
thread. Once running back in the faulting thread in PAL_DispatchException if the VM/debugger
code/hardware exception catching doesn't want this exception the exception message is forwarded
to the next exception port if one. Otherwise the process is aborted.

If the exception is forwarded, the faulting thread just busy waits until it gets hijacked
again by the next PAL exception thread in the system.

The exception message is always sent success as a reply after after the faulting thread is
hijacked. All the reply forwarding logic has been removed. This means we assume that OSX
default action for unhandled exception is to abort the process. We don't send reply with
KERN_FAILURE like before.

The exception message is now also passed to PAL_DispatchException along with the ExceptionRecord
and Context so it can be used to forward the message if the VM doesn't want it (via a new function
called ForwardMachException).

Removed creating the reply port MachMessage::ForwardNotification and handle/ignore replies
in worker thread.

The original hijack logic queried the faulting thread's current state to build the thread CONTEXT
and the ExceptionRecord. Because the faulting thread runs now and forwards the exception notification
in its context, the hijack logic needs to use the thread state from the message to build the thread
CONTEXT. Refactored CONTEXT_GetThreadContextFromThreadState out of CONTEXT_GetThreadContextFromPort
as a part of this. Also needed to deal with x86_THREAD_STATE thread state flavor (which can be either
32 or 64 bit) instead of the x86_THREAD_STATE32/x86_THREAD_STATE64 explicitly used to get the thread
state in the original code.

Removed the code in ExceptionRecordFromMessage (formerly known as exception_from_trap_code) to
explicitly get the fault address from the thread instead of using the extra "code" in the exception
message to fill in the ExceptionInformation[1] field for access violations. Getting the faulting
address from the thread port doesn't work if the exception was forwarded and the "code" in the
exception message is accurate.

Since ICLRRuntimeHost2::RegisterMacEHPort() isn't implemented or used anymore and to simplify
the MAC exception code, removed s_TopExceptionPort and the top/bottom exception port logic.

Removed the s_ExceptionPortSet and just use s_ExceptionPort directly because we no longer
wait to receive messages from the reply port when forwarding the exception.

General cleanup. Renaming functions not to have underscores and locals not have the first letter
capitalized.

renamed:
        catch_exception_raise -> HijackFaultingThread
        exception_from_trap_code -> ExceptionRecordFromMessage

removed:
        malloc_zone_t *s_pExecutableHeap
        struct ForwardedNotification
        PROCThreadFromMachPort(mach_port_t hTargetThread)
        IsWithinCoreCLR(void *pAddr)
        all the malloc_zone utilities in machexception.cpp
        IsHandledException(MachMessage *pNotification, CorUnix::CPalThread *pThread)