### PR TITLE
Fix build on NetBSD: Walkaround compiler strictness regarding const c…

### DIFF
--- a/src/pal/tests/palsuite/c_runtime/sscanf/test4/test4.c
+++ b/src/pal/tests/palsuite/c_runtime/sscanf/test4/test4.c
@@ -19,6 +19,8 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
+
     if (PAL_Initialize(argc, argv))
     {
         return FAIL;
@@ -29,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest("-1", "%d", -1);
     DoNumTest("0x1234", "%d", 0);
     DoNumTest("012", "%d", 12);
-    DoShortNumTest("-1", "%hd", 65535);
+    DoShortNumTest("-1", "%hd", n65535);
     DoShortNumTest("65536", "%hd", 0);
     DoNumTest("-1", "%ld", -1);
     DoNumTest("65536", "%ld", 65536);

--- a/src/pal/tests/palsuite/c_runtime/sscanf/test5/test5.c
+++ b/src/pal/tests/palsuite/c_runtime/sscanf/test5/test5.c
@@ -18,6 +18,8 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
+
     if (PAL_Initialize(argc, argv))
     {
         return FAIL;
@@ -28,7 +30,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest("-1", "%i", -1);
     DoNumTest("0x1234", "%i", 0x1234);
     DoNumTest("012", "%i", 10);
-    DoShortNumTest("-1", "%hi", 65535);
+    DoShortNumTest("-1", "%hi", n65535);
     DoShortNumTest("65536", "%hi", 0);
     DoNumTest("-1", "%li", -1);
     DoNumTest("65536", "%li", 65536);

--- a/src/pal/tests/palsuite/c_runtime/sscanf/test6/test6.c
+++ b/src/pal/tests/palsuite/c_runtime/sscanf/test6/test6.c
@@ -18,6 +18,7 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
 
     if (PAL_Initialize(argc, argv))
     {
@@ -29,7 +30,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest("-1", "%o", -1);
     DoNumTest("0x1234", "%o", 0);
     DoNumTest("012", "%o", 10);
-    DoShortNumTest("-1", "%ho", 65535);
+    DoShortNumTest("-1", "%ho", n65535);
     DoShortNumTest("200000", "%ho", 0);
     DoNumTest("-1", "%lo", -1);
     DoNumTest("200000", "%lo", 65536);

--- a/src/pal/tests/palsuite/c_runtime/sscanf/test7/test7.c
+++ b/src/pal/tests/palsuite/c_runtime/sscanf/test7/test7.c
@@ -18,6 +18,8 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
+
     if (PAL_Initialize(argc, argv))
     {
         return FAIL;
@@ -28,7 +30,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest("-1", "%x", -1);
     DoNumTest("0x1234", "%x", 0x1234);
     DoNumTest("012", "%x", 0x12);
-    DoShortNumTest("-1", "%hx", 65535);
+    DoShortNumTest("-1", "%hx", n65535);
     DoShortNumTest("10000", "%hx", 0);
     DoNumTest("-1", "%lx", -1);
     DoNumTest("10000", "%lx", 65536);

--- a/src/pal/tests/palsuite/c_runtime/sscanf/test8/test8.c
+++ b/src/pal/tests/palsuite/c_runtime/sscanf/test8/test8.c
@@ -18,6 +18,8 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
+
     if (PAL_Initialize(argc, argv))
     {
         return FAIL;
@@ -28,7 +30,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest("-1", "%u", -1);
     DoNumTest("0x1234", "%u", 0);
     DoNumTest("012", "%u", 12);
-    DoShortNumTest("-1", "%hu", 65535);
+    DoShortNumTest("-1", "%hu", n65535);
     DoShortNumTest("65536", "%hu", 0);
     DoNumTest("-1", "%lu", -1);
     DoNumTest("65536", "%lu", 65536);

--- a/src/pal/tests/palsuite/c_runtime/swscanf/test4/test4.c
+++ b/src/pal/tests/palsuite/c_runtime/swscanf/test4/test4.c
@@ -19,6 +19,7 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
 
     if (PAL_Initialize(argc, argv))
     {
@@ -30,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest(convert("-1"), convert("%d"), -1);
     DoNumTest(convert("0x1234"), convert("%d"), 0);
     DoNumTest(convert("012"), convert("%d"), 12);
-    DoShortNumTest(convert("-1"), convert("%hd"), 65535);
+    DoShortNumTest(convert("-1"), convert("%hd"), n65535);
     DoShortNumTest(convert("65536"), convert("%hd"), 0);
     DoNumTest(convert("-1"), convert("%ld"), -1);
     DoNumTest(convert("65536"), convert("%ld"), 65536);

--- a/src/pal/tests/palsuite/c_runtime/swscanf/test5/test5.c
+++ b/src/pal/tests/palsuite/c_runtime/swscanf/test5/test5.c
@@ -19,6 +19,7 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
 
     if (PAL_Initialize(argc, argv))
     {
@@ -30,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest(convert("-1"), convert("%i"), -1);
     DoNumTest(convert("0x1234"), convert("%i"), 0x1234);
     DoNumTest(convert("012"), convert("%i"), 10);
-    DoShortNumTest(convert("-1"), convert("%hi"), 65535);
+    DoShortNumTest(convert("-1"), convert("%hi"), n65535);
     DoShortNumTest(convert("65536"), convert("%hi"), 0);
     DoNumTest(convert("-1"), convert("%li"), -1);
     DoNumTest(convert("65536"), convert("%li"), 65536);

--- a/src/pal/tests/palsuite/c_runtime/swscanf/test6/test6.c
+++ b/src/pal/tests/palsuite/c_runtime/swscanf/test6/test6.c
@@ -19,6 +19,8 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
+
     if (PAL_Initialize(argc, argv))
     {
         return FAIL;
@@ -29,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest(convert("-1"), convert("%o"), -1);
     DoNumTest(convert("0x1234"), convert("%o"), 0);
     DoNumTest(convert("012"), convert("%o"), 10);
-    DoShortNumTest(convert("-1"), convert("%ho"), 65535);
+    DoShortNumTest(convert("-1"), convert("%ho"), n65535);
     DoShortNumTest(convert("200000"), convert("%ho"), 0);
     DoNumTest(convert("-1"), convert("%lo"), -1);
     DoNumTest(convert("200000"), convert("%lo"), 65536);

--- a/src/pal/tests/palsuite/c_runtime/swscanf/test7/test7.c
+++ b/src/pal/tests/palsuite/c_runtime/swscanf/test7/test7.c
@@ -19,6 +19,7 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
 
     if (PAL_Initialize(argc, argv))
     {
@@ -30,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest(convert("-1"), convert("%x"), -1);
     DoNumTest(convert("0x1234"), convert("%x"), 0x1234);
     DoNumTest(convert("012"), convert("%x"), 0x12);
-    DoShortNumTest(convert("-1"), convert("%hx"), 65535);
+    DoShortNumTest(convert("-1"), convert("%hx"), n65535);
     DoShortNumTest(convert("10000"), convert("%hx"), 0);
     DoNumTest(convert("-1"), convert("%lx"), -1);
     DoNumTest(convert("10000"), convert("%lx"), 65536);

--- a/src/pal/tests/palsuite/c_runtime/swscanf/test8/test8.c
+++ b/src/pal/tests/palsuite/c_runtime/swscanf/test8/test8.c
@@ -19,6 +19,8 @@
 
 int __cdecl main(int argc, char *argv[])
 {
+    int n65535 = 65535; /* Walkaround compiler strictness */
+
     if (PAL_Initialize(argc, argv))
     {
         return FAIL;
@@ -29,7 +31,7 @@ int __cdecl main(int argc, char *argv[])
     DoNumTest(convert("-1"), convert("%u"), -1);
     DoNumTest(convert("0x1234"), convert("%u"), 0);
     DoNumTest(convert("012"), convert("%u"), 12);
-    DoShortNumTest(convert("-1"), convert("%hu"), 65535);
+    DoShortNumTest(convert("-1"), convert("%hu"), n65535);
     DoShortNumTest(convert("65536"), convert("%hu"), 0);
     DoNumTest(convert("-1"), convert("%lu"), -1);
     DoNumTest(convert("65536"), convert("%lu"), 65536);


### PR DESCRIPTION
…onversion

This commit walks-around over-cautious Clang/LLVM alerts like:

```
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/tests/palsuite/c_runtime/sscanf/test4/test4.c:32:33: error: implicit conversion from
                'int' to 'short' changes value from 65535 to -1 [-Werror,-Wconstant-conversion]
 DoShortNumTest("-1", "%hd", 65535);
                ^~~~~~~~~~~~~~~~~~~
```

This closes #2968 "implicit conversion from 'int' to 'short' changes value from 65535 to -1"

Thanks Jan Kotas (Microsoft) for pointers.