### PR TITLE
Fix build issue on NetBSD: Remove unneeded -nostdinc++ flag

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,11 +88,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
   # This prevents inclusion of standard C compiler headers
   add_compile_options(-nostdinc)
 
-  if(NOT CLR_CMAKE_PLATFORM_DARWIN)
-    # This prevents inclusion of standard C++ compiler headers
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdinc++")
-  endif(NOT CLR_CMAKE_PLATFORM_DARWIN)
-
   set (NATIVE_RESOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/nativeresources)
   include_directories(${NATIVE_RESOURCE_DIR})
   set (RC_TO_CPP ${NATIVE_RESOURCE_DIR}/rctocpp.awk)


### PR DESCRIPTION
This flag isn't recognized by clang on NetBSD:

```
clang-3.9: warning: argument unused during compilation: `-nostdinc++`
```

```
$ pkg_info |grep -E 'lldb|llvm|clang'
llvm-3.9.0nb20160213 Low Level Virtual Machine compiler infrastructure
clang-3.9.0nb20160213 C language family frontend for LLVM
lldb-3.9.0nb20160213 next generation, high-performance debugger
```

```
$ uname -a
NetBSD chieftec 7.99.26 NetBSD 7.99.26 (GENERIC) #0: Wed Feb 10 21:58:18 UTC 2016
root@chieftec:/tmp/netbsd-tmp/sys/arch/amd64/compile/GENERIC amd64
```

This flag was disabled also for Darwin in #125 by @jkotas