### PR TITLE
Improve robustness of intrinsic fallback path

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5823,7 +5823,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
                 {
                     if (opts.IsReadyToRun())
                     {
-                        assert(callInfo->kind == CORINFO_CALL);
+                        noway_assert(callInfo->kind == CORINFO_CALL);
                         call->gtIntrinsic.gtEntryPoint = callInfo->codePointerLookup.constLookup;
                     }
                     else

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -5568,8 +5568,10 @@ void CEEInfo::getCallInfo(
             // Note that it is safe to devirtualize in the following cases, since a servicing event cannot later modify it
             //  1) Callvirt on a virtual final method of a value type - since value types are sealed types as per ECMA spec
             //  2) Delegate.Invoke() - since a Delegate is a sealed class as per ECMA spec
+            //  3) JIT intrinsics - since they have pre-defined behavior
             devirt = pTargetMD->GetMethodTable()->IsValueType() ||
-                     (pTargetMD->GetMethodTable()->IsDelegate() && ((DelegateEEClass*)(pTargetMD->GetMethodTable()->GetClass()))->m_pInvokeMethod == pMD);
+                     (pTargetMD->GetMethodTable()->IsDelegate() && ((DelegateEEClass*)(pTargetMD->GetMethodTable()->GetClass()))->m_pInvokeMethod == pMD) ||
+                     (pTargetMD->IsFCall() && ECall::GetIntrinsicID(pTargetMD) != CORINFO_INTRINSIC_Illegal);
 
             callVirtCrossingVersionBubble = true;
         }


### PR DESCRIPTION
- The fallback path for intrinsics nodes is assumed to be direct call. Verify this assumption using no_way assert instead of regular assert.
- Make VM to always tell the JIT to use direct calls for intrinsics, even in version resilient code