### PR TITLE
Remove duplicate calls to GetPerSsaData

### DIFF
--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -855,8 +855,9 @@ void SsaBuilder::AddDefPoint(GenTree* tree, BasicBlock* blk)
     m_pCompiler->lvaTable[lclNum].lvNumSsaNames++;
 #endif
     // Record where the defn happens.
-    m_pCompiler->lvaTable[lclNum].GetPerSsaData(defSsaNum)->m_defLoc.m_blk = blk;
-    m_pCompiler->lvaTable[lclNum].GetPerSsaData(defSsaNum)->m_defLoc.m_tree = tree;
+    LclSsaVarDsc* ssaDef = m_pCompiler->lvaTable[lclNum].GetPerSsaData(defSsaNum);
+    ssaDef->m_defLoc.m_blk = blk;
+    ssaDef->m_defLoc.m_tree = tree;
 
 #ifdef SSA_FEATURE_USEDEF
     SsaVarName key(lclNum, defSsaNum);

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -4015,8 +4015,9 @@ void Compiler::fgValueNumber()
             // We use the VNF_InitVal(i) from here so we know that this value is loop-invariant
             // in all loops.
             ValueNum initVal = vnStore->VNForFunc(varDsc->TypeGet(), VNF_InitVal, vnStore->VNForIntCon(i));
-            varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->m_vnPair.SetBoth(initVal);
-            varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->m_defLoc.m_blk = fgFirstBB;
+            LclSsaVarDsc* ssaDef = varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM);
+            ssaDef->m_vnPair.SetBoth(initVal);
+            ssaDef->m_defLoc.m_blk = fgFirstBB;
         }
         else if (info.compInitMem || varDsc->lvMustInit ||
                  (varDsc->lvTracked && VarSetOps::IsMember(this, fgFirstBB->bbLiveIn, varDsc->lvVarIndex)))
@@ -4073,8 +4074,9 @@ void Compiler::fgValueNumber()
 #endif
             assert(initVal != ValueNumStore::NoVN);
 
-            varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->m_vnPair.SetBoth(initVal);
-            varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM)->m_defLoc.m_blk = fgFirstBB;
+            LclSsaVarDsc* ssaDef = varDsc->GetPerSsaData(SsaConfig::FIRST_SSA_NUM);
+            ssaDef->m_vnPair.SetBoth(initVal);
+            ssaDef->m_defLoc.m_blk = fgFirstBB;
         }
     }
     // Give "Heap" an initial value number (about which we know nothing).


### PR DESCRIPTION
The code is too complex for the C++ compiler to figure out that it is duplicated and the generated code contains a second call to `ExpandArray::EnsureCoversInd` for what is otherwise just a trivial assignment.