### PR TITLE
Fix to SquareRootUInt16 test failure under JitStress=1/2

### DIFF
--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -405,7 +405,7 @@ void Compiler::gsParamsToShadows()
         }
 
         if (!varDsc->lvIsPtr && !varDsc->lvIsUnsafeBuffer)
-        {            
+        {
             continue;
         }
 
@@ -414,7 +414,18 @@ void Compiler::gsParamsToShadows()
         // Copy some info
 
         var_types type = varTypeIsSmall(varDsc->TypeGet()) ? TYP_INT : varDsc->TypeGet();
-        lvaTable[shadowVar].lvType        = type;
+        lvaTable[shadowVar].lvType = type;
+
+#ifdef FEATURE_SIMD
+        lvaTable[shadowVar].lvSIMDType = varDsc->lvSIMDType;
+        lvaTable[shadowVar].lvUsedInSIMDIntrinsic = varDsc->lvUsedInSIMDIntrinsic;
+        if (varDsc->lvSIMDType)
+        {
+            lvaTable[shadowVar].lvBaseType = varDsc->lvBaseType;
+        }
+#endif
+        lvaTable[shadowVar].lvRegStruct = varDsc->lvRegStruct;
+
         lvaTable[shadowVar].lvAddrExposed = varDsc->lvAddrExposed;
         lvaTable[shadowVar].lvDoNotEnregister = varDsc->lvDoNotEnregister;
 #ifdef DEBUG


### PR DESCRIPTION
JitStress=1/2 is inducing GS check as a result of which the Vector argument gets shadow copied and all occurrences of original arg gets replaced by its shadow copy lcl var.  But on the shadow copy lcl var SIMD specific state is not set and as a result of which rationalization doesn't happen properly leading to silent bad codegen.

This fixes half of issue #2886.