### PR TITLE
Inline refactoring: start untangling observation and policy

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -61,6 +61,7 @@ set( JIT_SOURCES
   loopcloning.cpp
   lower.cpp
   lsra.cpp
+  inline.cpp
 )
 
 if(CLR_CMAKE_PLATFORM_ARCH_AMD64)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4362,7 +4362,7 @@ int           Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     {
         if (compIsForInlining())
         {
-            compInlineResult->setNever("Inlinee marked as skipped");
+            compInlineResult->noteFatal(InlineObservation::CALLEE_MARKED_AS_SKIPPED);
         }
         return CORJIT_SKIPPED;
     }
@@ -5079,8 +5079,12 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
             (fgBBcount > 5) &&
             !forceInline)
         {
-            compInlineResult->setNever("Too many basic blocks in the inlinee");
-            goto _Next;
+            compInlineResult->note(InlineObservation::CALLEE_TOO_MANY_BASIC_BLOCKS);
+
+            if (compInlineResult->isFailure()) 
+            {
+                goto _Next;
+            }
         }
 
 #ifdef  DEBUG
@@ -5760,7 +5764,7 @@ START:
         {
             // Note that we failed to compile the inlinee, and that
             // there's no point trying to inline it again anywhere else.
-            inlineInfo->inlineResult->setNever("Error compiling inlinee");
+            inlineInfo->inlineResult->noteFatal(InlineObservation::CALLEE_COMPILATION_ERROR);
         }
         param.result = __errc;       
     }

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1583,8 +1583,7 @@ inline unsigned     Compiler::lvaGrabTemp(bool shortLifetime
         if (pComp->lvaHaveManyLocals())
         {
             // Don't create more LclVar with inlining 
-            JITLOG((LL_INFO1000000, INLINER_FAILED "Inlining requires new LclVars and we already have too many locals."));
-            compInlineResult->setFailure("Inlining requires new LclVars and we already have too many locals.");
+            compInlineResult->noteFatal(InlineObservation::CALLSITE_TOO_MANY_LOCALS);
         }
 
         unsigned tmpNum = pComp->lvaGrabTemp(shortLifetime DEBUGARG(reason));

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4438,7 +4438,7 @@ DECODE_OPCODE:
             {
                 if (stateNetCFQuirks >= 0)
                 {
-                    compInlineResult->setNever("Windows Phone OS 7 compatibility - Inlinee contains control flow");
+                    compInlineResult->noteFatal(InlineObservation::CALLEE_WP7QUIRK_CONTROL_FLOW);
                     return;
                 }
             }
@@ -4484,13 +4484,13 @@ DECODE_OPCODE:
 
                 if (stateNetCFQuirks >= 0)
                 {
-                    compInlineResult->setNever("Windows Phone OS 7 compatibility - Inlinee contains control flow");
+                    compInlineResult->noteFatal(InlineObservation::CALLEE_WP7QUIRK_CONTROL_FLOW);
                     return;
                 }
 
 #endif // FEATURE_LEGACYNETCF
 
-                compInlineResult->setNever("Inlinee contains SWITCH instruction");
+                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_SWITCH);
                 return;
             }
 
@@ -4554,7 +4554,7 @@ DECODE_OPCODE:
             {
                 if (stateNetCFQuirks >= 0)
                 {
-                    compInlineResult->setNever("Windows Phone OS 7 compatibility - Inlinee contains prefix");
+                    compInlineResult->noteFatal(InlineObservation::CALLEE_WP7QUIRK_PREFIX);
                     return;
                 }
             }
@@ -4580,7 +4580,7 @@ DECODE_OPCODE:
             {
                 if (stateNetCFQuirks >= 0)
                 {
-                    compInlineResult->setNever("Windows Phone OS 7 compatibility - Inlinee contains throw");
+                    compInlineResult->noteFatal(InlineObservation::CALLEE_WP7QUIRK_THROW);
                     return;
                 }
             }
@@ -4631,15 +4631,7 @@ DECODE_OPCODE:
             //Consider making this only for not force inline.
             if (compIsForInlining())
             {
-                const char* message;
-#ifdef DEBUG
-                message = (char*)compAllocator->nraAlloc(128);
-                sprintf((char*)message, "Unsupported opcode for inlining: %s\n",
-                        opcodeNames[opcode]);
-#else
-                message = "Unsupported opcode for inlining";
-#endif
-                compInlineResult->setNever(message);
+                compInlineResult->noteFatal(InlineObservation::CALLEE_UNSUPPORTED_OPCODE);
                 return;
             }
             break;
