### PR TITLE
Remove Useless Security Checks.

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -437,6 +437,7 @@ namespace System.Reflection.Emit
         [System.Security.SecurityCritical]  // auto-generated
         private void PerformSecurityCheck(Module m, ref StackCrawlMark stackMark, bool skipVisibility)
         {
+#if !FEATURE_CORECLR
             if (m == null) 
                 throw new ArgumentNullException("m");
             Contract.EndContractBlock();
@@ -476,11 +477,13 @@ namespace System.Reflection.Emit
                 new SecurityPermission(SecurityPermissionFlag.ControlEvidence).Demand();
 #pragma warning restore 618
 #endif //FEATURE_CORECLR
+#endif //!FEATURE_CORECLR
         }
 
         [System.Security.SecurityCritical]  // auto-generated
         private void PerformSecurityCheck(Type owner, ref StackCrawlMark stackMark, bool skipVisibility)
         {
+#if !FEATURE_CORECLR
             if (owner == null)
                 throw new ArgumentNullException("owner");
 
@@ -518,6 +521,7 @@ namespace System.Reflection.Emit
                 new SecurityPermission(SecurityPermissionFlag.ControlEvidence).Demand();
 #pragma warning restore 618
 #endif //FEATURE_CORECLR
+#endif //!FEATURE_CORECLR
         }
 
         //

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -5466,9 +5466,11 @@ namespace System
 
                     if (ace.m_ctor != null)
                     {
+#if !FEATURE_CORECLR
                         // Perform security checks if needed
                         if (ace.m_bNeedSecurityCheck)
                             RuntimeMethodHandle.PerformSecurityCheck(instance, ace.m_hCtorMethodHandle, this, (uint)INVOCATION_FLAGS.INVOCATION_FLAGS_CONSTRUCTOR_INVOKE);
+#endif
 
                         // Call ctor (value types wont have any)
                         try

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -5412,6 +5412,9 @@ namespace System
                 bCanBeCached = false;
             }
 #endif
+#if FEATURE_CORECLR
+            bSecurityCheckOff = true;       // CoreCLR does not use security at all.   
+#endif
 
             Object instance = RuntimeTypeHandle.CreateInstance(this, publicOnly, bSecurityCheckOff, ref bCanBeCached, ref runtime_ctor, ref bNeedSecurityCheck);
 

--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -1195,16 +1195,20 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static extern internal uint GetSpecialSecurityFlags(IRuntimeMethodInfo method);
 
+#if !FEATURE_CORECLR
         [System.Security.SecurityCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static extern internal void PerformSecurityCheck(Object obj, RuntimeMethodHandleInternal method, RuntimeType parent, uint invocationFlags);
+#endif //!FEATURE_CORECLR
 
         [System.Security.SecurityCritical]
         static internal void PerformSecurityCheck(Object obj, IRuntimeMethodInfo method, RuntimeType parent, uint invocationFlags)
         {
+#if !FEATURE_CORECLR
             RuntimeMethodHandle.PerformSecurityCheck(obj, method.Value, parent, invocationFlags);
             GC.KeepAlive(method);
             return;
+#endif //!FEATURE_CORECLR
         }
         #endregion
 

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -576,7 +576,9 @@ FCFuncStart(gRuntimeMethodHandle)
     QCFuncElement("GetCallerType", RuntimeMethodHandle::GetCallerType)
     FCFuncElement("GetLoaderAllocator", RuntimeMethodHandle::GetLoaderAllocator)
     FCFuncElement("GetSpecialSecurityFlags", ReflectionInvocation::GetSpecialSecurityFlags)
+#ifndef FEATURE_CORECLR
     FCFuncElement("PerformSecurityCheck", ReflectionInvocation::PerformSecurityCheck)
+#endif // FEATURE_CORECLR
 FCFuncEnd()
 
 FCFuncStart(gCOMDefaultBinderFuncs)

--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -3,9 +3,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //
 //
-
 //
-
 
 #include "common.h"
 #include "reflectioninvocation.h"
@@ -901,6 +899,8 @@ FCIMPL1(DWORD, ReflectionInvocation::GetSpecialSecurityFlags, ReflectMethodObjec
 }
 FCIMPLEND
 
+#ifndef FEATURE_CORECLR
+
 // Can not inline this function.
 #ifdef _MSC_VER
 __declspec(noinline)
@@ -1000,6 +1000,8 @@ FCIMPL4(void, ReflectionInvocation::PerformSecurityCheck, Object *target, Method
     HELPER_METHOD_FRAME_END();
 }
 FCIMPLEND
+
+#endif // FEATURE_CORECLR
 
 /****************************************************************************/
 /* boxed Nullable<T> are represented as a boxed T, so there is no unboxed


### PR DESCRIPTION
CoreClr does not provide code access security features.  

However there is (expensive) code that is still being run associated with this feature.   This change #if defs this out for CoreCLR (we don't delete it because the code is still shared with desktop).   

Note that there may be more that can be ripped out.  I only did the stuff that was relatively easy to find.   There may also be dead code that has not be eliminated



