### PR TITLE
Fix warning in Windows build of readytorun tests

### DIFF
--- a/tests/src/readytorun/mainv1.csproj
+++ b/tests/src/readytorun/mainv1.csproj
@@ -42,11 +42,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="test">
-      <HintPath>$(TargetDir)\testv1\test.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)

--- a/tests/src/readytorun/mainv2.csproj
+++ b/tests/src/readytorun/mainv2.csproj
@@ -40,11 +40,6 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="test">
-      <HintPath>$(TargetDir)\testv1\test.dll</HintPath>
-    </Reference>
-  </ItemGroup>
   <PropertyGroup>
     <CLRTestBatchPreCommands><![CDATA[
 $(CLRTestBatchPreCommands)


### PR DESCRIPTION
There was an extra reference to the test.dll besides the reference to the test
csproj. This was causing warnings during the test build.