### PR TITLE
Make the coreclr build-process support rtags

### DIFF
--- a/src/pal/tools/gen-buildsys-clang.sh
+++ b/src/pal/tools/gen-buildsys-clang.sh
@@ -144,6 +144,7 @@ cmake \
   "-DCMAKE_OBJDUMP=$llvm_objdump" \
   "-DCMAKE_BUILD_TYPE=$buildtype" \
   "-DCMAKE_ENABLE_CODE_COVERAGE=$code_coverage" \
+  "-DCMAKE_EXPORT_COMPILE_COMMANDS=1 " \
   "-DCLR_CMAKE_BUILD_TESTS=$build_tests" \
   $cmake_extra_defines \
   "$__UnprocessedCMakeArgs" \


### PR DESCRIPTION
[rtags](https://github.com/Andersbakken/rtags) is a popular c/c++ client/server indexer, but for it to be able to build its index, it depends on cmake to export its build commands.

Adding this flag makes cmake do that.