### PR TITLE
Fix loading of native images on Unix

### DIFF
--- a/src/inc/pedecoder.inl
+++ b/src/inc/pedecoder.inl
@@ -1340,11 +1340,20 @@ inline void PEDecoder::GetPEKindAndMachine(DWORD * pdwPEKind, DWORD *pdwMachine)
                 dwKind |= (DWORD)pe32Unmanaged;
             }
 
-            if (HasReadyToRunHeader() && (GetReadyToRunHeader()->Flags & READYTORUN_FLAG_PLATFORM_NEUTRAL_SOURCE) != 0)
+            if (HasReadyToRunHeader())
             {
-                // Supply the original PEKind/Machine to the assembly binder to make the full assembly name look like the original
-                dwKind = peILonly;
-                dwMachine = IMAGE_FILE_MACHINE_I386;
+                if (dwMachine == IMAGE_FILE_MACHINE_NATIVE_NI)
+                {
+                    // Supply the original machine type to the assembly binder
+                    dwMachine = IMAGE_FILE_MACHINE_NATIVE;
+                }
+
+                if ((GetReadyToRunHeader()->Flags & READYTORUN_FLAG_PLATFORM_NEUTRAL_SOURCE) != 0)
+                {
+                    // Supply the original PEKind/Machine to the assembly binder to make the full assembly name look like the original
+                    dwKind = peILonly;
+                    dwMachine = IMAGE_FILE_MACHINE_I386;
+                }
             }
         }
         else


### PR DESCRIPTION
R2R images that were compiled from architecture-specific IL images failed to load with bad image format exception on Unix. The fix is to take IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE into account for the platform check.