### PR TITLE
Unify reference count access

### DIFF
--- a/src/inc/ceegentokenmapper.h
+++ b/src/inc/ceegentokenmapper.h
@@ -65,7 +65,7 @@ public:
         SUPPORTS_DAC_HOST_ONLY;
 
         ULONG cRefs = --m_cRefs;
-        if (m_cRefs == 0)
+        if (cRefs == 0)
         {
             if (m_pIMapToken)
             {


### PR DESCRIPTION
The original code is correct, yet looks suspicious - it's unclear why `m_cRefs` is accessed instead of `cRefs`. It's clearer to just use `cRefs` (the "new value") everywhere.