### PR TITLE
[aarch64] INTTERUPT_ defines are used in a switch which needs to resp…

### DIFF
--- a/src/vm/gccover.cpp
+++ b/src/vm/gccover.cpp
@@ -1134,7 +1134,16 @@ bool IsGcCoverageInterrupt(LPVOID ip)
     }
 
     // Now it's safe to dereference the IP to check the instruction
+    // The instruction is of variable length depending on the architecture
+    // Check gccover.h and ensure that you switch on the proper length
+    // to avoid narrowing issues
+#if defined(_TARGET_X86_) || defined(_TARGET_AMD64_)
     UINT8 instructionCode = *reinterpret_cast<UINT8 *>(ip);
+#elif defined(_TARGET_ARM64_)
+    UINT32 instructionCode = *reinterpret_cast<UINT32 *>(ip);
+#else
+#error Implement me for your architecture
+#endif
     switch (instructionCode)
     {
         case INTERRUPT_INSTR:

--- a/src/vm/gccover.h
+++ b/src/vm/gccover.h
@@ -102,8 +102,8 @@ public:
 // "Arm Architecture Reference Manual ARMv8"
 //
 #define INTERRUPT_INSTR                 0xBADC0DE0
-#define INTERRUPT_INSTR_CALL            0xBADC0DE1         
-#define INTERRUPT_INSTR_PROTECT_RET     0xBADC0DE2  
+#define INTERRUPT_INSTR_CALL            0xBADC0DE1
+#define INTERRUPT_INSTR_PROTECT_RET     0xBADC0DE2
 
 #endif // _TARGET_*
 


### PR DESCRIPTION
…ect c++11 narrowing

ARM is going to be a bit trickier, since it has 16 and 32-bit encodings -- tag @benpye you're it.