### PR TITLE
Detect libunwind features allowing LLVMs libunwind to be used

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -228,26 +228,38 @@ endif(CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   if(PAL_CMAKE_PLATFORM_ARCH_ARM)
-    target_link_libraries(coreclrpal
-      unwind-arm
-    )
+    find_library(UNWIND_ARCH NAMES unwind-arm)
   endif()
 
   if(PAL_CMAKE_PLATFORM_ARCH_AMD64)
-    target_link_libraries(coreclrpal
-      unwind-x86_64
-    )
+    find_library(UNWIND_ARCH NAMES unwind-x86_64)
   endif()
+
+  find_library(UNWIND NAMES unwind)
+  find_library(UNWIND_GENERIC NAMES unwind-generic)
 
   target_link_libraries(coreclrpal
     gcc_s
     pthread
     rt
     dl
-    unwind
-    unwind-generic
     uuid
   )
+
+  if(UNWIND STREQUAL UNWIND-NOTFOUND)
+    message(FATAL_ERROR "Cannot find libunwind. Try installing libunwind8-dev and libunwind8.")
+  endif(UNWIND STREQUAL UNWIND-NOTFOUND)
+
+  target_link_libraries(coreclrpal ${UNWIND})
+
+  if(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
+    target_link_libraries(coreclrpal ${UNWIND_GENERIC})
+  endif(NOT UNWIND_GENERIC STREQUAL UNWIND_GENERIC-NOTFOUND)
+
+  if(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
+    target_link_libraries(coreclrpal ${UNWIND_ARCH})
+  endif(NOT UNWIND_ARCH STREQUAL UNWIND_ARCH-NOTFOUND)
+
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL NetBSD)

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -75,6 +75,8 @@ check_function_exists(directio HAVE_DIRECTIO)
 check_function_exists(semget HAS_SYSV_SEMAPHORES)
 check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
+check_function_exists(unw_get_save_loc HAVE_UNW_GET_SAVE_LOC)
+check_function_exists(unw_get_accessors HAVE_UNW_GET_ACCESSORS)
 
 check_struct_has_member ("struct stat" st_atimespec "sys/types.h;sys/stat.h" HAVE_STAT_TIMESPEC)
 check_struct_has_member ("struct stat" st_atimensec "sys/types.h;sys/stat.h" HAVE_STAT_NSEC)


### PR DESCRIPTION
This allows for LLVMs libunwind to be used. This detects the available libunwind libraries and if the remote unwind and context pointer features are implemented, mostly by adding configure checks to toggle the current OS X workarounds. See issue #872 for some of the motivation behind this, it may also help for #2910.