### PR TITLE
Fix build issue on NetBSD: Make RPATH optional and user-settable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,12 @@ cmake_minimum_required(VERSION 2.8.12)
 # Set the project name
 project(CoreCLR)
 
-# Enable @rpath support for shared libraries.
-set(MACOSX_RPATH ON)
+set(CORECLR_SET_RPATH ON)
+
+if(CORECLR_SET_RPATH)
+    # Enable @rpath support for shared libraries.
+    set(MACOSX_RPATH ON)
+endif(CORECLR_SET_RPATH)
 
 if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
     cmake_policy(SET CMP0042 NEW)

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Set the RPATH of sos so that it can find dependencies without needing to set LD_LIBRARY_PATH
 # For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
-if(CLR_CMAKE_PLATFORM_DARWIN)
+if (CORECLR_SET_RPATH)
+  if(CLR_CMAKE_PLATFORM_DARWIN)
     set(CMAKE_INSTALL_RPATH "@loader_path")
-else()
+  else()
     set(CMAKE_INSTALL_RPATH "\$ORIGIN")
-endif(CLR_CMAKE_PLATFORM_DARWIN)
+  endif(CLR_CMAKE_PLATFORM_DARWIN)
+endif (CORECLR_SET_RPATH)
 
 if(CLR_CMAKE_PLATFORM_ARCH_AMD64)
   add_definitions(-DSOS_TARGET_AMD64=1)

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -1,11 +1,13 @@
 
 # Set the RPATH of mscordbi so that it can find dependencies without needing to set LD_LIBRARY_PATH
 # For more information: http://www.cmake.org/Wiki/CMake_RPATH_handling.
-if(CLR_CMAKE_PLATFORM_DARWIN)
+if(CORECLR_SET_RPATH)
+  if(CLR_CMAKE_PLATFORM_DARWIN)
     set(CMAKE_INSTALL_RPATH "@loader_path")
-else()
+  else()
     set(CMAKE_INSTALL_RPATH "\$ORIGIN")
-endif(CLR_CMAKE_PLATFORM_DARWIN)
+  endif(CLR_CMAKE_PLATFORM_DARWIN)
+endif(CORECLR_SET_RPATH)
 
 set(MSCORDBI_SOURCES
   mscordbi.cpp

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -8,8 +8,10 @@ project(coreclrpal)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Enable @rpath support for shared libraries.
-set(MACOSX_RPATH ON)
+if(CORECLR_SET_RPATH)
+    # Enable @rpath support for shared libraries.
+    set(MACOSX_RPATH ON)
+endif(CORECLR_SET_RPATH)
 
 if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
     cmake_policy(SET CMP0042 NEW)


### PR DESCRIPTION
The `$ORIGIN` linker feature isn't supported on NetBSD.

All `RPATH` is done via `pkgsrc` on all supported platforms, allow to override it.
`pkgsrc` will set `CORECLR_SET_RPATH:BOOL=OFF` and specify manually needed options.