### PR TITLE
Add support for NetBSD-style gregs on x86

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -58,6 +58,7 @@
 #cmakedefine01 HAVE_BSD_REGS_T
 #cmakedefine01 HAVE_PT_REGS
 #cmakedefine01 HAVE_GREGSET_T
+#cmakedefine01 HAVE___GREGSET_T
 #cmakedefine01 HAVE_SIGINFO_T
 #cmakedefine01 HAVE_UCONTEXT_T
 #cmakedefine01 HAVE_PTHREAD_RWLOCK_T

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -76,6 +76,7 @@ check_struct_has_member ("struct stat" st_atimespec "sys/types.h;sys/stat.h" HAV
 check_struct_has_member ("struct stat" st_atimensec "sys/types.h;sys/stat.h" HAVE_STAT_NSEC)
 check_struct_has_member ("struct tm" tm_gmtoff time.h HAVE_TM_GMTOFF)
 check_struct_has_member ("ucontext_t" uc_mcontext.gregs[0] ucontext.h HAVE_GREGSET_T)
+check_struct_has_member ("ucontext_t" uc_mcontext.__gregs[0] ucontext.h HAVE___GREGSET_T)
 
 set(CMAKE_EXTRA_INCLUDE_FILES machine/reg.h)
 check_type_size("struct reg" BSD_REGS_T)

--- a/src/pal/src/include/pal/context.h
+++ b/src/pal/src/include/pal/context.h
@@ -44,7 +44,48 @@ typedef ucontext_t native_context_t;
 #include <mach/mach_port.h>
 #endif // !HAVE_MACH_EXCEPTIONS else
 
-#if HAVE_GREGSET_T
+#if HAVE___GREGSET_T
+
+#ifdef BIT64
+#define MCREG_Rbx(mc)       ((mc).__gregs[_REG_RBX])
+#define MCREG_Rcx(mc)       ((mc).__gregs[_REG_RCX])
+#define MCREG_Rdx(mc)       ((mc).__gregs[_REG_RDX])
+#define MCREG_Rsi(mc)       ((mc).__gregs[_REG_RSI])
+#define MCREG_Rdi(mc)       ((mc).__gregs[_REG_RDI])
+#define MCREG_Rbp(mc)       ((mc).__gregs[_REG_RBP])
+#define MCREG_Rax(mc)       ((mc).__gregs[_REG_RAX])
+#define MCREG_Rip(mc)       ((mc).__gregs[_REG_RIP])
+#define MCREG_Rsp(mc)       ((mc).__gregs[_REG_RSP])
+#define MCREG_SegCs(mc)     ((mc).__gregs[_REG_CS])
+#define MCREG_SegSs(mc)     ((mc).__gregs[_REG_SS])
+#define MCREG_R8(mc)        ((mc).__gregs[_REG_R8])
+#define MCREG_R9(mc)        ((mc).__gregs[_REG_R9])
+#define MCREG_R10(mc)       ((mc).__gregs[_REG_R10])
+#define MCREG_R11(mc)       ((mc).__gregs[_REG_R11])
+#define MCREG_R12(mc)       ((mc).__gregs[_REG_R12])
+#define MCREG_R13(mc)       ((mc).__gregs[_REG_R13])
+#define MCREG_R14(mc)       ((mc).__gregs[_REG_R14])
+#define MCREG_R15(mc)       ((mc).__gregs[_REG_R15])
+#define MCREG_EFlags(mc)    ((mc).__gregs[_REG_RFLAGS])
+
+#else // BIT64
+
+#define MCREG_Ebx(mc)       ((mc).__gregs[_REG_EBX])
+#define MCREG_Ecx(mc)       ((mc).__gregs[_REG_ECX])
+#define MCREG_Edx(mc)       ((mc).__gregs[_REG_EDX])
+#define MCREG_Esi(mc)       ((mc).__gregs[_REG_ESI])
+#define MCREG_Edi(mc)       ((mc).__gregs[_REG_EDI])
+#define MCREG_Ebp(mc)       ((mc).__gregs[_REG_EBP])
+#define MCREG_Eax(mc)       ((mc).__gregs[_REG_EAX])
+#define MCREG_Eip(mc)       ((mc).__gregs[_REG_EIP])
+#define MCREG_Esp(mc)       ((mc).__gregs[_REG_ESP])
+#define MCREG_SegCs(mc)     ((mc).__gregs[_REG_CS])
+#define MCREG_SegSs(mc)     ((mc).__gregs[_REG_SS])
+#define MCREG_EFlags(mc)    ((mc).__gregs[_REG_RFLAGS])
+
+#endif // BIT64
+
+#elif HAVE_GREGSET_T
 
 #ifdef BIT64
 #define MCREG_Rbx(mc)       ((mc).gregs[REG_RBX])


### PR DESCRIPTION
Floating point registers will be added later.

```
typedef struct {
        __gregset_t     __gregs;
        __greg_t        _mc_tlsbase;
        __fpregset_t    __fpregs;
} mcontext_t;
```

 --- `/usr/include/amd64/mcontext.h`
     (linked to `machine/mcontext.h` on NetBSD/amd64)

```
typedef struct {
        __gregset_t     __gregs;
        __fpregset_t    __fpregs;
        __greg_t        _mc_tlsbase;
} mcontext_t;
```

 --- `/usr/include/i386/mcontext.h`
     (linked to `machine/mcontext.h` on NetBSD/i386)