### PR TITLE
Fix issues with passing 16-byte structs on Arm64

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4096,6 +4096,9 @@ public :
         }
     }
 
+    // Convert a BYTE which represents the VM's CorInfoGCtype to the JIT's var_types
+    var_types   getJitGCType(BYTE gcType);
+
     // Get the "primitive" type, if any, that is used to pass or return
     // values of the given struct type.
     var_types    argOrReturnTypeForStruct(CORINFO_CLASS_HANDLE clsHnd, bool forReturn);
@@ -8134,6 +8137,12 @@ public :
 #endif
         return false;
     }
+
+#if FEATURE_MULTIREG_ARGS
+    // Given a GenTree node of TYP_STRUCT that represents a pass by value argument
+    // return the gcPtr layout for the pointers sized fields 
+    void getStructGcPtrsFromOp(GenTreePtr op, BYTE *gcPtrsOut);
+#endif // FEATURE_MULTIREG_ARGS
 
     // Returns true if the method being compiled returns a value
     bool                compMethodHasRetVal()

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -3271,7 +3271,8 @@ struct GenTreeStmt: public GenTree
 
 struct GenTreeLdObj: public GenTreeUnOp
 {
-    CORINFO_CLASS_HANDLE gtClass;   // object being loaded            
+    CORINFO_CLASS_HANDLE gtClass;   // object being loaded   
+                                    // TODO-Cleanup: Consider adding the GC layout information to this node
     GenTreePtr *    gtFldTreeList;  // The list of trees that represents the fields of this struct
 
     GenTreeLdObj(var_types type, GenTreePtr op, CORINFO_CLASS_HANDLE cls) : 

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -720,13 +720,14 @@ private:
     regNumber allocateBusyReg(Interval *current, RefPosition *refPosition);
     regNumber assignCopyReg(RefPosition * refPosition);
 
-    void assignPhysReg( RegRecord * physRegInterval, Interval * interval);
+    void checkAndAssignInterval(RegRecord * regRec, Interval * interval);
+    void assignPhysReg(RegRecord * regRec, Interval * interval);
     void assignPhysReg( regNumber reg, Interval * interval) { assignPhysReg(getRegisterRecord(reg), interval); }
 
-    void unassignPhysReg( RegRecord* reg, RefPosition* spillRefPosition);
+    void checkAndClearInterval(RegRecord * regRec, RefPosition* spillRefPosition);
+    void unassignPhysReg(RegRecord * regRec, RefPosition* spillRefPosition);
     void unassignPhysRegNoSpill( RegRecord* reg);
     void unassignPhysReg( regNumber reg) { unassignPhysReg(getRegisterRecord(reg), nullptr); }
-
 
     void spillInterval(Interval* interval, RefPosition* fromRefPosition, RefPosition* toRefPosition);
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -7340,15 +7340,8 @@ GenTreePtr Compiler::fgMorphOneAsgBlockOp(GenTreePtr tree)
         if (size == REGSIZE_BYTES)
         {
             BYTE gcPtr;
-
             info.compCompHnd->getClassGClayout(clsHnd, &gcPtr);
-
-            if       (gcPtr == TYPE_GC_NONE)
-                type = TYP_I_IMPL;
-            else if  (gcPtr == TYPE_GC_REF)
-                type = TYP_REF;
-            else if  (gcPtr == TYPE_GC_BYREF)
-                type = TYP_BYREF;
+            type = getJitGCType(gcPtr);
         }
     }
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -5870,7 +5870,7 @@ WorkingDir=JIT\Directed\StructABI\StructABI
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988
+Categories=JIT;EXPECTED_FAIL;ISSUE_2988;NEED_TRIAGE
 [leave1.exe_2915]
 RelativePath=JIT\Directed\IL\leave\leave1\leave1.exe
 WorkingDir=JIT\Directed\IL\leave\leave1
