### PR TITLE
Update buildtools version for test builds

### DIFF
--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -161,6 +161,13 @@ set __msbuildCommonArgs=/nologo /nodeReuse:false %__msbuildCleanBuildArgs% %__ms
 if not defined __BuildSequential (
     set __msbuildCommonArgs=%__msbuildCommonArgs% /maxcpucount
 )
+REM =========================================================================================
+REM ===
+REM === Restore Build Tools
+REM ===
+REM =========================================================================================
+call %__ProjectDir%\init-tools.cmd 
+
 
 REM =========================================================================================
 REM ===

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -9,24 +9,27 @@
   
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00121</BuildToolsVersion>
-    <BuildToolsCoreCLRVersion>1.0.3-prerelease</BuildToolsCoreCLRVersion>
-    <DnxVersion Condition="'$(OsEnvironment)'!='Unix'">1.0.0-rc2-16128</DnxVersion>
-    <DnxVersion Condition="'$(OsEnvironment)'=='Unix'">1.0.0-rc2-16128</DnxVersion>
-    <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
-    <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>
     <RoslynVersion>1.0.0-rc3-20150510-01</RoslynVersion>
     <RoslynPackageName>Microsoft.Net.ToolsetCompilers</RoslynPackageName>
-    <BuildToolsCoreCLRPackageName>Microsoft.DotNet.BuildTools.CoreCLR</BuildToolsCoreCLRPackageName>
-    <BuildToolsCoreCLRLocation>$(ToolsDir)$(BuildToolsCoreCLRPackageName).$(BuildToolsCoreCLRVersion)</BuildToolsCoreCLRLocation>
   </PropertyGroup>
+
+  <!--   
+    Switching to the .NET Core version of the BuildTools tasks seems to break numerous scenarios, such as VS intellisense and resource designer   
+    as well as runnning the build on mono. Until we can get these sorted out we will continue using the .NET 4.5 version of the tasks.   
+   -->   
+  <PropertyGroup>  
+    <BuildToolsTargets45>true</BuildToolsTargets45>   
+  </PropertyGroup>  
+
 
   <!-- Common repo directories -->
   <PropertyGroup>
     <ProjectDir>$(MSBuildThisFileDirectory)</ProjectDir>
     <SourceDir>$(ProjectDir)src\</SourceDir>
-    <PackagesDir>$(ProjectDir)packages\</PackagesDir>
-    <ToolsDir>$(PackagesDir)Microsoft.DotNet.BuildTools.$(BuildToolsVersion)\lib\</ToolsDir>
+    <PackagesDir>$(ProjectDir)..\packages\</PackagesDir>
+    <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)..\Tools\</ToolsDir>  
+    <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(ToolsDir)dotnetcli/bin/</DotnetCliPath> 
+    <BuildToolsTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(ToolsDir)net45/</BuildToolsTaskDir> 
   </PropertyGroup>
 
   <!-- Common nuget properties -->
@@ -56,14 +59,13 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <DnxPackageDir Condition="'$(DnxPackageDir)'==''">$(PackagesDir)/$(DnxPackageName)/</DnxPackageDir>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'!='Unix'">$(DnxPackageDir)\bin\dnu.cmd</DnuToolPath>
-    <DnuToolPath Condition="'$(DnuToolPath)'=='' and '$(OsEnvironment)'=='Unix'">$(DnxPackageDir)/bin/dnu</DnuToolPath>
+    <DotnetToolCommand Condition="'$(DotnetToolCommand)'=='' and '$(OsEnvironment)'!='Unix'">$(DotnetCliPath)dotnet.exe</DotnetToolCommand>    
+    <DotnetToolCommand Condition="'$(DotnetToolCommand)'=='' and '$(OsEnvironment)'=='Unix'">$(DotnetCliPath)dotnet</DotnetToolCommand>    
 
     <DnuRestoreSource>@(DnuSourceList -> '--source %(Identity)', ' ')</DnuRestoreSource>
     <DnuRestoreDirs>@(DnuRestoreDir -> '%(Identity)', ' ')</DnuRestoreDirs>
     
-    <DnuRestoreCommand>"$(DnuToolPath)"</DnuRestoreCommand>
+    <DnuRestoreCommand>"$(DotnetToolCommand)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('\\'))"</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>

