### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/vm/securityconfig.cpp
+++ b/src/vm/securityconfig.cpp
@@ -546,7 +546,7 @@ CLEANUP:
     return retval;
 }
 
-static BOOL CacheOutOfDate( FILETIME* cacheFileTime, HANDLE cache, __in_opt __in_z WCHAR* cacheFileName )
+static BOOL CacheOutOfDate( FILETIME* cacheFileTime, HANDLE cache, __in_z_opt WCHAR* cacheFileName )
 {
     CONTRACTL
     {

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -4037,6 +4037,7 @@ int RedirectedHandledJITCaseExceptionFilter(
     // Copy the saved context record into the EH context;
     ReplaceExceptionContextRecord(pExcepPtrs->ContextRecord, pCtx);
 
+    DWORD espValue = pCtx->Esp;
     if (pThread->GetSavedRedirectContext())
     {
         delete pCtx;
@@ -4062,7 +4063,7 @@ int RedirectedHandledJITCaseExceptionFilter(
     EXCEPTION_REGISTRATION_RECORD *pCurSEH = GetCurrentSEHRecord();
 
     // Unlink all records above the target resume ESP
-    PopSEHRecords((LPVOID)(size_t)pCtx->Esp);
+    PopSEHRecords((LPVOID)(size_t)espValue);
 
     // Link the special OS handler back in to the top
     pCurSEH->Next = GetCurrentSEHRecord();

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -298,8 +298,5 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinning\object-pin\object-pin\object-pin.cmd" >
              <Issue>2452</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\Finalizer\Finalizer.cmd" >
-             <Issue>2744</Issue>
-        </ExcludeList>
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Related to #2411
- Disabled the assert for CoreCLR. The assert is verifying the circumstances under which this code path is taken on desktop CLR.

Fixes #2744
- Updated the test to deterministically remove the reference to the finalizable object
- Re-enabled the test

Some fixes for issues found with static analysis.