@@ -8075,7 +8075,7 @@ WorkingDir=JIT\Directed\StructPromote\SP2c
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_FAIL;ISSUE_3151
 [attributector.exe_2053]
 RelativePath=CoreMangLib\cti\system\resources\satellitecontractversionattribute\AttributeCtor\AttributeCtor.exe
 WorkingDir=CoreMangLib\cti\system\resources\satellitecontractversionattribute\AttributeCtor
@@ -13318,7 +13318,7 @@ WorkingDir=JIT\Methodical\Invoke\25params\25param2a_cs_d
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988
+Categories=JIT;EXPECTED_PASS;ISSUE_2988
 [r8nandiv_cs_r.exe_4486]
 RelativePath=JIT\Methodical\NaN\r8NaNdiv_cs_r\r8NaNdiv_cs_r.exe
 WorkingDir=JIT\Methodical\NaN\r8NaNdiv_cs_r
@@ -13836,7 +13836,7 @@ WorkingDir=JIT\Directed\StructPromote\SP2b
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_FAIL;ISSUE_3151
 [ldfldahack.exe_5577]
 RelativePath=JIT\Regression\CLR-x86-JIT\v2.1\DDB\B168384\LdfldaHack\LdfldaHack.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\v2.1\DDB\B168384\LdfldaHack
@@ -19177,7 +19177,7 @@ WorkingDir=JIT\Methodical\Invoke\25params\25param2a_cs_do
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988
+Categories=JIT;EXPECTED_FAIL;ISSUE_2988;ISSUE_2987
 [_il_relconv_i8_i.exe_3892]
 RelativePath=JIT\Methodical\ELEMENT_TYPE_IU\_il_relconv_i8_i\_il_relconv_i8_i.exe
 WorkingDir=JIT\Methodical\ELEMENT_TYPE_IU\_il_relconv_i8_i
@@ -20654,7 +20654,7 @@ WorkingDir=JIT\Methodical\Invoke\25params\25param2a_cs_ro
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988
+Categories=JIT;EXPECTED_FAIL;ISSUE_2988;ISSUE_2987
 [weakreferenceisaliveb_psc.exe_2559]
 RelativePath=CoreMangLib\cti\system\weakreference\WeakReferenceIsAliveb_PSC\WeakReferenceIsAliveb_PSC.exe
 WorkingDir=CoreMangLib\cti\system\weakreference\WeakReferenceIsAliveb_PSC
@@ -24616,7 +24616,7 @@ WorkingDir=JIT\Methodical\Invoke\25params\25param2a_cs_r
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988
+Categories=JIT;EXPECTED_PASS;ISSUE_2988
 [_il_dbgu_native.exe_4533]
 RelativePath=JIT\Methodical\refany\_il_dbgu_native\_il_dbgu_native.exe
 WorkingDir=JIT\Methodical\refany\_il_dbgu_native
@@ -34234,7 +34234,7 @@ WorkingDir=JIT\Directed\StructPromote\SP2a
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_FAIL;ISSUE_3151
 [b15222.exe_4865]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15222\b15222\b15222.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15222\b15222
@@ -40555,7 +40555,7 @@ WorkingDir=JIT\jit64\gc\misc\struct6_2
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988
+Categories=JIT;EXPECTED_PASS;ISSUE_2988
 [interlockedaddint_4.exe_153]
 RelativePath=baseservices\threading\interlocked\add\InterlockedAddInt_4\InterlockedAddInt_4.exe
 WorkingDir=baseservices\threading\interlocked\add\InterlockedAddInt_4


### PR DESCRIPTION
Properly track the GC pointers that are being loaded/stored or copied from these pass by value structs.
Implements passing 16-byte value types in the outgoing stack area, previously not implemented.
Added utility method getJitGCtype for converting the VM's CorInfoGCType to the JIT's var_types enum
Added utility method getStructGcPtrsFromOp to examine a GT_LDOPB or GT_LCL_VAR
 that represents a 16-byte struct and get the GC layout information
Allow LSRA to pick two consecutive registers to pass 16-byte structs on the stack
Added utility methods checkAndAssignInterval and checkAndClearInterval to handle the
 second register used to pass arguments on ARM64.