### PR TITLE
NetBSD doesn't ship with SI_KERNEL

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -631,6 +631,8 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
                 case SEGV_MAPERR:   // Address not mapped to object
                 case SEGV_ACCERR:   // Invalid permissions for mapped object
                     return EXCEPTION_ACCESS_VIOLATION;
+
+#ifdef SI_KERNEL
                 case SI_KERNEL:
                 {
                     // Identify privileged instructions that are not identified as such by the system
@@ -644,6 +646,7 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
                     }
                     // fall through
                 }
+#endif
                 default:
                     break;
             }
@@ -662,7 +665,9 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
         case SIGTRAP:
             switch (siginfo->si_code)
             {
+#ifdef SI_KERNEL
                 case SI_KERNEL:
+#endif
                 case SI_USER:
                 case TRAP_BRKPT:    // Process breakpoint
                     return EXCEPTION_BREAKPOINT;


### PR DESCRIPTION
`SI_KERNEL` is available in Linux and FreeBSD. It's unspecified what does it mean.

Linux:

```
#define SI_KERNEL       0x80            /* sent by the kernel from somewhere */
```

  -- `include/uapi/asm-generic/siginfo.h`

FreeBSD:

```
                    SI_KERNEL            signal generated by miscellaneous
                                         parts of the kernel
```

  -- `siginfo`(3)