### PR TITLE
Fix unwound funclet GC stack reporting on Unix

### DIFF
--- a/src/vm/stackwalk.cpp
+++ b/src/vm/stackwalk.cpp
@@ -1788,6 +1788,7 @@ ProcessFuncletsForGCReporting:
                                 m_sfParent = sfFuncletParent;
                                 m_sfFuncletParent = sfFuncletParent;
                                 m_fProcessNonFilterFunclet = true;
+                                m_fDidFuncletReportGCReferences = false;
                             }
                         }
 #endif // FEATURE_PAL


### PR DESCRIPTION
This change fixes a problem with reporting object on stack for GC when
GC scan is performed right after a funclet is unwound during exception handling.
In such case, the parent of the funclet should report live object references,
but it was not doing so on Unix.
On Unix, the unwound funclet is detected in a different way than on Windows due
to the fact that the stack frames of the funclet are already reclaimed, while on
Windows, they are still there.
When we detect the unwound funclet on Unix, we set state of the stack walker so
that it behaves in the same way as on Windows. But we were missing one state
variable that makes the parent report the references instead of the funclet,
the m_fDidFuncletReportGCReferences.