### PR TITLE
Fix a bug in JIT value numbering.

### DIFF
--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -397,7 +397,13 @@ public:
     // (liberal/conservative) to read from the SSA def referenced in the phi argument.
     ValueNum VNForMapSelect(ValueNumKind vnk, var_types typ, ValueNum op1VN, ValueNum op2VN);
 
-    ValueNum VNForMapSelectWork(ValueNumKind vnk, var_types typ, ValueNum op1VN, ValueNum op2VN, unsigned* pBudget);
+    // A method that does the work for VNForMapSelect and may call itself recursively.
+    ValueNum VNForMapSelectWork(ValueNumKind vnk,
+                                var_types typ,
+                                ValueNum op1VN,
+                                ValueNum op2VN,
+                                unsigned* pBudget,
+                                bool* pUsedRecursiveVN);
 
     // A specialized version of VNForFunc that is used for VNF_MapStore and provides some logging when verbose is set
     ValueNum VNForMapStore(var_types typ, ValueNum arg0VN, ValueNum arg1VN, ValueNum arg2VN);

--- a/tests/src/JIT/Regression/JitBlue/devdiv_174983/app.config
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_174983/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/JitBlue/devdiv_174983/devdiv_174983.cs
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_174983/devdiv_174983.cs
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+public class Test
+{
+    public int i;
+    public int j;
+
+    public static int l;
+
+    public static int Main()
+    {
+        Test test = new Test();
+        test.i = 3;
+        test.j = 5;
+        Test.l = 1;
+        if (test.Foo() == 8)
+        {
+            Console.WriteLine("PASS!");
+            return 100;
+        }
+        else
+        {
+            Console.WriteLine("FAIL!");
+            return 101;
+        }
+    }
+
+    // This tests a multi-entry loop where we have to evaluate recursive phi's
+    // for heap state in value numbering.
+    public int Foo()
+    {        
+        if (l != 17)
+        {
+            goto L2;
+        }
+
+        i = 0;
+
+L1:
+        if (l == 1)
+        {
+            // In the bug the compiler incorrectly concluded that i is always 0 here.
+            return i + j;
+        }       
+
+L2:
+        if (l == 12)
+        {
+            return i;
+        }
+        goto L1;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/devdiv_174983/devdiv_174983.csproj
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_174983/devdiv_174983.csproj
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="devdiv_174983.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)threading+thread\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This is a fix for a silent bad codegen bug in value numbering.
The value numbering algorithm tries to check whether heap PHI arguments
evaluate to the same value for the given query. In doing so, it may encounter
PHIs that recursively depend on each other (this corresponds to cycles in
control flow graph). A special value RecursiveVN is returned in such cases.
The algorithm uses the following rule:
if some PHI arguments evaluate to RecursiveVN but all others evaluate to the
same value that's not RecursiveVN, then that value can be used as the result.
Furthermore, in order to avoid exponential searches in case of many PHI's the
results of all PHI evaluations are memoized.

The bug was that if RecursiveVN was used to get the result, it can't always
be memoized. In particular, if the loop causing recursive PHIs is a multi-entry
loop, intermediate PHI results shouldn't be memoized. The fix is conservative in
that it always disables memoization if RecursiveVN was involved. Note that we
also have another mechanism (budget) to mitigate expensive PHI evaluations.

There were no diffs in SuperPMI and no measurable throughput impact.

I added a test with a simplified repro.
The original bug had code with yield return.

I also fixed some formatting and added several function headers.