### PR TITLE
Fix ReadyToRun on Unix

### DIFF
--- a/src/inc/pedecoder.h
+++ b/src/inc/pedecoder.h
@@ -379,6 +379,8 @@ class PEDecoder
     IMAGE_SECTION_HEADER *RvaToSection(RVA rva) const;
     IMAGE_SECTION_HEADER *OffsetToSection(COUNT_T fileOffset) const;
 
+    void SetRelocated();
+
   private:
 
     // ------------------------------------------------------------

--- a/src/inc/pedecoder.inl
+++ b/src/inc/pedecoder.inl
@@ -63,6 +63,11 @@ inline BOOL PEDecoder::IsRelocated() const
     return (m_flags & FLAG_RELOCATED) != 0;
 }
 
+inline void PEDecoder::SetRelocated()
+{
+    m_flags |= FLAG_RELOCATED;
+}
+
 inline BOOL PEDecoder::IsFlat() const
 {
     LIMITED_METHOD_CONTRACT;

--- a/src/pal/inc/unixasmmacrosamd64.inc
+++ b/src/pal/inc/unixasmmacrosamd64.inc
@@ -323,7 +323,8 @@ C_FUNC(\Name\()_End):
 
 .macro EPILOG_WITH_TRANSITION_BLOCK_RETURN
 
-        add rsp, __PWTB_StackAlloc
+        free_stack      __PWTB_StackAlloc
+        POP_ARGUMENT_REGISTERS
         POP_CALLEE_SAVED_REGISTERS
         ret
 

--- a/src/vm/amd64/externalmethodfixupthunk.S
+++ b/src/vm/amd64/externalmethodfixupthunk.S
@@ -30,7 +30,7 @@ NESTED_END ExternalMethodFixupStub, _TEXT
 
 NESTED_ENTRY DelayLoad_MethodCall, _TEXT, NoHandler
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, 10h, rdx, rcx, 0
+        PROLOG_WITH_TRANSITION_BLOCK 0, 0x10, rdx, rcx, 0
 
         lea     rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
         mov     rsi, rax                            // pIndirection
@@ -50,7 +50,7 @@ NESTED_END DelayLoad_MethodCall, _TEXT
 
 NESTED_ENTRY DelayLoad_Helper\suffix, _TEXT, NoHandler
 
-        PROLOG_WITH_TRANSITION_BLOCK 0, 10h, rdx, rcx, 0
+        PROLOG_WITH_TRANSITION_BLOCK 0, 0x10, rdx, rcx, 0
 
         mov     r8, \frameFlags
         lea     rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock


### PR DESCRIPTION
While making the ready to run tests run on Unix, I have discovered that the feature
doesn't really work on Unix. First, I have found that the test was generating the
native images into the NI subfolder, but the corerun on Unix doesn't use this
notation and expects these images to live side by side with the IL executables.
So, the test to verify that an image cannot be loaded multiple times was failing,
since the main exe loaded the IL test.dll instead of the native one and so explicit
load of the native test.dll wasn't considered a secondary load of the same image.
After fixing the test, I have found that attempt to load a ready to run image is
failing with an assert.
There were these issues:
 - the loaded native image was not marked as relocated
 - the EPILOG_WITH_TRANSITION_BLOCK_RETURN macro was missing popping argument registers
 - One of the asserts didn't take into account the fact that the ready to
   run native image is not considered to have native header.
 - The assembler helpers DelayLoad_Helper and DelayLoad_MethodCall were passing a hex
   number as a parameter to the PROLOG_WITH_TRANSITION_BLOCK, but it was using the "h"
   suffix notation. There is a known issue in the clang assembler which causes such
   suffix to be swallowed so the macro was getting just "10" instead of "10h". The fix
   was to use 0x prefix instead.

This change fixes the problem. The ready to run tests pass with it correctly.