### PR TITLE
Unique names for GlobalizationNative exports

### DIFF
--- a/src/corefx/System.Globalization.Native/calendarData.cpp
+++ b/src/corefx/System.Globalization.Native/calendarData.cpp
@@ -202,7 +202,8 @@ GetCalendars
 
 Returns the list of CalendarIds that are available for the specified locale.
 */
-extern "C" int32_t GetCalendars(const UChar* localeName, CalendarId* calendars, int32_t calendarsCapacity)
+extern "C" int32_t GlobalizationNative_GetCalendars(
+    const UChar* localeName, CalendarId* calendars, int32_t calendarsCapacity)
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
@@ -285,7 +286,7 @@ GetCalendarInfo
 Gets a single string of calendar information by filling the result parameter
 with the requested value.
 */
-extern "C" CalendarDataResult GetCalendarInfo(
+extern "C" CalendarDataResult GlobalizationNative_GetCalendarInfo(
     const UChar* localeName, CalendarId calendarId, CalendarDataType dataType, UChar* result, int32_t resultCapacity)
 {
     UErrorCode err = U_ZERO_ERROR;
@@ -539,11 +540,12 @@ Allows for a collection of calendar string data to be retrieved by invoking
 the callback for each value in the collection.
 The context parameter is passed through to the callback along with each string.
 */
-extern "C" int32_t EnumCalendarInfo(EnumCalendarInfoCallback callback,
-                                    const UChar* localeName,
-                                    CalendarId calendarId,
-                                    CalendarDataType dataType,
-                                    const void* context)
+extern "C" int32_t GlobalizationNative_EnumCalendarInfo(
+                        EnumCalendarInfoCallback callback, 
+                        const UChar* localeName, 
+                        CalendarId calendarId, 
+                        CalendarDataType dataType, 
+                        const void* context)
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
@@ -602,7 +604,7 @@ GetLatestJapaneseEra
 
 Gets the latest era in the Japanese calendar.
 */
-extern "C" int32_t GetLatestJapaneseEra()
+extern "C" int32_t GlobalizationNative_GetLatestJapaneseEra()
 {
     UErrorCode err = U_ZERO_ERROR;
     UCalendar* pCal = ucal_open(nullptr, 0, JAPANESE_LOCALE_AND_CALENDAR, UCAL_TRADITIONAL, &err);
@@ -622,7 +624,8 @@ GetJapaneseEraInfo
 
 Gets the starting Gregorian date of the specified Japanese Era.
 */
-extern "C" int32_t GetJapaneseEraStartDate(int32_t era, int32_t* startYear, int32_t* startMonth, int32_t* startDay)
+extern "C" int32_t GlobalizationNative_GetJapaneseEraStartDate(
+    int32_t era, int32_t* startYear, int32_t* startMonth, int32_t* startDay)
 {
     *startYear = -1;
     *startMonth = -1;

--- a/src/corefx/System.Globalization.Native/casing.cpp
+++ b/src/corefx/System.Globalization.Native/casing.cpp
@@ -15,46 +15,43 @@ ChangeCase
 Performs upper or lower casing of a string into a new buffer.
 No special casing is performed beyond that provided by ICU.
 */
-extern "C" void ChangeCase(const UChar* lpSrc,
-                           int32_t cwSrcLength,
-                           UChar* lpDst,
-                           int32_t cwDstLength,
-                           int32_t bToUpper)
+extern "C" void GlobalizationNative_ChangeCase(
+    const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength, int32_t bToUpper)
 {
-	// Iterate through the string, decoding the next one or two UTF-16 code units
-	// into a codepoint and updating srcIdx to point to the next UTF-16 code unit 
-	// to decode.  Then upper or lower case it, write dstCodepoint into lpDst at 
-	// offset dstIdx, and update dstIdx.
+    // Iterate through the string, decoding the next one or two UTF-16 code units
+    // into a codepoint and updating srcIdx to point to the next UTF-16 code unit 
+    // to decode.  Then upper or lower case it, write dstCodepoint into lpDst at 
+    // offset dstIdx, and update dstIdx.
 
-	// (The loop here has been manually cloned for each of the four cases, rather
-	// than having a single loop that internally branched based on bToUpper as the 
-	// compiler wasn't doing that optimization, and it results in an ~15-20% perf
-	// improvement on longer strings.)
+    // (The loop here has been manually cloned for each of the four cases, rather
+    // than having a single loop that internally branched based on bToUpper as the 
+    // compiler wasn't doing that optimization, and it results in an ~15-20% perf
+    // improvement on longer strings.)
 
-	UBool isError = FALSE;
-	int32_t srcIdx = 0, dstIdx = 0;
-	UChar32 srcCodepoint, dstCodepoint;
+    UBool isError = FALSE;
+    int32_t srcIdx = 0, dstIdx = 0;
+    UChar32 srcCodepoint, dstCodepoint;
 
-	if (bToUpper)
-	{
-		while (srcIdx < cwSrcLength)
-		{
-			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-			dstCodepoint = u_toupper(srcCodepoint);
-			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-			assert(isError == FALSE && srcIdx == dstIdx);
-		}
-	}
-	else
-	{
-		while (srcIdx < cwSrcLength)
-		{
-			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-			dstCodepoint = u_tolower(srcCodepoint);
-			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-			assert(isError == FALSE && srcIdx == dstIdx);
-		}
-	}
+    if (bToUpper)
+    {
+        while (srcIdx < cwSrcLength)
+        {
+            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+            dstCodepoint = u_toupper(srcCodepoint);
+            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+            assert(isError == FALSE && srcIdx == dstIdx);
+        }
+    }
+    else
+    {
+        while (srcIdx < cwSrcLength)
+        {
+            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+            dstCodepoint = u_tolower(srcCodepoint);
+            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+            assert(isError == FALSE && srcIdx == dstIdx);
+        }
+    }
 }
 
 /*
@@ -65,44 +62,41 @@ Performs upper or lower casing of a string into a new buffer.
 Special casing is performed to ensure that invariant casing 
 matches that of Windows in certain situations, e.g. Turkish i's.
 */
-extern "C" void ChangeCaseInvariant(const UChar* lpSrc,
-                                    int32_t cwSrcLength,
-                                    UChar* lpDst,
-                                    int32_t cwDstLength,
-                                    int32_t bToUpper)
+extern "C" void GlobalizationNative_ChangeCaseInvariant(
+    const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength, int32_t bToUpper)
 {
-	// See algorithmic comment in ChangeCase.
+    // See algorithmic comment in ChangeCase.
 
-	UBool isError = FALSE;
-	int32_t srcIdx = 0, dstIdx = 0;
-	UChar32 srcCodepoint, dstCodepoint;
+    UBool isError = FALSE;
+    int32_t srcIdx = 0, dstIdx = 0;
+    UChar32 srcCodepoint, dstCodepoint;
 
-	if (bToUpper)
-	{
-		while (srcIdx < cwSrcLength)
-		{
-			// On Windows with InvariantCulture, the LATIN SMALL LETTER DOTLESS I (U+0131)
-			// capitalizes to itself, whereas with ICU it capitalizes to LATIN CAPITAL LETTER I (U+0049).
-			// We special case it to match the Windows invariant behavior.
-			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-			dstCodepoint = ((srcCodepoint == (UChar32)0x0131) ? (UChar32)0x0131 : u_toupper(srcCodepoint));
-			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-			assert(isError == FALSE && srcIdx == dstIdx);
-		}
-	}
-	else
-	{
-		while (srcIdx < cwSrcLength)
-		{
-			// On Windows with InvariantCulture, the LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130)
-			// lower cases to itself, whereas with ICU it lower cases to LATIN SMALL LETTER I (U+0069).
-			// We special case it to match the Windows invariant behavior.
-			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-			dstCodepoint = ((srcCodepoint == (UChar32)0x0130) ? (UChar32)0x0130 : u_tolower(srcCodepoint));
-			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-			assert(isError == FALSE && srcIdx == dstIdx);
-		}
-	}
+    if (bToUpper)
+    {
+        while (srcIdx < cwSrcLength)
+        {
+            // On Windows with InvariantCulture, the LATIN SMALL LETTER DOTLESS I (U+0131)
+            // capitalizes to itself, whereas with ICU it capitalizes to LATIN CAPITAL LETTER I (U+0049).
+            // We special case it to match the Windows invariant behavior.
+            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+            dstCodepoint = ((srcCodepoint == (UChar32)0x0131) ? (UChar32)0x0131 : u_toupper(srcCodepoint));
+            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+            assert(isError == FALSE && srcIdx == dstIdx);
+        }
+    }
+    else
+    {
+        while (srcIdx < cwSrcLength)
+        {
+            // On Windows with InvariantCulture, the LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130)
+            // lower cases to itself, whereas with ICU it lower cases to LATIN SMALL LETTER I (U+0069).
+            // We special case it to match the Windows invariant behavior.
+            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+            dstCodepoint = ((srcCodepoint == (UChar32)0x0130) ? (UChar32)0x0130 : u_tolower(srcCodepoint));
+            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+            assert(isError == FALSE && srcIdx == dstIdx);
+        }
+    }
 }
 
 /*
@@ -112,40 +106,37 @@ ChangeCaseTurkish
 Performs upper or lower casing of a string into a new buffer, performing special
 casing for Turkish.
 */
-extern "C" void ChangeCaseTurkish(const UChar* lpSrc,
-								  int32_t cwSrcLength,
-								  UChar* lpDst,
-								  int32_t cwDstLength,
-								  int32_t bToUpper)
+extern "C" void GlobalizationNative_ChangeCaseTurkish(
+    const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength, int32_t bToUpper)
 {
-	// See algorithmic comment in ChangeCase.
+    // See algorithmic comment in ChangeCase.
 
-	UBool isError = FALSE;
-	int32_t srcIdx = 0, dstIdx = 0;
-	UChar32 srcCodepoint, dstCodepoint;
+    UBool isError = FALSE;
+    int32_t srcIdx = 0, dstIdx = 0;
+    UChar32 srcCodepoint, dstCodepoint;
 
-	if (bToUpper)
-	{
-		while (srcIdx < cwSrcLength)
-		{
-			// In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN
-			// CAPITAL LETTER I WITH DOT ABOVE (U+0130).
-			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-			dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
-			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-			assert(isError == FALSE && srcIdx == dstIdx);
-		}
-	}
-	else
-	{
-		while (srcIdx < cwSrcLength)
-		{
-			// In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to
-			// LATIN SMALL LETTER DOTLESS I (U+0131).
-			U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-			dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
-			U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-			assert(isError == FALSE && srcIdx == dstIdx);
-		}
-	}
+    if (bToUpper)
+    {
+        while (srcIdx < cwSrcLength)
+        {
+            // In turkish casing, LATIN SMALL LETTER I (U+0069) upper cases to LATIN
+            // CAPITAL LETTER I WITH DOT ABOVE (U+0130).
+            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+            dstCodepoint = ((srcCodepoint == (UChar32)0x0069) ? (UChar32)0x0130 : u_toupper(srcCodepoint));
+            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+            assert(isError == FALSE && srcIdx == dstIdx);
+        }
+    }
+    else
+    {
+        while (srcIdx < cwSrcLength)
+        {
+            // In turkish casing, LATIN CAPITAL LETTER I (U+0049) lower cases to
+            // LATIN SMALL LETTER DOTLESS I (U+0131).
+            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+            dstCodepoint = ((srcCodepoint == (UChar32)0x0049) ? (UChar32)0x0131 : u_tolower(srcCodepoint));
+            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+            assert(isError == FALSE && srcIdx == dstIdx);
+        }
+    }
 }

--- a/src/corefx/System.Globalization.Native/collation.cpp
+++ b/src/corefx/System.Globalization.Native/collation.cpp
@@ -295,7 +295,7 @@ UCollator* CloneCollatorWithOptions(const UCollator* pCollator, int32_t options,
     return pClonedCollator;
 }
 
-extern "C" SortHandle* GetSortHandle(const char* lpLocaleName)
+extern "C" SortHandle* GlobalizationNative_GetSortHandle(const char* lpLocaleName)
 {
     SortHandle* pSortHandle = new SortHandle();
 
@@ -315,7 +315,7 @@ extern "C" SortHandle* GetSortHandle(const char* lpLocaleName)
     return pSortHandle;
 }
 
-extern "C" void CloseSortHandle(SortHandle* pSortHandle)
+extern "C" void GlobalizationNative_CloseSortHandle(SortHandle* pSortHandle)
 {
     ucol_close(pSortHandle->regular);
     pSortHandle->regular = nullptr;
@@ -367,12 +367,8 @@ const UCollator* GetCollatorFromSortHandle(SortHandle* pSortHandle, int32_t opti
 Function:
 CompareString
 */
-extern "C" int32_t CompareString(SortHandle* pSortHandle,
-                                 const UChar* lpStr1,
-                                 int32_t cwStr1Length,
-                                 const UChar* lpStr2,
-                                 int32_t cwStr2Length,
-                                 int32_t options)
+extern "C" int32_t GlobalizationNative_CompareString(
+    SortHandle* pSortHandle, const UChar* lpStr1, int32_t cwStr1Length, const UChar* lpStr2, int32_t cwStr2Length, int32_t options)
 {
     static_assert(UCOL_EQUAL == 0, "managed side requires 0 for equal strings");
     static_assert(UCOL_LESS < 0, "managed side requires less than zero for a < b");
@@ -394,8 +390,13 @@ extern "C" int32_t CompareString(SortHandle* pSortHandle,
 Function:
 IndexOf
 */
-extern "C" int32_t
-IndexOf(SortHandle* pSortHandle, const UChar* lpTarget, int32_t cwTargetLength, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t GlobalizationNative_IndexOf(
+                        SortHandle* pSortHandle, 
+                        const UChar* lpTarget, 
+                        int32_t cwTargetLength, 
+                        const UChar* lpSource, 
+                        int32_t cwSourceLength, 
+                        int32_t options)
 {
     static_assert(USEARCH_DONE == -1, "managed side requires -1 for not found");
 
@@ -421,8 +422,13 @@ IndexOf(SortHandle* pSortHandle, const UChar* lpTarget, int32_t cwTargetLength, 
 Function:
 LastIndexOf
 */
-extern "C" int32_t LastIndexOf(
-    SortHandle* pSortHandle, const UChar* lpTarget, int32_t cwTargetLength, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t GlobalizationNative_LastIndexOf(
+                        SortHandle* pSortHandle, 
+                        const UChar* lpTarget, 
+                        int32_t cwTargetLength, 
+                        const UChar* lpSource, 
+                        int32_t cwSourceLength, 
+                        int32_t options)
 {
     static_assert(USEARCH_DONE == -1, "managed side requires -1 for not found");
 
@@ -472,11 +478,8 @@ static bool AreEqualOrdinalIgnoreCase(UChar32 one, UChar32 two)
 Function:
 IndexOfOrdinalIgnoreCase
 */
-extern "C" int32_t
-IndexOfOrdinalIgnoreCase(
-    const UChar* lpTarget, int32_t cwTargetLength, 
-    const UChar* lpSource, int32_t cwSourceLength, 
-    int32_t findLast)
+extern "C" int32_t GlobalizationNative_IndexOfOrdinalIgnoreCase(
+    const UChar* lpTarget, int32_t cwTargetLength, const UChar* lpSource, int32_t cwSourceLength, int32_t findLast)
 {
     int32_t result = -1;
 
@@ -520,8 +523,13 @@ IndexOfOrdinalIgnoreCase(
 /*
  Return value is a "Win32 BOOL" (1 = true, 0 = false)
  */
-extern "C" int32_t StartsWith(
-    SortHandle* pSortHandle, const UChar* lpTarget, int32_t cwTargetLength, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t GlobalizationNative_StartsWith(
+                        SortHandle* pSortHandle, 
+                        const UChar* lpTarget, 
+                        int32_t cwTargetLength, 
+                        const UChar* lpSource, 
+                        int32_t cwSourceLength, 
+                        int32_t options)
 {
     int32_t result = FALSE;
     UErrorCode err = U_ZERO_ERROR;
@@ -582,8 +590,13 @@ extern "C" int32_t StartsWith(
 /*
  Return value is a "Win32 BOOL" (1 = true, 0 = false)
  */
-extern "C" int32_t EndsWith(
-    SortHandle* pSortHandle, const UChar* lpTarget, int32_t cwTargetLength, const UChar* lpSource, int32_t cwSourceLength, int32_t options)
+extern "C" int32_t GlobalizationNative_EndsWith(
+                        SortHandle* pSortHandle, 
+                        const UChar* lpTarget, 
+                        int32_t cwTargetLength, 
+                        const UChar* lpSource, 
+                        int32_t cwSourceLength, 
+                        int32_t options)
 {
     int32_t result = FALSE;
     UErrorCode err = U_ZERO_ERROR;
@@ -617,12 +630,13 @@ extern "C" int32_t EndsWith(
     return result;
 }
 
-extern "C" int32_t GetSortKey(SortHandle* pSortHandle,
-                              const UChar* lpStr,
-                              int32_t cwStrLength,
-                              uint8_t* sortKey,
-                              int32_t cbSortKeyLength,
-                              int32_t options)
+extern "C" int32_t GlobalizationNative_GetSortKey(
+                        SortHandle* pSortHandle, 
+                        const UChar* lpStr, 
+                        int32_t cwStrLength, 
+                        uint8_t* sortKey, 
+                        int32_t cbSortKeyLength, 
+                        int32_t options)
 {
     UErrorCode err = U_ZERO_ERROR;
     const UCollator* pColl = GetCollatorFromSortHandle(pSortHandle, options, &err);
@@ -636,8 +650,8 @@ extern "C" int32_t GetSortKey(SortHandle* pSortHandle,
     return result;
 }
 
-extern "C" int32_t
-CompareStringOrdinalIgnoreCase(const UChar* lpStr1, int32_t cwStr1Length, const UChar* lpStr2, int32_t cwStr2Length)
+extern "C" int32_t GlobalizationNative_CompareStringOrdinalIgnoreCase(
+    const UChar* lpStr1, int32_t cwStr1Length, const UChar* lpStr2, int32_t cwStr2Length)
 {
     assert(lpStr1 != nullptr);
     assert(cwStr1Length >= 0);

--- a/src/corefx/System.Globalization.Native/idna.cpp
+++ b/src/corefx/System.Globalization.Native/idna.cpp
@@ -38,7 +38,8 @@ Return values:
 0: internal error during conversion.
 >0: the length of the converted string (not including the null terminator).
 */
-extern "C" int32_t ToAscii(uint32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+extern "C" int32_t GlobalizationNative_ToAscii(
+    uint32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
 {
     UErrorCode err = U_ZERO_ERROR;
     UIDNAInfo info = UIDNA_INFO_INITIALIZER;
@@ -63,7 +64,8 @@ Return values:
 0: internal error during conversion.
 >0: the length of the converted string (not including the null terminator).
 */
-extern "C" int32_t ToUnicode(int32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+extern "C" int32_t GlobalizationNative_ToUnicode(
+    int32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
 {
     UErrorCode err = U_ZERO_ERROR;
     UIDNAInfo info = UIDNA_INFO_INITIALIZER;

--- a/src/corefx/System.Globalization.Native/idna.cpp
+++ b/src/corefx/System.Globalization.Native/idna.cpp
@@ -53,6 +53,15 @@ extern "C" int32_t GlobalizationNative_ToAscii(
     return ((U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) && (info.errors == 0)) ? asciiStrLen : 0;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the corefx managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ToAscii(
+    uint32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+{
+    return GlobalizationNative_ToAscii(flags, lpSrc, cwSrcLength, lpDst, cwDstLength);
+}
+
 /*
 Function:
 ToUnicode
@@ -77,4 +86,13 @@ extern "C" int32_t GlobalizationNative_ToUnicode(
     uidna_close(pIdna);
 
     return ((U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) && (info.errors == 0)) ? unicodeStrLen : 0;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the corefx managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ToUnicode(
+    int32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+{
+    return GlobalizationNative_ToUnicode(flags, lpSrc, cwSrcLength, lpDst, cwDstLength);
 }

--- a/src/corefx/System.Globalization.Native/locale.cpp
+++ b/src/corefx/System.Globalization.Native/locale.cpp
@@ -110,7 +110,7 @@ int32_t FixupLocaleName(UChar* value, int32_t valueLength)
     return i;
 }
 
-extern "C" int32_t GetLocaleName(const UChar* localeName, UChar* value, int32_t valueLength)
+extern "C" int32_t GlobalizationNative_GetLocaleName(const UChar* localeName, UChar* value, int32_t valueLength)
 {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -130,7 +130,7 @@ extern "C" int32_t GetLocaleName(const UChar* localeName, UChar* value, int32_t 
     return UErrorCodeToBool(status);
 }
 
-extern "C" int32_t GetDefaultLocaleName(UChar* value, int32_t valueLength)
+extern "C" int32_t GlobalizationNative_GetDefaultLocaleName(UChar* value, int32_t valueLength)
 {
     char localeNameBuffer[ULOC_FULLNAME_CAPACITY];
     UErrorCode status = U_ZERO_ERROR;

--- a/src/corefx/System.Globalization.Native/locale.hpp
+++ b/src/corefx/System.Globalization.Native/locale.hpp
@@ -5,15 +5,6 @@
 #include "unicode/locid.h"
 
 /*
-PAL Function:
-GetLocaleName
-
-Obtains a canonical locale name given a user-specified locale name
-Returns 1 for success, 0 otherwise
-*/
-extern "C" int32_t GetLocaleName(const UChar* localeName, UChar* value, int32_t valueLength);
-
-/*
 Function:
 UErrorCodeToBool
 

--- a/src/corefx/System.Globalization.Native/localeNumberData.cpp
+++ b/src/corefx/System.Globalization.Native/localeNumberData.cpp
@@ -395,7 +395,8 @@ GetLocaleInfoInt
 Obtains integer locale information
 Returns 1 for success, 0 otherwise
 */
-extern "C" int32_t GetLocaleInfoInt(const UChar* localeName, LocaleNumberData localeNumberData, int32_t* value)
+extern "C" int32_t GlobalizationNative_GetLocaleInfoInt(
+    const UChar* localeName, LocaleNumberData localeNumberData, int32_t* value)
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
@@ -520,10 +521,8 @@ GetLocaleInfoGroupingSizes
 Obtains grouping sizes for decimal and currency
 Returns 1 for success, 0 otherwise
 */
-extern "C" int32_t GetLocaleInfoGroupingSizes(const UChar* localeName,
-                                              LocaleNumberData localeGroupingData,
-                                              int32_t* primaryGroupSize,
-                                              int32_t* secondaryGroupSize)
+extern "C" int32_t GlobalizationNative_GetLocaleInfoGroupingSizes(
+    const UChar* localeName, LocaleNumberData localeGroupingData, int32_t* primaryGroupSize, int32_t* secondaryGroupSize)
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];

--- a/src/corefx/System.Globalization.Native/localeStringData.cpp
+++ b/src/corefx/System.Globalization.Native/localeStringData.cpp
@@ -164,8 +164,8 @@ GetLocaleInfoString
 Obtains string locale information.
 Returns 1 for success, 0 otherwise
 */
-extern "C" int32_t
-GetLocaleInfoString(const UChar* localeName, LocaleStringData localeStringData, UChar* value, int32_t valueLength)
+extern "C" int32_t GlobalizationNative_GetLocaleInfoString(
+    const UChar* localeName, LocaleStringData localeStringData, UChar* value, int32_t valueLength)
 {
     UErrorCode status = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];
@@ -295,7 +295,8 @@ GetLocaleTimeFormat
 Obtains time format information (in ICU format, it needs to be coverted to .NET Format).
 Returns 1 for success, 0 otherwise
 */
-extern "C" int32_t GetLocaleTimeFormat(const UChar* localeName, int shortFormat, UChar* value, int32_t valueLength)
+extern "C" int32_t GlobalizationNative_GetLocaleTimeFormat(
+    const UChar* localeName, int shortFormat, UChar* value, int32_t valueLength)
 {
     UErrorCode err = U_ZERO_ERROR;
     char locale[ULOC_FULLNAME_CAPACITY];

--- a/src/corefx/System.Globalization.Native/normalization.cpp
+++ b/src/corefx/System.Globalization.Native/normalization.cpp
@@ -48,7 +48,8 @@ Return values:
 1: lpStr is normalized.
 -1: internal error during normalization.
 */
-extern "C" int32_t IsNormalized(NormalizationForm normalizationForm, const UChar* lpStr, int32_t cwStrLength)
+extern "C" int32_t GlobalizationNative_IsNormalized(
+    NormalizationForm normalizationForm, const UChar* lpStr, int32_t cwStrLength)
 {
     UErrorCode err = U_ZERO_ERROR;
     const UNormalizer2* pNormalizer = GetNormalizerForForm(normalizationForm, &err);
@@ -76,7 +77,7 @@ Return values:
 0: internal error during normalization.
 >0: the length of the normalized string (not counting the null terminator).
 */
-extern "C" int32_t NormalizeString(
+extern "C" int32_t GlobalizationNative_NormalizeString(
     NormalizationForm normalizationForm, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
 {
     UErrorCode err = U_ZERO_ERROR;

--- a/src/corefx/System.Globalization.Native/normalization.cpp
+++ b/src/corefx/System.Globalization.Native/normalization.cpp
@@ -65,6 +65,15 @@ extern "C" int32_t GlobalizationNative_IsNormalized(
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the corefx managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t IsNormalized(
+    NormalizationForm normalizationForm, const UChar* lpStr, int32_t cwStrLength)
+{
+    return GlobalizationNative_IsNormalized(normalizationForm, lpStr, cwStrLength);
+}
+
 /*
 Function:
 NormalizeString
@@ -85,4 +94,13 @@ extern "C" int32_t GlobalizationNative_NormalizeString(
     int32_t normalizedLen = unorm2_normalize(pNormalizer, lpSrc, cwSrcLength, lpDst, cwDstLength, &err);
 
     return (U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) ? normalizedLen : 0;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the corefx managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t NormalizeString(
+    NormalizationForm normalizationForm, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+{
+    return GlobalizationNative_NormalizeString(normalizationForm, lpSrc, cwSrcLength, lpDst, cwDstLength);
 }

--- a/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
+++ b/src/corefx/System.Globalization.Native/timeZoneInfo.cpp
@@ -12,7 +12,7 @@ ReadLink
 
 Gets the symlink value for the path.
 */
-extern "C" int32_t ReadLink(const char* path, char* result, size_t resultCapacity)
+extern "C" int32_t GlobalizationNative_ReadLink(const char* path, char* result, size_t resultCapacity)
 {
     ssize_t r = readlink(path, result, resultCapacity - 1); // subtract one to make room for the NULL character
 

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Calendar.cs
@@ -15,20 +15,20 @@ internal static partial class Interop
            [MarshalAs(UnmanagedType.LPWStr)] string calendarString,
            IntPtr context);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendars")]
         internal static extern int GetCalendars(string localeName, CalendarId[] calendars, int calendarsCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetCalendarInfo")]
         internal static extern CalendarDataResult GetCalendarInfo(string localeName, CalendarId calendarId, CalendarDataType calendarDataType, [Out] StringBuilder result, int resultCapacity);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EnumCalendarInfo")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EnumCalendarInfo(EnumCalendarInfoCallback callback, string localeName, CalendarId calendarId, CalendarDataType calendarDataType, IntPtr context);
 
-        [DllImport(Libraries.GlobalizationInterop)]
+        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetLatestJapaneseEra")]
         internal static extern int GetLatestJapaneseEra();
 
-        [DllImport(Libraries.GlobalizationInterop)]
+        [DllImport(Libraries.GlobalizationInterop, EntryPoint = "GlobalizationNative_GetJapaneseEraStartDate")]
         internal static extern bool GetJapaneseEraStartDate(int era, out int startYear, out int startMonth, out int startDay);
     }
 }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
@@ -12,15 +12,15 @@ internal static partial class Interop
     internal static partial class GlobalizationInterop
     {
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCase")]
         internal unsafe static extern void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseInvariant")]
         internal unsafe static extern void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseTurkish")]
         internal unsafe static extern void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
     }
 }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Collation.cs
@@ -12,45 +12,45 @@ internal static partial class Interop
     internal static partial class GlobalizationInterop
     {
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortHandle")]
         internal unsafe static extern SafeSortHandle GetSortHandle(byte[] localeName);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CloseSortHandle")]
         internal unsafe static extern void CloseSortHandle(IntPtr handle);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareString")]
         internal unsafe static extern int CompareString(SafeSortHandle sortHandle, char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len, CompareOptions options);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOf")]
         internal unsafe static extern int IndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_LastIndexOf")]
         internal unsafe static extern int LastIndexOf(SafeSortHandle sortHandle, string target, int cwTargetLength, char* pSource, int cwSourceLength, CompareOptions options);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IndexOfOrdinalIgnoreCase")]
         internal unsafe static extern int IndexOfOrdinalIgnoreCase(string target, int cwTargetLength, char* pSource, int cwSourceLength, bool findLast);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_StartsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool StartsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_EndsWith")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool EndsWith(SafeSortHandle sortHandle, string target, int cwTargetLength, string source, int cwSourceLength, CompareOptions options);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetSortKey")]
         internal unsafe static extern int GetSortKey(SafeSortHandle sortHandle, string str, int strLength, byte* sortKey, int sortKeyLength, CompareOptions options);
 
         [SecurityCritical]
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_CompareStringOrdinalIgnoreCase")]
         internal unsafe static extern int CompareStringOrdinalIgnoreCase(char* lpStr1, int cwStr1Len, char* lpStr2, int cwStr2Len);
 
         [SecurityCritical]

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.Locale.cs
@@ -10,27 +10,27 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleName(string localeName, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoString")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoString(string localeName, uint localeStringData, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetDefaultLocaleName")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetDefaultLocaleName([Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleTimeFormat")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleTimeFormat(string localeName, bool shortFormat, [Out] StringBuilder value, int valueLength);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoInt")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoInt(string localeName, uint localeNumberData, ref int value);
 
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_GetLocaleInfoGroupingSizes")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal unsafe static extern bool GetLocaleInfoGroupingSizes(string localeName, uint localeGroupingData, ref int primaryGroupSize, ref int secondaryGroupSize);
     }

--- a/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
+++ b/src/mscorlib/corefx/Interop/Unix/System.Globalization.Native/Interop.TimeZoneInfo.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationInterop
     {
-        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi)] // readlink requires char*
+        [DllImport(Libraries.GlobalizationInterop, CharSet = CharSet.Ansi, EntryPoint = "GlobalizationNative_ReadLink")] // readlink requires char*
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool ReadLink(string filePath, [Out] StringBuilder result, uint resultCapacity);
     }


### PR DESCRIPTION
For consistency and to enable eventual sharing of the same code with CoreRT, I have changed the naming convention for System.Globalization.Native exports to match dotnet/corefx#4818.

The change includes temporary un-prefixed wrappers for the couple of methods that are used by corefx.