### PR TITLE
String.Compare - Prefer quick index compare before full string equals

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2067,24 +2067,20 @@ namespace System {
                                                       Environment.GetResourceString("ArgumentOutOfRange_Index"));
             }
             
-            if( ( length == 0 )  ||
-                ((strA == strB) && (indexA == indexB)) ){
+            if (length == 0 ||
+                (indexA == indexB && strA.Length == strB.Length && EqualsHelper(strA, strB))) {
                 return 0;
             }
 
             int lengthA = length;
             int lengthB = length;
 
-            if (strA!=null) {
-                if (strA.Length - indexA < lengthA) {
-                  lengthA = (strA.Length - indexA);
-                }
+            if (strA.Length - indexA < lengthA) {
+                lengthA = (strA.Length - indexA);
             }
 
-            if (strB!=null) {
-                if (strB.Length - indexB < lengthB) {
-                    lengthB = (strB.Length - indexB);
-                }
+            if (strB.Length - indexB < lengthB) {
+                lengthB = (strB.Length - indexB);
             }
     
             switch (comparisonType) {


### PR DESCRIPTION
A couple of `string.Compare(string, int, string, int, int, StringComparison)` optimisations.
- Do the quick int index compare before getting into a full string comparison.
- Remove redundant null checks that have already been performed at the start of the function.