@@ -4764,7 +4756,7 @@ ARG_PUSH:
                     stateNetCFQuirks++;
                     if (varNum != expectedVarNum)
                     {
-                        compInlineResult->setNever("Windows Phone OS 7 compatibility - out of order ldarg");
+                        compInlineResult->noteFatal(InlineObservation::CALLEE_WP7QUIRK_LDARG_ORDER);
                         return;
                     }
                 }
@@ -4783,7 +4775,7 @@ ADDR_TAKEN:
             {
                 if (stateNetCFQuirks >= 0)
                 {
-                    compInlineResult->setNever("Windows Phone OS 7 compatibility - address taken");
+                    compInlineResult->noteFatal(InlineObservation::CALLEE_WP7QUIRK_ADDRESS_TAKEN);
                     return;
                 }
             }
@@ -4910,7 +4902,7 @@ ARG_WRITE:
                 /* The inliner keeps the args as trees and clones them.  Storing the arguments breaks that
                  * simplification.  To allow this, flag the argument as written to and spill it before
                  * inlining.  That way the STARG in the inlinee is trivial. */
-                compInlineResult->setNever("Inlinee writes to an argument");
+                compInlineResult->noteFatal(InlineObservation::CALLEE_STORES_TO_ARGUMENT);
                 return;
             }
             else
@@ -21916,7 +21908,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call,
             printf("Recursive or deep inline recursion detected. Will not expand this INLINECANDIDATE \n");
         }
 #endif // DEBUG
-        inlineResult->setFailure("Recursive or deep inline");
+        inlineResult->noteFatal(InlineObservation::CALLSITE_IS_RECURSIVE_OR_DEEP);
         return;
     }
 
@@ -21991,7 +21983,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call,
 
             if (result != CORJIT_OK)
             {
-                pParam->inlineInfo->inlineResult->setFailure("Error invoking the compiler for the inlinee");
+                pParam->inlineInfo->inlineResult->noteFatal(InlineObservation::CALLSITE_COMPILATION_FAILURE);
             }
         }
     }
@@ -22004,7 +21996,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call,
                     eeGetMethodFullName(fncHandle));
         }
 #endif // DEBUG
-        inlineResult->setFailure("Exception invoking the compiler for the inlinee");
+        inlineResult->noteFatal(InlineObservation::CALLSITE_COMPILATION_ERROR);
     }
     endErrorTrap();
 
@@ -22038,7 +22030,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call,
                     eeGetMethodFullName(fncHandle));
         }
 #endif // DEBUG
-        inlineResult->setNever("inlinee did not contain a return expression");
+        inlineResult->noteFatal(InlineObservation::CALLEE_LACKS_RETURN);
         return;
     }
 
