### PR TITLE
Fix build issue on NetBSD: Include <stdlib.h> for alloca(3)

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -2,7 +2,6 @@
 #define _PAL_CONFIG_H_INCLUDED 1
 
 #cmakedefine01 HAVE_IEEEFP_H
-#cmakedefine01 HAVE_ALLOCA_H
 #cmakedefine01 HAVE_SYS_VMPARAM_H
 #cmakedefine01 HAVE_MACH_VM_TYPES_H
 #cmakedefine01 HAVE_MACH_VM_PARAM_H

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -19,7 +19,6 @@ endif()
 list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_FILE_OFFSET_BITS=64)
 
 check_include_files(ieeefp.h HAVE_IEEEFP_H)
-check_include_files(alloca.h HAVE_ALLOCA_H)
 check_include_files(sys/vmparam.h HAVE_SYS_VMPARAM_H)
 check_include_files(mach/vm_types.h HAVE_MACH_VM_TYPES_H)
 check_include_files(mach/vm_param.h HAVE_MACH_VM_PARAM_H)

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -29,10 +29,6 @@ Abstract:
 #include "pal/malloc.hpp"
 #include "signal.hpp"
 
-#if HAVE_ALLOCA_H
-#include "alloca.h"
-#endif
-
 #if HAVE_MACH_EXCEPTIONS
 #include "machexception.h"
 #else

--- a/src/pal/src/file/directory.cpp
+++ b/src/pal/src/file/directory.cpp
@@ -25,9 +25,7 @@ Revision History:
 #include "pal/file.h"
 #include "pal/stackstring.hpp"
 
-#if HAVE_ALLOCA_H
-#include <alloca.h>
-#endif  // HAVE_ALLOCA_H
+#include <stdlib.h>
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/pal/src/file/path.cpp
+++ b/src/pal/src/file/path.cpp
@@ -30,9 +30,7 @@ Revision History:
 #include <errno.h>
 
 #include <unistd.h>
-#if HAVE_ALLOCA_H
-#include <alloca.h>
-#endif  // HAVE_ALLOCA_H
+#include <stdlib.h>
 
 SET_DEFAULT_DEBUG_CHANNEL(FILE);
 

--- a/src/pal/src/include/pal/malloc.hpp
+++ b/src/pal/src/include/pal/malloc.hpp
@@ -24,10 +24,7 @@ Abstract:
 #include "pal/thread.hpp"
 
 #include <stdarg.h>
-
-#if HAVE_ALLOCA_H
-#include <alloca.h>
-#endif  // HAVE_ALLOCA_H  
+#include <stdlib.h>
 
 extern "C"
 {

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -44,9 +44,7 @@ Abstract:
 #else   // NEED_DLCOMPAT
 #include <dlfcn.h>
 #endif  // NEED_DLCOMPAT
-#if HAVE_ALLOCA_H
-#include <alloca.h>
-#endif  // HAVE_ALLOCA_H
+#include <stdlib.h>
 
 #ifdef __APPLE__
 #include <mach-o/dyld.h>


### PR DESCRIPTION
Header `<alloca.h>` isn't needed on other supported systems either.

```
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/file/directory.cpp:605:
warning: Warning: reference to the libc supplied alloca(3); this most likely will
not work. Please use the compiler provided version of alloca(3), by supplying the
appropriate compiler flags (e.g. not -std=c89).
```

```
$ uname -a
NetBSD chieftec 7.99.25 NetBSD 7.99.25 (GENERIC) #0: Fri Dec 25 20:51:06 UTC 2015  root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC amd64
```