### PR TITLE
Fix cast to interface other than the most derived one

### DIFF
--- a/src/inc/testhook.h
+++ b/src/inc/testhook.h
@@ -143,7 +143,7 @@ public:
 			|| IsEqualIID(riid, IID_ICLRTestHook3))
         {
             AddRef();
-            *ppv = (ICLRTestHook*) (this);
+            *ppv = static_cast<ICLRTestHook3*>(this);
             return S_OK;
         }
         else


### PR DESCRIPTION
The current code casts to `ICLRTestHook` no matter which interface is requested. So when the caller requests `ICLRTestHook3` he still gets `ICLRTestHook` and although `ICLRTestHook3` *is* `ICLRTestHook` the opposite is not true so formally the caller gets an invalid pointer.

Also `static_cast` will help catch dumb errors later.