### PR TITLE
Inliner refactoring: consolidate logging, reporting and dumping

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -878,14 +878,16 @@ class JitInlineResult
 public:
 
     // Construct a new JitInlineResult.
-    JitInlineResult(COMP_HANDLE            compiler,
+    JitInlineResult(Compiler*              compiler,
                     CORINFO_METHOD_HANDLE  inliner,
-                    CORINFO_METHOD_HANDLE  inlinee)
-        : inlComp(compiler)
+                    CORINFO_METHOD_HANDLE  inlinee,
+                    const char*            context)
+        : inlCompiler(compiler)
         , inlDecision(InlineDecision::UNDECIDED)
         , inlInliner(inliner)
         , inlInlinee(inlinee)
         , inlReason(nullptr)
+        , inlContext(context)
         , inlReported(false)
     {
         // empty
@@ -904,6 +906,26 @@ public:
                 return INLINE_FAIL;
             case InlineDecision::NEVER:
                 return INLINE_NEVER;
+            default:
+                assert(!"Unexpected: interim inline result");
+                unreached();
+        }
+    }
+
+    // Translate into string for dumping
+    const char* resultString() const 
+    { 
+        switch (inlDecision) {
+            case InlineDecision::SUCCESS:
+                return "success";
+            case InlineDecision::FAILURE:
+                return "failed this call site";
+            case InlineDecision::NEVER:
+                return "failed this callee";
+            case InlineDecision::CANDIDATE:
+                return "candidate";            
+            case InlineDecision::UNDECIDED:
+                return "undecided";
             default:
                 assert(!"Unexpected: interim inline result");
                 unreached();
@@ -1012,7 +1034,7 @@ public:
         setCommon(InlineDecision::NEVER, reason);
     }
     
-    // Report decision, if necessary.
+    // Report/log/dump decision as appropriate
     ~JitInlineResult() 
     {
         report();
@@ -1021,7 +1043,7 @@ public:
     const char * reason() const { return inlReason; }
     
     // setReported indicates that this particular result doesn't need
-    // to be reported back to the runtime, either becaus the runtime
+    // to be reported back to the runtime, either because the runtime
     // already knows, or we weren't actually inlining yet.
     void setReported() { inlReported = true; }
     
@@ -1038,21 +1060,15 @@ private:
         inlDecision = decision;
         inlReason = reason;
     }
-    
-    void report() 
-    {
-        if (!inlReported && isDecided()) 
-        {
-            inlComp->reportInliningDecision(inlInliner, inlInlinee, result(), inlReason);
-        }
-        inlReported = true;
-    }
-    
-    COMP_HANDLE             inlComp;
+
+    void report();
+
+    Compiler*               inlCompiler;
     InlineDecision          inlDecision;
     CORINFO_METHOD_HANDLE   inlInliner;
     CORINFO_METHOD_HANDLE   inlInlinee;
     const char*             inlReason;
+    const char*             inlContext;
     bool                    inlReported;
 };
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -22053,9 +22053,6 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call,
         if (!(info.compCompHnd->initClass(NULL /* field */, fncHandle /* method */,
                 inlineCandidateInfo->exactContextHnd /* context */) & CORINFO_INITCLASS_INITIALIZED))
         {
-            JITLOG((LL_INFO100000, INLINER_FAILED "Could not complete class init side effect: "
-                    "%s called by %s\n",
-                    eeGetMethodFullName(fncHandle), info.compFullName));
             inlineResult->setNever("Failed class init side-effect");
             return;
         }

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5617,8 +5617,7 @@ bool        Compiler::fgMorphCallInline(GenTreePtr node)
     // Prepare to record information about this inline
     CORINFO_METHOD_HANDLE callerHandle = call->gtCall.gtInlineCandidateInfo->ilCallerHandle;
     CORINFO_METHOD_HANDLE calleeHandle = call->gtCall.gtCallType == CT_USER_FUNC ? call->gtCall.gtCallMethHnd : nullptr;
-    COMP_HANDLE comp = info.compCompHnd;
-    JitInlineResult inlineResult(comp, callerHandle, calleeHandle);
+    JitInlineResult inlineResult(this, callerHandle, calleeHandle, "fgMorphCallInline");
 
     // Attempt the inline
     fgMorphCallInlineHelper(call, &inlineResult);
@@ -5682,8 +5681,6 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, JitInlineResult* resul
 
     if (opts.compNeedSecurityCheck)
     {
-        JITLOG((LL_INFO100000, INLINER_FAILED "Caller (%s) needs security check.\n",
-                info.compFullName));
         result->setFailure("Caller needs security check");
         return;
     }


### PR DESCRIPTION
With this change the responsibility for dumping, logging, and reporting
inline decisions is moved into the JitInlineResult class instead of being
distributed throughout the code base. This insures all the relevant inline
information is handled in a consistent manner.

The JitInlineResult is updated to hold a compiler instance and now
requires a context string describing the what the jit is doing as it evaluates
an inline candidate. There are 4 distinct contexts in use currently.