### PR TITLE
Don't access deleted object, return proper error code

### DIFF
--- a/src/ToolBox/PdbTypeMatch/callback.h
+++ b/src/ToolBox/PdbTypeMatch/callback.h
@@ -17,13 +17,14 @@ public:
         return m_nRefCount;
     }
     ULONG STDMETHODCALLTYPE Release() {
-        if ( (--m_nRefCount) == 0 )
+        ULONG newRefCount = --m_nRefCount;
+        if ( newRefCount == 0 )
             delete this;
-        return m_nRefCount;
+        return newRefCount;
     }
     HRESULT STDMETHODCALLTYPE QueryInterface( REFIID rid, void **ppUnk ) {
         if ( ppUnk == NULL ) {
-            return E_INVALIDARG;
+            return E_POINTER;
         }
         if (rid == __uuidof( IDiaLoadCallback2 ) )
             *ppUnk = (IDiaLoadCallback2 *)this;


### PR DESCRIPTION
The original code accesses the current object after it's been deleted with `delete this` which causes undefined behavior.

Also `E_POINTER` is the proper code to return when a null pointer is passed for "out" parameter.