### PR TITLE
NetBSD: Fix portability of isspace(3) usage

### DIFF
--- a/src/pal/src/safecrt/input.inl
+++ b/src/pal/src/safecrt/input.inl
@@ -73,11 +73,7 @@
 
 #define _MBTOWC(x,y,z) _minimal_chartowchar( x, y )
 
-#ifdef UNICODE
-#define _istspace(x)    isspace( ( char )( x & 0x00FF ) )
-#else
-#define _istspace(x)    isspace(x)
-#endif
+#define _istspace(x)    isspace((unsigned char)x)
 
 #define _malloc_crt PAL_malloc
 #define _realloc_crt PAL_realloc
@@ -1316,4 +1312,3 @@ static int __cdecl _whiteout(int* counter, miniFILE* fileptr)
 }
 
 #endif  /* CPRFLAG */
-


### PR DESCRIPTION
```
NAME
     isspace - white-space character test

LIBRARY
     Standard C Library (libc, -lc)

SYNOPSIS
     #include <ctype.h>

     int
     isspace(int c);

STANDARDS
     The isspace() function conforms to ANSI X3.159-1989 (``ANSI C89'').

CAVEATS
     The argument to isspace() must be EOF or representable as an unsigned
     char; otherwise, the behavior is undefined.
```

-- NetBSD man-page

This behavior is POSIX and Standard C:

```
The c argument is an int, the value of which the application shall ensure is a
character representable as an unsigned char or equal to the value of the macro
EOF. If the argument has any other value, the behavior is undefined.
```

-- The Open Group Base Specifications Issue 6
   IEEE Std 1003.1, 2004 Edition

C11 standard:

```
The header declares several functions useful for classifying and mapping
characters In all cases the argument is an int, the value of which shall be
representable as an unsigned char or shall equal the value of the macro EOF. If
the argument has any other value, the behavior is undefined.
```
-- 7.4 Character handling `<ctype.h>` paragraph 1