### PR TITLE
Remove InternalStrdup from PAL

### DIFF
--- a/src/pal/src/cruntime/malloc.cpp
+++ b/src/pal/src/cruntime/malloc.cpp
@@ -120,15 +120,5 @@ PAL__strdup(
     const char *c_szStr
     )
 {
-    return InternalStrdup(c_szStr);
-}
-
-char *
-CorUnix::InternalStrdup(
-    const char *c_szStr
-    )
-{
-    char *pszStrCopy;
-    pszStrCopy = strdup(c_szStr);
-    return pszStrCopy;
+    return strdup(c_szStr);
 }

--- a/src/pal/src/cruntime/misc.cpp
+++ b/src/pal/src/cruntime/misc.cpp
@@ -500,7 +500,7 @@ BOOL MiscPutenv(const char *string, BOOL deleteIfEmpty)
         // See if we are replacing an item or adding one.
         
         // Make our copy up front, since we'll use it either way.
-        copy = InternalStrdup(string);
+        copy = strdup(string);
         if (copy == NULL)
         {
             goto done;

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -168,9 +168,9 @@ void FILEGetProperNotFoundError( LPSTR lpPath, LPDWORD lpErrorCode )
         return;
     }
 
-    if ( NULL == ( lpDupedPath = InternalStrdup( lpPath ) ) )
+    if ( NULL == ( lpDupedPath = strdup(lpPath) ) )
     {
-        ERROR( "InternalStrdup() failed!\n" );
+        ERROR( "strdup() failed!\n" );
         *lpErrorCode = ERROR_NOT_ENOUGH_MEMORY;
         return;
     }
