### PR TITLE
NetBSD: Stop assuming that __hppa__ is HP-UX

### DIFF
--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -71,7 +71,7 @@ Revision History:
 
 SET_DEFAULT_DEBUG_CHANNEL(MISC);
 
-#if defined(__hppa__) || ( defined (_IA64_) && defined (_HPUX_) )
+#if defined(_HPUX_) && ( defined (_IA64_) || defined (__hppa__) )
 #include <sys/pstat.h>
 #include <sys/vmparam.h>
 #endif
@@ -130,7 +130,7 @@ GetSystemInfo(
     lpSystemInfo->dwActiveProcessorMask_PAL_Undefined = 0;
 
 #if HAVE_SYSCONF
-#if defined(__hppa__) || ( defined (_IA64_) && defined (_HPUX_) )
+#if defined(_HPUX_) && ( defined (_IA64_) || defined (__hppa__) )
     struct pst_dynamic psd;
     if (pstat_getdynamic(&psd, sizeof(psd), (size_t)1, 0) != -1) {
         nrcpus = psd.psd_proc_cnt;
@@ -351,4 +351,3 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 
     return cacheSize;
 }
-


### PR DESCRIPTION
HPPA is one of the NetBSD ports.