### PR TITLE
Avoid unnecessary copies of AllSuccessorIter and LocationInfo

### DIFF
--- a/src/inc/expandarray.h
+++ b/src/inc/expandarray.h
@@ -149,6 +149,13 @@ class ExpandArrayStack: public ExpandArray<T>
         return this->m_members[m_used-1];
     }
 
+    // Requires Size() > 0
+    T& TopRef()
+    {
+        assert(Size() > 0);
+        return this->m_members[m_used-1];
+    }
+
     // Requires that "idx" < "m_used" (asserting this in debug), and returns
     // "Get(idx)" (which is covered, by the invariant that all indices in "[0..m_used)" are
     // covered).

--- a/src/jit/arraystack.h
+++ b/src/jit/arraystack.h
@@ -88,6 +88,12 @@ public:
         return data[tosIndex-1];
     }
 
+    T& TopRef()
+    {
+        assert(tosIndex > 0);
+        return data[tosIndex-1];
+    }
+
     // return the i'th from the top
     T Index(int idx)
     {

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -2951,13 +2951,13 @@ LinearScan::buildRefPositionsForNode(GenTree *tree,
             assert(consume <= 1);
             if (consume == 1)
             {
-                Interval * srcInterval = stack->Top().interval;
+                Interval * srcInterval = stack->TopRef().interval;
                 if (srcInterval->relatedInterval == nullptr)
                 {
                     // Preference the source to the dest, unless this is a non-last-use localVar.
                     // Note that the last-use info is not correct, but it is a better approximation than preferencing
                     // the source to the dest, if the source's lifetime extends beyond the dest.
-                    if (!srcInterval->isLocalVar || (stack->Top().treeNode->gtFlags & GTF_VAR_DEATH) != 0)
+                    if (!srcInterval->isLocalVar || (stack->TopRef().treeNode->gtFlags & GTF_VAR_DEATH) != 0)
                     {
                         srcInterval->assignRelatedInterval(varDefInterval);
                     }
@@ -3036,7 +3036,7 @@ LinearScan::buildRefPositionsForNode(GenTree *tree,
         // we don't want the def of the copy to kill the lclVar register, if it is assigned the same register
         // (which is actually what we hope will happen).
         JITDUMP("Setting putarg_reg as a pass-through of a non-last use lclVar\n");
-        Interval * srcInterval = stack->Top().interval;
+        Interval * srcInterval = stack->TopRef().interval;
         assert(srcInterval->isLocalVar);
         prefSrcInterval = srcInterval;
         isSpecialPutArg = true;

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -75,13 +75,12 @@ static void TopologicalSortHelper(BasicBlock* block, Compiler* comp, bool* visit
         }
 #endif
 
-        if (iterators.Top() != ends.Top())
+        if (iterators.TopRef() != ends.TopRef())
         {
             // if the block on TOS still has unreached successors, visit them
-            AllSuccessorIter iter = iterators.Pop();
+            AllSuccessorIter& iter = iterators.TopRef();
             BasicBlock* succ = *iter;
             ++iter;
-            iterators.Push(iter);
             // push the child
 
             if (!visited[succ->bbNum])

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -1476,7 +1476,7 @@ bool ValueNumStore::SelectIsBeingEvaluatedRecursively(ValueNum map, ValueNum ind
 bool ValueNumStore::FixedPointMapSelsTopHasValue(ValueNum map, ValueNum index)
 {
     if (m_fixedPointMapSels.Size() == 0) return false;
-    VNDefFunc2Arg top = m_fixedPointMapSels.Top();
+    VNDefFunc2Arg& top = m_fixedPointMapSels.TopRef();
     return top.m_func == VNF_MapSelect
         && top.m_arg0 == map
         && top.m_arg1 == index;


### PR DESCRIPTION
`ArrayStack<T>::Top` returns a copy rather than a reference like typical C++ containers do. For large `T`s like `AllSuccessorIterator` and `LocationInfo` this results in a lot of code bloat and unncessary copying. Add a `T& TopRef()` function to avoid such copying.