@@ -269,10 +269,10 @@ CorUnix::InternalCanonicalizeRealPath(LPCSTR lpUnixPath, LPSTR lpBuffer, DWORD c
     lpRealPath = realpath(lpUnixPath, lpBuffer);
 #else   // !REALPATH_SUPPORTS_NONEXISTENT_FILES
 
-    lpExistingPath = InternalStrdup(lpUnixPath);
+    lpExistingPath = strdup(lpUnixPath);
     if (lpExistingPath == NULL)
     {
-        ERROR ("InternalStrdup failed with error %d\n", errno);
+        ERROR ("strdup failed with error %d\n", errno);
         palError = ERROR_NOT_ENOUGH_MEMORY;
         goto LExit;
     }
@@ -515,10 +515,10 @@ CorUnix::InternalCreateFile(
         goto done;
     }
 
-    lpUnixPath = InternalStrdup(lpFileName);
+    lpUnixPath = strdup(lpFileName);
     if ( lpUnixPath == NULL )
     {
-        ERROR("InternalStrdup() failed\n");
+        ERROR("strdup() failed\n");
         palError = ERROR_NOT_ENOUGH_MEMORY;
         goto done;
     }
@@ -1219,7 +1219,7 @@ DeleteFileA(
     if (palError != NO_ERROR)
     {
         InternalFree(lpFullUnixFileName);
-        lpFullUnixFileName = InternalStrdup(lpUnixFileName);
+        lpFullUnixFileName = strdup(lpUnixFileName);
         if (!lpFullUnixFileName)
         {
             palError = ERROR_NOT_ENOUGH_MEMORY;
@@ -3989,10 +3989,10 @@ CopyFileA(
     }
 
     /* Need to preserve the owner/group and chmod() flags */
-    lpUnixPath = InternalStrdup(lpExistingFileName);
+    lpUnixPath = strdup(lpExistingFileName);
     if ( lpUnixPath == NULL )
     {
-        ERROR("InternalStrdup() failed\n");
+        ERROR("strdup() failed\n");
         pThread->SetLastError(FILEGetLastErrorFromErrno());
         goto done;
     }
@@ -4019,10 +4019,10 @@ CopyFileA(
     }
 
     InternalFree(lpUnixPath);
-    lpUnixPath = InternalStrdup(lpNewFileName);
+    lpUnixPath = strdup(lpNewFileName);
     if ( lpUnixPath == NULL )
     {
-        ERROR("InternalStrdup() failed\n");
+        ERROR("strdup() failed\n");
         pThread->SetLastError(FILEGetLastErrorFromErrno());
         goto done;
     }
@@ -4146,9 +4146,9 @@ SetFileAttributesA(
         goto done;
     }
 
-    if ((UnixFileName = InternalStrdup(lpFileName)) == NULL)
+    if ((UnixFileName = strdup(lpFileName)) == NULL)
     {
-        ERROR("InternalStrdup() failed\n");
+        ERROR("strdup() failed\n");
         dwLastError = ERROR_NOT_ENOUGH_MEMORY;
         goto done;
     }

--- a/src/pal/src/file/find.cpp
+++ b/src/pal/src/file/find.cpp
@@ -178,7 +178,7 @@ FindFirstFileA(
              *      c:\temp\foo.txt\bar  - ERROR_DIRECTORY
              *
              */
-            LPSTR lpTemp = InternalStrdup((LPSTR)lpFileName);
+            LPSTR lpTemp = strdup((LPSTR)lpFileName);
             if ( !lpTemp )
             {
                 ERROR( "strdup failed!\n" );

--- a/src/pal/src/include/pal/malloc.hpp
+++ b/src/pal/src/include/pal/malloc.hpp
@@ -78,11 +78,6 @@ namespace CorUnix{
         void *pvMem
         );
 
-    char *
-    InternalStrdup(
-        const char *c_szStr
-        );  
-
     // Define common code for "new" style allocators below.
 #define INTERNAL_NEW_COMMON()                    \
         T *pMem = (T*)InternalMalloc(sizeof(T)); \

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -1131,7 +1131,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
     struct stat theStats;
 
     /* if a path is specified, only search there */
-    if(strchr(exe_name, '/'))
+    if (strchr(exe_name, '/'))
     {
         if ( -1 == stat( exe_name, &theStats ) )
         {
@@ -1162,7 +1162,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
             }
             else
             {
-                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1, 
+                if (!MultiByteToWideChar(CP_ACP, 0, real_path, -1, 
                                         return_value, return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
@@ -1180,16 +1180,16 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
 
     /* no path was specified : search $PATH */
 
-    env_path=MiscGetenv("PATH");
-    if(!env_path || *env_path=='\0')
+    env_path = MiscGetenv("PATH");
+    if (!env_path || *env_path=='\0')
     {
         WARN("$PATH isn't set.\n");
         goto last_resort;
     }
 
     /* get our own copy of env_path so we can modify it */
-    env_path=InternalStrdup(env_path);
-    if(!env_path)
+    env_path = strdup(env_path);
+    if (!env_path)
     {
         ERROR("Not enough memory to copy $PATH!\n");
         return NULL;
@@ -1199,24 +1199,24 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
 
     cur_dir=env_path;
 
-    while(cur_dir)
+    while (cur_dir)
     {
         LPSTR full_path;
         struct stat theStats;
 
         /* skip all leading ':' */
-        while(*cur_dir==':')
+        while (*cur_dir==':')
         {
             cur_dir++;
         }
-        if(*cur_dir=='\0')
+        if (*cur_dir=='\0')
         {
             break;
         }
 
         /* cut string at next ':' */
-        path_ptr=strchr(cur_dir, ':');
-        if(path_ptr)
+        path_ptr = strchr(cur_dir, ':');
+        if (path_ptr)
         {
             /* check if we need to add a '/' between the path and filename */
             need_slash=(*(path_ptr-1))!='/';
@@ -1235,7 +1235,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
         /* build tentative full file name */
         int iLength = (strlen(cur_dir)+exe_name_length+2);
         full_path = reinterpret_cast<LPSTR>(InternalMalloc(iLength));
-        if(!full_path)
+        if (!full_path)
         {
             ERROR("Not enough memory!\n");
             break;
@@ -1249,7 +1249,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
             return NULL;
         }
 
-        if(need_slash)
+        if (need_slash)
         {
             if (strcat_s(full_path, iLength, "/") != SAFECRT_SUCCESS)
             {
@@ -1274,7 +1274,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
             if( UTIL_IsExecuteBitsSet( &theStats ) )
             {
                 /* generate canonical path */
-                if(!realpath(full_path, real_path))
+                if (!realpath(full_path, real_path))
                 {
                     ERROR("realpath() failed!\n");
                     InternalFree(full_path);
@@ -1299,7 +1299,7 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                     return NULL;
                 }
 
-                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1, return_value,
+                if (!MultiByteToWideChar(CP_ACP, 0, real_path, -1, return_value,
                                     return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
@@ -1311,27 +1311,30 @@ static LPWSTR INIT_FindEXEPath(LPCSTR exe_name)
                     TRACE("found %s in %s; real path is %s\n", exe_name,
                           cur_dir,real_path);
                 }
+
                 InternalFree(env_path);
                 return return_value;
             }
         }
+
         /* file doesn't exist : keep searching */
         InternalFree(full_path);
 
         /* path_ptr is NULL if there's no ':' after this directory */
         cur_dir=path_ptr;
     }
+
     InternalFree(env_path);
     TRACE("No %s found in $PATH (%s)\n", exe_name, MiscGetenv("PATH"));
 
 last_resort:
     /* last resort : see if the executable is in the current directory. This is
        possible if it comes from a exec*() call. */
-    if(0 == stat(exe_name,&theStats))
+    if (0 == stat(exe_name,&theStats))
     {
         if ( UTIL_IsExecuteBitsSet( &theStats ) )
         {
-            if(!realpath(exe_name, real_path))
+            if (!realpath(exe_name, real_path))
             {
                 ERROR("realpath() failed!\n");
                 return NULL;
@@ -1352,7 +1355,7 @@ last_resort:
             }
             else
             {
-                if(!MultiByteToWideChar(CP_ACP, 0, real_path, -1, 
+                if (!MultiByteToWideChar(CP_ACP, 0, real_path, -1, 
                                         return_value, return_size))
                 {
                     ASSERT("MultiByteToWideChar failure\n");
@@ -1364,6 +1367,7 @@ last_resort:
                     TRACE("full path to executable is %s\n", real_path);
                 }
             }
+
             return return_value;
         }
         else
@@ -1377,6 +1381,7 @@ last_resort:
         TRACE("last resort failed : executable %s is not in the current "
               "directory\n",exe_name);
     }
+
     ERROR("executable %s not found anywhere!\n", exe_name);
     return NULL;
 #else // !__APPLE__
@@ -1408,7 +1413,7 @@ last_resort:
     }
     else
     {
-        if(!MultiByteToWideChar(CP_ACP, 0, exec_path, -1, 
+        if (!MultiByteToWideChar(CP_ACP, 0, exec_path, -1, 
                                 return_value, return_size))
         {
             ASSERT("MultiByteToWideChar failure\n");

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -177,10 +177,10 @@ LoadLibraryExA(
     }
 
     /* do the Dos/Unix conversion on our own copy of the name */
-    lpstr = InternalStrdup(lpLibFileName);
+    lpstr = strdup(lpLibFileName);
     if (!lpstr)
     {
-        ERROR("InternalStrdup failure!\n");
+        ERROR("strdup failure!\n");
         SetLastError(ERROR_NOT_ENOUGH_MEMORY);
         goto Done;
     }

--- a/src/pal/src/misc/identity.cpp
+++ b/src/pal/src/misc/identity.cpp
@@ -223,7 +223,7 @@ GetUserNameW(
     }
 
     // make a copy so that we can modify it
-    szUserName = InternalStrdup(pPalThread, pPasswd->pw_name);
+    szUserName = strdup(pPasswd->pw_name);
     if (NULL == szUserName)
     {
         InternalLeaveCriticalSection(pPalThread, &identity_critsec);


### PR DESCRIPTION
Remove the `InternalStrdup` function from the PAL, since it just wraps `strdup`.