### PR TITLE
Fix build on NetBSD: Stop mixing PAL and system headers in tests

### DIFF
--- a/src/pal/tests/palsuite/threading/GetThreadTimes/test1/test1.c
+++ b/src/pal/tests/palsuite/threading/GetThreadTimes/test1/test1.c
@@ -13,9 +13,7 @@
 **
 **=========================================================*/
 
-#define _GNU_SOURCE
 #include <palsuite.h>
-#include <sched.h>
 
 int __cdecl main(int argc, char *argv[]) {
     int ret = FAIL;
@@ -102,6 +100,3 @@ int __cdecl main(int argc, char *argv[]) {
 EXIT:
     return ret;
 }
-
-
-

--- a/src/pal/tests/palsuite/threading/QueryThreadCycleTime/test1/test1.c
+++ b/src/pal/tests/palsuite/threading/QueryThreadCycleTime/test1/test1.c
@@ -13,9 +13,7 @@
 **
 **=========================================================*/
 
-#define _GNU_SOURCE
 #include <palsuite.h>
-#include <sched.h>
 
 int __cdecl main(int argc, char *argv[]) {
     int ret = FAIL;
@@ -98,6 +96,3 @@ int __cdecl main(int argc, char *argv[]) {
 EXIT:
     return ret;
 }
-
-
-


### PR DESCRIPTION
Including both system and PAL headers results in clasesh like:

```
In file included from /tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/tests/palsuite/threading/GetThreadTimes/test1/test1.c:18:
In file included from /usr/include/sched.h:37:
In file included from /usr/include/sys/sched.h:73:
/usr/include/sys/types.h:54:18: error: typedef redefinition with different types ('__int8_t' (aka 'signed char') vs 'char')
typedef __int8_t        int8_t;
                        ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/inc/pal_mstypes.h:224:16: note: previous definition is here
typedef __int8 int8_t;
               ^
```

This fixes #2993 "Conflicts with system headers on NetBSD"

Thanks to Jan Kotas (Microsoft) for showing the right direction.