--- a/tests/dir.targets
+++ b/tests/dir.targets
@@ -1,122 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" InitialTargets="_RestoreBuildToolsWrapper" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <!-- Inline task to bootstrap the build to enable downloading nuget.exe -->
-  <UsingTask TaskName="DownloadFile" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v12.0.dll">
-    <ParameterGroup>
-      <Address ParameterType="System.String" Required="true" />
-      <FileName ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Reference Include="System" />
-      <Reference Include="System.IO" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-            var directory = System.IO.Path.GetDirectoryName(FileName);
-            Directory.CreateDirectory(directory);
-
-            var tempFile = Path.Combine(directory, Path.GetRandomFileName());
-            var client = new System.Net.WebClient();
-            client.Proxy = System.Net.WebRequest.DefaultWebProxy;
-            if (client.Proxy != null) client.Proxy.Credentials = System.Net.CredentialCache.DefaultCredentials;
-            var tryCount = 1;
-            var maxTries = 3;
-
-            while (tryCount <= maxTries)
-            {
-                try
-                {
-                    Log.LogMessage("Attempting to download {0}...", Address);
-                    client.DownloadFile(Address, tempFile);
-                    break;
-                }
-                catch (System.Net.WebException e)
-                {
-                    tryCount++;
-                    if (tryCount > maxTries)
-                    {
-                        throw;
-                    }
-                    else
-                    {
-                        Log.LogMessage(MessageImportance.High, "Download failed, retrying: {0}", e.Message);
-                    }
-                }
-            }
-
-            try
-            {
-                if (!File.Exists(FileName))
-                    File.Move(tempFile, FileName);
-            }
-            finally
-            {
-                if (File.Exists(tempFile))
-                    File.Delete(tempFile);
-            }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!--
-    Needed to avoid the IntialTargets from having an Output which ends up getting
-    added to the output references when you have a project to project reference.
-  -->
-  <Target Name="_RestoreBuildToolsWrapper" DependsOnTargets="_RestoreBuildTools" />
-
-  <Target Name="_RestoreBuildTools"
-          Inputs="$(MSBuildThisFileDirectory)dir.props;$(SourceDir).nuget/packages.$(OsEnvironment).config"
-          Outputs="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath);$(DnuToolPath)">
-    <Message Importance="High" Text="Restoring build tools..." />
-
-    <Copy Condition="Exists('$(NuGetCachedPath)')" SourceFiles="$(NuGetCachedPath)" DestinationFiles="$(NuGetToolPath)" SkipUnchangedFiles="true" />
-
-    <!-- Download latest nuget.exe -->
-    <DownloadFile FileName="$(NuGetToolPath)"
-                  Address="https://www.nuget.org/nuget.exe"
-                  Condition="!Exists('$(NuGetToolPath)') and '$(OsEnvironment)'=='Windows_NT'" />
-
-    <Exec Command="curl -sSL --create-dirs -o $(NuGetToolPath) https://api.nuget.org/downloads/nuget.exe"
-          Condition="!Exists('$(NuGetToolPath)') and '$(OsEnvironment)'=='Unix'" />
-
-    <PropertyGroup>
-      <_RestoreBuildToolsCommand>$(NugetRestoreCommand) "$(SourceDir).nuget/packages.$(OsEnvironment).config"</_RestoreBuildToolsCommand>
-    </PropertyGroup>
-
-    <!-- Restore build tools -->
-    <Exec Command="$(_RestoreBuildToolsCommand)" StandardOutputImportance="Low" />
-
-    <!-- currently DNU doesn't support -ConfigFile: https://github.com/aspnet/dnx/issues/1693
-         Our DnuRestoreCommand doesn't force a config file  and we rely on the
-         directory probing for it to find nuget.config.  This works for restore from source,
-         but not restore from PackagesDir as happens for test project restore since PackagesDir
-         will not be under src.  To workaround, copy our nuget.config to packages. -->
-    <Copy Condition="Exists('$(NuGetConfigFile)')" SourceFiles="$(NuGetConfigFile)" DestinationFolder="$(PackagesDir)" SkipUnchangedFiles="true" />
-    <!-- <Copy Condition="Exists('$(NuGetConfigFile)')" SourceFiles="$(NuGetConfigFile)" DestinationFolder="$(IntermediateOutputRootPath)" SkipUnchangedFiles="true" /> -->
-
-    <!-- Add DNU and Roslyn tool execute rights -->
-    <Exec Condition="'$(OsEnvironment)'=='Unix'"
-          Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnu&quot;" />
-    <Exec Condition="'$(OsEnvironment)'=='Unix'"
-          Command="chmod a+x &quot;$(DnxPackageDir)/bin/dnx&quot;" />
-    <Exec Condition="'$(OsEnvironment)'=='Unix'"
-          Command="find '$(RoslynPackageDir)tools' -name &quot;*.exe&quot; -exec chmod &quot;+x&quot; '{}' ';'" />
-
-    <Error Condition="'$(ErrorIfBuildToolsRestoredFromIndividualProject)'=='true'"
-           Text="The build tools package was just restored and so we cannot continue the build of an individual project because targets from the build tools package were not able to be imported. Please retry the build the individual project again." />
-
-    <!--
-      There are cases where the inputs could be newer than the outputs but the
-      download or restore may not need to update. In such cases we need to touch
-      these files otherwise we continually run this target over and over for
-      every project until these files are cleaned (if the are ever cleaned).
-    -->
-    <Touch Files="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll;$(NugetToolPath);$(DnuToolPath)" />
+<Project ToolsVersion="12.0" InitialTargets="CheckForBuildTools" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  
+  <Target Name="CheckForBuildTools">
+    <Error Condition="!Exists('$(ToolsDir)')"
+           Text="The tools directory [$(ToolsDir)] does not exist. Please run init-tools.cmd in your enlistment to ensure the tools are installed before attempting to build an individual project." />
   </Target>
 
-  <!-- Provide default empty targets for BuildAndTest and Test which can be hooked onto or overridden as necessary -->
+  <!-- Provide default targets which can be hooked onto or overridden as necessary -->
   <Target Name="BuildAndTest" DependsOnTargets="Build;Test" />
-
+  <Target Name="RebuildAndTest" DependsOnTargets="Rebuild;Test" />
   <Target Name="Test" />
+
 </Project>
+

--- a/tests/publishdependency.targets
+++ b/tests/publishdependency.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(ToolsDir)Microsoft.DotNet.Build.Tasks.dll"/>
+  <UsingTask TaskName="PrereleaseResolveNuGetPackageAssets" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll"/>
   <ItemGroup>
     <TestTargetFramework Include="DNXCore,Version=v5.0">
       <Folder>dnxcore50</Folder>

--- a/tests/src/.nuget/packages.Unix.config
+++ b/tests/src/.nuget/packages.Unix.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00121" />
-</packages>

--- a/tests/src/.nuget/packages.Windows_NT.config
+++ b/tests/src/.nuget/packages.Windows_NT.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00121" />
-  <package id="dnx-coreclr-win-x86" version="1.0.0-rc2-16128" />
-</packages>


### PR DESCRIPTION
1. Use the buildtools version that is used for product build.
2. Use the same package and tools folder as product build