### PR TITLE
Fix to issue #2700

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7810,7 +7810,7 @@ GenTree* Compiler::fgCreateMonitorTree(unsigned lvaMonAcquired, unsigned lvaThis
         GenTree* retNode = block->lastStmt()->gtStmtExpr;
         GenTree* retExpr = retNode->gtOp.gtOp1;
         
-        if (retExpr)
+        if (retExpr != nullptr)
         {
             // have to insert this immediately before the GT_RETURN so we transform:
             // ret(...) ->
@@ -7831,7 +7831,8 @@ GenTree* Compiler::fgCreateMonitorTree(unsigned lvaMonAcquired, unsigned lvaThis
         }
         else
         {
-            fgInsertStmtAtEnd(block, tree);
+            // Insert this immediately before the GT_RETURN
+            fgInsertStmtNearEnd(block, tree);
         }
     }
     else

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -14120,35 +14120,52 @@ void                Compiler::fgMorphBlocks()
                     fgReturnCount--;
                 }
 
+                // Block is guaranteed to have last stmt as its jump kind is BBJ_RETURN
+                noway_assert(block->bbTreeList);
+                GenTreePtr last = block->bbTreeList->gtPrev;
+                noway_assert(last != nullptr);
+                noway_assert(last->gtNext == nullptr);
+                noway_assert(last->gtOper == GT_STMT);
+
+                // Block's last stmt must be GT_RETURN
+                GenTreePtr ret = last->gtStmt.gtStmtExpr;
+                noway_assert(ret != nullptr);
+                noway_assert(ret->OperGet() == GT_RETURN);
+                noway_assert(ret->gtGetOp2() == nullptr);
+
                 //replace the GT_RETURN node to be a GT_ASG that stores the return value into genReturnLocal.
                 if (genReturnLocal != BAD_VAR_NUM)
                 {
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
                     noway_assert(info.compRetType != TYP_VOID);
-#else // !defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
+#else 
                     noway_assert(info.compRetType != TYP_VOID && info.compRetNativeType != TYP_STRUCT);
-#endif // !defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-                    noway_assert(block->bbTreeList);
+#endif
 
-                    GenTreePtr last = block->bbTreeList->gtPrev;
-                    noway_assert(last && last->gtNext == NULL && last->gtOper == GT_STMT);
-                    GenTreePtr ret = last->gtStmt.gtStmtExpr;
-                    noway_assert(ret && ret->gtOper == GT_RETURN && ret->gtOp.gtOp1 && !(ret->gtOp.gtOp2));
-                    last->gtStmt.gtStmtExpr = gtNewTempAssign(genReturnLocal, ret->gtOp.gtOp1);
+                    // GT_RETURN must have non-null operand as the method is returning the value assigned to genReturnLocal
+                    noway_assert(ret->gtGetOp1() != nullptr);
+
+                    last->gtStmt.gtStmtExpr = gtNewTempAssign(genReturnLocal, ret->gtGetOp1());
 
                     //make sure that copy-prop ignores this assignment.
                     last->gtStmt.gtStmtExpr->gtFlags |= GTF_DONT_CSE;
-
-#ifdef DEBUG
-                    if  (verbose)
-                    {
-                        printf( "morph BB%02u to point at onereturn.  New block is\n",
-                                block->bbNum );
-                        fgTableDispBasicBlock(block);
-                    }
-#endif
+                }
+                else
+                {
+                    // Must be a void GT_RETURN with null operand; delete it as this block branches to oneReturn block
+                    noway_assert(ret->gtGetOp1() == nullptr);
+                    noway_assert(ret->TypeGet() == TYP_VOID);
+                    fgRemoveStmt(block, last);
                 }
 
+#ifdef DEBUG
+                if (verbose)
+                {
+                    printf("morph BB%02u to point at onereturn.  New block is\n",
+                        block->bbNum);
+                    fgTableDispBasicBlock(block);
+                }
+#endif
              }
         }
 


### PR DESCRIPTION
This is a case of a method returning a struct > 16-bytes in size via hidden RetBuf arg.  Hence its return type is morphed to TYP_VOID.  Initially method (in repro case is an PInvoke IL Stub that returns Struct) starts off  with a single basic block BB01 and the last top level stmt of BB01 is GT_RETURN of type TYP_VOID.

Since the method has PInvokes, JIT decides to add a sigle-return block, BB02,  to the method.  After adding BB02

BB01 - last top level stmt is still GT_RETURN but its branch type is changed to BBJ_ALWAYS and its destination branch is changed to BB02.
BB02 - now has some PInvoke frame un-linking logic and ends with GT_RETURN and marked as BBJ_RETURN.

That is both BB01 and BB02 are ending with GT_RETURN top level stmt.  This happens both in Windows and Linux.  

Issue on Windows:
This is problematic on windows when running under profiler, since codegen will generate Leave callbacks when GT_RETURN stmnt is encountered.

Issue on Linux:
Apart from the profiler issue, it can also lead to silent bad codegen, since Amd64 Unix ABI requires that RetBuf be returned in RAX.  Right now Linux codegen generates "mov rax, retbuf-addr" when a GT_RETURN with void type is encountered and the method has a hidden RetBuf argument.  As a result, when GT_RETURN is encountered in BB01

mov rax, RetBuf-addr

is generated.

But rax is allocated for PInvoke Frame Root var.  While un-linking PInvoke frame (i.e. BB02 codegen), jitted code will endup writing to RetBuf instead of to PInvoke frame and thereby corrupting RetBuf (or struct ret val from the PInvoke).  This leads to test failure.  Under LSRA stress it is so happening that PInvoke Frame Root Var gets allocated to Rax and hence this issue repros only under LSRA stress.

Fix: is to delete GT_RETURN stmnt of TYP_VOID from BB01.  Also added some asserts in fgMorphBlocks() when blocks like BB01 are getting converted to branch to oneReturn blocks.  These assert that a basic block with bbJumpKind == GT_RETURN ends with a GT_RETURN stmnt.  These asserts exposed another bug in fgCreateMonitorTree() that is meant for inserting Monitor.Enter and Monitor.Exit() stmtnts.  The issue is when a synchronized method has TYP_VOID return, fgCreateMonitorTree() is inserting Monitor.Exit call after GT_RETURN instead of immediately before GT_RETURN.  Fix is to use fgInsertStmtNearEnd() instead of fgInsertStmtAtEnd().

Fix #2700 

