### PR TITLE
Disable running CscBench off windows

### DIFF
--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -216,4 +216,5 @@ JIT/Methodical/eh/nested/cascadedcatchret/throwincascadedexceptnofin_r/throwinca
 JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621/b13621.sh
 JIT/Performance/CodeQuality/Serialization/Serialize/Serialize.sh
 JIT/Performance/CodeQuality/Serialization/Deserialize/Deserialize.sh
+JIT/Performance/CodeQuality/Roslyn/CscBench/CscBench.sh
 


### PR DESCRIPTION
Disable this test when running off Windows for now, while we're getting to the root cause of #2728.