### PR TITLE
Fix build on NetBSD: Allow to overload definition of wchar_t

### DIFF
--- a/src/pal/inc/pal_char16.h
+++ b/src/pal/inc/pal_char16.h
@@ -29,6 +29,8 @@ This file is used to define the wchar_t type as a 16-bit type on Unix.
 #ifndef PAL_STDCPP_COMPAT
 #if defined (PLATFORM_UNIX) && defined(__GNUC__)
 #undef wchar_t
+#undef __WCHAR_TYPE__
+#define __WCHAR_TYPE__ __wchar_16_cpp__
 #define wchar_t __wchar_16_cpp__
 #endif // PLATFORM_UNIX
 
@@ -39,8 +41,12 @@ This file is used to define the wchar_t type as a 16-bit type on Unix.
 #if !defined(_WCHAR_T_DEFINED) || !defined(_MSC_VER)
 #if defined (PLATFORM_UNIX)
 #if defined(__cplusplus)
+#undef __WCHAR_TYPE__
+#define __WCHAR_TYPE__ char16_t
 typedef char16_t wchar_t;
 #else
+#undef __WCHAR_TYPE__
+#define __WCHAR_TYPE__ unsigned short
 typedef unsigned short wchar_t;
 #endif // __cplusplus
 #endif // PLATFORM_UNIX
@@ -49,4 +55,3 @@ typedef unsigned short wchar_t;
 #endif // !_WCHAR_T_DEFINED
 #endif // !_WCHAR_T_DEFINED || !_MSC_VER
 #endif // !PAL_STDCPP_COMPAT
-


### PR DESCRIPTION
This allows to build 100% of the sources on NetBSD.

```
In file included from /tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/safecrt/safecrt_output_l.c:70:
/usr/pkg/bin/../lib/clang/3.9.0/include/stddef.h:90:24: error: typedef redefinition with different types ('int' vs 'unsigned short')
typedef __WCHAR_TYPE__ wchar_t;
                       ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/inc/pal_char16.h:32:17: note: expanded from macro 'wchar_t'
                ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/inc/pal_char16.h:44:24: note: previous definition is here
typedef unsigned short wchar_t;
                       ^
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/inc/pal_char16.h:32:17: note: expanded from macro 'wchar_t'
                ^
1 error generated.
```

Closes `wchar_t` redefinition broken on NetBSD #2937