### PR TITLE
Fix build on NetBSD: Mark destructors of few classes as virtual

### DIFF
--- a/src/debug/ee/controller.h
+++ b/src/debug/ee/controller.h
@@ -540,6 +540,9 @@ class DebuggerPatchTable : private CHashTableAndData<CNewZeroData>
 {
     VPTR_BASE_CONCRETE_VTABLE_CLASS(DebuggerPatchTable);
 
+public:
+    virtual ~DebuggerPatchTable() = default;
+
     friend class DebuggerRCThread;
 private:
     //incremented so that we can get DPT-wide unique PIDs.

--- a/src/debug/ee/debugger.h
+++ b/src/debug/ee/debugger.h
@@ -3084,6 +3084,9 @@ public:
 
 class DebuggerPendingFuncEvalTable : private CHashTableAndData<CNewZeroData>
 {
+  public:
+    virtual ~DebuggerPendingFuncEvalTable() = default;
+
   private:
 
     BOOL Cmp(SIZE_T k1, const HASHENTRY * pc2)
@@ -3167,6 +3170,11 @@ typedef DPTR(struct DebuggerModuleEntry) PTR_DebuggerModuleEntry;
 
 class DebuggerModuleTable : private CHashTableAndData<CNewZeroData>
 {
+#ifdef DACCESS_COMPILE
+  public:
+    virtual ~DebuggerModuleTable() = default;
+#endif
+
   private:
 
     BOOL Cmp(SIZE_T k1, const HASHENTRY * pc2)
@@ -3206,7 +3214,7 @@ public:
 #ifndef DACCESS_COMPILE
 
     DebuggerModuleTable();
-    ~DebuggerModuleTable();
+    virtual ~DebuggerModuleTable();
 
     void AddModule(DebuggerModule *module);
 
@@ -3273,6 +3281,9 @@ struct DebuggerMethodInfoEntry
 class DebuggerMethodInfoTable : private CHashTableAndData<CNewZeroData>
 {
     VPTR_BASE_CONCRETE_VTABLE_CLASS(DebuggerMethodInfoTable);
+
+  public:
+    virtual ~DebuggerMethodInfoTable() = default;
 
   private:
     BOOL Cmp(SIZE_T k1, const HASHENTRY * pc2)
@@ -3973,4 +3984,3 @@ void FixupDispatcherContext(T_DISPATCHER_CONTEXT* pDispatcherContext, T_CONTEXT*
 #endif
 
 #endif /* DEBUGGER_H_ */
-


### PR DESCRIPTION
In the `DeleteInteropSafe` function there is accepted a class type (template):

```
    template<class T> void DeleteInteropSafe(T *p)
```

Inside this function there is a call of a destructor:

```
    p->~T();
```

Recent Clang/LLVM is upset when the passed `T` class doesn't contain a virtual
destructor.

Example error message:

```
In file included from /tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/debug/ee/debugger.cpp:13:
In file included from /tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/debug/ee/stdafx.h:33:
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/debug/ee/debugger.h:3652:9: error: destructor called on non-final 'DebuggerPendingFuncEvalTable' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
        p->~T();
        ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/debug/ee/debugger.cpp:1310:13: note: in instantiation of function template specialization 'DeleteInteropSafe<DebuggerPendingFuncEvalTable>' requested here
            DeleteInteropSafe(pPendingEvals);
            ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/debug/ee/debugger.h:3652:13: note: qualify call to silence this warning
        p->~T();
            ^
            DebuggerPendingFuncEvalTable::
```

Reported and fixed on:
```
$ uname -a
NetBSD chieftec 7.99.25 NetBSD 7.99.25 (GENERIC) #0: Fri Dec 25 20:51:06 UTC 2015  root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC amd64
```

```
$ clang --version
clang version 3.9.0
Target: x86_64-unknown-netbsd7.99.25
Thread model: posix
InstalledDir: /usr/pkg/bin
```

```
$ llvm-config --version
3.9.0svn
```