### PR TITLE
Fix build issue on NetBSD: Include <time.h> for time(3) in gc.cpp

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6027,6 +6027,7 @@ CoCreateGuid(OUT GUID * pguid);
 #define localtime     PAL_localtime
 #define mktime        PAL_mktime
 #define rand          PAL_rand
+#define time          PAL_time
 #define getenv        PAL_getenv
 #define fgets         PAL_fgets
 #define fgetws        PAL_fgetws

--- a/src/pal/src/cruntime/misc.cpp
+++ b/src/pal/src/cruntime/misc.cpp
@@ -206,7 +206,7 @@ See MSDN for more details.
 --*/
 
 PAL_time_t 
-__cdecl 
+__cdecl
 PAL_mktime(struct PAL_tm *tm)
 {
     time_t result;
@@ -257,6 +257,30 @@ PAL_rand(void)
     LOGEXIT("rand() returning %d\n", ret);
     PERF_EXIT(rand);
     return ret;
+}
+
+
+/*++
+Function:
+
+   time
+
+See MSDN for more details.
+--*/
+PAL_time_t
+__cdecl
+PAL_time(PAL_time_t *tloc)
+{
+    time_t result;
+
+    PERF_ENTRY(time);
+    ENTRY( "time( tloc=%p )\n",tloc );
+
+    result = time(tloc);
+
+    LOGEXIT( "time returning %#lx\n",result );
+    PERF_EXIT(time);
+    return result;
 }
 
 

--- a/src/pal/src/include/pal/misc.h
+++ b/src/pal/src/include/pal/misc.h
@@ -41,11 +41,18 @@ extern CRITICAL_SECTION gcsEnvironment;
 Function :
 
     PAL_rand
-    
-    Calls rand and mitigates the difference between RAND_MAX 
+
+    Calls rand and mitigates the difference between RAND_MAX
     on Windows and FreeBSD.
 --*/
 int __cdecl PAL_rand(void);
+
+/*++
+Function :
+
+    PAL_time
+--*/
+PAL_time_t __cdecl PAL_time(PAL_time_t*);
 
 /*++
 Function:
@@ -128,4 +135,3 @@ void MiscUnsetenv(const char *name);
 #endif // __cplusplus
 
 #endif /* __MISC_H_ */
-

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -199,7 +199,6 @@ function_name() to call the system's implementation
 #define srand DUMMY_srand
 #define atoi DUMMY_atoi
 #define atof DUMMY_atof
-#define time DUMMY_time
 #define tm PAL_tm
 #define size_t DUMMY_size_t
 #define time_t PAL_time_t


### PR DESCRIPTION
```
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/gc/gc.cpp:33869:
warning: warning: reference to compatibility time(); include <time.h> for correct reference
```

```
$ uname -a
NetBSD chieftec 7.99.25 NetBSD 7.99.25 (GENERIC) #0: Fri Dec 25 20:51:06 UTC 2015  root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC amd64
```