### PR TITLE
Fix warnings in JIT test build

### DIFF
--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/add.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/add.il
@@ -13,7 +13,7 @@
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
 
-.class _add {
+.class explicit _add {
 
 .field [0] int32 global0
 .field [4] int32 global1

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/add.il
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/add.il
@@ -14,7 +14,7 @@
                         }
 
 
-.class _add {
+.class explicit _add {
 
 .field [0] int32 global0
 .field [4] int32 global1

--- a/tests/src/JIT/Directed/pinning/object-pin/mirror.cpp
+++ b/tests/src/JIT/Directed/pinning/object-pin/mirror.cpp
@@ -4,13 +4,14 @@
 #define EXPORT_API extern "C" __attribute__((visibility("default")))
 #endif 
 
+#include <cstddef>
 
 EXPORT_API unsigned __int32 Ret_Int(unsigned __int32 argVal){
 	unsigned __int32 retVal = (unsigned __int32)argVal;
 	return retVal;
 }
 EXPORT_API unsigned __int32 Ret_Ptr(void *argVal){
-	unsigned __int32 retVal = (unsigned __int32)argVal;
+	unsigned __int32 retVal = (unsigned __int32)(size_t)argVal;
 	return retVal;
 }
 

--- a/tests/src/JIT/Methodical/explicit/misc/refarg_box_f8.il
+++ b/tests/src/JIT/Methodical/explicit/misc/refarg_box_f8.il
@@ -1,17 +1,13 @@
-
-
 .assembly extern mscorlib
 {
-                           
-  
-           
-  
+}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
 }
 .assembly 'refarg_box_f8'
 {
-
-  
-  
 }
 .module 'refarg_box_f8.exe'
 .namespace Test

--- a/tests/src/JIT/Methodical/tailcall_v4/hijacking.il
+++ b/tests/src/JIT/Methodical/tailcall_v4/hijacking.il
@@ -14,6 +14,17 @@
     .ver 4:0:0:0
     .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A)
 }
+.assembly extern System.Threading
+{
+    .ver 4:0:0:0
+    .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A)
+}
+.assembly extern System.Threading.Thread
+{
+    .ver 4:0:0:0
+    .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A)
+}
+.assembly extern mscorlib { }
 .assembly hijacking
 {
   .custom instance void [System.Runtime]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32879/b32879.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32879/b32879.il
@@ -9,9 +9,6 @@
 .class public auto ansi HiDad extends [mscorlib]System.Object
 {
   .custom instance void [mscorlib]Microsoft.VisualBasic.Globals.StandardModuleAttribute::.ctor() = ( 01 00 00 00 ) 
-  .export public 'HiDad'
-  {
-  }
   .method public static void main() il managed forwardref
   {
     .maxstack  8
@@ -60,9 +57,6 @@
 
 .class auto ansi _vbProject extends [mscorlib]System.Object
 {
-  .export '_vbProject'
-  {
-  }
   .field static assembly class [mscorlib]System.Collections.Dictionary _vbEventCollection
   .method public static int32 _main(class [mscorlib]System.String[] _s) il managed forwardref
   {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b65423/b65423.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b65423/b65423.il
@@ -14,9 +14,6 @@
 .module 'b1904.exe'
 .class private auto ansi b1904 extends ['mscorlib']System.Object
 {
-  .export 'b1904'
-  {
-  }
   .field private static int32 Count
   .method public static void RunTest() il managed forwardref
   {

--- a/tests/src/JIT/jit64/regress/vsw/153682/test.il
+++ b/tests/src/JIT/jit64/regress/vsw/153682/test.il
@@ -13,7 +13,7 @@
 }
 .assembly legacy library test {}
 
-.class auto ansi sealed nested public save extends [mscorlib]System.Object
+.class auto ansi sealed public save extends [mscorlib]System.Object
 {
   .field public static class [mscorlib]System.Exception bb
   .method private specialname rtspecialname static 


### PR DESCRIPTION
Attempt to maintain the same build artifacts but remove the build warnings.  I believe I did that in all cases except the changes to `add.il`.  In that case, we decided to change layout type to explicit since it appears the tests may be layout sensitive even though the explicit layouts chosen should match the natural/auto alignment anyway.

Below are the (fixed) warnings for reference.

```
warning : Layout specified for auto-layout class
    C:\git\coreclr\tests\src\JIT\Directed\PREFIX\unaligned\1\add.ilproj
    C:\git\coreclr\tests\src\JIT\Directed\PREFIX\volatile\1\add.ilproj

warning : Non-nested class has nested visibility (0x00000102), changed to non-nested (0x00000101)
    C:\git\coreclr\tests\src\JIT\jit64\regress\vsw\153682\test.ilproj

warning : Reference to undeclared extern assembly '<assembly>'. Attempting autodetect
    C:\git\coreclr\tests\src\JIT\Methodical\explicit\misc\_il_dbgrefarg_box_f8.ilproj (System.Console)
    C:\git\coreclr\tests\src\JIT\Methodical\explicit\misc\_il_relrefarg_box_f8.ilproj (System.Console)
    C:\git\coreclr\tests\src\JIT\Methodical\tailcall_v4\hijacking.ilproj (mscorlib, System.Threading, System.Threading.Thread)

warning : Undefined implementation in ExportedType '<type>' -- ExportType not emitted
    C:\git\coreclr\tests\src\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32879\b32879.ilproj (HiDad, _vbProject)
    C:\git\coreclr\tests\src\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b65423\b65423.ilproj (b1904)

warning C4311: 'type cast': pointer truncation from 'void *' to 'unsigned int' (+redundant C4302)
    C:\git\coreclr\bin\Native\src\JIT\Directed\pinning\object-pin\mirror.vcxproj
```

@dotnet/jit-contrib PTAL