### PR TITLE
Fix gc-hole while emitting CORINFO_HELP_ASSIGN_BYREF helper call on Unix

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -809,6 +809,10 @@ regMaskTP Compiler::compNoGCHelperCallKillSet(CorInfoHelpFunc helper)
     case CORINFO_HELP_PROF_FCN_TAILCALL:
         return RBM_PROFILER_LEAVE_TRASH;
 
+    case CORINFO_HELP_ASSIGN_BYREF:
+        // this helper doesn't trash RSI and RDI
+        return RBM_CALLEE_TRASH_NOGC & ~(RBM_RSI | RBM_RDI);
+
     default:
         return RBM_CALLEE_TRASH_NOGC;
     }


### PR DESCRIPTION
CORINFO_HELP_ASSIGN_BYREF is a no-gc helper that takes its parameters in RSI and RDI and doesn't trash them.

compNoGCHelperCallKillSet() is used by emitter to compute the registers that are trashed by a helper call to update gc-info state maintained by emitter (see emitxarch.cpp!emitins_call()).  compNoGCHelperCallKillSet() on Windows is modeled to return RBM_CALLEE_TRASH_NOGC (which is same as RBM_CALLEE_TRASH) and it happens to work fine because RSI and RDI are not part of RBM_CALLEE_TRASH set.  But on Unix Amd64, RSI and RDI are part of RBM_CALLEE_TRASH and hence gets reported as killed by ASSIGN_BYREF helper and hence the gc-hole.

Fix: exclude RSI and RDI in set of registers killed by ASSIGN_BYREF helper.

Fixes #2763