### PR TITLE
Port fix for CoreCLR issue 2850

### DIFF
--- a/src/binder/coreclrbindercommon.cpp
+++ b/src/binder/coreclrbindercommon.cpp
@@ -44,6 +44,7 @@ HRESULT CCoreCLRBinderHelper::DefaultBinderSetupContext(DWORD dwAppDomainId,CLRP
             if(SUCCEEDED(hr))
             {
                 pApplicationContext->SetAppDomainId(dwAppDomainId);
+                pBinder->SetManagedAssemblyLoadContext(NULL);
                 *ppTPABinder = clr::SafeAddRef(pBinder.Extract());
             }
         }


### PR DESCRIPTION


An uninitialized field triggers a code path when a load context cannot find an assembly resulting in invalid GC HandleTable lookups that crash the process.