### PR TITLE
Fix DateTimeFormat.FormatCustomized optimization bug

### DIFF
--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -288,10 +288,9 @@ namespace System {
     
         //
         // The pos should point to a quote character. This method will
-        // get the length, including beginning and ending quote, of the
-        // quoted string.
+        // get the string encloed by the quote character.
         //
-        internal static int ParseQuoteString(String format, int pos)
+        internal static int ParseQuoteString(String format, int pos, StringBuilder result)
         {
             //
             // NOTE : pos will be the index of the quote character in the 'format' string.
@@ -316,13 +315,15 @@ namespace System {
                     //  minute: 45"
                     // because the second double quote is escaped.
                     if (pos < formatLen) {
-                        pos++;
+                        result.Append(format[pos++]);
                     } else {
                             //
                             // This means that '\' is at the end of the formatting string.
                             //
                             throw new FormatException(Environment.GetResourceString("Format_InvalidString"));
                     }                    
+                } else {
+                    result.Append(ch);
                 }
             }
             
@@ -334,7 +335,7 @@ namespace System {
                             CultureInfo.CurrentCulture,
                             Environment.GetResourceString("Format_BadQuote"), quoteChar));
             }
-
+            
             //
             // Return the character count including the begin/end quote characters and enclosed string.
             //
@@ -629,8 +630,9 @@ namespace System {
                         break;
                     case '\'':
                     case '\"':
-                        tokenLen = ParseQuoteString(format, i);
-                        result.Append(format, i + 1, tokenLen - 2);
+                        StringBuilder enquotedString = new StringBuilder();
+                        tokenLen = ParseQuoteString(format, i, enquotedString); 
+                        result.Append(enquotedString);
                         break;
                     case '%':
                         // Optional format character.

--- a/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
+++ b/src/mscorlib/src/System/Globalization/DateTimeFormat.cs
@@ -288,7 +288,7 @@ namespace System {
     
         //
         // The pos should point to a quote character. This method will
-        // get the string encloed by the quote character.
+        // append to the result StringBuilder the string encloed by the quote character.
         //
         internal static int ParseQuoteString(String format, int pos, StringBuilder result)
         {
@@ -630,9 +630,7 @@ namespace System {
                         break;
                     case '\'':
                     case '\"':
-                        StringBuilder enquotedString = new StringBuilder();
-                        tokenLen = ParseQuoteString(format, i, enquotedString); 
-                        result.Append(enquotedString);
+                        tokenLen = ParseQuoteString(format, i, result); 
                         break;
                     case '%':
                         // Optional format character.

--- a/src/mscorlib/src/System/Globalization/TimeSpanFormat.cs
+++ b/src/mscorlib/src/System/Globalization/TimeSpanFormat.cs
@@ -232,8 +232,9 @@ namespace System.Globalization {
                         break;
                     case '\'':
                     case '\"':
-                        tokenLen = DateTimeFormat.ParseQuoteString(format, i); 
-                        result.Append(format, i + 1, tokenLen - 2);
+                        StringBuilder enquotedString = new StringBuilder();
+                        tokenLen = DateTimeFormat.ParseQuoteString(format, i, enquotedString); 
+                        result.Append(enquotedString);
                         break;
                     case '%':
                         // Optional format character.

--- a/src/mscorlib/src/System/Globalization/TimeSpanFormat.cs
+++ b/src/mscorlib/src/System/Globalization/TimeSpanFormat.cs
@@ -232,9 +232,7 @@ namespace System.Globalization {
                         break;
                     case '\'':
                     case '\"':
-                        StringBuilder enquotedString = new StringBuilder();
-                        tokenLen = DateTimeFormat.ParseQuoteString(format, i, enquotedString); 
-                        result.Append(enquotedString);
+                        tokenLen = DateTimeFormat.ParseQuoteString(format, i, result); 
                         break;
                     case '%':
                         // Optional format character.


### PR DESCRIPTION
After reverting #2617, which resulted in backslash escapes being included incorrectly, replaces it with a simpler fix that avoids the same allocations and copies by simply passing in the overarching StringBuilder.  The call sites throw away the StringBuilder if an exception occurs, so we can simply write to it directly rather than first writing to a temporary and then dumping that temporary into the overarching result.

Fixes https://github.com/dotnet/coreclr/issues/2892
cc: @jkotas, @tarekgh 

(@tarekgh, thanks for investigating, and sorry for the silly mistake.)