### PR TITLE
Making Intrinsic Optional in RyuJit

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -231,11 +231,11 @@ TODO: Talk about initializing strutures before use
 #if COR_JIT_EE_VERSION > 460
 
 // Update this one
-SELECTANY const GUID JITEEVersionIdentifier = { /* b26841f8-74d6-4fc9-9d81-6500cd662549 */
-    0xb26841f8,
-    0x74d6,
-    0x4fc9,
-    { 0x9d, 0x81, 0x65, 0x00, 0xcd, 0x66, 0x25, 0x49 }
+SELECTANY const GUID JITEEVersionIdentifier = { /* 13accf3d-12d7-4fd4-bc65-d73578b1a474 */
+    0x13accf3d,
+    0x12d7,
+    0x4fd4,
+    { 0xbc, 0x65, 0xd7, 0x35, 0x78, 0xb1, 0xa4, 0x74 }
 };
 
 #else
@@ -2426,9 +2426,16 @@ public:
 
     // If a method's attributes have (getMethodAttribs) CORINFO_FLG_INTRINSIC set,
     // getIntrinsicID() returns the intrinsic ID.
+#if COR_JIT_EE_VERSION > 460
+    virtual CorInfoIntrinsics getIntrinsicID(
+            CORINFO_METHOD_HANDLE       method,
+            bool*                       pMustExpand = NULL      /* OUT */
+            ) = 0;
+#else
     virtual CorInfoIntrinsics getIntrinsicID(
             CORINFO_METHOD_HANDLE       method
             ) = 0;
+#endif
 
     // Is the given module the System.Numerics.Vectors module?
     // This defaults to false.

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2880,7 +2880,13 @@ GenTreePtr      Compiler::impIntrinsic(CORINFO_CLASS_HANDLE     clsHnd,
                                        bool                     readonlyCall,
                                        CorInfoIntrinsics *      pIntrinsicID)
 {
+    bool mustExpand = false;
+#if COR_JIT_EE_VERSION > 460
+    CorInfoIntrinsics intrinsicID = info.compCompHnd->getIntrinsicID(method, &mustExpand);
+#else
     CorInfoIntrinsics intrinsicID = info.compCompHnd->getIntrinsicID(method);
+#endif
+    *pIntrinsicID = intrinsicID;
 #ifndef _TARGET_ARM_
     genTreeOps interlockedOperator;
 #endif
@@ -2888,31 +2894,26 @@ GenTreePtr      Compiler::impIntrinsic(CORINFO_CLASS_HANDLE     clsHnd,
     if (intrinsicID == CORINFO_INTRINSIC_StubHelpers_GetStubContext)
     {
         // must be done regardless of DbgCode and MinOpts
-        *pIntrinsicID = intrinsicID;
         return gtNewLclvNode(lvaStubArgumentVar, TYP_I_IMPL);
     }
 #ifdef _TARGET_64BIT_ 
     if (intrinsicID == CORINFO_INTRINSIC_StubHelpers_GetStubContextAddr)
     {
         // must be done regardless of DbgCode and MinOpts
-        *pIntrinsicID = intrinsicID;
         return gtNewOperNode(GT_ADDR, TYP_I_IMPL, gtNewLclvNode(lvaStubArgumentVar, TYP_I_IMPL));
     }
 #endif
 
+    GenTreePtr retNode = nullptr;
+
     //
     // We disable the inlining of instrinsics for MinOpts.
     //
-    if  (opts.compDbgCode || opts.MinOpts())
+    if (!mustExpand && (opts.compDbgCode || opts.MinOpts()))
     {
         *pIntrinsicID = CORINFO_INTRINSIC_Illegal;
-        return nullptr;
+        return retNode;
     }
-
-    *pIntrinsicID = intrinsicID;
-
-    if (intrinsicID < 0 || CORINFO_INTRINSIC_Count <= intrinsicID)
-        return nullptr;
 
     // Currently we don't have CORINFO_INTRINSIC_Exp because it does not
     // seem to work properly for Infinity values, we don't do
@@ -3012,8 +3013,7 @@ GenTreePtr      Compiler::impIntrinsic(CORINFO_CLASS_HANDLE     clsHnd,
                     break;
 
                 default:
-                    assert(!"Unsupport number of args for Math Instrinsic");
-                    return nullptr;
+                    NO_WAY("Unsupport number of args for Math Instrinsic");
             }
         }
         
@@ -3023,7 +3023,8 @@ GenTreePtr      Compiler::impIntrinsic(CORINFO_CLASS_HANDLE     clsHnd,
             op1->gtFlags |= GTF_CALL;
         }
 #endif
-        return op1;
+        retNode = op1;
+        break;
 
 
 #ifdef _TARGET_XARCH_
@@ -3063,7 +3064,8 @@ InterlockedBinOpCommon:
 
         op1 = gtNewOperNode(interlockedOperator, genActualType(callType), op1, op2);
         op1->gtFlags |= GTF_GLOB_EFFECT;
-        return op1;
+        retNode = op1;
+        break;
 #endif // _TARGET_XARCH_
 
     case CORINFO_INTRINSIC_MemoryBarrier:
@@ -3072,7 +3074,8 @@ InterlockedBinOpCommon:
 
         op1 = new (this, GT_MEMORYBARRIER) GenTree(GT_MEMORYBARRIER, TYP_VOID);
         op1->gtFlags |= GTF_GLOB_EFFECT;
-        return op1;
+        retNode = op1;
+        break;
 
 #ifdef _TARGET_XARCH_
         // TODO-ARM-CQ: reenable treating InterlockedCmpXchg32 operation as intrinsic
@@ -3093,7 +3096,8 @@ InterlockedBinOpCommon:
                 GenTreeCmpXchg(genActualType(callType), op1, op2, op3);
 
             node->gtCmpXchg.gtOpLocation->gtFlags |= GTF_DONT_CSE;
-            return node;
+            retNode = node;
+            break;
         }
 #endif
 
@@ -3111,22 +3115,26 @@ InterlockedBinOpCommon:
             op1 = gtNewOperNode(GT_ADD, TYP_BYREF, op1, gtNewIconNode(offsetof(CORINFO_String, stringLen), TYP_I_IMPL));
             op1 = gtNewOperNode(GT_IND, TYP_INT, op1);
         }
