### PR TITLE
Fix for test build errors

### DIFF
--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -20,8 +20,12 @@
     </ItemGroup>
     
     <ItemGroup>
-      <Project Include="*\**\*.csproj" Exclude="@(DisabledProjects)"/>
-      <Project Include="*\**\*.ilproj" Exclude="@(DisabledProjects)"/>
+      <Project Include="*\**\*.csproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
+      <Project Include="*\**\*.ilproj" Exclude="@(DisabledProjects)">
+        <AdditionalProperties>OSGroup=$(OSGroup)</AdditionalProperties>
+      </Project>
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
OSGroup value does not get passed along to reference projects. This causes msbuild to build the same project twice because the target bin dir would differ. But the intermediate dir would remain the same. If they happen to build at the same ...this is will cause build errors due to write to same file.