### PR TITLE
Preserve value numbers when discarding a cast.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -5520,6 +5520,7 @@ protected:
     bool                optNarrowTree   (GenTreePtr     tree,
                                          var_types      srct,
                                          var_types      dstt,
+                                         ValueNumPair   vnpNarrow,
                                          bool           doit);
 
     /**************************************************************************

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -640,6 +640,10 @@ public:
             return gtVNPair.SetConservative(vn);
         }
     }
+    void                SetVNs(ValueNumPair vnp)
+    {
+        gtVNPair = vnp;
+    }
     void                ClearVN()
     {
         gtVNPair = ValueNumPair();          // Initializes both elements to "NoVN".

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -710,9 +710,9 @@ OPTIMIZECAST:
                 if  (!tree->gtOverflow()                  &&
                      !gtIsActiveCSE_Candidate(oper)       &&
                      (opts.compFlags & CLFLG_TREETRANS)   &&
-                     optNarrowTree(oper, srcType, dstType, false))
+                     optNarrowTree(oper, srcType, dstType, tree->gtVNPair, false))
                 {
-                    optNarrowTree(oper, srcType, dstType,  true);
+                    optNarrowTree(oper, srcType, dstType,  tree->gtVNPair, true);
                     
                     /* If oper is changed into a cast to TYP_INT, or to a GT_NOP, we may need to discard it */
                     if (oper->gtOper == GT_CAST && oper->CastToType() == genActualType(oper->CastFromType()))

--- a/tests/src/JIT/Regression/JitBlue/devdiv_180411/app.config
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_180411/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/JitBlue/devdiv_180411/devdiv_180411.il
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_180411/devdiv_180411.il
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+.assembly extern legacy library mscorlib {}
+
+.assembly devdiv_180411
+{
+}
+.class _simple {
+
+.method static int32 main(class System.String[]) {
+.entrypoint
+.maxstack	100
+call       int64 [devdiv_180411]_simple::test()
+conv.i4
+ldc.i4 100
+add     
+ret  
+}
+
+.method static int64 test() {
+.maxstack	100
+.locals init (int32 local_0x1)
+
+ldloc.s      0
+neg         
+conv.ovf.u8 
+conv.i4     
+neg         
+conv.u8
+ret  
+}
+
+}

--- a/tests/src/JIT/Regression/JitBlue/devdiv_180411/devdiv_180411.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_180411/devdiv_180411.ilproj
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="devdiv_180411.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>


### PR DESCRIPTION
This is a fix for an assert during CSE. After processing a CSE definition
the tree got morphed. During morphing a cast was discarded by narrowing
the operand of the cast. The value number of the operand was cleared. Later,
when processing a use of the CSE, the code was attempting to process the side effects
in the tree of the use and was encountering a node with no value number resulting
in an assert. The fix is to transfer the value number from the cast node to the narrowed
operand.