-        return op1;
+        retNode = op1;
+        break;
         
     case CORINFO_INTRINSIC_StringGetChar:
         op2 = impPopStack().val;
         op1 = impPopStack().val;
         op1 = gtNewIndexRef(TYP_CHAR, op1, op2);
         op1->gtFlags |= GTF_INX_STRING_LAYOUT;
-        return op1;
+        retNode = op1;
+        break;
     
     case CORINFO_INTRINSIC_InitializeArray:
-        return impInitializeArrayIntrinsic(sig);
+        retNode = impInitializeArrayIntrinsic(sig);
+        break;
 
     case CORINFO_INTRINSIC_Array_Address:
     case CORINFO_INTRINSIC_Array_Get:
     case CORINFO_INTRINSIC_Array_Set:
-        return impArrayAccessIntrinsic(clsHnd, sig, memberRef, readonlyCall, intrinsicID);
+        retNode = impArrayAccessIntrinsic(clsHnd, sig, memberRef, readonlyCall, intrinsicID);
+        break;
 
     case CORINFO_INTRINSIC_GetTypeFromHandle:
         op1 = impStackTop(0).val;
@@ -3136,10 +3144,10 @@ InterlockedBinOpCommon:
             op1 = impPopStack().val;
             // Change call to return RuntimeType directly.
             op1->gtType = TYP_REF;
-            return op1;
+            retNode = op1;
         }
         // Call the regular function.
-        return NULL;
+        break;
 
     case CORINFO_INTRINSIC_RTH_GetValueInternal:
         op1 = impStackTop(0).val;
@@ -3162,10 +3170,10 @@ InterlockedBinOpCommon:
             assert(op1->IsList());
             assert(op1->gtOp.gtOp2 == nullptr);
             op1 = op1->gtOp.gtOp1;
-            return op1;
+            retNode = op1;
         }
         // Call the regular function.
-        return NULL;
+        break;
 
 #ifndef LEGACY_BACKEND
     case CORINFO_INTRINSIC_Object_GetType:
