### PR TITLE
TimeZoneInfo.DisplayName values are not localized on Linux

### DIFF
--- a/src/corefx/System.Globalization.Native/errors.h
+++ b/src/corefx/System.Globalization.Native/errors.h
@@ -1,0 +1,36 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#pragma once
+
+#include <unicode/utypes.h>
+
+/*
+* These values should be kept in sync with
+* Interop.GlobalizationInterop.ResultCode
+*/
+enum ResultCode : int32_t
+{
+    Success = 0,
+    UnknownError = 1,
+    InsufficentBuffer = 2,
+};
+
+/*
+Converts a UErrorCode to a ResultCode.
+*/
+static ResultCode GetResultCode(UErrorCode err)
+{
+    if (err == U_BUFFER_OVERFLOW_ERROR || err == U_STRING_NOT_TERMINATED_WARNING)
+    {
+        return InsufficentBuffer;
+    }
+
+    if (U_SUCCESS(err))
+    {
+        return Success;
+    }
+
+    return UnknownError;
+}

--- a/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
+++ b/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
@@ -5,11 +5,13 @@
 
 #include <stdint.h>
 #include <unistd.h>
+#include <unicode/ucal.h>
+
+#include "locale.hpp"
+#include "holders.h"
+#include "errors.h"
 
 /*
-Function:
-ReadLink
-
 Gets the symlink value for the path.
 */
 extern "C" int32_t GlobalizationNative_ReadLink(const char* path, char* result, size_t resultCapacity)
@@ -21,4 +23,37 @@ extern "C" int32_t GlobalizationNative_ReadLink(const char* path, char* result, 
 
     result[r] = '\0';
     return true;
+}
+
+/*
+These values should be kept in sync with the managed Interop.GlobalizationInterop.TimeZoneDisplayNameType enum.
+*/
+enum TimeZoneDisplayNameType : int32_t
+{
+    Generic = 0,
+    Standard = 1,
+    DaylightSavings = 2,
+};
+
+/*
+Gets the localized display name for the specified time zone.
+*/
+extern "C" ResultCode GlobalizationNative_GetTimeZoneDisplayName(
+    const UChar* localeName, const UChar* timeZoneId, TimeZoneDisplayNameType type, UChar* result, int32_t resultLength)
+{
+    UErrorCode err = U_ZERO_ERROR;
+    char locale[ULOC_FULLNAME_CAPACITY];
+    GetLocale(localeName, locale, ULOC_FULLNAME_CAPACITY, false, &err);
+
+    int32_t timeZoneIdLength = -1; // timeZoneId is NULL-terminated
+    UCalendar* calendar = ucal_open(timeZoneId, timeZoneIdLength, locale, UCAL_DEFAULT, &err);
+    UCalendarHolder calendarHolder(calendar, err);
+
+    // TODO (https://github.com/dotnet/corefx/issues/5741): need to support Generic names, but ICU "C" api
+    // has no public option for this. For now, just use the ICU standard name for both Standard and Generic
+    // (which is the same behavior on Windows with the mincore TIME_ZONE_INFORMATION APIs).
+    ucal_getTimeZoneDisplayName(
+        calendar, type == DaylightSavings ? UCAL_DST : UCAL_STANDARD, locale, result, resultLength, &err);
+
+    return GetResultCode(err);
 }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -19,10 +19,9 @@ internal static partial class Interop
         internal static extern int GetCalendars(string localeName, CalendarId[] calendars, int calendarsCapacity);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
-        internal static extern CalendarDataResult GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, [Out] StringBuilder result, int resultCapacity);
+        internal static extern ResultCode GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, [Out] StringBuilder result, int resultCapacity);
 
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
-        [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EnumCalendarInfo(EnumCalendarInfoCallback callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
 
         [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.ResultCode.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.ResultCode.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+internal static partial class Interop
+{
+    internal static partial class GlobalizationInterop
+    {
+        // needs to be kept in sync with ResultCode in System.Globalization.Native
+        internal enum ResultCode
+        {
+            Success = 0,
+            UnknownError = 1,
+            InsufficentBuffer = 2,
+        }
+    }
+}

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -10,7 +10,22 @@ internal static partial class Interop
     internal static partial class GlobalizationInterop
     {
         [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi, EntryPoint = "GlobalizationNative_ReadLink")] // readlink requires char*
-        [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
+
+        // needs to be kept in sync with TimeZoneDisplayNameType in System.Globalization.Native
+        internal enum TimeZoneDisplayNameType
+        {
+            Generic = 0,
+            Standard = 1,
+            DaylightSavings = 2,
+        }
+
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetTimeZoneDisplayName")]
+        internal static extern ResultCode GetTimeZoneDisplayName(
+            string localeName, 
+            string timeZoneId, 
+            TimeZoneDisplayNameType type, 
+            [Out] StringBuilder result, 
+            int resultLength);
     }
 }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Utils.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Utils.cs
@@ -1,0 +1,52 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text;
+
+internal static partial class Interop
+{
+    /// <summary>
+    /// Helper for making interop calls that return a string, but we don't know
+    /// the correct size of buffer to make. So invoke the interop call with an
+    /// increasing buffer until the size is big enough.
+    /// </summary>
+    internal static bool CallStringMethod<TArg1, TArg2, TArg3>(
+        Func<TArg1, TArg2, TArg3, StringBuilder, GlobalizationInterop.ResultCode> interopCall,
+        TArg1 arg1,
+        TArg2 arg2,
+        TArg3 arg3,
+        out string result)
+    {
+        const int initialStringSize = 80;
+        const int maxDoubleAttempts = 5;
+
+        StringBuilder stringBuilder = StringBuilderCache.Acquire(initialStringSize);
+
+        for (int i = 0; i < maxDoubleAttempts; i++)
+        {
+            GlobalizationInterop.ResultCode resultCode = interopCall(arg1, arg2, arg3, stringBuilder);
+
+            if (resultCode == GlobalizationInterop.ResultCode.Success)
+            {
+                result = StringBuilderCache.GetStringAndRelease(stringBuilder);
+                return true;
+            }
+            else if (resultCode == GlobalizationInterop.ResultCode.InsufficentBuffer)
+            {
+                // increase the string size and loop
+                stringBuilder.EnsureCapacity(stringBuilder.Capacity * 2);
+            }
+            else
+            {
+                // if there is an unknown error, don't proceed
+                break;
+            }
+        }
+
+        StringBuilderCache.Release(stringBuilder);
+        result = null;
+        return false;
+    }
+}

--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -789,7 +789,9 @@
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Casing.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Collation.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Locale.cs" />
+    <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.ResultCode.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.TimeZoneInfo.cs" />
+    <GlobalizationSources Include="$(CoreFxSourcesRoot)\Interop\Unix\System.Globalization.Native\Interop.Utils.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CalendarData.Unix.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CompareInfo.Unix.cs" />
     <GlobalizationSources Include="$(CoreFxSourcesRoot)\System\Globalization\CultureData.Unix.cs" />


### PR DESCRIPTION
Fixed by calling ICU's ucal_getTimeZoneDisplayName to read the display names for the current locale.

Fix https://github.com/dotnet/corefx/issues/2748

@tarekgh @ellismg @stephentoub 