### PR TITLE
Fix fallout from enabling profiling

### DIFF
--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -103,8 +103,6 @@
 
     <FeatureStubsAsIL>true</FeatureStubsAsIL>
 
-    <ProfilingSupportedBuild>false</ProfilingSupportedBuild>
-
     <!-- Windows specific features -->
     <FeatureWin32Registry>false</FeatureWin32Registry>
     <FeatureAppX>false</FeatureAppX>

--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -11373,8 +11373,8 @@
       <Member Name="MarshalToManagedVaListInternal(System.IntPtr,System.IntPtr)" />
       <Member Name="MarshalToUnmanagedVaListInternal(System.IntPtr,System.UInt32,System.IntPtr)" />
       <Member Name="CalcVaListSize(System.IntPtr)" />
-      <Member Name="ProfilerBeginTransitionCallback(System.IntPtr,System.IntPtr,System.Object)" Platform="Win" /> <!-- EE -->
-      <Member Name="ProfilerEndTransitionCallback(System.IntPtr,System.IntPtr)" Platform="Win" /> <!-- EE -->
+      <Member Name="ProfilerBeginTransitionCallback(System.IntPtr,System.IntPtr,System.Object)" /> <!-- EE -->
+      <Member Name="ProfilerEndTransitionCallback(System.IntPtr,System.IntPtr)" /> <!-- EE -->
       <Member Name="SafeHandleAddRef(System.Runtime.InteropServices.SafeHandle,System.Boolean@)" />
       <Member Name="SafeHandleRelease(System.Runtime.InteropServices.SafeHandle)" />
       <Member Name="ValidateObject(System.Object,System.IntPtr,System.Object)" />

--- a/src/vm/arm/unixstubs.cpp
+++ b/src/vm/arm/unixstubs.cpp
@@ -35,4 +35,19 @@ extern "C"
     {
         PORTABILITY_ASSERT("Implement for PAL");
     }
+
+    void ProfileEnterNaked(FunctionIDOrClientID functionIDOrClientID)
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
+
+    void ProfileLeaveNaked(FunctionIDOrClientID functionIDOrClientID)
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
+
+    void ProfileTailcallNaked(FunctionIDOrClientID functionIDOrClientID)
+    {
+        PORTABILITY_ASSERT("Implement for PAL");
+    }
 };


### PR DESCRIPTION
- Compiler optimization assumption invalid: EE expects method to exist: System.StubHelpers.StubHelpers:ProfilerBeginTransitionCallback
- Add stubs for ARM