### PR TITLE
Tweak Enum.TryParse whitespace skipping slightly

### DIFF
--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -428,7 +428,7 @@ namespace System
                 StringComparison.OrdinalIgnoreCase : 
                 StringComparison.Ordinal;
 
-            int valueIndex = 0;
+            int valueIndex = firstNonWhitespaceIndex;
             while (valueIndex <= value.Length) // '=' is to handle invalid case of an ending comma
             {
                 // Find the next separator, if there is one, otherwise the end of the string.


### PR DESCRIPTION
As a simple addendum to my previous Enum.TryParse change (https://github.com/dotnet/coreclr/pull/2933), if the string begins with whitespace, we already know where the whitespace ends, so we don't need to re-traverse it.

cc: @jkotas 