### PR TITLE
Disable initialization of _lvArgReg and _lvOtherArgReg on x86.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -7914,7 +7914,7 @@ CodeGen::genIntrinsic(GenTreePtr treeNode)
 unsigned
 CodeGen::getFirstArgWithStackSlot()
 {
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
     unsigned baseVarNum = compiler->lvaFirstStackIncomingArgNum;
 
     if (compiler->lvaFirstStackIncomingArgNum != BAD_VAR_NUM)
@@ -7942,11 +7942,11 @@ CodeGen::getFirstArgWithStackSlot()
     }
 
     return baseVarNum;
-#elif _TARGET_AMD64_
+#elif defined(_TARGET_AMD64_)
     return 0;
 #else
     // Not implemented for x86.
-     NYI_X86("getFirstArgWithStackSlot not yet implemented for x86.");
+    NYI_X86("getFirstArgWithStackSlot not yet implemented for x86.");
     return BAD_VAR_NUM;
 #endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
 }

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1116,14 +1116,14 @@ void                Compiler::fgExtendDbgLifetimes()
         }
     }
 
-    /* raMarkStkVars() reserves stack space for unused variables (which
-       needs to be initialized). However, arguments don't need to be initialized.
-       So just ensure that they don't have a 0 ref cnt */
+    // raMarkStkVars() reserves stack space for unused variables (which
+    //   needs to be initialized). However, arguments don't need to be initialized.
+    //   So just ensure that they don't have a 0 ref cnt
 
     unsigned lclNum = 0;
     for (LclVarDsc* varDsc = lvaTable; lclNum < lvaCount; lclNum++, varDsc++)
     {
-        if (varDsc->lvRefCnt == 0 && varDsc->lvArgReg)
+        if (varDsc->lvRefCnt == 0 && varDsc->lvIsRegArg)
         {
             varDsc->lvRefCnt = 1;
         }


### PR DESCRIPTION
It causes an assert in liveness analysis.
Assert failure(PID 22244 [0x000056e4], Thread: 20900 [0x51a4]): Assertion
failed 'VarSetOps::Equal(this, VarSetOps::Intersection(this, life,
block->bbLiveIn), life)' in 'TestClass2:.ctor(ref):this' (IL size 58)

    File: e:\dd\projectk\src\ndp\clr\src\jit\liveness.cpp Line: 2806
        Image:
	E:\DD\PROJECTK\SRC\DDSUITES\SRC\CLR\X86\jit\Directed\Languages\Python\test_methods_d.exe