### PR TITLE
Fix build on NetBSD: Mark EXTERNAL (@plt) calls which need to go via PLT

### DIFF
--- a/src/vm/amd64/externalmethodfixupthunk.S
+++ b/src/vm/amd64/externalmethodfixupthunk.S
@@ -18,7 +18,7 @@ NESTED_ENTRY ExternalMethodFixupStub, _TEXT, NoHandler
         mov             rdx, 0                              // sectionIndex
         mov             rcx, 0                              // pModule
 
-        call            C_FUNC(ExternalMethodFixupWorker)
+        call            EXTERNAL_C_FUNC(ExternalMethodFixupWorker)
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
 PATCH_LABEL ExternalMethodFixupPatchLabel
@@ -35,7 +35,7 @@ NESTED_ENTRY DelayLoad_MethodCall, _TEXT, NoHandler
         lea     rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
         mov     rsi, rax                            // pIndirection
 
-        call            C_FUNC(ExternalMethodFixupWorker)
+        call            EXTERNAL_C_FUNC(ExternalMethodFixupWorker)
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
 
@@ -56,7 +56,7 @@ NESTED_ENTRY DelayLoad_Helper\suffix, _TEXT, NoHandler
         lea     rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
         mov     rsi, rax                            // pIndirection
 
-        call    C_FUNC(DynamicHelperWorker)
+        call    EXTERNAL_C_FUNC(DynamicHelperWorker)
 
         test    rax,rax
         jnz     LOCAL_LABEL(TailCallDelayLoad_Helper\suffix)
@@ -89,7 +89,7 @@ NESTED_ENTRY VirtualMethodFixupStub, _TEXT, NoHandler
 
         lea             rdi, [rsp + __PWTB_TransitionBlock] // pTransitionBlock
         sub             rsi, 5                              // pThunk
-        call            C_FUNC(VirtualMethodFixupWorker)
+        call            EXTERNAL_C_FUNC(VirtualMethodFixupWorker)
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
 PATCH_LABEL VirtualMethodFixupPatchLabel

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -19,7 +19,7 @@ LEAF_END JIT_PatchedCodeStart, _TEXT
 LEAF_ENTRY JIT_WriteBarrier, _TEXT
 #ifdef _DEBUG
         // In debug builds, this just contains jump to the debug version of the write barrier by default
-        jmp C_FUNC(JIT_WriteBarrier_Debug)
+        jmp EXTERNAL_C_FUNC(JIT_WriteBarrier_Debug)
 #endif
 
         // Do the move into the GC .  It is correct to take an AV here, the EH code

--- a/src/vm/amd64/pinvokestubs.S
+++ b/src/vm/amd64/pinvokestubs.S
@@ -22,7 +22,7 @@ LEAF_ENTRY GenericPInvokeCalliHelper, _TEXT
         //
         mov             rax, [PINVOKE_CALLI_SIGTOKEN_REGISTER + OFFSETOF__VASigCookie__pNDirectILStub]
         test            rax, rax
-        jz              C_FUNC(GenericPInvokeCalliGenILStub)
+        jz              EXTERNAL_C_FUNC(GenericPInvokeCalliGenILStub)
 
         //
         // We need to distinguish between a MethodDesc* and an unmanaged target in PInvokeStubForHost().
@@ -55,7 +55,7 @@ NESTED_ENTRY GenericPInvokeCalliGenILStub, _TEXT, NoHandler
         lea             rdi, [rsp + __PWTB_TransitionBlock]     // pTransitionBlock*
         mov             rsi, PINVOKE_CALLI_SIGTOKEN_REGISTER    // pVASigCookie
         mov             rdx, METHODDESC_REGISTER                // pUnmanagedTarget
-        call            C_FUNC(GenericPInvokeCalliStubWorker)
+        call            EXTERNAL_C_FUNC(GenericPInvokeCalliStubWorker)
 
         //
         // restore target
