### PR TITLE
Modify crossgen to always set DLL bit in PE header

### DIFF
--- a/src/zap/zapimage.cpp
+++ b/src/zap/zapimage.cpp
@@ -1852,7 +1852,14 @@ void ZapImage::OutputTables()
 
     if (IsReadyToRunCompilation())
     {
+#ifndef FEATURE_CORECLR
+        // Some older versions of Windows (e.g., Win7) can incorrectly fixup
+        // relocations if IsDll is not set. In CoreCLR, we handle this by
+        // always using the default value of IsDll, which is true. We can't
+        // use the same fix in desktop CLR, since in this case the ReadyToRun
+        // image can be used to create processes.
         SetIsDll(m_ModuleDecoder.IsDll());
+#endif
 
         SetSizeOfStackReserve(m_ModuleDecoder.GetSizeOfStackReserve());
         SetSizeOfStackCommit(m_ModuleDecoder.GetSizeOfStackCommit());


### PR DESCRIPTION
Having a Ready-To-Run image without the DLL bit in the PE header causes relocation errors in older Windows (see #2153). This is resolved by always setting the DLL bit in Ready-To-Run images (and native images).