### PR TITLE
Prefer BSD uuid over libuuid

### DIFF
--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -35,7 +35,6 @@ check_include_files(libunwind.h HAVE_LIBUNWIND_H)
 check_include_files(runetype.h HAVE_RUNETYPE_H)
 check_include_files(lttng/tracepoint.h HAVE_LTTNG_TRACEPOINT_H)
 check_include_files(uuid/uuid.h HAVE_LIBUUID_H)
-check_include_files(uuid.h HAVE_BSD_UUID_H)
 
 check_function_exists(kqueue HAVE_KQUEUE)
 check_function_exists(getpwuid_r HAVE_GETPWUID_R)
@@ -109,6 +108,16 @@ check_cxx_symbol_exists(CHAR_BIT limits.h HAVE_CHAR_BIT)
 check_cxx_symbol_exists(_DEBUG sys/user.h USER_H_DEFINES_DEBUG)
 check_cxx_symbol_exists(_SC_PHYS_PAGES unistd.h HAVE__SC_PHYS_PAGES)
 check_cxx_symbol_exists(_SC_AVPHYS_PAGES unistd.h HAVE__SC_AVPHYS_PAGES)
+
+check_cxx_source_runs("
+#include <uuid.h>
+
+int main(void) {
+  uuid_t uuid;
+  uint32_t status;
+  uuid_create(&uuid, &status);
+  return 0;
+}" HAVE_BSD_UUID_H)
 
 check_cxx_source_runs("
 #include <sys/param.h>

--- a/src/pal/src/misc/miscpalapi.cpp
+++ b/src/pal/src/misc/miscpalapi.cpp
@@ -33,10 +33,10 @@ Revision History:
 #include <pthread.h>
 #include <dlfcn.h>
 
-#if HAVE_LIBUUID_H
-#include <uuid/uuid.h>
-#elif HAVE_BSD_UUID_H
+#if HAVE_BSD_UUID_H
 #include <uuid.h>
+#elif HAVE_LIBUUID_H
+#include <uuid/uuid.h>
 #endif
 
 #include <pal_endian.h>
@@ -352,15 +352,7 @@ HRESULT
 PALAPI
 CoCreateGuid(OUT GUID * pguid)
 {
-#if HAVE_LIBUUID_H
-    uuid_generate_random(*(uuid_t*)pguid);
-
-    // Change the byte order of the Data1, 2 and 3, since the uuid_generate_random
-    // generates them with big endian while GUIDS need to have them in little endian.
-    pguid->Data1 = SWAP32(pguid->Data1);
-    pguid->Data2 = SWAP16(pguid->Data2);
-    pguid->Data3 = SWAP16(pguid->Data3);
-#elif HAVE_BSD_UUID_H
+#if HAVE_BSD_UUID_H
     uuid_t uuid;
     uint32_t status;
     uuid_create(&uuid, &status);
@@ -372,6 +364,14 @@ CoCreateGuid(OUT GUID * pguid)
 
     // Encode the uuid with little endian.
     uuid_enc_le(pguid, &uuid);
+#elif HAVE_LIBUUID_H
+    uuid_generate_random(*(uuid_t*)pguid);
+
+    // Change the byte order of the Data1, 2 and 3, since the uuid_generate_random
+    // generates them with big endian while GUIDS need to have them in little endian.
+    pguid->Data1 = SWAP32(pguid->Data1);
+    pguid->Data2 = SWAP16(pguid->Data2);
+    pguid->Data3 = SWAP16(pguid->Data3);
 #else
     #error Don't know how to generate UUID on this platform
 #endif


### PR DESCRIPTION
This fixes recent build breakage:

```
../libcoreclrpal.a(miscpalapi.cpp.o): In function `CoCreateGuid':
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/misc/miscpalapi.cpp:356: undefined reference to `uuid_generate_random'
clang-3.9: error: linker command failed with exit code 1 (use -v to see invocation)
```

No need to link with libuuid.