### PR TITLE
String.StartsWith performance - OrdinalCompareSubstring

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -372,19 +372,23 @@ namespace System {
                 char* a = ap;
                 char* b = bp;
 
-                // unroll the loop
-#if AMD64
+#if WIN64
+                // Single int read aligns pointers for the following long reads
+                // PERF: No length check needed as there is always an int32 worth of string allocated
+                //       This read can also include the null terminator which both strings will have
+                if (*(int*)a != *(int*)b) return false;
+                length -= 2; a += 2; b += 2;
+
                 // for AMD64 bit platform we unroll by 12 and
                 // check 3 qword at a time. This is less code
                 // than the 32 bit case and is a shorter path length.
-                // Reads are unaligned
 
                 while (length >= 12)
                 {
                     if (*(long*)a     != *(long*)b) return false;
                     if (*(long*)(a+4) != *(long*)(b+4)) return false;
                     if (*(long*)(a+8) != *(long*)(b+8)) return false;
-                    a += 12; b += 12; length -= 12;
+                    length -= 12; a += 12; b += 12;
                 }
 #else
                 while (length >= 10)
@@ -394,7 +398,7 @@ namespace System {
                     if (*(int*)(a+4) != *(int*)(b+4)) return false;
                     if (*(int*)(a+6) != *(int*)(b+6)) return false;
                     if (*(int*)(a+8) != *(int*)(b+8)) return false;
-                    a += 10; b += 10; length -= 10;
+                    length -= 10; a += 10; b += 10;
                 }
 #endif
 
@@ -405,13 +409,70 @@ namespace System {
                 while (length > 0) 
                 {
                     if (*(int*)a != *(int*)b) break;
-                    a += 2; b += 2; length -= 2;
+                    length -= 2; a += 2; b += 2;
                 }
 
                 return (length <= 0);
             }
         }