@@ -3177,13 +3185,21 @@ InterlockedBinOpCommon:
         // Set also the EXCEPTION flag because the native implementation of 
         // CORINFO_INTRINSIC_Object_GetType intrinsic can throw NullReferenceException.
         op1->gtFlags |= (GTF_CALL | GTF_EXCEPT);
-        return op1;
+        retNode = op1;
+        break;
 #endif
 
     default:
         /* Unknown intrinsic */
-        return nullptr;
+        break;
     }
+
+    if (mustExpand && (retNode == nullptr))
+    {
+        NO_WAY("JIT must expand the intrinsic!");
+    }
+
+    return retNode;
 }
 
 /*****************************************************************************/

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -8934,7 +8934,8 @@ CORINFO_MODULE_HANDLE CEEInfo::getMethodModule (CORINFO_METHOD_HANDLE methodHnd)
 }
 
 /*********************************************************************/
-CorInfoIntrinsics CEEInfo::getIntrinsicID(CORINFO_METHOD_HANDLE methodHnd)
+CorInfoIntrinsics CEEInfo::getIntrinsicID(CORINFO_METHOD_HANDLE methodHnd,
+                                          bool * pMustExpand)
 {
     CONTRACTL {
         SO_TOLERANT;
@@ -8946,6 +8947,11 @@ CorInfoIntrinsics CEEInfo::getIntrinsicID(CORINFO_METHOD_HANDLE methodHnd)
     CorInfoIntrinsics result = CORINFO_INTRINSIC_Illegal;
 
     JIT_TO_EE_TRANSITION();
+
+    if (pMustExpand != NULL)
+    {
+        *pMustExpand = false;
+    }
 
     MethodDesc* method = GetMethod(methodHnd);
 

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -764,7 +764,8 @@ public:
             unsigned * pOffsetAfterIndirection
             );
 
-    CorInfoIntrinsics getIntrinsicID(CORINFO_METHOD_HANDLE method);
+    CorInfoIntrinsics getIntrinsicID(CORINFO_METHOD_HANDLE method,
+            bool * pMustExpand = NULL);
 
     bool isInSIMDModule(CORINFO_CLASS_HANDLE classHnd);
 

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -4597,9 +4597,10 @@ void ZapInfo::getMethodVTableOffset(CORINFO_METHOD_HANDLE method,
     m_pEEJitInfo->getMethodVTableOffset(method, pOffsetOfIndirection, pOffsetAfterIndirection);
 }
 
-CorInfoIntrinsics ZapInfo::getIntrinsicID(CORINFO_METHOD_HANDLE method)
+CorInfoIntrinsics ZapInfo::getIntrinsicID(CORINFO_METHOD_HANDLE method,
+                                          bool * pMustExpand)
 {
-    return m_pEEJitInfo->getIntrinsicID(method);
+    return m_pEEJitInfo->getIntrinsicID(method, pMustExpand);
 }
 
 bool ZapInfo::isInSIMDModule(CORINFO_CLASS_HANDLE classHnd)

--- a/src/zap/zapinfo.h
+++ b/src/zap/zapinfo.h
@@ -746,7 +746,8 @@ public:
                                unsigned * pOffsetOfIndirection,
                                unsigned * pOffsetAfterIndirection);
 
-    CorInfoIntrinsics getIntrinsicID(CORINFO_METHOD_HANDLE method);
+    CorInfoIntrinsics getIntrinsicID(CORINFO_METHOD_HANDLE method,
+                                     bool * pMustExpand = NULL);
     bool isInSIMDModule(CORINFO_CLASS_HANDLE classHnd);
     CorInfoUnmanagedCallConv getUnmanagedCallConv(CORINFO_METHOD_HANDLE method);
     BOOL pInvokeMarshalingRequired(CORINFO_METHOD_HANDLE method, CORINFO_SIG_INFO* sig);


### PR DESCRIPTION
Currently intrinsic is disabled under MIN_OPT while being enabled under OPT.
This adds new explicit Jit flags that can override this behavior, like what native compiler has /Oi[-] options.
This allows us to stage CoreRT's EE implementation by controlling these flags.