### PR TITLE
Fix build on NetBSD: Don't increment iterator twice in for(;;)

### DIFF
--- a/src/dlls/mscorpe/pewriter.cpp
+++ b/src/dlls/mscorpe/pewriter.cpp
@@ -1544,7 +1544,6 @@ void PEWriter::setSectionIndex(IMAGE_SECTION_HEADER * h, unsigned sectionIndex) 
             h->SectionIndex = VAL32(m_iSeedSections + DWORD(s - SpecialNames));
             break;
         }
-        s++;
     }
 
 }


### PR DESCRIPTION
If I'm reading it correctly, we will never catch the `".cormeta"` value.