@@ -115,7 +115,7 @@ NESTED_ENTRY VarargPInvokeGenILStub, _TEXT, NoHandler
         lea             rdi, [rsp + __PWTB_TransitionBlock]     // pTransitionBlock*
         mov             rsi, PINVOKE_CALLI_SIGTOKEN_REGISTER    // pVASigCookie
         mov             rdx, METHODDESC_REGISTER                // pMD
-        call            C_FUNC(VarargPInvokeStubWorker)
+        call            EXTERNAL_C_FUNC(VarargPInvokeStubWorker)
 
         //
         // restore target

--- a/src/vm/amd64/theprestubamd64.S
+++ b/src/vm/amd64/theprestubamd64.S
@@ -14,7 +14,7 @@ NESTED_ENTRY ThePreStub, _TEXT, NoHandler
         //
         lea             rdi, [rsp + __PWTB_TransitionBlock]     // pTransitionBlock*
         mov             rsi, METHODDESC_REGISTER
-        call            C_FUNC(PreStubWorker)
+        call            EXTERNAL_C_FUNC(PreStubWorker)
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
         TAILJMP_RAX
@@ -27,4 +27,3 @@ LEAF_ENTRY ThePreStubPatch, _TEXT
 PATCH_LABEL ThePreStubPatchLabel
         ret
 LEAF_END ThePreStubPatch, _TEXT
-

--- a/src/vm/amd64/umthunkstub.S
+++ b/src/vm/amd64/umthunkstub.S
@@ -17,7 +17,7 @@ NESTED_ENTRY TheUMEntryPrestub, _TEXT, UnhandledExceptionHandlerUnix
     END_PROLOGUE
 
     mov rdi, METHODDESC_REGISTER 
-    call C_FUNC(TheUMEntryPrestubWorker)
+    call EXTERNAL_C_FUNC(TheUMEntryPrestubWorker)
     
     // we're going to tail call to the exec stub that we just setup 
 
@@ -75,7 +75,7 @@ NESTED_ENTRY UMThunkStub, _TEXT, UnhandledExceptionHandlerUnix
         //
         // Call GetThread()
         //
-        call            C_FUNC(GetThread)
+        call            EXTERNAL_C_FUNC(GetThread)
         test            rax, rax
         jz              LOCAL_LABEL(DoThreadSetup)
 
@@ -152,17 +152,17 @@ LOCAL_LABEL(PostCall):
 
 
 LOCAL_LABEL(DoThreadSetup):
-        call            C_FUNC(CreateThreadBlockThrow)
+        call            EXTERNAL_C_FUNC(CreateThreadBlockThrow)
         jmp             LOCAL_LABEL(HaveThread)
         
 LOCAL_LABEL(InvalidTransition):
         //No arguments to setup , ReversePInvokeBadTransition will failfast
-        call            C_FUNC(ReversePInvokeBadTransition)
+        call            EXTERNAL_C_FUNC(ReversePInvokeBadTransition)
 
 LOCAL_LABEL(DoTrapReturningThreadsTHROW):
         mov             rdi, r12                                                                        // Thread* pThread
         mov             rsi, [rbp - UMThunkStubAMD64_RBP_OFFSET + UMThunkStubAMD64_METHODDESC_OFFSET]   // UMEntryThunk* pUMEntry
-        call            C_FUNC(UMThunkStubRareDisableWorker)
+        call            EXTERNAL_C_FUNC(UMThunkStubRareDisableWorker)
 
         jmp             LOCAL_LABEL(InCooperativeMode)
 

--- a/src/vm/amd64/unixasmhelpers.S
+++ b/src/vm/amd64/unixasmhelpers.S
@@ -26,7 +26,7 @@ LEAF_ENTRY PrecodeFixupThunk, _TEXT
         lea     METHODDESC_REGISTER,[rax+r11*8]
 
         // Tail call to prestub
-        jmp C_FUNC(ThePreStub)
+        jmp EXTERNAL_C_FUNC(ThePreStub)
 
 LEAF_END PrecodeFixupThunk, _TEXT
 
