### PR TITLE
NetBSD: Disable check for minimal stack size for undefined PTHREAD_ST…

### DIFF
--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -616,11 +616,13 @@ CorUnix::InternalCreateThread(
         dwStackSize = CPalThread::s_dwDefaultThreadStackSize;
     }
 
+#ifdef PTHREAD_STACK_MIN
     if (PTHREAD_STACK_MIN > pthreadStackSize)
     {
         WARN("default stack size is reported as %d, but PTHREAD_STACK_MIN is "
              "%d\n", pthreadStackSize, PTHREAD_STACK_MIN);
     }
+#endif
     
     if (pthreadStackSize < dwStackSize)
     {


### PR DESCRIPTION
…ACK_MIN

An alternative would be `sysconf(_SC_THREAD_STACK_MIN)`, but it might be no
good reason to prohibit single page stack size (`PAGE_SIZE`).