### PR TITLE
Have `skiptests` control PAL tests as well

### DIFF
--- a/src/pal/CMakeLists.txt
+++ b/src/pal/CMakeLists.txt
@@ -10,5 +10,8 @@ add_compile_options(-gdwarf-3)
 add_compile_options(-fexceptions)
 
 add_subdirectory(src)
-add_subdirectory(tests)
+
+if(CLR_CMAKE_BUILD_TESTS)
+  add_subdirectory(tests)
+endif(CLR_CMAKE_BUILD_TESTS)
 


### PR DESCRIPTION
Don't build the PAL test projects when "skiptests" is passed to build.sh.