@@ -113,7 +113,7 @@ NESTED_ENTRY NDirectImportThunk, _TEXT, NoHandler
         // Call NDirectImportWorker w/ the NDirectMethodDesc*
         //
         mov             rdi, METHODDESC_REGISTER
-        call            C_FUNC(NDirectImportWorker)
+        call            EXTERNAL_C_FUNC(NDirectImportWorker)
         
         RESTORE_FLOAT_ARGUMENT_REGISTERS 0
 
@@ -160,7 +160,7 @@ NESTED_ENTRY JIT_RareDisableHelper, _TEXT, NoHandler
     // Second float return register
     movdqa              xmmword ptr [rsp+0x10], xmm1
 
-    call                C_FUNC(JIT_RareDisableHelperWorker)
+    call                EXTERNAL_C_FUNC(JIT_RareDisableHelperWorker)
 
     movdqa              xmm0, xmmword ptr [rsp]
     movdqa              xmm1, xmmword ptr [rsp+0x10]
@@ -330,7 +330,7 @@ LEAF_ENTRY SinglecastDelegateInvokeStub, _TEXT
                                                                                       
 NullObject:                                                                           
         mov     rdi, CORINFO_NullReferenceException_ASM                               
-        jmp     C_FUNC(JIT_InternalThrow)
+        jmp     EXTERNAL_C_FUNC(JIT_InternalThrow)
                                                                                       
 LEAF_END SinglecastDelegateInvokeStub, _TEXT
 
@@ -372,4 +372,3 @@ LEAF_ENTRY StartUnwindingNativeFrames, _TEXT
         mov     rdi, rsi 
         jmp     EXTERNAL_C_FUNC(ThrowExceptionHelper)
 LEAF_END StartUnwindingNativeFrames, _TEXT
-

--- a/src/vm/amd64/virtualcallstubamd64.S
+++ b/src/vm/amd64/virtualcallstubamd64.S
@@ -35,7 +35,7 @@ NESTED_ENTRY ResolveWorkerAsmStub, _TEXT, NoHandler
         and             rcx,  7                                    // flags
         sub             rsi, rcx                                   // indirection cell
 
-        call            C_FUNC(VSD_ResolveWorker)
+        call            EXTERNAL_C_FUNC(VSD_ResolveWorker)
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
         TAILJMP_RAX
@@ -99,7 +99,7 @@ NESTED_ENTRY StubDispatchFixupStub, _TEXT, NoHandler
         mov             rdx,0                               // sectionIndex
         mov             rcx,0                               // pModule
 
-        call            C_FUNC(StubDispatchFixupWorker)
+        call            EXTERNAL_C_FUNC(StubDispatchFixupWorker)
 
         EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
 PATCH_LABEL StubDispatchFixupPatchLabel


### PR DESCRIPTION
This fixes issues like:

```
/usr/bin/ld: ../../../vm/wks/libcee_wks.a(externalmethodfixupthunk.S.o): relocation R_X86_64_PC32 against symbol `ExternalMethodFixupWorker' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: Bad value
clang-3.9: error: linker command failed with exit code 1 (use -v to see invocation)
```

```
$ pkg_info |grep -E 'llvm|lldb|clang'
llvm-3.9.0nb20160205 Low Level Virtual Machine compiler infrastructure
clang-3.9.0nb20160205 C language family frontend for LLVM
lldb-3.9.0nb20160206 next generation, high-performance debugger
```

```
$ uname -a
NetBSD chieftec 7.99.25 NetBSD 7.99.25 (GENERIC) #0: Fri Dec 25 20:51:06 UTC 2015  root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC amd64
```

Closes #3020 Relocation against symbol can not be used when making a shared object

Issue nailed down thanks to Joerg Sonnenberg (@jsonn) via pkgsrc-users@NetBSD.org
http://mail-index.netbsd.org/pkgsrc-users/2016/02/10/msg022940.html

Thanks Peter Jas (@jasonwilliams200OK) for help with this issue.