### PR TITLE
Write null pointer for unsupported interfaces

### DIFF
--- a/src/zap/zapwriter.h
+++ b/src/zap/zapwriter.h
@@ -358,6 +358,7 @@ class ZapWriter : public IStream
             *ppv = static_cast<IStream *>(this);
         }
         else {
+            *ppv = NULL;
             hr = E_NOINTERFACE;
         }
         return hr;


### PR DESCRIPTION
QueryInterface() must set the "out" parameter to null pointer when the requested interface is not supported