### PR TITLE
Fix const string literal warning

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4631,7 +4631,7 @@ DECODE_OPCODE:
             //Consider making this only for not force inline.
             if (compIsForInlining())
             {
-                char *message;
+                const char* message;
 #ifdef DEBUG
                 message = (char*)compAllocator->nraAlloc(128);
                 sprintf((char*)message, "Unsupported opcode for inlining: %s\n",


### PR DESCRIPTION
This came up during an FI from LLVM, testing LLILC, see microsoft/llvm#140 .