### PR TITLE
[Port to RC2] Fix missing setting of ScanContext::stack_limit

### DIFF
--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -1466,6 +1466,8 @@ BOOL TransitionFrame::Protects(OBJECTREF * ppORef)
 {
     WRAPPER_NO_CONTRACT;
     IsObjRefProtectedScanContext sc (ppORef);
+    // Set the stack limit for the scan to the SP of the managed frame above the transition frame
+    sc.stack_limit = GetSP();
     GcScanRoots (IsObjRefProtected, &sc);
     return sc.oref_protected;
 }


### PR DESCRIPTION
There is a code path executed when the GCStress is on and that was missing setting the stack_limit
value that the PromoteCarefully uses to detect objects on the stack.