### PR TITLE
Remove assert from the JitInlineResult dtor

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1012,11 +1012,9 @@ public:
         setCommon(InlineDecision::NEVER, reason);
     }
     
-    // Ensure a decision has been made, and then then report it if
-    // necessary.
+    // Report decision, if necessary.
     ~JitInlineResult() 
     {
-        assert(inlDecision != InlineDecision::UNDECIDED);
         report();
     }
     


### PR DESCRIPTION
Don't assert here, instead rely on existing checks in the
frames that create JitInlineResults to verify an appropriate
decision was made.

Closes #3037.