@@ -22049,7 +22041,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall* call,
         if (!(info.compCompHnd->initClass(NULL /* field */, fncHandle /* method */,
                 inlineCandidateInfo->exactContextHnd /* context */) & CORINFO_INITCLASS_INITIALIZED))
         {
-            inlineResult->setNever("Failed class init side-effect");
+            inlineResult->noteFatal(InlineObservation::CALLEE_CLASS_INIT_FAILURE);
             return;
         }
     }

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -1,0 +1,154 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "jitpch.h"
+#ifdef _MSC_VER
+#pragma hdrstop
+#endif
+
+// Lookup table for inline description strings
+
+static const char* InlineDescriptions[] = 
+{
+#define INLINE_OBSERVATION(name, type, description, impact, target) description,
+#include "inline.def"
+#undef INLINE_OBSERVATION
+};
+
+// Lookup table for inline targets
+
+static const InlineTarget InlineTargets[] =
+{
+#define INLINE_OBSERVATION(name, type, description, impact, target) InlineTarget::target,
+#include "inline.def"
+#undef INLINE_OBSERVATION
+};
+
+// Lookup table for inline impacts
+
+static const InlineImpact InlineImpacts[] =
+{
+#define INLINE_OBSERVATION(name, type, description, impact, target) InlineImpact::impact,
+#include "inline.def"
+#undef INLINE_OBSERVATION
+};
+
+#ifdef DEBUG
+
+//------------------------------------------------------------------------
+// inlIsValidObservation: run a validity check on an inline observation
+//
+// Arguments:
+//    obs - the observation in question
+//
+// Return Value:
+//    true if the observation is valid
+
+static bool inlIsValidObservation(InlineObservation obs)
+{
+    return((obs > InlineObservation::CALLEE_UNUSED_INITIAL) &&
+           (obs < InlineObservation::CALLEE_UNUSED_FINAL));
+}
+
+#endif // DEBUG
+
+//------------------------------------------------------------------------
+// inlGetDescriptionString: get a string describing this inline observation
+//
+// Arguments:
+//    obs - the observation in question
+//
+// Return Value:
+//    string describing the observation
+
+const char* inlGetDescriptionString(InlineObservation obs)
+{
+    assert(inlIsValidObservation(obs));
+    return InlineDescriptions[static_cast<int>(obs)];
+}
+
+//------------------------------------------------------------------------
+// inlGetTarget: get the target of an inline observation
+//
+// Arguments:
+//    obs - the observation in question
+//
+// Return Value:
+//    enum describing the target
+
+InlineTarget inlGetTarget(InlineObservation obs)
+{
+    assert(inlIsValidObservation(obs));
+    return InlineTargets[static_cast<int>(obs)];
+}
+
+//------------------------------------------------------------------------
+// inlGetTargetString: get a string describing the target of an inline observation
+//
+// Arguments:
+//    obs - the observation in question
+//
+// Return Value:
+//    string describing the target
+
+const char* inlGetTargetstring(InlineObservation obs)
+{
+    InlineTarget t = inlGetTarget(obs);
+    switch (t) 
+    {
+    case InlineTarget::CALLER:
+        return "caller";
+    case InlineTarget::CALLEE:
+        return "callee";
+    case InlineTarget::CALLSITE:
+        return "call site";
+    default:
+        return "unexpected target";
+    }
+}
+
+//------------------------------------------------------------------------
+// inlGetImpact: get the impact of an inline observation
+//
+// Arguments:
+//    obs - the observation in question
+//
+// Return Value:
+//    enum value describing the impact
+
+InlineImpact inlGetImpact(InlineObservation obs)
+{
+    assert(inlIsValidObservation(obs));
+    return InlineImpacts[static_cast<int>(obs)];
+}
+
+//------------------------------------------------------------------------
+// inlGetImpactString: get a string describing the impact of an inline observation
+//
+// Arguments:
+//    obs - the observation in question
+//
+// Return Value:
+//    string describing the impact
+
+const char* inlGetImpactString(InlineObservation obs)
+{
+    InlineImpact i = inlGetImpact(obs);
+    switch (i) 
+    {
+    case InlineImpact::FATAL:
+        return "correctness -- fatal";
+    case InlineImpact::FUNDAMENTAL:
+        return "correctness -- fundamental limitation";
+    case InlineImpact::LIMITATION:
+        return "correctness -- jit limitation";
+    case InlineImpact::PERFORMANCE:
+        return "performance";
+    case InlineImpact::INFORMATION:
+        return "information";
+    default:
+        return "unexpected impact";
+    }
+}
+

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -1,0 +1,153 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Macro template for inline observations
+//
+// INLINE_OBSERVATION(name, type, description, impact, target)
+//
+// name will be used to create an InlineObservation enum member
+//    (enum name prepends scope, eg CALLEE_MARKED_AS_SKIPPED)
+// type is the data type for the observation
+// description is a user string for diagnostics
+// impact is one of the members of InlineImpact
+// target is one of the members of InlineTarget
+//
+// Note: the impact classification is work in progress.
+//
+// Some subset of the FATAL cases here can be refined to SERIOUS,
+// LIMITATION, or PERFORMANCE. While the refined observations may
+// eventually veto inlining, the jit can safely keep making more 
+// observations.
+
+// ------ Initial Sentinel ------- 
+
+INLINE_OBSERVATION(UNUSED_INITIAL,            bool,   "unused initial observation",    FATAL,       CALLEE)
+
+// ------ Callee Fatal ------- 
+
+INLINE_OBSERVATION(BAD_ARGUMENT_NUMBER,       bool,   "invalid argument number",       FATAL,       CALLEE)
+INLINE_OBSERVATION(BAD_LOCAL_NUMBER,          bool,   "invalid local number",          FATAL,       CALLEE)
+INLINE_OBSERVATION(CLASS_INIT_FAILURE,        bool,   "class init failed",             FATAL,       CALLEE)
+INLINE_OBSERVATION(COMPILATION_ERROR,         bool,   "compilation error",             FATAL,       CALLEE)
+INLINE_OBSERVATION(EXCEEDS_THRESHOLD,         bool,   "exceeds profit threshold",      FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_DELEGATE_INVOKE,       bool,   "delegate invoke",               FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_EH,                    bool,   "has exception handling",        FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_ENDFILTER,             bool,   "has endfilter",                 FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_ENDFINALLY,            bool,   "has endfinally",                FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_LEAVE,                 bool,   "has leave"    ,                 FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_MANAGED_VARARGS,       bool,   "managed varargs",               FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_NATIVE_VARARGS,        bool,   "native varargs",                FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_NO_BODY,               bool,   "has no body",                   FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_NULL_FOR_LDELEM,       bool,   "has null pointer for ldelem",   FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_PINNED_LOCALS,         bool,   "has pinned locals",             FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_ARRAY_METHOD,           bool,   "is array method",               FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_GENERIC_VIRTUAL,        bool,   "generic virtual",               FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_JIT_NOINLINE,           bool,   "noinline per JitNoinline",      FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_NATIVE,                 bool,   "is implemented natively",       FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_NOINLINE,               bool,   "noinline per IL/cached result", FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_SYNCHRONIZED,           bool,   "is synchronized",               FATAL,       CALLEE)
+INLINE_OBSERVATION(IS_VM_NOINLINE,            bool,   "noinline per VM",               FATAL,       CALLEE)
+INLINE_OBSERVATION(LACKS_RETURN,              bool,   "no return opcode",              FATAL,       CALLEE)
+INLINE_OBSERVATION(LDFLD_NEEDS_HELPER,        bool,   "ldfld needs helper",            FATAL,       CALLEE)
+INLINE_OBSERVATION(MARKED_AS_SKIPPED,         bool,   "skipped by complus request",    FATAL,       CALLEE)
+INLINE_OBSERVATION(MAXSTACK_TOO_BIG,          bool,   "maxstack too big"  ,            FATAL,       CALLEE)
+INLINE_OBSERVATION(NEEDS_SECURITY_CHECK,      bool,   "needs security check",          FATAL,       CALLEE)
+INLINE_OBSERVATION(NO_METHOD_INFO,            bool,   "cannot get method info",        FATAL,       CALLEE)
+INLINE_OBSERVATION(RETURN_TYPE_IS_COMPOSITE,  bool,   "has composite return type",     FATAL,       CALLEE)
+INLINE_OBSERVATION(STACK_CRAWL_MARK,          bool,   "uses stack crawl mark",         FATAL,       CALLEE)
+INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLEE)
+INLINE_OBSERVATION(STORES_TO_ARGUMENT,        bool,   "stores to argument",            FATAL,       CALLEE)
+INLINE_OBSERVATION(THROW_WITH_INVALID_STACK,  bool,   "throw with invalid stack",      FATAL,       CALLEE)
+INLINE_OBSERVATION(TOO_MANY_ARGUMENTS,        bool,   "too many arguments",            FATAL,       CALLEE)
+INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",               FATAL,       CALLEE)
+INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",            FATAL,       CALLEE)
+
+#ifdef FEATURE_LEGACYNETCF
+
+INLINE_OBSERVATION(WP7QUIRK_ADDRESS_TAKEN,    bool,   "WinPhone7 quirk address taken", FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_CONTROL_FLOW,     bool,   "WinPhone7 quirk has ctl flow",  FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_HAS_EH,           bool,   "WinPhone7 quirk has eh",        FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_HAS_FP_ARG,       bool,   "WinPhone7 quirk has float arg", FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_HAS_FP_RET,       bool,   "WinPhone7 quirk has float ret", FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_HAS_LOCALS,       bool,   "WinPhone7 quirk has locals",    FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_IL_TOO_BIG,       bool,   "WinPhone7 quirk il too big",    FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_LDARG_ORDER,      bool,   "WinPhone7 quirk ldarg order",   FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_PREFIX,           bool,   "WinPhone7 quirk has prefix",    FATAL,       CALLEE)
+INLINE_OBSERVATION(WP7QUIRK_THROW,            bool,   "WinPhone7 quirk has throw",     FATAL,       CALLEE)
+
+#endif // FEATURE_LEGACYNETCF
+
+// ------ Callee Performance ------- 
+
+INLINE_OBSERVATION(LDFLD_STATIC_VALUECLASS,   bool,   "ldsfld of value class",         PERFORMANCE, CALLEE)
+INLINE_OBSERVATION(TOO_MANY_BASIC_BLOCKS,     bool,   "too many basic blocks",         PERFORMANCE, CALLEE)
+INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",             PERFORMANCE, CALLEE)
+
+// ------ Callee Information ------- 
+
+INLINE_OBSERVATION(HAS_FORCE_INLINE,          bool,   "has aggressive inline attr",    INFORMATION, CALLEE)
+INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
+INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLEE)
+INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",           INFORMATION, CALLEE)
+INLINE_OBSERVATION(NUMBER_OF_IL_BYTES,        int,    "number of bytes of IL",         INFORMATION, CALLEE)
+INLINE_OBSERVATION(NUMBER_OF_LOCALS,          int,    "number of locals",              INFORMATION, CALLEE)
+
+// ------ Caller Corectness ------- 
+
+INLINE_OBSERVATION(DEBUG_CODEGEN,             bool,   "debug codegen",                 FATAL,       CALLER)
+INLINE_OBSERVATION(NEEDS_SECURITY_CHECK,      bool,   "needs security check",          FATAL,       CALLER)
+
+// ------ Call Site Correctness ------- 
+
+INLINE_OBSERVATION(ARG_HAS_NULL_THIS,         bool,   "this pointer argument is null", FATAL,       CALLSITE)
+INLINE_OBSERVATION(ARG_HAS_SIDE_EFFECT,       bool,   "argument has side effect",      FATAL,       CALLSITE)
+INLINE_OBSERVATION(ARG_IS_MKREFANY,           bool,   "argument is mkrefany",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(ARG_NO_BASH_TO_INT,        bool,   "argument can't bash to int",    FATAL,       CALLSITE)
+INLINE_OBSERVATION(ARG_NO_BASH_TO_REF,        bool,   "argument can't bash to ref",    FATAL,       CALLSITE)
+INLINE_OBSERVATION(ARG_TYPES_INCOMPATIBLE,    bool,   "argument types incompatible",   FATAL,       CALLSITE)
+INLINE_OBSERVATION(CANT_EMBED_PINVOKE_COOKIE, bool,   "can't embed pinvoke cookie",    FATAL,       CALLSITE)
+INLINE_OBSERVATION(CANT_EMBED_VARARGS_COOKIE, bool,   "can't embed varargs cookie",    FATAL,       CALLSITE)
+INLINE_OBSERVATION(CLASS_INIT_FAILURE_SPEC,   bool,   "speculative class init failed", FATAL,       CALLSITE)
+INLINE_OBSERVATION(COMPILATION_ERROR,         bool,   "compilation error",             FATAL,       CALLSITE)
+INLINE_OBSERVATION(COMPILATION_FAILURE,       bool,   "failed to compile",             FATAL,       CALLSITE)
+INLINE_OBSERVATION(CONDITIONAL_THROW,         bool,   "conditional throw",             FATAL,       CALLSITE)
+INLINE_OBSERVATION(CROSS_BOUNDARY_CALLI,      bool,   "cross-boundary calli",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(CROSS_BOUNDARY_SECURITY,   bool,   "cross-boundary security check", FATAL,       CALLSITE)
+INLINE_OBSERVATION(EXCEEDS_THRESHOLD,         bool,   "exeeds profit threshold",       FATAL,       CALLSITE)
+INLINE_OBSERVATION(EXPLICIT_TAIL_PREFIX,      bool,   "explicit tail prefix",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(GENERIC_DICTIONARY_LOOKUP, bool,   "runtime dictionary lookup",     FATAL,       CALLSITE)
+INLINE_OBSERVATION(HAS_CALL_VIA_LDVIRTFTN,    bool,   "call via ldvirtftn",            FATAL,       CALLSITE)
+INLINE_OBSERVATION(HAS_COMPLEX_HANDLE,        bool,   "complex handle access",         FATAL,       CALLSITE)
+INLINE_OBSERVATION(HAS_LDSTR_RESTRICTION,     bool,   "has ldstr VM restriction",      FATAL,       CALLSITE)
+INLINE_OBSERVATION(IMPLICIT_REC_TAIL_CALL,    bool,   "implicit recursive tail call",  FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_CALL_TO_HELPER,         bool,   "target is helper",              FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_NOT_DIRECT,             bool,   "target not direct",             FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_NOT_DIRECT_MANAGED,     bool,   "target not direct managed",     FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_RECURSIVE_OR_DEEP,      bool,   "recursive or too deep",         FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_VIRTUAL,                bool,   "virtual",                       FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_VM_NOINLINE,            bool,   "noinline per VM",               FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_WITHIN_CATCH,           bool,   "within catch region",           FATAL,       CALLSITE)
+INLINE_OBSERVATION(IS_WITHIN_FILTER,          bool,   "within filterregion",           FATAL,       CALLSITE)
+INLINE_OBSERVATION(LDARGA_NOT_LOCAL_VAR,      bool,   "ldarga not on local var",       FATAL,       CALLSITE)
+INLINE_OBSERVATION(LDFLD_NEEDS_HELPER,        bool,   "ldfld needs helper",            FATAL,       CALLSITE)
+INLINE_OBSERVATION(LDVIRTFN_ON_NON_VIRTUAL,   bool,   "ldvirtfn on non-virtual",       FATAL,       CALLSITE)
+INLINE_OBSERVATION(NOT_CANDIDATE,             bool,   "not inline candidate",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(REQUIRES_SAME_THIS,        bool,   "requires same this",            FATAL,       CALLSITE)
+INLINE_OBSERVATION(RETURN_TYPE_MISMATCH,      bool,   "return type mismatch",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLSITE)
+INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",               FATAL,       CALLSITE)
+
+// ------ Call Site Peformance ------- 
+
+
+// ------ Call Site Information ------- 
+
+INLINE_OBSERVATION(BENEFIT_MULTIPLIER,        double, "benefit multiplier",            INFORMATION, CALLSITE)
+INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLSITE)
+
+// ------ Final Sentinel ------- 
+
+INLINE_OBSERVATION(UNUSED_FINAL,              bool,   "unused final observation",      FATAL,       CALLEE)
+

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#ifndef _INLINE_H_
+#define _INLINE_H_
+
+// InlineDecision describes the various states the jit goes through when
+// evaluating an inline candidate. It is distinct from CorInfoInline
+// because it must capture internal states that don't get reported back
+// to the runtime.
+
+enum class InlineDecision 
+{
+    UNDECIDED,
+    CANDIDATE,
+    SUCCESS,
+    FAILURE,
+    NEVER
+};
+
+// Possible targets of an inline observation
+
+enum class InlineTarget
+{
+    CALLEE,         // observation applies to all calls to this callee
+    CALLER,         // observation applies to all calls made by this caller
+    CALLSITE        // observation applies to a specific call site
+};
+
+// Possible impact of an inline observation
+
+enum class InlineImpact
+{
+    FATAL,          // inlining impossible, unsafe to evaluate further
+    FUNDAMENTAL,    // inlining impossible for fundamental reasons, deeper exploration safe
+    LIMITATION,     // inlining impossible because of jit limitations, deeper exploration safe
+    PERFORMANCE,    // inlining inadvisable because of performance concerns
+    INFORMATION     // policy-free observation to provide data for later decision making
+};
+
+// The set of possible inline observations
+
+enum class InlineObservation
+{
+#define INLINE_OBSERVATION(name, type, description, impact, scope) scope ## _ ## name,
+#include "inline.def"
+#undef INLINE_OBSERVATION
+};
+
+// Get a string describing this observation
+
+const char* inlGetDescriptionString(InlineObservation obs);
+
+// Get a string describing the target of this observation
+
+const char* inlGetTargetString(InlineObservation obs);
+
+// Get a string describing the impact of this observation
+
+const char* inlGetImpactString(InlineObservation obs);
+
+// Get the target of this observation
+
+InlineTarget inlGetTarget(InlineObservation obs);
+
+// Get the impact of this observation
+
+InlineImpact inlGetImpact(InlineObservation obs);
+
+#endif // _INLINE_H_
+

--- a/src/jit/jit.settings.targets
+++ b/src/jit/jit.settings.targets
@@ -80,6 +80,7 @@
         <CppCompile Include="..\AssertionProp.cpp" />
         <CppCompile Include="..\RangeCheck.cpp" />
         <CppCompile Include="..\LoopCloning.cpp" />
+        <CppCompile Include="..\inline.cpp" />
         <CppCompile Condition="'$(ClDefines.Contains(`LEGACY_BACKEND`))'=='True'" Include="..\CodeGenLegacy.cpp" />
         <CppCompile Condition="'$(ClDefines.Contains(`LEGACY_BACKEND`))'=='False'"  Include="..\Lower.cpp" />
         <CppCompile Condition="'$(ClDefines.Contains(`LEGACY_BACKEND`))'=='False'"  Include="..\LSRA.cpp" />

--- a/src/jit/jitpch.h
+++ b/src/jit/jitpch.h
@@ -28,3 +28,5 @@
 #include "ssaconfig.h"
 #include "blockset.h"
 #include "bitvec.h"
+#include "inline.h"
+

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5659,14 +5659,19 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, JitInlineResult* resul
 {
     if  (lvaCount >= MAX_LV_NUM_COUNT_FOR_INLINING)
     {
-        result->setFailure("Too many local variables in the inliner");
+        // For now, attributing this to call site, though it's really
+        // more of a budget issue (lvaCount currently includes all
+        // caller and prospective callee locals). We still might be
+        // able to inline other callees into this caller, or inline
+        // this callee in other callers.
+        result->noteFatal(InlineObservation::CALLSITE_TOO_MANY_LOCALS);
         return;
     }
 
     if (call->IsVirtual())
     {
-       result->setFailure("Virtual call");
-       return;
+        result->noteFatal(InlineObservation::CALLSITE_IS_VIRTUAL);
+        return;
     }
 
     // impMarkInlineCandidate() is expected not to mark tail prefixed calls
@@ -5681,14 +5686,14 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, JitInlineResult* resul
 
     if (opts.compNeedSecurityCheck)
     {
-        result->setFailure("Caller needs security check");
+        result->noteFatal(InlineObservation::CALLER_NEEDS_SECURITY_CHECK);
         return;
     }
 
     if ((call->gtFlags & GTF_CALL_INLINE_CANDIDATE) == 0)
     {
-       result->setFailure("Not an inline candidate");
-       return;
+        result->noteFatal(InlineObservation::CALLSITE_NOT_CANDIDATE);
+        return;
     }
     
     //


### PR DESCRIPTION
Create set of observations that can be made during inlining. These
are implemented as a set of static tables plus some helper methods.
Each observation has an enum name, a type, a description string,
an impact, and a target.

For now most observations are about blocking issues and are classified
as having FATAL impact. There are a handful of INFORMATIONAL and
PERFORMANCE observations but they're not widely used yet.

This change also updates the bulk of the jit code to report
observations to the JitInlineResult instead of directly requesting
changes to the JitInlineResult state. Over on the JitInlineResult side,
the current legacy policy is implemented and fails fast if any blocking
observation is made. For now, any any FATAL impact observation must be
made via `noteFatal`, and all other observations be made via `note`.

As with the previous refactorings, this change tries not to alter
any code generation. There are a few cases where observations that
are made solely about the callee are now targeted that way instead of
being targeted at callsites. For instance a method that is marked by
COMPLUS_JitNoInline will never be inlined. This can sometimes lead to
localized code diffs, since the jit creates slightly different IR for a
call to an inline candidate than a call to a non-candidate, and is not
always able to undo this later if inlining fails. However the number of
diffs should be small. Will verify diffs further before merging. There
are no inlining changes crossgenning mscorlib.

Some of the message strings associated with inlining failures have
changed. The messages use `caller` and `callee` to describe the two
methods involved, and `callsite` for the instance in question, and
deprecate `inlinee`. These message strings can be seen in the jit
dumps and logs and are reported back to the VM where they presumably
make their way into other diagnostic reporting streams.

Subsequent work will re-examine the FATAL observations and likely
reclassify a number of them to have less dramatic immediate impact.
Subsequent work will also begin extracting the policy into a separate
class to lay the groundwork for supporting alternate policies while
still being able to fall back to the legacy policy.