### PR TITLE
Exclude some tests from GCStress runs

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -302,4 +302,9 @@
              <Issue>2744</Issue>
         </ExcludeList>
     </ItemGroup>
+    <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(COMPlus_GCStress)' != ''">	
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\**\*" >
+             <Issue>2759; These tests fail by design under GcStress</Issue>
+        </ExcludeList>
+    </ItemGroup>    
 </Project>


### PR DESCRIPTION
JIT/Methodical/doublearray/* tests fail by design under GCStress.
So, exclude them from testing in issues.targets when
COMPlus_GCStress is set.

The exclusion is not added to testsUnsupportedOutsideWindows.txt
because the there is no facility to do conditional exclusion there.
However, the exclusion will work once the non-windows platforms use
msbuild like harness that consumes the issues.targets script.

Fixes #2759