-        
+
+        [System.Security.SecuritySafeCritical]  // auto-generated
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        private unsafe static bool StartsWithOrdinalHelper(String str, String startsWith)
+        {
+            Contract.Requires(str != null);
+            Contract.Requires(startsWith != null);
+            Contract.Requires(str.Length >= startsWith.Length);
+
+            int length = startsWith.Length;
+
+            fixed (char* ap = &str.m_firstChar) fixed (char* bp = &startsWith.m_firstChar)
+            {
+                char* a = ap;
+                char* b = bp;
+
+#if WIN64
+                // Single int read aligns pointers for the following long reads
+                // No length check needed as this method is called when length >= 2
+                Contract.Assert(length >= 2);
+                if (*(int*)a != *(int*)b) goto ReturnFalse;
+                length -= 2; a += 2; b += 2;
+
+                while (length >= 12)
+                {
+                    if (*(long*)a != *(long*)b) goto ReturnFalse;
+                    if (*(long*)(a + 4) != *(long*)(b + 4)) goto ReturnFalse;
+                    if (*(long*)(a + 8) != *(long*)(b + 8)) goto ReturnFalse;
+                    length -= 12; a += 12; b += 12;
+                }
+#else
+                while (length >= 10)
+                {
+                    if (*(int*)a != *(int*)b) goto ReturnFalse;
+                    if (*(int*)(a+2) != *(int*)(b+2)) goto ReturnFalse;
+                    if (*(int*)(a+4) != *(int*)(b+4)) goto ReturnFalse;
+                    if (*(int*)(a+6) != *(int*)(b+6)) goto ReturnFalse;
+                    if (*(int*)(a+8) != *(int*)(b+8)) goto ReturnFalse;
+                    length -= 10; a += 10; b += 10;
+                }
+#endif
+
+                while (length >= 2)
+                {
+                    if (*(int*)a != *(int*)b) goto ReturnFalse;
+                    length -= 2; a += 2; b += 2;
+                }
+
+                // PERF: This depends on the fact that the String objects are always zero terminated 
+                // and that the terminating zero is not included in the length. For even string sizes
+                // this compare can include the zero terminator. Bitwise OR avoids a branch.
+                return length == 0 | *a == *b;
+
+                ReturnFalse:
+                return false;
+            }
+        }
+
         [System.Security.SecuritySafeCritical]  // auto-generated
         private unsafe static int CompareOrdinalHelper(String strA, String strB)
         {
@@ -453,9 +514,9 @@ namespace System {
                         diffOffset = 8;
                         break;
                     }
+                    length -= 10;
                     a += 10; 
                     b += 10; 
-                    length -= 10;
                 }
 
                 if( diffOffset != -1) {
@@ -479,9 +540,9 @@ namespace System {
                     if (*(int*)a != *(int*)b) {
                         break;
                     }
+                    length -= 2;
                     a += 2; 
                     b += 2; 
-                    length -= 2;
                 }
 
                 if( length > 0) { 
@@ -2559,7 +2620,7 @@ namespace System {
                     }
                     return (value.Length == 1) ?
                             true :                 // First char is the same and thats all there is to compare
-                            (nativeCompareOrdinalEx(this, 0, value, 0, value.Length) == 0);
+                            StartsWithOrdinalHelper(this, value);
 
                 case StringComparison.OrdinalIgnoreCase:
                     if( this.Length < value.Length) {


### PR DESCRIPTION
Alternative to https://github.com/dotnet/coreclr/pull/2667

Improves the performance of an ordinal based StartsWith comparison. The existing code has the overhead of figuring out the exact index that differs along with redundant argument validation.

OrdinalCompareSubstring is a variation of EqualsHelper which is aware when it has reached the end of the string and can control the result of reading the null terminator (or next character after the provided length). The bitwise OR provided the best performance while avoiding having a branch or a result dependency.

The new function does not replace EqualsHelper as it has enough of a different performance profile than I was comfortable applying to `String.Equals`. One of those is the goto's as suggested by @jkotas, they perform better if the branch is not taken but worse than an inline return if they are taken. However with the `StartsWith` call all string lengths are faster so it seems like a good trade off to leave them in.

Results for when strings match:
(Note: These times include the full StartsWith code path)

Method | Len |    AvrTime |    StdDev |           op/s |
-------------- |---------: |-----------: |----------: |---------------: |
 ClrStartsWith |        1 | 11.4500 ns | 0.5563 ns |  87,470,557.18 |
 NewStartsWith |        1 |  6.3501 ns | 0.1414 ns | 157,528,084.28 |
 ClrStartsWith |        2 | 11.4065 ns | 0.0603 ns |  87,670,904.06 |
 NewStartsWith |        2 |  8.5795 ns | 0.0200 ns | 116,557,876.54 |
 ClrStartsWith |        3 | 12.2927 ns | 0.1062 ns |  81,352,873.14 |
 NewStartsWith |        3 |  9.1690 ns | 0.4990 ns | 109,285,431.49 |
 ClrStartsWith |        4 | 13.2371 ns | 0.3956 ns |  75,589,313.28 |
 NewStartsWith |        4 |  9.1914 ns | 0.0640 ns | 108,800,916.92 |
 ClrStartsWith |        5 | 13.9384 ns | 0.0406 ns |  71,744,795.08 |
 NewStartsWith |        5 |  9.3449 ns | 0.0755 ns | 107,014,566.89 |
 ClrStartsWith |        6 | 12.2244 ns | 0.0416 ns |  81,804,531.80 |
 NewStartsWith |        6 | 10.5490 ns | 0.0625 ns |  94,797,830.26 |
 ClrStartsWith |        7 | 13.0502 ns | 0.0408 ns |  76,627,530.52 |
 NewStartsWith |        7 | 11.5211 ns | 0.9869 ns |  87,216,552.58 |
 ClrStartsWith |        8 | 13.8708 ns | 0.0710 ns |  72,095,355.70 |
 NewStartsWith |        8 | 11.4602 ns | 0.1205 ns |  87,264,586.34 |
 ClrStartsWith |        9 | 14.6428 ns | 0.0146 ns |  68,292,867.94 |
 NewStartsWith |        9 | 11.3612 ns | 0.0964 ns |  88,023,104.15 |
 ClrStartsWith |       10 | 13.4256 ns | 0.5080 ns |  74,554,428.16 |
 NewStartsWith |       10 | 12.4931 ns | 0.0115 ns |  80,044,045.86 |
 ClrStartsWith |       15 | 15.3432 ns | 0.0472 ns |  65,175,852.27 |
 NewStartsWith |       15 | 10.0709 ns | 0.1339 ns |  99,307,847.30 |
 ClrStartsWith |       16 | 16.4699 ns | 0.2721 ns |  60,728,076.89 |
 NewStartsWith |       16 | 10.8500 ns | 0.0934 ns |  92,170,333.14 |
 ClrStartsWith |       17 | 17.2434 ns | 0.2048 ns |  57,998,490.10 |
 NewStartsWith |       17 | 10.7882 ns | 0.0498 ns |  92,695,078.11 |
 ClrStartsWith |       23 | 18.5733 ns | 0.6475 ns |  53,884,111.58 |
 NewStartsWith |       23 | 13.5250 ns | 0.0982 ns |  73,939,859.16 |
 ClrStartsWith |       24 | 19.9289 ns | 0.1498 ns |  50,180,204.82 |
 NewStartsWith |       24 | 11.0373 ns | 0.4187 ns |  90,686,846.76 |
 ClrStartsWith |       25 | 20.3670 ns | 0.0665 ns |  49,099,487.17 |
 NewStartsWith |       25 | 17.9949 ns | 0.1059 ns |  55,572,612.28 |
 ClrStartsWith |       31 | 20.5799 ns | 0.4610 ns |  48,607,483.32 |
 NewStartsWith |       31 | 13.2028 ns | 0.3117 ns |  75,769,599.22 |
 ClrStartsWith |       32 | 22.7187 ns | 1.3742 ns |  44,128,031.33 |
 NewStartsWith |       32 | 14.0159 ns | 0.1796 ns |  71,355,220.97 |
 ClrStartsWith |       33 | 22.7469 ns | 0.7618 ns | 43,995,277.95 |
 NewStartsWith |       33 | 14.0615 ns | 0.3022 ns | 71,137,849.71 |
 ClrStartsWith |       39 | 22.9895 ns | 0.5827 ns | 43,516,504.16 |
 NewStartsWith |       39 | 12.4601 ns | 0.0629 ns | 80,257,497.57 |
 ClrStartsWith |       40 | 23.1409 ns | 0.0703 ns | 43,213,820.21 |
 NewStartsWith |       40 | 13.9697 ns | 0.3000 ns | 71,605,570.42 |
 ClrStartsWith |       41 | 23.7431 ns | 0.0572 ns | 42,117,603.72 |
 NewStartsWith |       41 | 13.5549 ns | 0.1095 ns | 73,777,036.09 |
 ClrStartsWith |       47 | 23.7786 ns | 0.0996 ns | 42,055,055.00 |
 NewStartsWith |       47 | 16.9212 ns | 0.1138 ns | 59,099,298.06 |
 ClrStartsWith |       48 | 24.5809 ns | 0.0047 ns | 40,681,920.61 |
 NewStartsWith |       48 | 18.3364 ns | 0.0462 ns | 54,536,444.32 |
 ClrStartsWith |       49 | 25.8340 ns | 0.1865 ns | 38,709,989.78 |
 NewStartsWith |       49 | 14.4705 ns | 0.9587 ns | 69,314,948.96 |
 ClrStartsWith |       55 | 26.7904 ns | 0.1677 ns | 37,327,809.43 |
 NewStartsWith |       55 | 15.8341 ns | 0.1374 ns | 63,157,981.10 |
 ClrStartsWith |       56 | 28.2237 ns | 0.2463 ns | 35,433,003.40 |
 NewStartsWith |       56 | 16.9207 ns | 0.2360 ns | 59,106,749.89 |
 ClrStartsWith |       57 | 28.6957 ns | 0.6784 ns | 34,861,620.31 |
 NewStartsWith |       57 | 17.0855 ns | 0.2301 ns | 58,536,124.19 |
 ClrStartsWith |       63 | 29.6037 ns | 0.3151 ns | 33,782,080.83 |
 NewStartsWith |       63 | 15.4634 ns | 0.4325 ns | 64,702,660.34 |
 ClrStartsWith |       64 | 31.9466 ns | 1.0954 ns | 31,327,290.51 |
 NewStartsWith |       64 | 16.5770 ns | 0.7782 ns | 60,411,142.27 |
 ClrStartsWith |       65 | 32.1430 ns | 0.2698 ns | 31,112,412.96 |
 NewStartsWith |       65 | 16.3406 ns | 0.0405 ns | 61,197,663.86 |
 ClrStartsWith |       95 |  34.3080 ns | 0.9018 ns | 29,160,999.91 |
 NewStartsWith |       95 |  19.5439 ns | 0.5334 ns | 51,191,994.59 |
 ClrStartsWith |       96 |  34.5307 ns | 0.1197 ns | 28,959,961.14 |
 NewStartsWith |       96 |  16.8685 ns | 0.0815 ns | 59,282,994.49 |
 ClrStartsWith |       97 |  35.8156 ns | 0.3923 ns | 27,923,043.31 |
 NewStartsWith |       97 |  16.8585 ns | 0.0402 ns | 59,317,339.50 |
 ClrStartsWith |      100 |  35.7483 ns | 0.9179 ns | 27,985,525.16 |
 NewStartsWith |      100 |  17.9313 ns | 0.2584 ns | 55,776,124.71 |
 ClrStartsWith |      127 |  40.7176 ns | 0.3486 ns | 24,560,578.67 |
 NewStartsWith |      127 |  23.1166 ns | 1.5395 ns | 43,386,935.30 |
 ClrStartsWith |      128 |  41.5086 ns | 0.0515 ns | 24,091,437.72 |
 NewStartsWith |      128 |  21.8633 ns | 0.0536 ns | 45,738,973.34 |
 ClrStartsWith |      129 |  43.0288 ns | 1.4601 ns | 23,257,760.55 |
 NewStartsWith |      129 |  21.8181 ns | 0.0395 ns | 45,833,706.88 |
 ClrStartsWith |      255 |  73.8711 ns | 0.4582 ns | 13,537,443.88 |
 NewStartsWith |      255 |  32.0884 ns | 0.0992 ns | 31,164,128.69 |
 ClrStartsWith |      256 |  74.3100 ns | 0.5996 ns | 13,457,728.36 |
 NewStartsWith |      256 |  32.7835 ns | 0.2055 ns | 30,503,944.85 |
 ClrStartsWith |      257 |  76.5002 ns | 1.6331 ns | 13,075,804.91 |
 NewStartsWith |      257 |  32.7005 ns | 0.1149 ns | 30,580,797.38 |
 ClrStartsWith |      511 | 128.5744 ns | 0.1405 ns |  7,777,602.65 |
 NewStartsWith |      511 |  72.3023 ns | 0.7706 ns | 13,831,869.26 |
 ClrStartsWith |      512 | 129.3073 ns | 0.6877 ns |  7,733,659.29 |
 NewStartsWith |      512 |  73.2512 ns | 0.7754 ns | 13,652,667.92 |

cc @jkotas @benaadams @justinvp 