### PR TITLE
Fix fprintf in crossgen

### DIFF
--- a/src/jit/host.h
+++ b/src/jit/host.h
@@ -33,6 +33,20 @@ void gcDump_logf(const char* fmt, ...);
 
 void logf(unsigned level, const char* fmt, ...);
 
+#if defined(CROSSGEN_COMPILE) && !defined(PLATFORM_UNIX) && !defined(fprintf)
+// On Windows, CrossGen configures its stdout to allow Unicode output only.
+// The following wrapper allows fprintf to work with stdout.
+inline int fprintfCrossgen(FILE *stream, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int ret = stream == stdout ? logf_stdout(fmt, args) : vfprintf(stream, fmt, args);
+    va_end(args);
+    return ret;
+}
+#define fprintf fprintfCrossgen
+#endif
+
 extern  "C" 
 void    __cdecl     assertAbort(const char *why, const char *file, unsigned line);
 


### PR DESCRIPTION
CrossGen configures its stdout to allow only Unicode output functions.
Add a wrapper to fprintf to allow it to work inside crossgen. (Issue #3128)