### PR TITLE
Remove dotnet-coreclr-testDependencies feed

### DIFF
--- a/tests/src/NuGet.Config
+++ b/tests/src/NuGet.Config
@@ -7,7 +7,6 @@
     <clear/>
     <add key="myget.org dotnet-corefx" value="https://www.myget.org/F/dotnet-core/" />
     <add key="myget.org dotnet-buildtools" value="https://www.myget.org/F/dotnet-buildtools/" />
-    <add key="myget.org Microsoft.DotNet.CoreCLR.TestDependencies" value="https://www.myget.org/F/dotnet-coreclr-testdependecies/" />
     <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
   </packageSources>
   <activePackageSource>


### PR DESCRIPTION
As part of our feed migration this feed was deleted and so restore
started failing. It only contained one package so I that package on
our dotnet-core feed and eliminated the need for this one extra feed.

fixes https://github.com/dotnet/coreclr/issues/3028