### PR TITLE
Change the transport pipe and runtime startup semaphores permissions

### DIFF
--- a/src/debug/debug-pal/unix/twowaypipe.cpp
+++ b/src/debug/debug-pal/unix/twowaypipe.cpp
@@ -35,13 +35,12 @@ bool TwoWayPipe::CreateServer(DWORD id)
     GetPipeName(inPipeName, id, "in");
     GetPipeName(outPipeName, id, "out");
 
-    //TODO: REVIEW if S_IRWXU | S_IRWXG is the right access level in prof use
-    if (mkfifo(inPipeName, S_IRWXU | S_IRWXG) == -1)
+    if (mkfifo(inPipeName, S_IRWXU) == -1)
     {
         return false;
     }
 
-    if (mkfifo(outPipeName, S_IRWXU | S_IRWXG) == -1)
+    if (mkfifo(outPipeName, S_IRWXU) == -1)
     {
         remove(inPipeName);
         return false;

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1475,7 +1475,7 @@ public:
 
         // Create the continue semaphore first so we don't race with PAL_NotifyRuntimeStarted. This open will fail if another 
         // debugger is trying to attach to this process because the name will already exist.
-        m_continueSem = sem_open(continueSemName, O_CREAT | O_EXCL | O_RDWR, S_IRWXU | S_IRWXG | S_IRWXO, 0);
+        m_continueSem = sem_open(continueSemName, O_CREAT | O_EXCL | O_RDWR, S_IRWXU, 0);
         if (m_continueSem == SEM_FAILED)
         {
             TRACE("sem_open(continue) failed: errno is %d (%s)\n", errno, strerror(errno));
@@ -1485,7 +1485,7 @@ public:
 
         // Create the debuggee startup semaphore so the runtime (debuggee) knows to wait for a debugger 
         // connection.
-        m_startupSem = sem_open(startupSemName, O_CREAT | O_EXCL | O_RDWR, S_IRWXU | S_IRWXG | S_IRWXO, 0);
+        m_startupSem = sem_open(startupSemName, O_CREAT | O_EXCL | O_RDWR, S_IRWXU, 0);
         if (m_startupSem == SEM_FAILED)
         {
             TRACE("sem_open(startup) failed: errno is %d (%s)\n", errno, strerror(errno));


### PR DESCRIPTION
The permissions where changed from user, group and other to just user. Addresses issue #2672.

Since the mechanism used to enumerate process modules (/proc/xxxx/maps on Linux, running
vmvmap on OSX) is user only and the default group new users get on OSX is the same ("staff")
restricting the transport pipes and runtime startup named semaphores to user only is the
right way to go.

If we find some reason to give groups permissions, we can always change that later though
the process module enumeration would have to be figured out.