### PR TITLE
Revert "Add un-prefixed signatures as temporary workaround"

### DIFF
--- a/src/corefx/System.Globalization.Native/idna.cpp
+++ b/src/corefx/System.Globalization.Native/idna.cpp
@@ -53,15 +53,6 @@ extern "C" int32_t GlobalizationNative_ToAscii(
     return ((U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) && (info.errors == 0)) ? asciiStrLen : 0;
 }
 
-// TODO: temporarily keeping the un-prefixed signature of this method
-// to keep tests running in CI. This will be removed once the corefx managed assemblies
-// are synced up with the native assemblies.
-extern "C" int32_t ToAscii(
-    uint32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
-{
-    return GlobalizationNative_ToAscii(flags, lpSrc, cwSrcLength, lpDst, cwDstLength);
-}
-
 /*
 Function:
 ToUnicode
@@ -86,13 +77,4 @@ extern "C" int32_t GlobalizationNative_ToUnicode(
     uidna_close(pIdna);
 
     return ((U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) && (info.errors == 0)) ? unicodeStrLen : 0;
-}
-
-// TODO: temporarily keeping the un-prefixed signature of this method
-// to keep tests running in CI. This will be removed once the corefx managed assemblies
-// are synced up with the native assemblies.
-extern "C" int32_t ToUnicode(
-    int32_t flags, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
-{
-    return GlobalizationNative_ToUnicode(flags, lpSrc, cwSrcLength, lpDst, cwDstLength);
 }

--- a/src/corefx/System.Globalization.Native/normalization.cpp
+++ b/src/corefx/System.Globalization.Native/normalization.cpp
@@ -65,15 +65,6 @@ extern "C" int32_t GlobalizationNative_IsNormalized(
     }
 }
 
-// TODO: temporarily keeping the un-prefixed signature of this method
-// to keep tests running in CI. This will be removed once the corefx managed assemblies
-// are synced up with the native assemblies.
-extern "C" int32_t IsNormalized(
-    NormalizationForm normalizationForm, const UChar* lpStr, int32_t cwStrLength)
-{
-    return GlobalizationNative_IsNormalized(normalizationForm, lpStr, cwStrLength);
-}
-
 /*
 Function:
 NormalizeString
@@ -94,13 +85,4 @@ extern "C" int32_t GlobalizationNative_NormalizeString(
     int32_t normalizedLen = unorm2_normalize(pNormalizer, lpSrc, cwSrcLength, lpDst, cwDstLength, &err);
 
     return (U_SUCCESS(err) || (err == U_BUFFER_OVERFLOW_ERROR)) ? normalizedLen : 0;
-}
-
-// TODO: temporarily keeping the un-prefixed signature of this method
-// to keep tests running in CI. This will be removed once the corefx managed assemblies
-// are synced up with the native assemblies.
-extern "C" int32_t NormalizeString(
-    NormalizationForm normalizationForm, const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
-{
-    return GlobalizationNative_NormalizeString(normalizationForm, lpSrc, cwSrcLength, lpDst, cwDstLength);
 }


### PR DESCRIPTION
This reverts commit fb80bad2ed19970472ddefe539520abef42a52d0.