### PR TITLE
Change isDelegateCall to be LIMITED_METHOD_CONTRACT

### DIFF
--- a/src/vm/i386/virtualcallstubcpu.hpp
+++ b/src/vm/i386/virtualcallstubcpu.hpp
@@ -694,7 +694,7 @@ __declspec (naked) void BackPatchWorkerAsmStub()
 //
 BOOL isDelegateCall(BYTE *interiorPtr)
 {
-    WRAPPER_NO_CONTRACT; 
+    LIMITED_METHOD_CONTRACT;
 
     if (GCHeap::GetGCHeap()->IsHeapPointer((void*)interiorPtr))
     {


### PR DESCRIPTION
WRAPPER_NO_CONTRACT on isDelegateCall causes static contract analyzer to fail.  Change to LIMITED_METHOD_CONTRACT to fix this issue.