### PR TITLE
Fix missing format specifier in Utilities.py

### DIFF
--- a/src/scripts/Utilities.py
+++ b/src/scripts/Utilities.py
@@ -28,7 +28,7 @@ def walk_recursively_and_update(dcmp):
     #delete left only files
     for name in dcmp.left_only:
         path = dcmp.left + "/" + name
-        print("Deleting " % (path))
+        print("Deleting %s" % (path))
         if  os.path.isfile(path):
             os.remove(path)
         elif  os.path.isdir(path):


### PR DESCRIPTION
The Utilities.py script was missing the `%s` format specifier in
one of the prints and it was causing a build failure for me.