### PR TITLE
Fix build on NetBSD, casting pointer to function to pointer to data

### DIFF
--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -5193,7 +5193,7 @@ LPVOID NDirectMethodDesc::FindEntryPoint(HINSTANCE hMod) const
     if (GetEntrypointName()[0] == '#')
     {
         long ordinal = atol(GetEntrypointName()+1);
-        return GetProcAddress(hMod, (LPCSTR)(size_t)((UINT16)ordinal));
+        return reinterpret_cast<LPVOID>(GetProcAddress(hMod, (LPCSTR)(size_t)((UINT16)ordinal)));
     }
 
     // Just look for the unmangled name.  If it is unicode fcn, we are going


### PR DESCRIPTION
```
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/vm/method.cpp:5196:16: error: cannot initialize return object of type 'LPVOID' (aka 'void *') with an rvalue of type 'FARPROC' (aka 'long (*)()')
        return GetProcAddress(hMod, (LPCSTR)(size_t)((UINT16)ordinal));
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```