### PR TITLE
Make Unix event tracing conditionally enabled

### DIFF
--- a/src/inc/eventtracebase.h
+++ b/src/inc/eventtracebase.h
@@ -109,10 +109,10 @@ enum EtwThreadFlags
 #define ETWFireEvent(EventName)
 
 #define ETW_TRACING_INITIALIZED(RegHandle) (TRUE)
-#define ETW_EVENT_ENABLED(Context, EventDescriptor) (TRUE)
-#define ETW_CATEGORY_ENABLED(Context, Level, Keyword) (TRUE)
+#define ETW_EVENT_ENABLED(Context, EventDescriptor) (XplatEventLogger::IsEventLoggingEnabled())
+#define ETW_CATEGORY_ENABLED(Context, Level, Keyword) (XplatEventLogger::IsEventLoggingEnabled())
 #define ETW_TRACING_ENABLED(Context, EventDescriptor) (EventEnabled##EventDescriptor())
-#define ETW_TRACING_CATEGORY_ENABLED(Context, Level, Keyword) (TRUE)
+#define ETW_TRACING_CATEGORY_ENABLED(Context, Level, Keyword) (XplatEventLogger::IsEventLoggingEnabled())
 #define ETW_PROVIDER_ENABLED(ProviderSymbol) (TRUE)
 
 #endif // !defined(FEATURE_PAL)


### PR DESCRIPTION
Add condition around the expensive event tracing code to enable it conditionally only if the event tracing is enabled