### PR TITLE
Fix NetBSD build: Define virtual destructors when needed

### DIFF
--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -452,6 +452,7 @@ namespace CorUnix
         
     public:
         CSynchWaitController() : m_pProcLocalData(NULL) {}
+        virtual ~CSynchWaitController() = default;
         
         //
         // ISynchWaitController methods
@@ -479,8 +480,9 @@ namespace CorUnix
     {
     public:
         // NB: For perforformance purposes this class is supposed
-        //     to have no constructor or destructor
-        
+        //     to have no constructor
+        virtual ~CSynchStateController() = default;
+
         //
         // ISynchStateController methods
         //
@@ -1021,4 +1023,3 @@ namespace CorUnix
 }
 
 #endif // _SINCHMANAGER_HPP_
-


### PR DESCRIPTION
This fixes the following error with recent Clang (`3.9.0nb20160205`):

```
In file included from /tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/synchmgr/synchcontrollers.cpp:20:
In file included from /tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/synchmgr/synchmanager.hpp:24:
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/include/pal/synchcache.hpp:146:13: error: destructor called on non-final 'CorUnix::CSynchWaitController' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
            pobj->~T();
            ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/synchmgr/synchmanager.hpp:724:31: note: in instantiation of member function 'CorUnix::CSynchCache<CorUnix::CSynchWaitController>::Add' requested here
            m_cacheWaitCtrlrs.Add(pthrCurrent, pCtrlr);
                              ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/include/pal/synchcache.hpp:146:20: note: qualify call to silence this warning
            pobj->~T();
                   ^
                   CorUnix::CSynchWaitController::
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/include/pal/synchcache.hpp:146:13: error: destructor called on non-final 'CorUnix::CSynchStateController' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
            pobj->~T();
            ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/synchmgr/synchmanager.hpp:741:32: note: in instantiation of member function 'CorUnix::CSynchCache<CorUnix::CSynchStateController>::Add' requested here
            m_cacheStateCtrlrs.Add(pthrCurrent, pCtrlr);
                               ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/include/pal/synchcache.hpp:146:20: note: qualify call to silence this warning
            pobj->~T();
                   ^
                   CorUnix::CSynchStateController::
2 errors generated.
```