### PR TITLE
Support for CFI unwind info

### DIFF
--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -70,7 +70,8 @@ add_library(corguids ${CORGUIDS_SOURCES})
 
 # Binplace the inc files for packaging later.
 
-install (FILES cor.h
+install (FILES cfi.h
+               cor.h
                corhdr.h
                corinfo.h
                corjit.h

--- a/src/inc/cfi.h
+++ b/src/inc/cfi.h
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef CFI_H_
+#define CFI_H_
+
+#define DWARF_REG_ILLEGAL -1
+enum CFI_OPCODE
+{
+   CFI_ADJUST_CFA_OFFSET,    // Offset is adjusted relative to the current one.
+   CFI_DEF_CFA_REGISTER,     // New register is used to compute CFA
+   CFI_REL_OFFSET            // Register is saved at offset from the current CFA
+};
+
+struct CFI_CODE
+{
+    unsigned char CodeOffset;// Offset from the start of code the frame covers.
+    unsigned char CfiOpCode;
+    short DwarfReg;          // Dwarf register number. 0~32 for x64.
+    int Offset;
+    CFI_CODE(unsigned char codeOffset, unsigned char cfiOpcode,
+        short dwarfReg, int offset)
+        : CodeOffset(codeOffset)
+        , CfiOpCode(cfiOpcode)
+        , DwarfReg(dwarfReg)
+        , Offset(offset)
+    {}
+};
+typedef CFI_CODE* PCFI_CODE;
+
+#endif // CFI_H
+

--- a/src/inc/clrnt.h
+++ b/src/inc/clrnt.h
@@ -7,6 +7,7 @@
 #define CLRNT_H_
 
 #include "staticcontract.h"
+#include "cfi.h"
 
 //
 // This file is the result of some changes to the SDK header files.

--- a/src/inc/corjit.h
+++ b/src/inc/corjit.h
@@ -124,7 +124,7 @@ enum CorJitFlag
 #ifdef MDIL
     CORJIT_FLG_MDIL                = 0x00004000, // Generate MDIL code instead of machine code
 #else // MDIL
-    CORJIT_FLG_UNUSED7             = 0x00004000,
+    CORJIT_FLG_CFI_UNWIND          = 0x00004000, // Emit CFI unwind info
 #endif // MDIL
 
 #ifdef MDIL

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1175,6 +1175,10 @@ struct FuncInfoDsc
     BYTE                unwindCodes[offsetof(UNWIND_INFO, UnwindCode) + (0xFF*sizeof(UNWIND_CODE))];
     unsigned            unwindCodeSlot;
 
+#ifdef UNIX_AMD64_ABI
+    jitstd::vector<CFI_CODE>* cfiCodes;
+#endif // UNIX_AMD64_ABI
+
 #elif defined(_TARGET_ARMARCH_)
 
     UnwindInfo          uwi;        // Unwind information for this function/funclet's hot  section
@@ -6899,6 +6903,21 @@ private:
     void                unwindEmitFuncHelper(FuncInfoDsc* func, void* pHotCode, void* pColdCode, bool isHotCode);
     UNATIVE_OFFSET      unwindGetCurrentOffset(FuncInfoDsc* func);
 
+    void                unwindBegPrologWindows();
+    void                unwindPushWindows(regNumber reg);
+    void                unwindAllocStackWindows(unsigned size);
+    void                unwindSetFrameRegWindows(regNumber reg, unsigned offset);
+    void                unwindSaveRegWindows(regNumber reg, unsigned offset);
+
+#ifdef UNIX_AMD64_ABI
+    void                unwindBegPrologCFI();
+    void                unwindPushCFI(regNumber reg);
+    void                unwindAllocStackCFI(unsigned size);
+    void                unwindSetFrameRegCFI(regNumber reg, unsigned offset);
+    void                unwindSaveRegCFI(regNumber reg, unsigned offset);
+    int                 mapRegNumToDwarfReg(regNumber reg);
+    void                createCfiCode(FuncInfoDsc* func, UCHAR codeOffset, UCHAR opcode, USHORT dwarfReg, INT offset = 0);
+#endif // UNIX_AMD64_ABI
 #elif defined(_TARGET_ARM_)
 
     void                unwindPushPopMaskInt(regMaskTP mask, bool useOpsize16);


### PR DESCRIPTION
For Unix targeting CoreRT, this will provide platform specific unwind
info which is a dwarf format.
Unlike window’s UNWIND_INFO, we won’t encode the format within RyuJit
which is not only complex/error-prone but also will be slightly
different depending on platforms.
Instead, CFI pseudo instructions are encoded, which will be passed to
CoreRT/ObjectWriter whi will translate them to directly emit CFI
instructions in LLVM MC to establish frames.
Then LLVM MC will handle the details of laying out the  eh_frame
sections.
One a JitFlag is used to dynamically dispatch either Windows’s unwind
blob or this CFI instruction table. No JIT/EE interface change is needed
since we’ve already passing an opaque blob.
Initially when I looked at what Clang does, the prologue and the
sequence of CFI emissions are a bit different than Windows.
Since we will emit the same sequence of code with the same runtime that
we define, I assume this is unnecessary – I’ve verified the CFI sequence
here can work correctly with libunwind.
Basically we need only 3 operations – push reg is a combination of 1 and
2 below.
 1. Allocation – increase stack frame. Normally subtract esp in x64.
 2. Store – Copy a (callee save) register to stack (memory)
 3. SaveFP – Set frame pointer register
Since Windows operation is based on the relative value (all offsets,
etc are computed from the current point), I also use the similar form of
CFI instructions .
So, mostly one window’s code corresponds to two CFIs – we might optimize
this by aggregating allocation, but I’d like to keep the current
syntax/semantic same as Windows.
This results in a very simple transformation in par with Windows.