### PR TITLE
Fix cast to unrelated interface

### DIFF
--- a/src/vm/notifyexternals.cpp
+++ b/src/vm/notifyexternals.cpp
@@ -94,7 +94,7 @@ public:
 
         if (iid == IID_ITeardownNotification || iid == IID_IUnknown)
         {
-            *ppv = (IClassFactory2 *)this;
+            *ppv = static_cast<ITeardownNotification*>(this);
             AddRef();
         }
         else if (iid == IID_IMarshal || iid == IID_IAgileObject)


### PR DESCRIPTION
Original code tries a C-style cast from a pointer to class to a pointer to interface which is not implemented by that class.