### PR TITLE
Fix build issue on NetBSD: Enforce __builtin_alloca for alloca(3) on GCC

### DIFF
--- a/src/ToolBox/PdbTypeMatch/PrintSymbol.cpp
+++ b/src/ToolBox/PdbTypeMatch/PrintSymbol.cpp
@@ -1546,7 +1546,7 @@ void PrintType(IDiaSymbol *pSymbol)
         }
 
         if (pSymbol->get_types(0, &count, NULL) == S_OK) {
-          IDiaSymbol** rgpDiaSymbols = (IDiaSymbol**) _alloca(sizeof(IDiaSymbol *) * count);
+          IDiaSymbol** rgpDiaSymbols = (IDiaSymbol**) Alloca(sizeof(IDiaSymbol *) * count);
 
           if (pSymbol->get_types(count, &count, rgpDiaSymbols) == S_OK) {
             for (ULONG i = 0; i < count; i++) {

--- a/src/ToolBox/SOS/Strike/metadata.cpp
+++ b/src/ToolBox/SOS/Strike/metadata.cpp
@@ -41,7 +41,7 @@ static HRESULT NameForTypeDef_s(mdTypeDef tkTypeDef, IMetaDataImport *pImport,
     if (hr != S_OK) {
         return hr;
     }
-    WCHAR *name = (WCHAR*)_alloca((nameLen+1)*sizeof(WCHAR));
+    WCHAR *name = (WCHAR*)alloca((nameLen+1)*sizeof(WCHAR));
     wcscpy_s (name, nameLen+1, mdName);
     hr = NameForTypeDef_s(tkEnclosingClass,pImport,mdName, capacity_mdName);
     if (hr != S_OK) {
@@ -75,8 +75,8 @@ static HRESULT NameForTypeDefNew(mdTypeDef tkTypeDef, IMDInternalImport *pImport
 {
     DWORD flags;
     ULONG nameLen;
-    char *name = (char *)_alloca((mdNameLen+1)*sizeof(char));
-    char *namesp = (char *)_alloca((mdNameLen+1)*sizeof(char));
+    char *name = (char *)alloca((mdNameLen+1)*sizeof(char));
+    char *namesp = (char *)alloca((mdNameLen+1)*sizeof(char));
     
     HRESULT hr = pImport->GetNameOfTypeDef(tkTypeDef, name, namesp);
     if (FAILED(hr))

--- a/src/ToolBox/SOS/Strike/sildasm.cpp
+++ b/src/ToolBox/SOS/Strike/sildasm.cpp
@@ -774,7 +774,7 @@ PCCOR_SIGNATURE PrettyPrintType(
 // set Reiterate to true, so we only execute through the loop once!
 #pragma warning(disable:6263) // "Suppress PREfast warnings about stack overflow due to _alloca in a loop."
 #endif
-                    int* lowerBounds = (int*) _alloca(sizeof(int)*2*rank);
+                    int* lowerBounds = (int*) alloca(sizeof(int)*2*rank);
                     int* sizes       = &lowerBounds[rank];  
                     memset(lowerBounds, 0, sizeof(int)*2*rank); 
                     
@@ -899,7 +899,7 @@ PCCOR_SIGNATURE PrettyPrintType(
 const char *const szStdNamePrefix[] = {"MO","TR","TD","","FD","","MD","","PA","II","MR","","CA","","PE","","","SG","","","EV",
 "","","PR","","","MOR","TS","","","","","AS","","","AR","","","FL","ET","MAR"};
 
-#define MAKE_NAME_IF_NONE(psz, tk) { if(!(psz && *psz)) { char* sz = (char*)_alloca(16); \
+#define MAKE_NAME_IF_NONE(psz, tk) { if(!(psz && *psz)) { char* sz = (char*)alloca(16); \
 sprintf_s(sz,16,"$%s$%X",szStdNamePrefix[tk>>24],tk&0x00FFFFFF); psz = sz; } }
 
 const char* PrettyPrintClass(

--- a/src/ToolBox/SOS/Strike/stressLogDump.cpp
+++ b/src/ToolBox/SOS/Strike/stressLogDump.cpp
@@ -255,7 +255,7 @@ void formatOutput(struct IDebugDataSpaces* memCallBack, ___in FILE* file, __inou
                 // need to _alloca, instead of declaring a local buffer
                 // since we may have more than one %s in the format
                 ULONG cbStrBuf = 256;
-                char* strBuf = (char *)_alloca(cbStrBuf);
+                char* strBuf = (char *)alloca(cbStrBuf);
                 
                 hr = memCallBack->ReadVirtual(TO_CDADDR((char* )args[iArgCount]), strBuf, cbStrBuf, 0);
                 if (hr != S_OK) 
@@ -272,7 +272,7 @@ void formatOutput(struct IDebugDataSpaces* memCallBack, ___in FILE* file, __inou
                 // need to _alloca, instead of declaring a local buffer
                 // since we may have more than one %s in the format
                 ULONG cbWstrBuf = 256 * sizeof(WCHAR);
-                WCHAR* wstrBuf = (WCHAR *)_alloca(cbWstrBuf);
+                WCHAR* wstrBuf = (WCHAR *)alloca(cbWstrBuf);
                 
                 hr = memCallBack->ReadVirtual(TO_CDADDR((char* )args[iArgCount]), wstrBuf, cbWstrBuf, 0);
                 if (hr != S_OK)

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -12752,7 +12752,7 @@ DECLARE_API(SaveModule)
 
     int nSection = Header.FileHeader.NumberOfSections;
     ExtOut("%u sections in file\n",nSection);
-    MemLocation *memLoc = (MemLocation*)_alloca(nSection*sizeof(MemLocation));
+    MemLocation *memLoc = (MemLocation*)alloca(nSection*sizeof(MemLocation));
     int indxSec = -1;
     int slot;
     for (int n = 0; n < nSection; n++)
@@ -12805,7 +12805,7 @@ DECLARE_API(SaveModule)
     }
 
     ULONG pageSize = OSPageSize();
-    char *buffer = (char *)_alloca(pageSize);
+    char *buffer = (char *)alloca(pageSize);
     DWORD nRead;
     DWORD nWrite;
     

--- a/src/classlibnative/bcltype/arraynative.cpp
+++ b/src/classlibnative/bcltype/arraynative.cpp
@@ -1306,7 +1306,7 @@ FCIMPL4(Object*, ArrayNative::CreateInstance, void* elementTypeHandle, INT32 ran
             if (!ClrSafeInt<DWORD>::multiply(boundsSize, sizeof(INT32), dwAllocaSize))
                 COMPlusThrowOM();
 
-            bounds = (INT32*) _alloca(dwAllocaSize);
+            bounds = (INT32*) Alloca(dwAllocaSize);
 
             for (int i=0;i<rank;i++) {
                 bounds[2*i] = pLowerBounds[i];
@@ -1320,7 +1320,7 @@ FCIMPL4(Object*, ArrayNative::CreateInstance, void* elementTypeHandle, INT32 ran
             if (!ClrSafeInt<DWORD>::multiply(boundsSize, sizeof(INT32), dwAllocaSize))
                 COMPlusThrowOM();
 
-            bounds = (INT32*) _alloca(dwAllocaSize);
+            bounds = (INT32*) Alloca(dwAllocaSize);
 
             // We need to create a private copy of pLengths to avoid holes caused
             // by caller mutating the array

--- a/src/debug/daccess/nidump.cpp
+++ b/src/debug/daccess/nidump.cpp
@@ -2380,14 +2380,14 @@ mdAssemblyRef NativeImageDumper::MapAssemblyRefToManifest(mdAssemblyRef token, I
     LPWSTR szAssemblyName           = NULL;
 
     if (cchName > 0)
-        szAssemblyName = (LPWSTR) _alloca(cchName * sizeof(WCHAR));
+        szAssemblyName = (LPWSTR) Alloca(cchName * sizeof(WCHAR));
 
     if (metadata.cbLocale > 0)
-        metadata.szLocale = (LPWSTR) _alloca(metadata.cbLocale * sizeof(WCHAR));
+        metadata.szLocale = (LPWSTR) Alloca(metadata.cbLocale * sizeof(WCHAR));
     if (metadata.ulProcessor > 0)
-        metadata.rProcessor = (DWORD*) _alloca(metadata.ulProcessor * sizeof(DWORD));
+        metadata.rProcessor = (DWORD*) Alloca(metadata.ulProcessor * sizeof(DWORD));
     if (metadata.ulOS > 0)
-        metadata.rOS = (OSINFO*) _alloca(metadata.ulOS * sizeof(OSINFO));
+        metadata.rOS = (OSINFO*) Alloca(metadata.ulOS * sizeof(OSINFO));
 
     const void *pbPublicKey;
     ULONG cbPublicKey;
@@ -2876,7 +2876,7 @@ IMetaDataImport2 * NativeImageDumper::TypeToString(PTR_CCOR_SIGNATURE &sig,
                 size_t cbLowerBounds;
                 if (!ClrSafeInt<size_t>::multiply(rank, 2*sizeof(int), cbLowerBounds/* passed by ref */))
                     ThrowHR(COR_E_OVERFLOW);
-                int* lowerBounds = (int*) _alloca(cbLowerBounds);
+                int* lowerBounds = (int*) Alloca(cbLowerBounds);
                 int* sizes       = &lowerBounds[rank];  
                 memset(lowerBounds, 0, sizeof(int)*2*rank); 
                 

--- a/src/debug/di/breakpoint.cpp
+++ b/src/debug/di/breakpoint.cpp
@@ -190,7 +190,7 @@ HRESULT CordbFunctionBreakpoint::Activate(BOOL fActivate)
     pProcess->ClearPatchTable(); // if we add something, then the right side 
                                 // view of the patch table is no longer valid
 
-    DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+    DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
 
     CordbAppDomain * pAppDomain = GetAppDomain();
     _ASSERTE (pAppDomain != NULL);
@@ -507,7 +507,7 @@ HRESULT CordbStepper::StepRange(BOOL fStepIn,
     // Build step event
     //
 
-    DebuggerIPCEvent * pEvent = reinterpret_cast<DebuggerIPCEvent *>(_alloca(CorDBIPC_BUFFER_SIZE));
+    DebuggerIPCEvent * pEvent = reinterpret_cast<DebuggerIPCEvent *>(Alloca(CorDBIPC_BUFFER_SIZE));
 
     pProcess->InitIPCEvent(pEvent, DB_IPCE_STEP, true, GetAppDomain()->GetADToken());
 
@@ -674,7 +674,7 @@ HRESULT CordbStepper::StepOut()
     // Build step event
     //
 
-    DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+    DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
 
     pProcess->InitIPCEvent(pEvent, DB_IPCE_STEP_OUT, true, GetAppDomain()->GetADToken());
 

--- a/src/debug/di/module.cpp
+++ b/src/debug/di/module.cpp
@@ -2322,7 +2322,7 @@ HRESULT CordbModule::ApplyChangesInternal(ULONG  cbMetaData,
         // We always copy over the whole buffer size which is bigger than sizeof(DebuggerIPCEvent)
         // This seems ugly, in this case we know the exact size of the event we want to read
         // why copy over all the extra data?
-        DebuggerIPCEvent *retEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+        DebuggerIPCEvent *retEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
 
         {
             //

--- a/src/debug/di/process.cpp
+++ b/src/debug/di/process.cpp
@@ -1970,7 +1970,7 @@ void SendAttachProcessWorkItem::Do()
     // This is being processed on the RCET, where it's safe to take the Stop-Go lock.
     RSLockHolder ch(this->GetProcess()->GetStopGoLock());
 
-    DebuggerIPCEvent *event = (DebuggerIPCEvent*) _alloca(CorDBIPC_BUFFER_SIZE);
+    DebuggerIPCEvent *event = (DebuggerIPCEvent*) Alloca(CorDBIPC_BUFFER_SIZE);
     
     // This just acts like an async-break, which will kick off things.
     // This will not induce any faked attach events from the VM (like it did in V2).
@@ -2511,7 +2511,7 @@ COM_METHOD CordbProcess::InvokePauseCallback()
     
     EX_TRY
     {
-        DebuggerIPCEvent * pIPCEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+        DebuggerIPCEvent * pIPCEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
         InitIPCEvent(pIPCEvent, DB_IPCE_NETCF_HOST_CONTROL_PAUSE, true, VMPTR_AppDomain::NullPtr());
 
         hr = m_cordb->SendIPCEvent(this, pIPCEvent, CorDBIPC_BUFFER_SIZE);
@@ -2530,7 +2530,7 @@ COM_METHOD CordbProcess::InvokeResumeCallback()
     
     EX_TRY
     {
-        DebuggerIPCEvent * pIPCEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+        DebuggerIPCEvent * pIPCEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
         InitIPCEvent(pIPCEvent, DB_IPCE_NETCF_HOST_CONTROL_RESUME, true, VMPTR_AppDomain::NullPtr());
 
         hr = m_cordb->SendIPCEvent(this, pIPCEvent, CorDBIPC_BUFFER_SIZE);
@@ -3090,7 +3090,7 @@ void CordbProcess::DetachShim()
         }
 
         // Go ahead and detach from the entire process now. This is like sending a "Continue".
-        DebuggerIPCEvent * pIPCEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+        DebuggerIPCEvent * pIPCEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
         InitIPCEvent(pIPCEvent, DB_IPCE_DETACH_FROM_PROCESS, true, VMPTR_AppDomain::NullPtr());
 
         hr = m_cordb->SendIPCEvent(this, pIPCEvent, CorDBIPC_BUFFER_SIZE);
@@ -3502,7 +3502,7 @@ HRESULT CordbProcess::StopInternal(DWORD dwTimeout, VMPTR_AppDomain pAppDomainTo
     }
 
     // Send the async break event to the RC.
-    event = (DebuggerIPCEvent*) _alloca(CorDBIPC_BUFFER_SIZE);
+    event = (DebuggerIPCEvent*) Alloca(CorDBIPC_BUFFER_SIZE);
     InitIPCEvent(event, DB_IPCE_ASYNC_BREAK, false, pAppDomainToken);
 
     STRESS_LOG1(LF_CORDB, LL_INFO1000, "CP::S: sending async stop to appd 0x%x.\n", VmPtrToCookie(pAppDomainToken));
@@ -4115,7 +4115,7 @@ HRESULT CordbProcess::ContinueInternal(BOOL fIsOutOfBand)
         STRESS_LOG2(LF_CORDB, LL_INFO1000, "Continue flags:special=%d, dowin32=%d\n", m_specialDeferment, fDoWin32Continue);
 #endif
         // Send to the RC to continue the process.
-        DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+        DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
 
         InitIPCEvent(pEvent, DB_IPCE_CONTINUE, false, pAppDomainToken);
 
@@ -8404,7 +8404,7 @@ HRESULT CordbProcess::StartSyncFromWin32Stop(BOOL * pfAsyncBreakSent)
             LOG((LF_CORDB, LL_INFO1000, "[%x] CP::SSFW32S: internal continue returned\n", GetCurrentThreadId()));
 
             // Send an async break to the left side now that its running.
-            DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) _alloca(CorDBIPC_BUFFER_SIZE);
+            DebuggerIPCEvent * pEvent = (DebuggerIPCEvent *) Alloca(CorDBIPC_BUFFER_SIZE);
             InitIPCEvent(pEvent, DB_IPCE_ASYNC_BREAK, false, VMPTR_AppDomain::NullPtr());
 
             LOG((LF_CORDB, LL_INFO1000, "[%x] CP::SSFW32S: sending async stop\n", GetCurrentThreadId()));
@@ -8616,7 +8616,7 @@ HRESULT CordbProcess::EnableLogMessages(BOOL fOnOff)
     ATT_REQUIRE_STOPPED_MAY_FAIL(this);
     HRESULT hr = S_OK;
 
-    DebuggerIPCEvent *event = (DebuggerIPCEvent*) _alloca(CorDBIPC_BUFFER_SIZE);
+    DebuggerIPCEvent *event = (DebuggerIPCEvent*) Alloca(CorDBIPC_BUFFER_SIZE);
     InitIPCEvent(event, DB_IPCE_ENABLE_LOG_MESSAGES, false, VMPTR_AppDomain::NullPtr());
     event->LogSwitchSettingMessage.iLevel = (int)fOnOff;
 
@@ -8642,7 +8642,7 @@ COM_METHOD CordbProcess::ModifyLogSwitch(__in_z WCHAR *pLogSwitchName, LONG lLev
 
     _ASSERTE (pLogSwitchName != NULL);
 
-    DebuggerIPCEvent *event = (DebuggerIPCEvent*) _alloca(CorDBIPC_BUFFER_SIZE);
+    DebuggerIPCEvent *event = (DebuggerIPCEvent*) Alloca(CorDBIPC_BUFFER_SIZE);
     InitIPCEvent(event, DB_IPCE_MODIFY_LOGSWITCH, false, VMPTR_AppDomain::NullPtr());
     event->LogSwitchSettingMessage.iLevel = lLevel;
     event->LogSwitchSettingMessage.szSwitchName.SetStringTruncate(pLogSwitchName);

--- a/src/debug/di/rsappdomain.cpp
+++ b/src/debug/di/rsappdomain.cpp
@@ -1029,7 +1029,7 @@ HRESULT CordbAppDomain::GetFunctionPointerType(ULONG32 cTypeArgs,
         return E_INVALIDARG;
     }
 
-    CordbType ** ppTypeInstantiations = reinterpret_cast<CordbType **>(_alloca(allocSize.Value()));
+    CordbType ** ppTypeInstantiations = reinterpret_cast<CordbType **>(Alloca(allocSize.Value()));
 
     for (unsigned int i = 0; i < cTypeArgs; i++)
     {

--- a/src/debug/di/rsclass.cpp
+++ b/src/debug/di/rsclass.cpp
@@ -405,7 +405,7 @@ HRESULT CordbClass::GetParameterizedType(CorElementType elementType,
 
     // Note: casting from (ICorDebugType **) to (CordbType **) is not valid.
     // Offsets may differ.  Copy and validate the type array.
-    CordbType ** ppArgTypes = reinterpret_cast<CordbType **>(_alloca( allocSize.Value()));
+    CordbType ** ppArgTypes = reinterpret_cast<CordbType **>(Alloca( allocSize.Value()));
 
     for (unsigned int i = 0; i < cTypeArgs; i++)
     {

--- a/src/debug/di/rsthread.cpp
+++ b/src/debug/di/rsthread.cpp
@@ -9368,7 +9368,7 @@ HRESULT CordbEval::GatherArgInfo(ICorDebugValue *pValue,
 
             _ASSERTE(fullArgTypeNodeCount > 0);
             unsigned int bufferSize = sizeof(DebuggerIPCE_TypeArgData) * fullArgTypeNodeCount;
-            DebuggerIPCE_TypeArgData *bufferFrom = (DebuggerIPCE_TypeArgData *) _alloca(bufferSize);
+            DebuggerIPCE_TypeArgData *bufferFrom = (DebuggerIPCE_TypeArgData *) Alloca(bufferSize);
 
             DebuggerIPCE_TypeArgData *curr = bufferFrom;
             CordbType::GatherTypeData(cv->m_type, &curr);
@@ -10332,7 +10332,7 @@ HRESULT CordbEval::NewParameterizedArray(ICorDebugType * pElementType,
     }
 
     // Just in case sizeof(SIZE_T) != sizeof(ULONG32)
-    SIZE_T * rgDimensionsSizeT = reinterpret_cast<SIZE_T *>(_alloca(allocSize.Value()));
+    SIZE_T * rgDimensionsSizeT = reinterpret_cast<SIZE_T *>(Alloca(allocSize.Value()));
 
     for (unsigned int i = 0; i < rank; i++)
     {

--- a/src/debug/di/rstype.cpp
+++ b/src/debug/di/rstype.cpp
@@ -976,7 +976,7 @@ CordbType::SigToType(CordbModule * pModule,
                 IfFailRet(E_OUTOFMEMORY);
             }
 
-            CordbType ** ppTypeInstantiations = reinterpret_cast<CordbType **>(_alloca( allocSize.Value()));
+            CordbType ** ppTypeInstantiations = reinterpret_cast<CordbType **>(Alloca( allocSize.Value()));
 
             for (unsigned int i = 0; i < cArgs;i++) 
             {
@@ -1082,7 +1082,7 @@ CordbType::SigToType(CordbModule * pModule,
                 IfFailRet(E_OUTOFMEMORY);
             }
 
-            CordbType ** ppTypeInstantiations = (CordbType **) _alloca( allocSize.Value() );
+            CordbType ** ppTypeInstantiations = (CordbType **) Alloca( allocSize.Value() );
 
             for (unsigned int i = 0; i <= cArgs; i++) 
             {

--- a/src/debug/ee/dactable.cpp
+++ b/src/debug/ee/dactable.cpp
@@ -69,13 +69,13 @@ void DacGlobals::InitializeEntries(TADDR baseAddress)
 
 #define VPTR_CLASS(name) \
     { \
-        void *pBuf = _alloca(sizeof(name)); \
+        void *pBuf = Alloca(sizeof(name)); \
         name *dummy = new (pBuf) name(0); \
         name##__vtAddr = PTR_TO_TADDR(*((PVOID*)dummy)) - baseAddress; \
     }
 #define VPTR_MULTI_CLASS(name, keyBase) \
     { \
-        void *pBuf = _alloca(sizeof(name)); \
+        void *pBuf = Alloca(sizeof(name)); \
         name *dummy = new (pBuf) name(0); \
         name##__##keyBase##__mvtAddr = PTR_TO_TADDR(*((PVOID*)dummy)) - baseAddress; \
     }

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -12341,7 +12341,7 @@ TypeHandle Debugger::TypeDataWalk::ReadInstantiation(Module *pModule, mdTypeDef 
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    TypeHandle * inst = (TypeHandle *) _alloca(dwAllocSize);
+    TypeHandle * inst = (TypeHandle *) Alloca(dwAllocSize);
     ReadTypeHandles(nTypeArgs, inst) ;
     TypeHandle th = g_pEEInterface->LoadInstantiation(pModule, tok, nTypeArgs, inst);
     if (th.IsNull())
@@ -12408,7 +12408,7 @@ TypeHandle Debugger::TypeDataWalk::ReadTypeHandle()
                 _ASSERTE(COR_E_OVERFLOW);
                 cbAllocSize = UINT_MAX;
             }
-            TypeHandle * inst = (TypeHandle *) _alloca(cbAllocSize);
+            TypeHandle * inst = (TypeHandle *) Alloca(cbAllocSize);
             ReadTypeHandles(data->numTypeArgs, inst) ;
             th = g_pEEInterface->LoadFnptrType(inst, data->numTypeArgs);
             break;

--- a/src/debug/ee/funceval.cpp
+++ b/src/debug/ee/funceval.cpp
@@ -1534,7 +1534,7 @@ void ResolveFuncEvalGenericArgInfo(DebuggerEval *pDE)
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    TypeHandle * pGenericArgs = (nGenericArgs == 0) ? NULL : (TypeHandle *) _alloca(cbAllocSize);
+    TypeHandle * pGenericArgs = (nGenericArgs == 0) ? NULL : (TypeHandle *) Alloca(cbAllocSize);
 
     //
     // Snag the type arguments from the input and get the
@@ -3203,7 +3203,7 @@ static void DoNormalFuncEval( DebuggerEval *pDE,
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    FuncEvalArgInfo * pFEArgInfo = (FuncEvalArgInfo *)_alloca(cbAllocSize);
+    FuncEvalArgInfo * pFEArgInfo = (FuncEvalArgInfo *)Alloca(cbAllocSize);
     memset(pFEArgInfo, 0, cbAllocSize);
 
     GatherFuncEvalArgInfo(pDE, mSig, argData, pFEArgInfo);
@@ -3275,7 +3275,7 @@ static void DoNormalFuncEval( DebuggerEval *pDE,
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    ARG_SLOT * pArguments = (ARG_SLOT *)_alloca(cbAllocSize);
+    ARG_SLOT * pArguments = (ARG_SLOT *)Alloca(cbAllocSize);
     memset(pArguments, 0, cbAllocSize);
 
     LPVOID pRetBuff = NULL;
@@ -3385,7 +3385,7 @@ static void GCProtectArgsAndDoNormalFuncEval(DebuggerEval *pDE,
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    OBJECTREF * pObjectRefArray = (OBJECTREF*)_alloca(cbAllocSize);
+    OBJECTREF * pObjectRefArray = (OBJECTREF*)Alloca(cbAllocSize);
     memset(pObjectRefArray, 0, cbAllocSize);
     GCPROTECT_ARRAY_BEGIN(*pObjectRefArray, pDE->m_argCount);
 
@@ -3398,7 +3398,7 @@ static void GCProtectArgsAndDoNormalFuncEval(DebuggerEval *pDE,
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    void ** pMaybeInteriorPtrArray = (void **)_alloca(cbAllocSize);
+    void ** pMaybeInteriorPtrArray = (void **)Alloca(cbAllocSize);
     memset(pMaybeInteriorPtrArray, 0, cbAllocSize);
     GCPROTECT_BEGININTERIOR_ARRAY(*pMaybeInteriorPtrArray, (UINT)(cbAllocSize/sizeof(OBJECTREF)));
 
@@ -3413,7 +3413,7 @@ static void GCProtectArgsAndDoNormalFuncEval(DebuggerEval *pDE,
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    void ** pByRefMaybeInteriorPtrArray = (void **)_alloca(cbAllocSize);
+    void ** pByRefMaybeInteriorPtrArray = (void **)Alloca(cbAllocSize);
     memset(pByRefMaybeInteriorPtrArray, 0, cbAllocSize);
     GCPROTECT_BEGININTERIOR_ARRAY(*pByRefMaybeInteriorPtrArray, (UINT)(cbAllocSize/sizeof(OBJECTREF)));
 
@@ -3426,7 +3426,7 @@ static void GCProtectArgsAndDoNormalFuncEval(DebuggerEval *pDE,
     {
         ThrowHR(COR_E_OVERFLOW);
     }
-    INT64 *pBufferForArgsArray = (INT64*)_alloca(cbAllocSize);
+    INT64 *pBufferForArgsArray = (INT64*)Alloca(cbAllocSize);
     memset(pBufferForArgsArray, 0, cbAllocSize);
 
     FrameWithCookie<ProtectValueClassFrame> protectValueClassFrame;
@@ -3539,7 +3539,7 @@ void FuncEvalHijackRealWorker(DebuggerEval *pDE, Thread* pThread, FuncEvalFrame*
         {
             ThrowHR(COR_E_OVERFLOW);
         }
-        TypeHandle *pGenericArgs = (nGenericArgs == 0) ? NULL : (TypeHandle *) _alloca(cbAllocSize);
+        TypeHandle *pGenericArgs = (nGenericArgs == 0) ? NULL : (TypeHandle *) Alloca(cbAllocSize);
         //
         // Snag the type arguments from the input and get the
         // method desc that corresponds to the instantiated desc.

--- a/src/debug/ildbsymlib/symread.cpp
+++ b/src/debug/ildbsymlib/symread.cpp
@@ -241,7 +241,7 @@ HRESULT SymReader::InitializeFromStream(
     // Make sure we're at the beginning of the stream
     IfFailGo(pIStream->Seek(li, STREAM_SEEK_SET, NULL));
 
-    IfNullGo(pSignature = (BYTE *)_alloca(ILDB_SIGNATURE_SIZE));
+    IfNullGo(pSignature = (BYTE *)Alloca(ILDB_SIGNATURE_SIZE));
     IfFailGo(ReadFromStream(pIStream, pSignature, ILDB_SIGNATURE_SIZE));
     
     // Verify that we're looking at an ILDB File

--- a/src/dlls/mscorpe/pewriter.cpp
+++ b/src/dlls/mscorpe/pewriter.cpp
@@ -1572,7 +1572,7 @@ HRESULT PEWriter::link() {
     // First collect all information into entries[]
 
     int sectCount = getSectCount();
-    entry *entries = (entry *) _alloca(sizeof(entry) * sectCount);
+    entry *entries = (entry *) Alloca(sizeof(entry) * sectCount);
 
     unsigned iUniqueSections, iEntries;
     HRESULT hr;
@@ -2279,7 +2279,7 @@ HRESULT PEWriter::write(void ** ppImage)
 {
     bool ExeOrDll = isExeOrDll(m_ntHeaders);
     const unsigned RoundUpVal = VAL32(m_ntHeaders->OptionalHeader.FileAlignment);
-    char *pad = (char *) _alloca(RoundUpVal);
+    char *pad = (char *) Alloca(RoundUpVal);
     memset(pad, 0, RoundUpVal);
 
     size_t lSize = filePos;

--- a/src/ilasm/assembler.cpp
+++ b/src/ilasm/assembler.cpp
@@ -952,7 +952,7 @@ BOOL Assembler::EmitField(FieldDescriptor* pFD)
             lVal /= sizeof(WCHAR);
 
 #if defined(ALIGN_ACCESS) || BIGENDIAN
-            void* pValueTemp = _alloca(lVal * sizeof(WCHAR));
+            void* pValueTemp = Alloca(lVal * sizeof(WCHAR));
             memcpy(pValueTemp, pValue, lVal * sizeof(WCHAR));
             pValue = pValueTemp;
 

--- a/src/inc/allocacheck.h
+++ b/src/inc/allocacheck.h
@@ -72,12 +72,12 @@ private:
 };
 
 #define ALLOCA_CHECK() AllocaCheck __allocaChecker
-#define ALLOCA(size)  __allocaChecker.add(_alloca(size+sizeof(AllocaCheck::AllocaSentinal)), size);
+#define ALLOCA(size)  __allocaChecker.add(Alloca(size+sizeof(AllocaCheck::AllocaSentinal)), size);
 
 #else
 
 #define ALLOCA_CHECK() 
-#define ALLOCA(size)  _alloca(size)
+#define ALLOCA(size)  Alloca(size)
 
 #endif
 	

--- a/src/inc/corperme.h
+++ b/src/inc/corperme.h
@@ -38,14 +38,14 @@ extern "C" {
 #define WIDEN(psz, pwsz) \
     LPCSTR _##psz = (LPCSTR) psz; \
     int _cc##psz = _##psz ? strlen(_##psz) + 1 : 0; \
-    LPWSTR pwsz = (LPWSTR) (_cc##psz ? _alloca((_cc##psz) * sizeof(WCHAR)) : NULL); \
+    LPWSTR pwsz = (LPWSTR) (_cc##psz ? Alloca((_cc##psz) * sizeof(WCHAR)) : NULL); \
     if(pwsz) WszMultiByteToWideChar(WIDEN_CP, 0, _##psz, _cc##psz, pwsz, _cc##psz);
 
 
 #define NARROW(pwsz, psz) \
     LPCWSTR _##pwsz = (LPCWSTR) pwsz; \
     int _cc##psz =  _##pwsz ? WszWideCharToMultiByte(WIDEN_CP, 0, _##pwsz, -1, NULL, 0, NULL, NULL) : 0; \
-    LPSTR psz = (LPSTR) (_cc##psz ? _alloca(_cc##psz) : NULL); \
+    LPSTR psz = (LPSTR) (_cc##psz ? Alloca(_cc##psz) : NULL); \
     if(psz) WszWideCharToMultiByte(WIDEN_CP, 0, _##pwsz, -1, psz, _cc##psz, NULL, NULL);
 
 

--- a/src/inc/daccess.h
+++ b/src/inc/daccess.h
@@ -1820,7 +1820,7 @@ typedef __VoidPtr PTR_CVOID;
 #define VPTR_ANY_CLASS_METHODS(name)                            \
         virtual ULONG32 VPtrSize(void) { SUPPORTS_DAC; return sizeof(name); } \
         static PVOID VPtrHostVTable() {                         \
-            void * pBuf = _alloca(sizeof(name));                \
+            void * pBuf = Alloca(sizeof(name));                \
             name * dummy = new (pBuf) name((TADDR)0, (TADDR)0); \
             return *((PVOID*)dummy); }
 

--- a/src/inc/formattype.cpp
+++ b/src/inc/formattype.cpp
@@ -564,7 +564,7 @@ PCCOR_SIGNATURE PrettyPrintType(
 #pragma prefast(push)
 #pragma prefast(disable:22009 "Suppress PREFAST warnings about integer overflow")
 #endif
-                    int* lowerBounds = (int*) _alloca(sizeof(int)*2*rank);
+                    int* lowerBounds = (int*) Alloca(sizeof(int)*2*rank);
                     int* sizes       = &lowerBounds[rank];  
                     memset(lowerBounds, 0, sizeof(int)*2*rank); 
                     
@@ -1204,7 +1204,7 @@ char* DumpMarshaling(IMDInternalImport* pImport,
 #pragma prefast(push)
 #pragma prefast(disable:22009 "Suppress PREFAST warnings about integer overflow")
 #endif
-                            strTemp = (LPUTF8)_alloca(strLen + 1);
+                            strTemp = (LPUTF8)Alloca(strLen + 1);
                             memcpy(strTemp, (LPUTF8)&pSigNativeType[cbCur], strLen);
                             strTemp[strLen] = 0;
                             buf.AppendPrintf(", \"%s\"", UnquotedProperName(strTemp));

--- a/src/inc/formattype.h
+++ b/src/inc/formattype.h
@@ -105,7 +105,7 @@ inline BOOL IsDup(mdToken tk)
     }
     return FALSE;
 }
-#define MAKE_NAME_IF_NONE(psz, tk) { if((!(psz && *psz))||IsDup(tk)) { char* sz = (char*)_alloca(16); \
+#define MAKE_NAME_IF_NONE(psz, tk) { if((!(psz && *psz))||IsDup(tk)) { char* sz = (char*)Alloca(16); \
 sprintf_s(sz,16,"$%s$%X",szStdNamePrefix[tk>>24],tk&0x00FFFFFF); psz = sz; } }
 
 

--- a/src/inc/nsutilpriv.h
+++ b/src/inc/nsutilpriv.h
@@ -223,14 +223,14 @@ void MakeNestedTypeName(                // throws on out of memory
 #define MAKE_FULL_PATH_ON_STACK_UTF8(toptr, pnamespace, pname) \
 { \
     int __i##toptr = ns::GetFullLength(pnamespace, pname); \
-    toptr = (char *) alloca(__i##toptr); \
+    toptr = (char *) Alloca(__i##toptr); \
     ns::MakePath(toptr, __i##toptr, pnamespace, pname); \
 }
 
 #define MAKE_FULL_PATH_ON_STACK_UNICODE(toptr, pnamespace, pname) \
 { \
     int __i##toptr = ns::GetFullLength(pnamespace, pname); \
-    toptr = (WCHAR *) alloca(__i##toptr * sizeof(WCHAR)); \
+    toptr = (WCHAR *) Alloca(__i##toptr * sizeof(WCHAR)); \
     ns::MakePath(toptr, __i##toptr, pnamespace, pname); \
 }
 
@@ -242,7 +242,7 @@ void MakeNestedTypeName(                // throws on out of memory
     __i##ptr += (pszMemberName ? (int) strlen(pszMemberName) : 0); \
     __i##ptr += (NAMESPACE_SEPARATOR_LEN * 2); \
     __i##ptr += (pszSig ? (int) strlen(pszSig) : 0); \
-    ptr = (LPUTF8) alloca(__i##ptr); \
+    ptr = (LPUTF8) Alloca(__i##ptr); \
     ns::MakePath(ptr, __i##ptr, pszNameSpace, pszClassName); \
     if (pszMemberName) { \
         strcat_s(ptr, __i##ptr, NAMESPACE_SEPARATOR_STR); \

--- a/src/inc/winwrap.h
+++ b/src/inc/winwrap.h
@@ -1013,11 +1013,11 @@ inline int LateboundMessageBoxA(HWND hWnd,
         lpCaption = "<null>";
 
     SIZE_T cchText = strlen(lpText) + 1;
-    LPWSTR wszText = (LPWSTR)_alloca(cchText * sizeof(WCHAR));
+    LPWSTR wszText = (LPWSTR)Alloca(cchText * sizeof(WCHAR));
     swprintf_s(wszText, cchText, W("%S"), lpText);
 
     SIZE_T cchCaption = strlen(lpCaption) + 1;
-    LPWSTR wszCaption = (LPWSTR)_alloca(cchCaption * sizeof(WCHAR));
+    LPWSTR wszCaption = (LPWSTR)Alloca(cchCaption * sizeof(WCHAR));
     swprintf_s(wszCaption, cchCaption, W("%S"), lpCaption);
 
     return LateboundMessageBoxW(hWnd, wszText, wszCaption, uType);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -6974,7 +6974,7 @@ void dumpConvertedVarSet(Compiler* comp, VARSET_VALARG_TP vars)
     BYTE* pVarNumSet;   // trivial set: one byte per varNum, 0 means not in set, 1 means in set.
 
     size_t varNumSetBytes = comp->lvaCount * sizeof(BYTE);
-    pVarNumSet = (BYTE*)_alloca(varNumSetBytes);
+    pVarNumSet = (BYTE*)Alloca(varNumSetBytes);
     memset(pVarNumSet, 0, varNumSetBytes);          // empty the set
 
     VARSET_ITER_INIT(comp, iter, vars, varIndex);

--- a/src/jit/error.cpp
+++ b/src/jit/error.cpp
@@ -293,7 +293,7 @@ void  __cdecl   assertAbort(const char *why, const char *file, unsigned line)
     const char* msg = why;
     LogEnv* env = LogEnv::cur();
     const int BUFF_SIZE = 8192;
-    char *buff = (char*)alloca(BUFF_SIZE);
+    char *buff = (char*)Alloca(BUFF_SIZE);
     if (env->compiler) {
         _snprintf_s(buff, BUFF_SIZE, _TRUNCATE, "Assertion failed '%s' in '%s' (IL size %d)\n", why, env->compiler->info.compFullName, env->compiler->info.compILCodeSize);
         msg = buff;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -19235,7 +19235,7 @@ ONE_FILE_PER_METHOD:;
         {
             wCharCount += wcslen(pathname) + 1;
         }
-        filename = (LPCWSTR) alloca(wCharCount * sizeof(WCHAR));
+        filename = (LPCWSTR) Alloca(wCharCount * sizeof(WCHAR));
         if (pathname != NULL)
         {
             swprintf_s((LPWSTR)filename, wCharCount, W("%s\\%S-%s.%s"), pathname, escapedString, phaseName, type);
@@ -19297,7 +19297,7 @@ ONE_FILE_PER_METHOD:;
         {
             wCharCount += wcslen(pathname) + 1;
         }
-        filename = (LPCWSTR) alloca(wCharCount * sizeof(WCHAR));
+        filename = (LPCWSTR) Alloca(wCharCount * sizeof(WCHAR));
         if (pathname != NULL)
         {
             swprintf_s((LPWSTR)filename, wCharCount, W("%s\\%s.%s"), pathname, origFilename, type);

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -4776,7 +4776,7 @@ GenTree::VtablePtr GenTree::GetVtableForOper(genTreeOps oper)
                 assert(!IsExOp(opKind));
                 assert(OperIsSimple(oper) || OperIsLeaf(oper));
                 // Need to provide non-null operands.
-                Compiler* comp = (Compiler*)_alloca(sizeof(Compiler));
+                Compiler* comp = (Compiler*)Alloca(sizeof(Compiler));
                 GenTreeIntCon dummyOp(TYP_INT, 0);
                 GenTreeOp gt(oper, TYP_INT, &dummyOp, ((opKind & GTK_UNOP) ? NULL : &dummyOp));
                 s_vtableForOp = *reinterpret_cast<VtablePtr*>(&gt);

--- a/src/jit/gtlist.h
+++ b/src/jit/gtlist.h
@@ -64,7 +64,7 @@ GTNODE(MEMORYBARRIER    , "memoryBarrier" ,0,GTK_LEAF)
 
 GTNODE(CAST             , "cast"          ,0,GTK_UNOP|GTK_EXOP) // conversion to another type
 GTNODE(CKFINITE         , "ckfinite"      ,0,GTK_UNOP)          // Check for NaN
-GTNODE(LCLHEAP          , "lclHeap"       ,0,GTK_UNOP)          // alloca()
+GTNODE(LCLHEAP          , "lclHeap"       ,0,GTK_UNOP)          // Alloca()
 GTNODE(JMP              , "jump"          ,0,GTK_LEAF)          // Jump to another function
 
 

--- a/src/jit/hashbv.cpp
+++ b/src/jit/hashbv.cpp
@@ -530,7 +530,7 @@ void hashBv::Resize(int newSize)
 
     hashBvNode ** newNodes = this->getNewVector(newSize);
 
-    hashBvNode *** insertionPoints = (hashBvNode ***) alloca(sizeof(hashBvNode *)* newSize);
+    hashBvNode *** insertionPoints = (hashBvNode ***) Alloca(sizeof(hashBvNode *)* newSize);
     memset(insertionPoints, 0, sizeof(hashBvNode *)* newSize);
 
     for (int i=0; i<newSize; i++)
@@ -1223,7 +1223,7 @@ template <typename Action> bool hashBv::MultiTraverseLHSBigger(hashBv *other)
     hashBvNode *** cursors;
     int shiftFactor = this->log2_hashSize - other->log2_hashSize;
     int expansionFactor = hts/ots;
-    cursors = (hashBvNode ***) alloca(expansionFactor*sizeof(void*));
+    cursors = (hashBvNode ***) Alloca(expansionFactor*sizeof(void*));
 
     for (int h=0; h<other->hashtable_size(); h++)
     {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -8470,7 +8470,7 @@ GenTreePtr Compiler::impCastClassOrIsInstToTree(GenTreePtr op1, GenTreePtr op2, 
 #define assertImp(cond)                                                        \
             do { if (!(cond)) {                                                \
                 const int cchAssertImpBuf = 600;                               \
-                char *assertImpBuf = (char*)alloca(cchAssertImpBuf);           \
+                char *assertImpBuf = (char*)Alloca(cchAssertImpBuf);           \
                 _snprintf_s(assertImpBuf, cchAssertImpBuf, cchAssertImpBuf - 1,\
                         "%s : Possibly bad IL with CEE_%s at offset %04Xh (op1=%s op2=%s stkDepth=%d)", \
                         #cond, impCurOpcName, impCurOpcOffs,                   \

--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -3032,7 +3032,7 @@ void                Compiler::fgVerifyHandlerTab()
 
     // blockNumMap[old block number] => new block number
     size_t blockNumBytes = (bbNumMax + 1) * sizeof(unsigned);
-    unsigned* blockNumMap = (unsigned*)_alloca(blockNumBytes);
+    unsigned* blockNumMap = (unsigned*)Alloca(blockNumBytes);
     memset(blockNumMap, 0, blockNumBytes);
 
     BasicBlock* block;
@@ -3069,8 +3069,8 @@ void                Compiler::fgVerifyHandlerTab()
     // over all blocks and verify that only handler begin blocks have bbCatchTyp == BBCT_NONE, and some other things.
 
     size_t blockBoolSetBytes = (bbNumMax + 1) * sizeof(bool);
-    bool* blockTryBegSet = (bool*)_alloca(blockBoolSetBytes);
-    bool* blockHndBegSet = (bool*)_alloca(blockBoolSetBytes);
+    bool* blockTryBegSet = (bool*)Alloca(blockBoolSetBytes);
+    bool* blockHndBegSet = (bool*)Alloca(blockBoolSetBytes);
     for (unsigned i = 0; i <= bbNumMax; i++)
     {
         blockTryBegSet[i] = false;
@@ -3390,8 +3390,8 @@ void                Compiler::fgVerifyHandlerTab()
     // a previously processed handler, so we ignore it.
 
     size_t blockIndexBytes = (bbNumMax + 1) * sizeof(unsigned short);
-    unsigned short* blockTryIndex = (unsigned short*)_alloca(blockIndexBytes);
-    unsigned short* blockHndIndex = (unsigned short*)_alloca(blockIndexBytes);
+    unsigned short* blockTryIndex = (unsigned short*)Alloca(blockIndexBytes);
+    unsigned short* blockHndIndex = (unsigned short*)Alloca(blockIndexBytes);
     memset(blockTryIndex, 0, blockIndexBytes);
     memset(blockHndIndex, 0, blockIndexBytes);
 

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -566,8 +566,8 @@ void Rationalizer::RenameUpdatedVars(Location loc)
     rename->ZeroAll();
     unexp->ZeroAll();
     
-    int *renameMap = (int *) alloca(sizeof(int) * comp->lvaCount);
-    var_types *renameTypeMap = (var_types *) alloca(sizeof(var_types) * comp->lvaCount);
+    int *renameMap = (int *) Alloca(sizeof(int) * comp->lvaCount);
+    var_types *renameTypeMap = (var_types *) Alloca(sizeof(var_types) * comp->lvaCount);
 
     // find locals that are redefined within the tree
     foreach_treenode_execution_order(tree, statement)

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -224,7 +224,7 @@ SsaBuilder::SsaBuilder(Compiler* pCompiler, IAllocator* pIAllocator)
 int SsaBuilder::TopologicalSort(BasicBlock** postOrder, int count)
 {
     // Allocate and initialize visited flags.
-    bool* visited = (bool*) alloca(count * sizeof(bool));
+    bool* visited = (bool*) Alloca(count * sizeof(bool));
     memset(visited, 0, count * sizeof(bool));
 
     // Display basic blocks.
@@ -1626,7 +1626,7 @@ void SsaBuilder::Build()
     JITDUMP("[SsaBuilder] Max block count is %d.\n", blockCount);
 
     // Allocate the postOrder array for the graph.
-    BasicBlock** postOrder = (BasicBlock**) alloca(blockCount * sizeof(BasicBlock*));
+    BasicBlock** postOrder = (BasicBlock**) Alloca(blockCount * sizeof(BasicBlock*));
 
     // Topologically sort the graph.
     int count = TopologicalSort(postOrder, blockCount);

--- a/src/md/compiler/custattr_import.cpp
+++ b/src/md/compiler/custattr_import.cpp
@@ -77,7 +77,7 @@ STDMETHODIMP RegMeta::GetCustomAttributeByName( // S_OK or error.
     pMiniMd = &(m_pStgdb->m_MiniMd);
 
     iLen = WszWideCharToMultiByte(CP_UTF8,0, wzName,-1, NULL,0, 0,0);
-    szName = (LPUTF8)_alloca(iLen);
+    szName = (LPUTF8)Alloca(iLen);
     VERIFY(WszWideCharToMultiByte(CP_UTF8,0, wzName,-1, szName,iLen, 0,0));
 
     hr = ImportHelper::GetCustomAttributeByName(pMiniMd, tkObj, szName, ppData, pcbData);

--- a/src/md/compiler/regmeta_emit.cpp
+++ b/src/md/compiler/regmeta_emit.cpp
@@ -1689,7 +1689,7 @@ HRESULT RegMeta::_DefineSetConstant(    // Return hresult.
         {
 #if BIGENDIAN
             void *pValueTemp;
-            pValueTemp = (void *)alloca(cbBlob);
+            pValueTemp = (void *)Alloca(cbBlob);
             IfFailGo(m_pStgdb->m_MiniMd.SwapConstant(pValue, dwCPlusTypeFlag, pValueTemp, cbBlob));
             pValue = pValueTemp;
 #endif

--- a/src/md/enc/imptlb.cpp
+++ b/src/md/enc/imptlb.cpp
@@ -703,7 +703,7 @@ HRESULT CImportTlb::GetAttrType(
 
                 // Build the sig.
                 dwMaxSigSize = 5 + sizeof(mdTypeRef) * 2;
-                pSig = (COR_SIGNATURE*)_alloca(dwMaxSigSize);
+                pSig = (COR_SIGNATURE*)Alloca(dwMaxSigSize);
                 pCurr = pSig;
                 *pCurr++ = IMAGE_CEE_CS_CALLCONV_DEFAULT_HASTHIS;
                 *pCurr++ = 2;
@@ -728,7 +728,7 @@ HRESULT CImportTlb::GetAttrType(
 
                 // Build the sig.
                 dwMaxSigSize = 4 + sizeof(mdTypeRef);
-                pSig = (COR_SIGNATURE*)_alloca(dwMaxSigSize);
+                pSig = (COR_SIGNATURE*)Alloca(dwMaxSigSize);
                 pCurr = pSig;
                 *pCurr++ = IMAGE_CEE_CS_CALLCONV_DEFAULT_HASTHIS;
                 *pCurr++ = 1;
@@ -3301,7 +3301,7 @@ HRESULT CImportTlb::_ConvFunction(
 
     //-------------------------------------------------------------------------
     // Get the parameter names.
-    rszParamNames = reinterpret_cast<BSTR*>(_alloca((psFunc->cParams+1) * sizeof(BSTR*)));
+    rszParamNames = reinterpret_cast<BSTR*>(Alloca((psFunc->cParams+1) * sizeof(BSTR*)));
 
     // Get list of names.
     IfFailGo(pITI->GetNames(psFunc->memid, rszParamNames, psFunc->cParams+1, &iNames));
@@ -6149,7 +6149,7 @@ HRESULT CImportTlb::_ConvSignature(     // S_OK, S_CONVERSION_LOSS, or error.
                     {
                         // Convert the UTF8 string to unicode.
                         int MngTypeNameStrLen = (int)(strlen(pConvertionInfo->m_strMngTypeName) + 1);
-                        WCHAR *strFullyQualifiedMngTypeName = (WCHAR *)_alloca(MngTypeNameStrLen * sizeof(WCHAR));
+                        WCHAR *strFullyQualifiedMngTypeName = (WCHAR *)Alloca(MngTypeNameStrLen * sizeof(WCHAR));
                         int ret = WszMultiByteToWideChar(CP_UTF8, 0, pConvertionInfo->m_strMngTypeName, MngTypeNameStrLen, strFullyQualifiedMngTypeName, MngTypeNameStrLen);
                         _ASSERTE(ret != 0);
                         if (!ret)
@@ -6184,7 +6184,7 @@ HRESULT CImportTlb::_ConvSignature(     // S_OK, S_CONVERSION_LOSS, or error.
         {
             // Convert the UTF8 string to unicode.
             int MngTypeNameStrLen = (int)(strlen(pConvertionInfo->m_strMngTypeName) + 1);
-            WCHAR *strFullyQualifiedMngTypeName = (WCHAR *)_alloca(MngTypeNameStrLen * sizeof(WCHAR));
+            WCHAR *strFullyQualifiedMngTypeName = (WCHAR *)Alloca(MngTypeNameStrLen * sizeof(WCHAR));
             int ret = WszMultiByteToWideChar(CP_UTF8, 0, pConvertionInfo->m_strMngTypeName, MngTypeNameStrLen, strFullyQualifiedMngTypeName, MngTypeNameStrLen);
             _ASSERTE(ret != 0);
             if (!ret)

--- a/src/md/enc/metamodelrw.cpp
+++ b/src/md/enc/metamodelrw.cpp
@@ -5968,7 +5968,7 @@ CMiniMdRW::FixParamSequence(
             IfFailRet(GetParamPtrRecord(endRid - 1, &pNewParamPtr));
         }
         int cbCopy = m_TableDefs[TBL_ParamPtr].m_cbRec;
-        void * pbBackup = _alloca(cbCopy);
+        void * pbBackup = Alloca(cbCopy);
         memcpy(pbBackup, pNewParamPtr, cbCopy);
         
         IfFailRet(getEndParamListOfMethod(md, &endRid));

--- a/src/md/enc/stgio.cpp
+++ b/src/md/enc/stgio.cpp
@@ -1305,7 +1305,7 @@ HRESULT StgIO::CopyFileInternal(        // Return code.
     DWORD       cbRead;                 // Byte count for buffer.
     DWORD       cbWrite;                // Check write of bytes.
     const DWORD cbBuff = 4096;          // Size of buffer for copy (in bytes).
-    BYTE       *pBuff = (BYTE*)alloca(cbBuff); // Buffer for copy.
+    BYTE       *pBuff = (BYTE*)Alloca(cbBuff); // Buffer for copy.
     HANDLE      hFile;                  // Target file.
     HRESULT     hr = S_OK;
 

--- a/src/md/inc/rwutil.h
+++ b/src/md/inc/rwutil.h
@@ -23,7 +23,7 @@ class UTSemReadWrite;
         else                                                \
         {                                                   \
             int cbBuffer = ((int)wcslen(wszInput) * 3) + 1; \
-            (szOutput) = (char *)_alloca(cbBuffer);         \
+            (szOutput) = (char *)Alloca(cbBuffer);         \
             Unicode2UTF((wszInput), (szOutput), cbBuffer);  \
         }                                                   \
     } while (0)

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6330,23 +6330,14 @@ PALIMPORT void * __cdecl realloc(void *, size_t);
 PALIMPORT char * __cdecl _strdup(const char *);
 
 #if defined(_MSC_VER)
-#define alloca _alloca
-#elif defined(PLATFORM_UNIX)
-#define _alloca alloca
+#define Alloca _alloca
+#elif defined(__GNUC__) /* GCC-compatbile */
+// Use explicitly alloca(3) as __builtin_alloca to more strongly prevent reuse
+// of a libc version. This was required on NetBSD.
+#define Alloca __builtin_alloca
 #else
-// MingW
-#define _alloca __builtin_alloca
-#define alloca __builtin_alloca
-#endif //_MSC_VER
-
-#if defined(__GNUC__) && defined(PLATFORM_UNIX)
-// we set -fno-builtin on the command line. This requires that if
-// we use alloca, with either have to call __builtin_alloca, or
-// ensure that the alloca call doesn't happen in code which is
-// modifying the stack (such as "memset (alloca(x), y, z)"
-
-#define alloca  __builtin_alloca
-#endif // __GNUC__
+#error Port me
+#endif
 
 #define max(a, b) (((a) > (b)) ? (a) : (b))
 #define min(a, b) (((a) < (b)) ? (a) : (b))

--- a/src/pal/src/debug/debug.cpp
+++ b/src/pal/src/debug/debug.cpp
@@ -1340,7 +1340,7 @@ ReadProcessMemory(
     lpBaseAddressAligned = (int*)((SIZE_T) lpBaseAddress & ~VIRTUAL_PAGE_MASK);
     offset = ((SIZE_T) lpBaseAddress & VIRTUAL_PAGE_MASK);
     char *data;
-    data = (char*)alloca(VIRTUAL_PAGE_SIZE);
+    data = (char*)Alloca(VIRTUAL_PAGE_SIZE);
     while (nSize > 0)
     {
         vm_size_t bytesRead;

--- a/src/pal/src/file/directory.cpp
+++ b/src/pal/src/file/directory.cpp
@@ -600,7 +600,7 @@ CreateDirectoryA(
 
         // Copy cwd, '/', path
         int iLen = strlen(cwd) + 1 + pathLength + 1;
-        realPath = static_cast<char *>(alloca(iLen));
+        realPath = static_cast<char *>(Alloca(iLen));
         sprintf_s(realPath, iLen, "%s/%s", cwd, UnixPathName);
 
         PAL_free((char *)cwd);

--- a/src/pal/src/file/file.cpp
+++ b/src/pal/src/file/file.cpp
@@ -3943,7 +3943,7 @@ CopyFileA(
     
     LPSTR lpUnixPath = NULL;
     const int    buffer_size = 16*1024;
-    char        *buffer = (char*)alloca(buffer_size);
+    char        *buffer = (char*)Alloca(buffer_size);
     DWORD        bytes_read;
     DWORD        bytes_written;
     int          permissions;

--- a/src/pal/src/file/path.cpp
+++ b/src/pal/src/file/path.cpp
@@ -224,7 +224,7 @@ GetFullPathNameW(
     }
     else
     {
-        fileNameA = static_cast<LPSTR>(alloca(fileNameLength));
+        fileNameA = static_cast<LPSTR>(Alloca(fileNameLength));
     }
     
     /* Now convert lpFileName to ANSI. */

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -315,7 +315,7 @@ GetProcAddress(
     if (pal_module && module->dl_handle == pal_module->dl_handle)
     {
         int iLen = 4 + strlen(lpProcName) + 1;
-        LPSTR lpPALProcName = (LPSTR) alloca(iLen);
+        LPSTR lpPALProcName = (LPSTR) Alloca(iLen);
 
         if (strcpy_s(lpPALProcName, iLen, "PAL_") != SAFECRT_SUCCESS)
         {

--- a/src/pal/src/misc/dbgmsg.cpp
+++ b/src/pal/src/misc/dbgmsg.cpp
@@ -475,7 +475,7 @@ Notes :
 int DBG_printf_gcc(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
                    LPCSTR function, LPCSTR file, INT line, LPCSTR format, ...)
 {
-    CHAR *buffer = (CHAR*)alloca(DBG_BUFFER_SIZE);
+    CHAR *buffer = (CHAR*)Alloca(DBG_BUFFER_SIZE);
     CHAR indent[MAX_NESTING+1];
     LPSTR buffer_ptr;
     INT output_size;
@@ -593,7 +593,7 @@ Notes :
 int DBG_printf_c99(DBG_CHANNEL_ID channel, DBG_LEVEL_ID level, BOOL bHeader,
                    LPSTR file, INT line, LPSTR format, ...)
 {
-    CHAR *buffer = (CHAR*)alloca(DBG_BUFFER_SIZE);
+    CHAR *buffer = (CHAR*)Alloca(DBG_BUFFER_SIZE);
     CHAR indent[MAX_NESTING+1];
     LPSTR buffer_ptr;
     INT output_size;
@@ -941,7 +941,7 @@ void PAL_DisplayDialogFormatted(const char *szTitle, const char *szTextFormat, .
     va_start(args, szTextFormat);
 
     const int cchBuffer = 4096;
-    char *szBuffer = (char*)alloca(cchBuffer);
+    char *szBuffer = (char*)Alloca(cchBuffer);
     PAL__vsnprintf(szBuffer, cchBuffer, szTextFormat, args);
     PAL_DisplayDialog(szTitle, szBuffer);
 

--- a/src/pal/tests/palsuite/c_runtime/_alloca/test1/test1.c
+++ b/src/pal/tests/palsuite/c_runtime/_alloca/test1/test1.c
@@ -30,7 +30,7 @@ int __cdecl main(int argc, char **argv)
 
 
     /* check that _alloca really gives us addressable memory */
-    testA = (char *)_alloca(20 * sizeof(char));
+    testA = (char *)Alloca(20 * sizeof(char));
     if (testA == NULL)
     {
         Fail ("The call to _alloca failed\n");

--- a/src/tools/metainfo/mdinfo.cpp
+++ b/src/tools/metainfo/mdinfo.cpp
@@ -3326,7 +3326,7 @@ HRESULT _FillVariant(
             V_VT(pvar) = VT_BSTR;
             WCHAR *TempString;;
 #if BIGENDIAN
-            TempString = (WCHAR *)alloca(cbValue);
+            TempString = (WCHAR *)Alloca(cbValue);
             memcpy(TempString, pValue, cbValue);
             SwapStringLength(TempString, cbValue/sizeof(WCHAR));
 #else

--- a/src/utilcode/genericstackprobe.cpp
+++ b/src/utilcode/genericstackprobe.cpp
@@ -316,7 +316,7 @@ void BaseStackMarker::SetMarker(float numPages)
     
     // We might not have committed our stack yet, so allocate the number of pages
     // we need so that they will be commited and we won't AV when we try to set the mark.
-    _alloca( (int)(OS_PAGE_SIZE * m_numPages) );
+    Alloca( (int)(OS_PAGE_SIZE * m_numPages) );
     m_pMarker = pMarker;
     *m_pMarker = STACK_COOKIE_VALUE;
 

--- a/src/utilcode/posterror.cpp
+++ b/src/utilcode/posterror.cpp
@@ -341,7 +341,7 @@ HRESULT __cdecl PostErrorVA(                      // Returned error.
 #ifdef FEATURE_COMINTEROP        
 
     const DWORD cchMsg = 4096;
-    WCHAR      *rcMsg = (WCHAR*)alloca(cchMsg * sizeof(WCHAR));             // Error message.
+    WCHAR      *rcMsg = (WCHAR*)Alloca(cchMsg * sizeof(WCHAR));             // Error message.
     HRESULT     hr;
 
     BEGIN_ENTRYPOINT_NOTHROW;

--- a/src/utilcode/prettyprintsig.cpp
+++ b/src/utilcode/prettyprintsig.cpp
@@ -315,7 +315,7 @@ static PCCOR_SIGNATURE PrettyPrintType(
             else 
             {
                 _ASSERTE(rank != 0);
-                int* lowerBounds = (int*) _alloca(sizeof(int)*2*rank);
+                int* lowerBounds = (int*) Alloca(sizeof(int)*2*rank);
                 int* sizes               = &lowerBounds[rank];
                 memset(lowerBounds, 0, sizeof(int)*2*rank); 
                 
@@ -752,7 +752,7 @@ static HRESULT PrettyPrintTypeA(
             else 
             {
                 _ASSERTE(rank != 0);
-                int* lowerBounds = (int*) _alloca(sizeof(int)*2*rank);
+                int* lowerBounds = (int*) Alloca(sizeof(int)*2*rank);
                 int* sizes       = &lowerBounds[rank];
                 memset(lowerBounds, 0, sizeof(int)*2*rank); 
                 

--- a/src/utilcode/sxshelpers.cpp
+++ b/src/utilcode/sxshelpers.cpp
@@ -1483,7 +1483,7 @@ HRESULT GetApplicationPathFromWin32Manifest(__out_ecount(dwBuffer) WCHAR* buffer
         if (GetLastError() == ERROR_INSUFFICIENT_BUFFER) 
         {
            
-            pInfo = (ACTIVATION_CONTEXT_DETAILED_INFORMATION*) alloca(nCount);
+            pInfo = (ACTIVATION_CONTEXT_DETAILED_INFORMATION*) Alloca(nCount);
             
             if (WszQueryActCtxW(0, hActCtx, NULL, ActivationContextDetailedInformation, 
                                 pInfo, nCount, &nCount) &&

--- a/src/vm/array.cpp
+++ b/src/vm/array.cpp
@@ -661,7 +661,7 @@ MethodTable* Module::CreateArrayMethodTable(TypeHandle elemTypeHnd, CorElementTy
             SSIZE_T AllocSizeSeries;
             if (!ClrSafeInt<SSIZE_T>::multiply(sizeof(CGCDescSeries*), nSeries, AllocSizeSeries))
                 COMPlusThrowOM();
-            CGCDescSeries** sortedSeries = (CGCDescSeries**) _alloca(AllocSizeSeries);
+            CGCDescSeries** sortedSeries = (CGCDescSeries**) Alloca(AllocSizeSeries);
             int index;
             for (index = 0; index < nSeries; index++)
                 sortedSeries[index] = &pByValueSeries[-index];
@@ -1278,7 +1278,7 @@ Stub *GenerateArrayOpStub(ArrayMethodDesc* pMD)
 
     MethodTable *pMT = pMD->GetMethodTable();
 
-    ArrayOpScript *paos = (ArrayOpScript*)_alloca(sizeof(ArrayOpScript) + sizeof(ArrayOpIndexSpec) * pMT->GetRank());
+    ArrayOpScript *paos = (ArrayOpScript*)Alloca(sizeof(ArrayOpScript) + sizeof(ArrayOpIndexSpec) * pMT->GetRank());
 
     GenerateArrayOpScript(pMD, paos);
 

--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1573,7 +1573,7 @@ HRESULT AssemblySpec::EmitToken(
             AMD.cbLocale = MultiByteToWideChar(CP_UTF8, 0, m_context.szLocale, -1, NULL, 0);
             if(AMD.cbLocale==0)
                 IfFailGo(HRESULT_FROM_GetLastError());
-            AMD.szLocale = (LPWSTR) alloca(AMD.cbLocale * sizeof(WCHAR) );
+            AMD.szLocale = (LPWSTR) Alloca(AMD.cbLocale * sizeof(WCHAR) );
             if(MultiByteToWideChar(CP_UTF8, 0, m_context.szLocale, -1, AMD.szLocale, AMD.cbLocale)==0)
                 IfFailGo(HRESULT_FROM_GetLastError());
         }

--- a/src/vm/baseassemblyspec.cpp
+++ b/src/vm/baseassemblyspec.cpp
@@ -498,7 +498,7 @@ HRESULT BaseAssemblySpec::Init(IAssemblyName *pName)
     hr = pName->GetProperty(ASM_NAME_CULTURE, NULL, &cbSize);
     
     if (hr == HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER)) {
-        LPWSTR pwName = (LPWSTR) alloca(cbSize);
+        LPWSTR pwName = (LPWSTR) Alloca(cbSize);
         IfFailRet(pName->GetProperty(ASM_NAME_CULTURE, pwName, &cbSize));
 
         hr = FString::ConvertUnicode_Utf8(pwName, & ((LPSTR &) m_context.szLocale));

--- a/src/vm/baseassemblyspec.inl
+++ b/src/vm/baseassemblyspec.inl
@@ -559,7 +559,7 @@ inline HRESULT BaseAssemblySpec::Init(mdToken tkAssemblyRef,
                                             NULL));       // [OUT] Flags.
 
         // Get the assembly name other naming properties
-        wszAssemblyName = (LPWSTR)_alloca(cchName * sizeof(WCHAR));
+        wszAssemblyName = (LPWSTR)Alloca(cchName * sizeof(WCHAR));
         IfFailRet(pImport->GetAssemblyProps(tkAssemblyRef,
                                             (const void **)&m_pbPublicKeyOrToken,
                                             &m_cbPublicKeyOrToken,
@@ -585,7 +585,7 @@ inline HRESULT BaseAssemblySpec::Init(mdToken tkAssemblyRef,
                                             NULL));       // [OUT] Flags.
 
         // Get the assembly name other naming properties
-        wszAssemblyName = (LPWSTR)_alloca(cchName * sizeof(WCHAR));
+        wszAssemblyName = (LPWSTR)Alloca(cchName * sizeof(WCHAR));
         IfFailRet(pImport->GetAssemblyRefProps(tkAssemblyRef,
                                             (const void **)&m_pbPublicKeyOrToken,
                                             &m_cbPublicKeyOrToken,

--- a/src/vm/callhelpers.cpp
+++ b/src/vm/callhelpers.cpp
@@ -473,7 +473,7 @@ ARG_SLOT MethodDescCallSite::CallTargetWorker(const ARG_SLOT *pArguments)
         // Note that SizeOfFrameArgumentArray does overflow checks with sufficient margin to prevent overflows here
         DWORD dwAllocaSize = TransitionBlock::GetNegSpaceSize() + sizeof(TransitionBlock) + nStackBytes;
 
-        LPBYTE pAlloc = (LPBYTE)_alloca(dwAllocaSize);
+        LPBYTE pAlloc = (LPBYTE)Alloca(dwAllocaSize);
 
         pTransitionBlock = pAlloc + TransitionBlock::GetNegSpaceSize();
 

--- a/src/vm/ceeload.cpp
+++ b/src/vm/ceeload.cpp
@@ -5203,7 +5203,7 @@ OBJECTHANDLE Module::ResolveStringRef(DWORD token, BaseDomain *pDomain, bool bNe
         #ifdef LOGGING 
         int length = strData.GetCharCount();
         length = min(length, 100);
-        WCHAR *szString = (WCHAR *)_alloca((length + 1) * sizeof(WCHAR));
+        WCHAR *szString = (WCHAR *)Alloca((length + 1) * sizeof(WCHAR));
         memcpyNoGCRefs((void*)szString, (void*)strData.GetStringBuffer(), length * sizeof(WCHAR));
         szString[length] = '\0';
         LOG((LF_APPDOMAIN, LL_INFO10000, "String literal \"%S\" won't be interned due to NoInterningAttribute\n", szString));
@@ -9057,7 +9057,7 @@ MethodDesc* Module::LoadIBCMethodHelper(CORBBTPROF_BLOB_PARAM_SIG_ENTRY * pBlobS
             if (!ClrSafeInt<SIZE_T>::multiply(nargs, sizeof(TypeHandle), cbMem/* passed by ref */))
                 ThrowHR(COR_E_OVERFLOW);
             
-            TypeHandle * pInst = (TypeHandle*) _alloca(cbMem);
+            TypeHandle * pInst = (TypeHandle*) Alloca(cbMem);
             SigTypeContext typeContext;   // empty type context
 
             for (DWORD i = 0; i < nargs; i++)

--- a/src/vm/class.cpp
+++ b/src/vm/class.cpp
@@ -321,15 +321,15 @@ VOID EEClass::FixupFieldDescForEnC(MethodTable * pMT, EnCFieldDesc *pFD, mdField
 
     MethodTableBuilder::bmtMetaDataInfo bmtMetaData;
     bmtMetaData.cFields = 1;
-    bmtMetaData.pFields = (mdToken*)_alloca(sizeof(mdToken));
+    bmtMetaData.pFields = (mdToken*)Alloca(sizeof(mdToken));
     bmtMetaData.pFields[0] = fieldDef;
-    bmtMetaData.pFieldAttrs = (DWORD*)_alloca(sizeof(DWORD));
+    bmtMetaData.pFieldAttrs = (DWORD*)Alloca(sizeof(DWORD));
     IfFailThrow(pImport->GetFieldDefProps(fieldDef, &bmtMetaData.pFieldAttrs[0]));
     
     MethodTableBuilder::bmtMethAndFieldDescs bmtMFDescs;
     // We need to alloc the memory, but don't have to fill it in.  InitializeFieldDescs
     // will copy pFD (1st arg) into here.
-    bmtMFDescs.ppFieldDescList = (FieldDesc**)_alloca(sizeof(FieldDesc*));
+    bmtMFDescs.ppFieldDescList = (FieldDesc**)Alloca(sizeof(FieldDesc*));
 
     MethodTableBuilder::bmtFieldPlacement bmtFP;
 
@@ -362,7 +362,7 @@ VOID EEClass::FixupFieldDescForEnC(MethodTable * pMT, EnCFieldDesc *pFD, mdField
     
     // We shouldn't have to fill this in b/c we're not allowed to EnC value classes, or
     // anything else with layout info associated with it.
-    LayoutRawFieldInfo *pLayoutRawFieldInfos = (LayoutRawFieldInfo*)_alloca((2) * sizeof(LayoutRawFieldInfo));
+    LayoutRawFieldInfo *pLayoutRawFieldInfos = (LayoutRawFieldInfo*)Alloca((2) * sizeof(LayoutRawFieldInfo));
 
     // If not NULL, it means there are some by-value fields, and this contains an entry for each instance or static field,
     // which is NULL if not a by value field, and points to the EEClass of the field if a by value field.  Instance fields

--- a/src/vm/classhash.cpp
+++ b/src/vm/classhash.cpp
@@ -306,7 +306,7 @@ VOID EEClassHashTable::ConstructKeyFromData(PTR_EEClassHashEntry pEntry, // IN  
             INT32 iAllocSize;
             if (!ClrSafeInt<INT32>::addition(iNSLength, iNameLength, iAllocSize))
                 COMPlusThrowOM();
-            LPUTF8 pszOutNameSpace = (LPUTF8) _alloca(iAllocSize);
+            LPUTF8 pszOutNameSpace = (LPUTF8) Alloca(iAllocSize);
             if (iNSLength == 1)
             {
                 *pszOutNameSpace = '\0';

--- a/src/vm/clrtocomcall.cpp
+++ b/src/vm/clrtocomcall.cpp
@@ -518,7 +518,7 @@ I4ARRAYREF SetUpWrapperInfo(MethodDesc *pMD)
 
         // Collects ParamDef information in an indexed array where element 0 represents
         // the return type.
-        mdParamDef *params = (mdParamDef*)_alloca((numArgs+1) * sizeof(mdParamDef));
+        mdParamDef *params = (mdParamDef*)Alloca((numArgs+1) * sizeof(mdParamDef));
         CollateParamTokens(msig.GetModule()->GetMDImport(), pMD->GetMemberDef(), numArgs, params);
 
 
@@ -728,7 +728,7 @@ UINT32 CLRToCOMLateBoundWorker(ComPlusMethodFrame* pFrame, ComPlusCallMethodDesc
                 if (allocSize < cAssoc)
                     COMPlusThrow(kTypeLoadException, IDS_EE_TOOMANYASSOCIATES);
                 
-                pAssoc = (ASSOCIATE_RECORD*) _alloca((size_t) allocSize);
+                pAssoc = (ASSOCIATE_RECORD*) Alloca((size_t) allocSize);
                 IfFailThrow(pMDImport->GetAllAssociates(&henum, pAssoc, cAssoc));
                 
                 pMDImport->EnumClose(&henum);

--- a/src/vm/clsload.cpp
+++ b/src/vm/clsload.cpp
@@ -1688,7 +1688,7 @@ ClassLoader::FindClassModuleThrowing(
                 return FALSE;
             }
 
-            pszLowerNameSpace = (LPUTF8)_alloca(allocLen);
+            pszLowerNameSpace = (LPUTF8)Alloca(allocLen);
             if (allocLen == 1)
             {
                 *pszLowerNameSpace = '\0';
@@ -1709,7 +1709,7 @@ ClassLoader::FindClassModuleThrowing(
             return FALSE;
         }
 
-        pszLowerClassName = (LPUTF8)_alloca(allocLen);
+        pszLowerClassName = (LPUTF8)Alloca(allocLen);
         if (!InternalCasingHelper::InvariantToLower(
                 pszLowerClassName, 
                 allocLen, 

--- a/src/vm/comdynamic.cpp
+++ b/src/vm/comdynamic.cpp
@@ -1415,7 +1415,7 @@ HRESULT COMDynamicWrite::EmitDebugInfoBegin(Module *pModule,
         if (debugDirDataSize > 0)
         {
             // Make some room for the data.
-            debugDirData = (BYTE*)_alloca(debugDirDataSize);
+            debugDirData = (BYTE*)Alloca(debugDirDataSize);
 
             // Actually get the data now.
             IfFailGo(pWriter->GetDebugInfo(&debugDirIDD,
@@ -1544,7 +1544,7 @@ HRESULT COMDynamicWrite::EmitDebugInfoEnd(Module *pModule,
         SIZE_T dotOffset = dot ? dot - filename : fnLen;
 
         size_t len = dotOffset + 6;
-            WCHAR *fn = (WCHAR*)_alloca(len * sizeof(WCHAR));
+            WCHAR *fn = (WCHAR*)Alloca(len * sizeof(WCHAR));
         wcsncpy_s(fn, len, filename, dotOffset);
 
         fn[dotOffset] = W('.');

--- a/src/vm/compile.cpp
+++ b/src/vm/compile.cpp
@@ -2639,7 +2639,7 @@ void CEECompileInfo::EncodeTypeLayout(CORINFO_CLASS_HANDLE classHandle, SigBuild
         size_t cbGCRefMap = (dwSize / sizeof(TADDR) + 7) / 8;
         _ASSERTE(cbGCRefMap > 0);
 
-        BYTE * pGCRefMap = (BYTE *)_alloca(cbGCRefMap);
+        BYTE * pGCRefMap = (BYTE *)Alloca(cbGCRefMap);
 
         ComputeGCRefMap(pMT, pGCRefMap, cbGCRefMap);
 

--- a/src/vm/comtoclrcall.cpp
+++ b/src/vm/comtoclrcall.cpp
@@ -1556,7 +1556,7 @@ void ComCallMethodDesc::InitNativeInfo()
 
             // Collects ParamDef information in an indexed array where element 0 represents 
             // the return type.
-            mdParamDef *params = (mdParamDef*)_alloca((numArgs+1) * sizeof(mdParamDef));
+            mdParamDef *params = (mdParamDef*)Alloca((numArgs+1) * sizeof(mdParamDef));
             CollateParamTokens(pInternalImport, md, numArgs, params);
 
 #ifdef _TARGET_X86_

--- a/src/vm/comwaithandle.cpp
+++ b/src/vm/comwaithandle.cpp
@@ -273,9 +273,9 @@ FCIMPL4(INT32, WaitHandleNative::CorWaitMultipleNative, Object* waitObjectsUNSAF
     arrayHolder.Initialize(numWaiters, (PTRARRAYREF*) &waitObjects);
     
     pWaitObjects = (PTRARRAYREF)waitObjects;  // array of objects on which to wait
-    HANDLE* internalHandles = (HANDLE*) _alloca(numWaiters*sizeof(HANDLE));
+    HANDLE* internalHandles = (HANDLE*) Alloca(numWaiters*sizeof(HANDLE));
 #ifndef FEATURE_CORECLR
-    BOOL *hasThreadAffinity = (BOOL*) _alloca(numWaiters*sizeof(BOOL));
+    BOOL *hasThreadAffinity = (BOOL*) Alloca(numWaiters*sizeof(BOOL));
 
     BOOL mayRequireThreadAffinity = FALSE;
 #endif // !FEATURE_CORECLR

--- a/src/vm/crossdomaincalls.cpp
+++ b/src/vm/crossdomaincalls.cpp
@@ -1243,7 +1243,7 @@ CrossDomainChannel::BlitAndCall()
         // since the srvObject is in the server domain and the TPMethodFrame m_pFrame is in the client domain.
         // I don't think we need to protect the srvOjbect in this case, since it's reachable from the transparent
         // proxy, which is protected by the TPMethodFrame.
-        SIZE_T* pTmpStackArgs = (SIZE_T*)_alloca(m_numStackSlotsToCopy * sizeof(SIZE_T));
+        SIZE_T* pTmpStackArgs = (SIZE_T*)Alloca(m_numStackSlotsToCopy * sizeof(SIZE_T));
         memcpy(pTmpStackArgs, pStackArgs, m_numStackSlotsToCopy * sizeof(SIZE_T));
         pStackArgs = pTmpStackArgs;
 
@@ -1571,10 +1571,10 @@ void CrossDomainChannel::MarshalAndCall_Wrapper(MarshalAndCallArgs * pArgs)
 
     // And a variable sized array and frame of marshaled arg GC references.
     OBJECTREF *pServerArgArray = NULL;
-    pServerArgArray = (OBJECTREF *) _alloca(pArgs->dwNumObjectsMarshalled * sizeof(OBJECTREF));
+    pServerArgArray = (OBJECTREF *) Alloca(pArgs->dwNumObjectsMarshalled * sizeof(OBJECTREF));
     ZeroMemory(pServerArgArray, sizeof(OBJECTREF) * pArgs->dwNumObjectsMarshalled);
 
-    TypeHandle* pServerArgTH = (TypeHandle *) _alloca(pArgs->dwNumObjectsMarshalled * sizeof(TypeHandle));
+    TypeHandle* pServerArgTH = (TypeHandle *) Alloca(pArgs->dwNumObjectsMarshalled * sizeof(TypeHandle));
     GCPROTECT_ARRAY_BEGIN(pServerArgArray[0], pArgs->dwNumObjectsMarshalled);
 
     // Initialize server side info, such as method address etc
@@ -1740,9 +1740,9 @@ void CrossDomainChannel::MarshalAndCall_Wrapper(MarshalAndCallArgs * pArgs)
             if (pMT->IsStructRequiringStackAllocRetBuf())
             {
                 SIZE_T sz = pMT->GetNumInstanceFieldBytes();
-                pvRetBuff = _alloca(sz);
+                pvRetBuff = Alloca(sz);
                 memset(pvRetBuff, 0, sz);
-                pValueClasses = new (_alloca(sizeof(ValueClassInfo))) ValueClassInfo(pvRetBuff, pMT, pValueClasses);
+                pValueClasses = new (Alloca(sizeof(ValueClassInfo))) ValueClassInfo(pvRetBuff, pMT, pValueClasses);
             }
             else
             {
@@ -2094,21 +2094,21 @@ CrossDomainChannel::MarshalAndCall()
 #endif // _TARGET_X86_
 
     // pArgAttribs tell where the marshalled objects should go, where they need unboxing etc
-    pArgAttribs = (DWORD*) _alloca(dwNumArgs * sizeof(DWORD));
+    pArgAttribs = (DWORD*) Alloca(dwNumArgs * sizeof(DWORD));
     ZeroMemory(pArgAttribs, sizeof(DWORD) * dwNumArgs);
     // pThByRefs has the typehandles of the by-ref args
-    pThByRefs = (TypeHandle *)_alloca(dwNumArgs * sizeof(TypeHandle));
+    pThByRefs = (TypeHandle *)Alloca(dwNumArgs * sizeof(TypeHandle));
     ZeroMemory(pThByRefs, sizeof(TypeHandle) *dwNumArgs);
     // pByRefArgAttribs tell where the by-ref args should go, after the call
-    pByRefArgAttribs = (int*) _alloca(dwNumArgs * sizeof(int));
+    pByRefArgAttribs = (int*) Alloca(dwNumArgs * sizeof(int));
     ZeroMemory(pByRefArgAttribs, sizeof(int) * dwNumArgs);
     // bMarshalledArgs is a bunch of flags that tell which args were marshalled
-    bMarshalledArgs = (BOOL*) _alloca(dwNumArgs * sizeof(BOOL));
+    bMarshalledArgs = (BOOL*) Alloca(dwNumArgs * sizeof(BOOL));
     ZeroMemory(bMarshalledArgs, sizeof(BOOL) * dwNumArgs);
 
     // pArgArray contains marshalled objects on the client side
     OBJECTREF *pClientArgArray = NULL;
-    pClientArgArray = (OBJECTREF *) _alloca(dwNumArgs * sizeof(OBJECTREF));
+    pClientArgArray = (OBJECTREF *) Alloca(dwNumArgs * sizeof(OBJECTREF));
     ZeroMemory(pClientArgArray, sizeof(OBJECTREF) * dwNumArgs);
     GCPROTECT_ARRAY_BEGIN(pClientArgArray[0], dwNumArgs);
 
@@ -2122,7 +2122,7 @@ CrossDomainChannel::MarshalAndCall()
     // spans registers and the stack.
     cbStackArgs += sizeof(ArgumentRegisters);
 #endif
-    SIZE_T *pStackArgs = (SIZE_T*)_alloca(cbStackArgs);
+    SIZE_T *pStackArgs = (SIZE_T*)Alloca(cbStackArgs);
     ZeroMemory(pStackArgs, cbStackArgs);
 #ifdef CALLDESCR_ARGREGS
     SIZE_T *pRegArgs = pStackArgs;

--- a/src/vm/customattribute.cpp
+++ b/src/vm/customattribute.cpp
@@ -576,7 +576,7 @@ FCIMPL5(VOID, Attribute::ParseAttributeArguments, void* pCa, INT32 cCa,
             size_t size = sizeof(CaArg) * cArgs;
             if ((size / sizeof(CaArg)) != cArgs) // uint over/underflow
                 IfFailGo(E_INVALIDARG);
-            pCaArgs = (CaArg*)_alloca(size);
+            pCaArgs = (CaArg*)Alloca(size);
             
             for (COUNT_T i = 0; i < cArgs; i ++)
             {
@@ -596,7 +596,7 @@ FCIMPL5(VOID, Attribute::ParseAttributeArguments, void* pCa, INT32 cCa,
             size_t size = sizeof(CaNamedArg) * cNamedArgs;
             if ((size / sizeof(CaNamedArg)) != cNamedArgs) // uint over/underflow
                 IfFailGo(E_INVALIDARG);
-            pCaNamedArgs = (CaNamedArg*)_alloca(size);
+            pCaNamedArgs = (CaNamedArg*)Alloca(size);
 
             for (COUNT_T i = 0; i < cNamedArgs; i ++)
             {
@@ -764,10 +764,10 @@ FCIMPL5(LPVOID, COMCustomAttribute::CreateCaObject, ReflectModuleBaseObject* pAt
         UINT cArgs = pSig->NumFixedArgs() + 1; // make room for the this pointer
         UINT i = 1; // used to flag that we actually get the right number of arg from the blob
         
-        args = (ARG_SLOT*)_alloca(cArgs * sizeof(ARG_SLOT));
+        args = (ARG_SLOT*)Alloca(cArgs * sizeof(ARG_SLOT));
         memset((void*)args, 0, cArgs * sizeof(ARG_SLOT));
         
-        OBJECTREF *argToProtect = (OBJECTREF*)_alloca(cArgs * sizeof(OBJECTREF));
+        OBJECTREF *argToProtect = (OBJECTREF*)Alloca(cArgs * sizeof(OBJECTREF));
         memset((void*)argToProtect, 0, cArgs * sizeof(OBJECTREF));
 
         // If we relax this, we need to insure custom attributes construct properly for Nullable<T>
@@ -1207,7 +1207,7 @@ TypeHandle COMCustomAttribute::GetTypeHandleFromBlob(Assembly *pCtorAssembly,
         if ((size+1 <= 1) || (size > endBlob - *pBlob))
             COMPlusThrow(kCustomAttributeFormatException);
 
-        LPUTF8 szName = (LPUTF8)_alloca(size + 1);
+        LPUTF8 szName = (LPUTF8)Alloca(size + 1);
         memcpy(szName, *pBlob, size);
         *pBlob += size;
         szName[size] = 0;

--- a/src/vm/dbggcinfodecoder.cpp
+++ b/src/vm/dbggcinfodecoder.cpp
@@ -309,7 +309,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
             {
                 m_IsInterruptible = true;
 
-                BYTE* callSiteLiveSet = (BYTE*) _alloca( ( numSlotMappings + 7 ) / 8 );
+                BYTE* callSiteLiveSet = (BYTE*) Alloca( ( numSlotMappings + 7 ) / 8 );
 
                 UINT32 i;
                 for( i=0; i<numSlotMappings/8; i++ )
@@ -323,7 +323,7 @@ bool GcInfoDecoder::EnumerateLiveSlots(
                 // Read slot mappings
                 //---------------------------------------------------------------------------
 
-                GcSlotDesc* slotMappings = (GcSlotDesc*) _alloca( numSlotMappings * sizeof( GcSlotDesc ) );
+                GcSlotDesc* slotMappings = (GcSlotDesc*) Alloca( numSlotMappings * sizeof( GcSlotDesc ) );
                 // Assert that we can read a GcSlotDesc with a single call to m_Reader.Read()
                 _ASSERTE( sizeof( GcSlotDesc ) <= sizeof ( size_t ) );
                 for( UINT32 i=0; i<numSlotMappings; i++ )

--- a/src/vm/debughelp.cpp
+++ b/src/vm/debughelp.cpp
@@ -884,7 +884,7 @@ StackWalkAction PrintStackTraceCallback(CrawlFrame* pCF, VOID* pData)
 
     MethodDesc* pMD = pCF->GetFunction();
     const int nLen = 2048 - 1;    // keep one character for "\n"
-    wchar_t *buff = (wchar_t*)alloca((nLen + 1) * sizeof(wchar_t));
+    wchar_t *buff = (wchar_t*)Alloca((nLen + 1) * sizeof(wchar_t));
     buff[0] = 0;
     buff[nLen-1] = W('\0');                    // make sure the buffer is always NULL-terminated
 

--- a/src/vm/dispatchinfo.cpp
+++ b/src/vm/dispatchinfo.cpp
@@ -1267,14 +1267,14 @@ void DispatchInfo::InvokeMemberWorker(DispatchMemberInfo*   pDispMemberInfo,
     HRESULT hr;
     
     // Allocate the array of used flags.
-    BYTE *aArgUsedFlags = (BYTE*)_alloca(NumParams * sizeof(BYTE));
+    BYTE *aArgUsedFlags = (BYTE*)Alloca(NumParams * sizeof(BYTE));
     memset(aArgUsedFlags, 0, NumParams * sizeof(BYTE));
 
     size_t cbByrefArgMngVariantIndex;
     if (!ClrSafeInt<size_t>::multiply(sizeof(DWORD), NumArgs, cbByrefArgMngVariantIndex))
         ThrowHR(COR_E_OVERFLOW);
 
-    DWORD *aByrefArgMngVariantIndex = (DWORD *)_alloca(cbByrefArgMngVariantIndex);
+    DWORD *aByrefArgMngVariantIndex = (DWORD *)Alloca(cbByrefArgMngVariantIndex);
 
     
     //
@@ -2182,7 +2182,7 @@ HRESULT DispatchInfo::InvokeMember(SimpleComCallWrapper *pSimpleWrap, DISPID id,
         if (!ClrSafeInt<size_t>::multiply(sizeof(OBJECTHANDLE *), NumArgs, cbStaticArrayBackupObjHandle))
             ThrowHR(COR_E_OVERFLOW);
 
-        OBJECTHANDLE *aByrefStaticArrayBackupObjHandle = (OBJECTHANDLE *)_alloca(cbStaticArrayBackupObjHandle);
+        OBJECTHANDLE *aByrefStaticArrayBackupObjHandle = (OBJECTHANDLE *)Alloca(cbStaticArrayBackupObjHandle);
         memset(aByrefStaticArrayBackupObjHandle, 0, cbStaticArrayBackupObjHandle);
 
         // Allocate the array that maps method params to their indices.
@@ -2190,14 +2190,14 @@ HRESULT DispatchInfo::InvokeMember(SimpleComCallWrapper *pSimpleWrap, DISPID id,
         if (!ClrSafeInt<size_t>::multiply(sizeof(int), NumArgs, cbManagedMethodParamIndexMap))
             ThrowHR(COR_E_OVERFLOW);
 
-        int *pManagedMethodParamIndexMap = (int *)_alloca(cbManagedMethodParamIndexMap);
+        int *pManagedMethodParamIndexMap = (int *)Alloca(cbManagedMethodParamIndexMap);
 
         // Allocate the array of byref objects.
         size_t cbByrefArgOleVariant;
         if (!ClrSafeInt<size_t>::multiply(sizeof(VARIANT *), NumArgs, cbByrefArgOleVariant))
             ThrowHR(COR_E_OVERFLOW);
 
-        VARIANT **aByrefArgOleVariant = (VARIANT **)_alloca(cbByrefArgOleVariant);
+        VARIANT **aByrefArgOleVariant = (VARIANT **)Alloca(cbByrefArgOleVariant);
       
         Objs.Target = pSimpleWrap->GetObjectRef();
 

--- a/src/vm/dllimport.cpp
+++ b/src/vm/dllimport.cpp
@@ -3668,7 +3668,7 @@ BOOL NDirect::MarshalingRequired(MethodDesc *pMD, PCCOR_SIGNATURE pSig /*= NULL*
     numArgs++;   // +1 for return type
 
     // We'll need to parse parameter native types
-    mdParamDef *pParamTokenArray = (mdParamDef *)_alloca(numArgs * sizeof(mdParamDef));
+    mdParamDef *pParamTokenArray = (mdParamDef *)Alloca(numArgs * sizeof(mdParamDef));
     IMDInternalImport *pMDImport = pModule->GetMDImport();
 
     SigTypeContext emptyTypeContext;
@@ -5511,7 +5511,7 @@ MethodDesc* NDirect::CreateCLRToNativeILStub(
     
     Module *pModule = pSigDesc->m_pModule;
     numParamTokens = numArgs + 1;
-    pParamTokenArray = (mdParamDef*)_alloca(numParamTokens * sizeof(mdParamDef));
+    pParamTokenArray = (mdParamDef*)Alloca(numParamTokens * sizeof(mdParamDef));
     CollateParamTokens(pModule->GetMDImport(), pSigDesc->m_tkMethodDef, numArgs, pParamTokenArray);
 
     // for interop vectors that have declarative security, we need
@@ -5615,7 +5615,7 @@ MethodDesc* NDirect::CreateFieldAccessILStub(
     int numParamTokens = numArgs + 1;
 
     // make sure we capture marshaling metadata
-    mdParamDef* pParamTokenArray = (mdParamDef *)_alloca(numParamTokens * sizeof(mdParamDef));
+    mdParamDef* pParamTokenArray = (mdParamDef *)Alloca(numParamTokens * sizeof(mdParamDef));
     pParamTokenArray[0] = mdParamDefNil;
     pParamTokenArray[numArgs] = (mdParamDef)fd;
 
@@ -6102,7 +6102,7 @@ void CreateCLRToDispatchCOMStub(
                                     &numArgs);
 
     numParamTokens = numArgs + 1;
-    pParamTokenArray = (mdParamDef*)_alloca(numParamTokens * sizeof(mdParamDef));
+    pParamTokenArray = (mdParamDef*)Alloca(numParamTokens * sizeof(mdParamDef));
     CollateParamTokens(sigDesc.m_pModule->GetMDImport(), sigDesc.m_tkMethodDef, numArgs, pParamTokenArray);
 
     DispatchStubState MyStubState;

--- a/src/vm/dllimportcallback.cpp
+++ b/src/vm/dllimportcallback.cpp
@@ -872,7 +872,7 @@ Stub *UMThunkMarshInfo::CompileNExportThunk(LoaderHeap *pLoaderHeap, PInvokeStat
     // parameters with copy constructors where we perform value-to-reference transformation
     UINT nStackBytesIncoming = nStackBytes;
 
-    UINT *psrcofs = (UINT *)_alloca((nStackBytes / STACK_ELEM_SIZE) * sizeof(UINT));
+    UINT *psrcofs = (UINT *)Alloca((nStackBytes / STACK_ELEM_SIZE) * sizeof(UINT));
     UINT psrcofsregs[NUM_ARGUMENT_REGISTERS];
     UINT retbufofs = UNUSED_STACK_OFFSET;
 

--- a/src/vm/dwbucketmanager.hpp
+++ b/src/vm/dwbucketmanager.hpp
@@ -596,7 +596,7 @@ void BaseBucketParamsManager::GetModuleName(__out_ecount(maxLength) WCHAR* targe
         if (pModule->IsManifest())
         {
             // Single-module assembly; allocate a buffer and convert assembly name.
-            fullName = reinterpret_cast< WCHAR* >(_alloca(sizeof(WCHAR)*(fullNameLength)));
+            fullName = reinterpret_cast< WCHAR* >(Alloca(sizeof(WCHAR)*(fullNameLength)));
             WszMultiByteToWideChar(CP_UTF8, 0, utf8AssemblyName, -1, fullName, fullNameLength);
         }
         else
@@ -624,7 +624,7 @@ void BaseBucketParamsManager::GetModuleName(__out_ecount(maxLength) WCHAR* targe
                 }
                 else
                 {
-                    fullName = reinterpret_cast< WCHAR* >(_alloca(AllocLen));
+                    fullName = reinterpret_cast< WCHAR* >(Alloca(AllocLen));
 
                     // Convert the assembly name.
                     WszMultiByteToWideChar(CP_UTF8, 0, utf8AssemblyName, -1, fullName, assemblyNameLength);

--- a/src/vm/dwreport.cpp
+++ b/src/vm/dwreport.cpp
@@ -459,8 +459,8 @@ HRESULT DwCheckCompany(                 // S_OK or error.
     }
 
     // Allocate the buffer for the version info structure
-    // _alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
-    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(_alloca(bufSize));
+    // Alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
+    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(Alloca(bufSize));
 
     // Extract the version information blob. The version information
     // contains much more than the actual item of interest.
@@ -595,8 +595,8 @@ int DwGetAppDescription(                // Number of characters written.
     }
 
     // Allocate the buffer for the version info structure
-    // _alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
-    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(_alloca(bufSize));
+    // Alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
+    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(Alloca(bufSize));
 
     // Extract the version information blob. The version information
     // contains much more than the actual item of interest.
@@ -718,8 +718,8 @@ int DwGetAssemblyVersion(               // Number of characters written.
     }
 
     // Allocate the buffer for the version info structure
-    // _alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
-    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(_alloca(bufSize));
+    // Alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
+    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(Alloca(bufSize));
 
     // Extract the version information blob. The version information
     // contains much more than the actual item of interest.

--- a/src/vm/encee.cpp
+++ b/src/vm/encee.cpp
@@ -654,7 +654,7 @@ HRESULT EditAndContinueModule::ResumeInUpdatedFunction(
     if( newFrameSize > oldFrameSize) 
     {
         DWORD frameIncrement = newFrameSize - oldFrameSize;
-        (void)alloca(frameIncrement);
+        (void)Alloca(frameIncrement);
     }
 
     // Ask the EECodeManager to actually fill in the context and stack for the new frame so that

--- a/src/vm/excep.cpp
+++ b/src/vm/excep.cpp
@@ -6643,7 +6643,7 @@ static STRINGREF MissingMemberException_FormatSignature_Internal(I1ARRAYREF* ppP
         return StringObject::NewString("Unknown signature");
     }
 
-    psig = (const BYTE*)_alloca(csig);
+    psig = (const BYTE*)Alloca(csig);
     CopyMemory((BYTE*)psig,
                (*ppPersistedSig)->GetDirectPointerToNonObjectElements(),
                csig);

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -4298,7 +4298,7 @@ void DumpClauses(IJitManager* pJitMan, const METHODTOKEN& MethToken, UINT_PTR uM
 }
 
 #define STACK_ALLOC_ARRAY(numElements, type) \
-    ((type *)_alloca((numElements)*(sizeof(type))))
+    ((type *)Alloca((numElements)*(sizeof(type))))
 
 static void DoEHLog(
     DWORD lvl,

--- a/src/vm/exceptmacros.h
+++ b/src/vm/exceptmacros.h
@@ -230,7 +230,7 @@ VOID DECLSPEC_NORETURN RealCOMPlusThrowSO();
 #if !defined(WIN64EXCEPTIONS)
 
 #define INSTALL_NESTED_EXCEPTION_HANDLER(frame)                                                                       \
-   NestedHandlerExRecord *__pNestedHandlerExRecord = (NestedHandlerExRecord*) _alloca(sizeof(NestedHandlerExRecord)); \
+   NestedHandlerExRecord *__pNestedHandlerExRecord = (NestedHandlerExRecord*) Alloca(sizeof(NestedHandlerExRecord)); \
    __pNestedHandlerExRecord->m_handlerInfo.m_hThrowable = NULL;                                                       \
    __pNestedHandlerExRecord->Init((PEXCEPTION_ROUTINE)COMPlusNestedExceptionHandler, frame);                          \
    INSTALL_EXCEPTION_HANDLING_RECORD(&(__pNestedHandlerExRecord->m_ExReg));

--- a/src/vm/fieldmarshaler.cpp
+++ b/src/vm/fieldmarshaler.cpp
@@ -1329,7 +1329,7 @@ VOID EEClassLayoutInfo::CollectLayoutFieldMetadataThrowing(
     {
         ThrowHR(COR_E_TYPELOAD);
     }
-    LayoutRawFieldInfo **pSortArray = (LayoutRawFieldInfo **)_alloca(cbSortArraySize.Value());
+    LayoutRawFieldInfo **pSortArray = (LayoutRawFieldInfo **)Alloca(cbSortArraySize.Value());
     LayoutRawFieldInfo **pSortArrayEnd = pSortArray;
     
     ULONG maxRid = pInternalImport->GetCountWithTokenKind(mdtFieldDef);
@@ -3297,7 +3297,7 @@ VOID FieldMarshaler_FixedStringAnsi::UpdateCLRImpl(const VOID *pNativeValue, OBJ
     if (allocSize < m_numchar)
         ThrowOutOfMemory();
     
-    LPSTR tempbuf = (LPSTR)(_alloca((size_t)allocSize));
+    LPSTR tempbuf = (LPSTR)(Alloca((size_t)allocSize));
     if (!tempbuf)
         ThrowOutOfMemory();
 
@@ -3310,7 +3310,7 @@ VOID FieldMarshaler_FixedStringAnsi::UpdateCLRImpl(const VOID *pNativeValue, OBJ
     if (allocSize < m_numchar)
         ThrowOutOfMemory();
     
-    LPWSTR    wsztemp = (LPWSTR)_alloca( (size_t)allocSize );
+    LPWSTR    wsztemp = (LPWSTR)Alloca( (size_t)allocSize );
     int ncwritten = MultiByteToWideChar(CP_ACP,
                                         MB_PRECOMPOSED,
                                         tempbuf,

--- a/src/vm/fusionbind.cpp
+++ b/src/vm/fusionbind.cpp
@@ -503,7 +503,7 @@ HRESULT FusionBind::AddEnvironmentProperty(__in LPCWSTR variable,
     WCHAR *pValue = &(rcValue[0]);
     size = WszGetEnvironmentVariable(variable, pValue, size);
     if(size > _MAX_PATH) {
-        pValue = (WCHAR*) _alloca(size * sizeof(WCHAR));
+        pValue = (WCHAR*) Alloca(size * sizeof(WCHAR));
         size = WszGetEnvironmentVariable(variable, pValue, size);
         size++; // Add in the null terminator
     }
@@ -540,7 +540,7 @@ HRESULT FusionBind::SetupFusionContext(LPCWSTR szAppBase,
     LPCWSTR pBase;
     // if the appbase is null then use the current directory
     if (szAppBase == NULL) {
-        pBase = (LPCWSTR) _alloca(_MAX_PATH * sizeof(WCHAR));
+        pBase = (LPCWSTR) Alloca(_MAX_PATH * sizeof(WCHAR));
         if(!WszGetCurrentDirectory(_MAX_PATH, (LPWSTR) pBase))
             IfFailGo(HRESULT_FROM_GetLastError());
     }

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -700,7 +700,7 @@ OBJECTREF   DupArrayForCloning(BASEARRAYREF pRef, BOOL bAllocateInLargeHeap)
     unsigned rank = arrayType.GetRank();
 
     DWORD numArgs =  rank*2;
-    INT32* args = (INT32*) _alloca(sizeof(INT32)*numArgs);
+    INT32* args = (INT32*) Alloca(sizeof(INT32)*numArgs);
 
     if (arrayType.GetInternalCorElementType() == ELEMENT_TYPE_ARRAY)
     {

--- a/src/vm/genericdict.cpp
+++ b/src/vm/genericdict.cpp
@@ -829,7 +829,7 @@ Dictionary::PopulateEntry(
                 if (!ClrSafeInt<SIZE_T>::multiply(nargs, sizeof(TypeHandle), cbMem/* passed by ref */))
                     ThrowHR(COR_E_OVERFLOW);
                         
-                TypeHandle * pInst = (TypeHandle*) _alloca(cbMem);
+                TypeHandle * pInst = (TypeHandle*) Alloca(cbMem);
                 for (DWORD i = 0; i < nargs; i++)
                 {
                     pInst[i] = ptr.GetTypeHandleThrowing(

--- a/src/vm/generics.cpp
+++ b/src/vm/generics.cpp
@@ -151,7 +151,7 @@ TypeHandle ClassLoader::LoadCanonicalGenericInstantiation(TypeKey *pTypeKey,
         DO_INTERIOR_STACK_PROBE_FOR_NOTHROW_CHECK_THREAD((10+dwAllocSize/PAGE_SIZE+1), NO_FORBIDGC_LOADER_USE_ThrowSO(););
     }
 #endif // DACCESS_COMPILE
-    TypeHandle *repInst = (TypeHandle*) _alloca(dwAllocSize);
+    TypeHandle *repInst = (TypeHandle*) Alloca(dwAllocSize);
 
     for (DWORD i = 0; i < ntypars; i++)
     {

--- a/src/vm/i386/excepcpu.h
+++ b/src/vm/i386/excepcpu.h
@@ -50,7 +50,7 @@ class Thread;
 // stackOverwriteBarrier is used to detect overwriting of stack which will mess up handler registration
 #if defined(_DEBUG)
 #define DECLARE_CPFH_EH_RECORD(pCurThread) \
-    FrameHandlerExRecordWithBarrier *___pExRecordWithBarrier = (FrameHandlerExRecordWithBarrier *)_alloca(sizeof(FrameHandlerExRecordWithBarrier)); \
+    FrameHandlerExRecordWithBarrier *___pExRecordWithBarrier = (FrameHandlerExRecordWithBarrier *)Alloca(sizeof(FrameHandlerExRecordWithBarrier)); \
     for (int ___i =0; ___i < STACK_OVERWRITE_BARRIER_SIZE; ___i++) \
         ___pExRecordWithBarrier->m_StackOverwriteBarrier[___i] = STACK_OVERWRITE_BARRIER_VALUE; \
     FrameHandlerExRecord *___pExRecord = &(___pExRecordWithBarrier->m_ExRecord); \
@@ -59,7 +59,7 @@ class Thread;
 
 #else
 #define DECLARE_CPFH_EH_RECORD(pCurThread) \
-    FrameHandlerExRecord *___pExRecord = (FrameHandlerExRecord *)_alloca(sizeof(FrameHandlerExRecord)); \
+    FrameHandlerExRecord *___pExRecord = (FrameHandlerExRecord *)Alloca(sizeof(FrameHandlerExRecord)); \
     ___pExRecord->m_ExReg.Handler = (PEXCEPTION_ROUTINE)COMPlusFrameHandler; \
     ___pExRecord->m_pEntryFrame = (pCurThread)->GetFrame();
 

--- a/src/vm/i386/excepx86.cpp
+++ b/src/vm/i386/excepx86.cpp
@@ -2209,7 +2209,7 @@ VOID PopNestedExceptionRecords(LPVOID pTargetSP, CONTEXT *pCtx, void *pSEH)
  * COMPlusThrowCallbackHelper
  *
  * This function is a simple helper function for COMPlusThrowCallback.  It is needed
- * because of the EX_TRY macro.  This macro does an alloca(), which allocates space
+ * because of the EX_TRY macro.  This macro does an Alloca(), which allocates space
  * off the stack, not free'ing it.  Thus, doing a EX_TRY in a loop can easily result
  * in a stack overflow error.  By factoring out the EX_TRY into a separate function,
  * we recover that stack space.

--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -398,7 +398,7 @@ void LazyMachState::unwindLazyState(LazyMachState* baseState,
 #ifdef _DEBUG
     int count = 0;
     const DWORD cInstructions = 1000;
-    PTR_BYTE *instructionBytes = (PTR_BYTE*)alloca(cInstructions * sizeof(PTR_BYTE));
+    PTR_BYTE *instructionBytes = (PTR_BYTE*)Alloca(cInstructions * sizeof(PTR_BYTE));
     memset(instructionBytes, 0, cInstructions * sizeof(PTR_BYTE));
 #endif
     bool bset16bit=false;

--- a/src/vm/interoputil.cpp
+++ b/src/vm/interoputil.cpp
@@ -4580,7 +4580,7 @@ void IUInvokeDispMethod(REFLECTCLASSBASEREF* pRefClassObj, OBJECTREF* pTarget, O
         UINT cPositionalArgs = cArgs - cNamedArgs;
        
         DispParams.cArgs = cArgs;
-        DispParams.rgvarg = (VARIANTARG *)_alloca(cArgs * sizeof(VARIANTARG));
+        DispParams.rgvarg = (VARIANTARG *)Alloca(cArgs * sizeof(VARIANTARG));
         params = new DispParamHolder[cArgs];
 
         // Initialize all the variants.
@@ -4670,12 +4670,12 @@ void IUInvokeDispMethod(REFLECTCLASSBASEREF* pRefClassObj, OBJECTREF* pTarget, O
             size_t allocSize = cNamesToConvert * sizeof(LPWSTR);
             if (allocSize < cNamesToConvert)
                 COMPlusThrowArgumentOutOfRange(W("namedParameters"), W("ArgumentOutOfRange_Capacity"));
-            LPWSTR *aNamesToConvert = (LPWSTR *)_alloca(allocSize);
+            LPWSTR *aNamesToConvert = (LPWSTR *)Alloca(allocSize);
             
             allocSize = cNamesToConvert * sizeof(DISPID);
             if (allocSize < cNamesToConvert)
                 COMPlusThrowArgumentOutOfRange(W("namedParameters"), W("ArgumentOutOfRange_Capacity"));
-            aDispID = (DISPID *)_alloca(allocSize);
+            aDispID = (DISPID *)Alloca(allocSize);
 
             // The first name to convert is the name of the method itself.
             aNamesToConvert[0] = (*pStrName)->GetBuffer();
@@ -4826,7 +4826,7 @@ void IUInvokeDispMethod(REFLECTCLASSBASEREF* pRefClassObj, OBJECTREF* pTarget, O
     if (cArgs > 0)
     {
         // Allocate the byref argument information.
-        aByrefArgInfos = (ByrefArgumentInfo*)_alloca(cArgs * sizeof(ByrefArgumentInfo));
+        aByrefArgInfos = (ByrefArgumentInfo*)Alloca(cArgs * sizeof(ByrefArgumentInfo));
         memset(aByrefArgInfos, 0, cArgs * sizeof(ByrefArgumentInfo));
 
         // Set the byref bit on the arguments that have the byref modifier.
@@ -4877,7 +4877,7 @@ void IUInvokeDispMethod(REFLECTCLASSBASEREF* pRefClassObj, OBJECTREF* pTarget, O
                 // If we are doing a property put then we need to set the DISPID of the
                 // argument to DISP_PROPERTYPUT if there is at least one argument.
                 DispParams.cNamedArgs = cNamedArgs + 1;
-                DispParams.rgdispidNamedArgs = (DISPID*)_alloca((cNamedArgs + 1) * sizeof(DISPID));
+                DispParams.rgdispidNamedArgs = (DISPID*)Alloca((cNamedArgs + 1) * sizeof(DISPID));
                 
                 // Fill in the array of named arguments.
                 DispParams.rgdispidNamedArgs[0] = DISPID_PROPERTYPUT;

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -1630,7 +1630,7 @@ ARG_SLOT Interpreter::ExecuteMethodWrapper(struct InterpreterMethodInfo* interpM
 #endif
 
     size_t sizeWithGS = GetFrameSize(interpMethInfo) + sizeof(GSCookie);
-    BYTE* frameMemoryGS = static_cast<BYTE*>(_alloca(sizeWithGS));
+    BYTE* frameMemoryGS = static_cast<BYTE*>(Alloca(sizeWithGS));
 
     ARG_SLOT retVal = 0;
     unsigned jmpCallToken = 0;
@@ -5965,7 +5965,7 @@ void Interpreter::NewObj()
             assert(m_curStackHt >= dwNumArgs);
             m_curStackHt -= dwNumArgs;
 
-            INT32* args = (INT32*)_alloca(dwNumArgs * sizeof(INT32));
+            INT32* args = (INT32*)Alloca(dwNumArgs * sizeof(INT32));
 
             unsigned dwArg;
             for (dwArg = 0; dwArg < dwNumArgs; dwArg++)
@@ -9381,13 +9381,13 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
     }
     else
     {
-        args = (ARG_SLOT*)_alloca(totalArgSlots * sizeof(ARG_SLOT));
+        args = (ARG_SLOT*)Alloca(totalArgSlots * sizeof(ARG_SLOT));
 #if defined(_ARM_)
         // The HFA return buffer, if any, is assumed to be at a negative
         // offset from the IL arg pointer, so adjust that pointer upward.
         args = args + HFAReturnArgSlots;
 #endif // defined(_ARM_)
-        argTypes = (InterpreterType*)_alloca(nSlots * sizeof(InterpreterType));
+        argTypes = (InterpreterType*)Alloca(nSlots * sizeof(InterpreterType));
     }
     // Make sure that we don't scan any of these until we overwrite them with
     // the real types of the arguments.
@@ -9647,7 +9647,7 @@ void Interpreter::DoCallWork(bool virtualCall, void* thisArg, CORINFO_RESOLVED_T
 #ifdef ENREGISTERED_RETURNTYPE_MAXSIZE
                 retBuffSize = max(retTypeSz, ENREGISTERED_RETURNTYPE_MAXSIZE);
 #endif // ENREGISTERED_RETURNTYPE_MAXSIZE
-                pLargeStructRetVal = (BYTE*)_alloca(retBuffSize);
+                pLargeStructRetVal = (BYTE*)Alloca(retBuffSize);
                 // Clear this in case a GC happens.
                 for (unsigned i = 0; i < retTypeSz; i++) pLargeStructRetVal[i] = 0;
                 // Register this as location needing GC.
@@ -10120,8 +10120,8 @@ void Interpreter::CallI()
     }
     else
     {
-        args = (ARG_SLOT*)_alloca(nSlots * sizeof(ARG_SLOT));
-        argTypes = (InterpreterType*)_alloca(nSlots * sizeof(InterpreterType));
+        args = (ARG_SLOT*)Alloca(nSlots * sizeof(ARG_SLOT));
+        argTypes = (InterpreterType*)Alloca(nSlots * sizeof(InterpreterType));
     }
     // Make sure that we don't scan any of these until we overwrite them with
     // the real types of the arguments.
@@ -10206,7 +10206,7 @@ void Interpreter::CallI()
 #ifdef ENREGISTERED_RETURNTYPE_MAXSIZE
                 retBuffSize = max(retTypeSz, ENREGISTERED_RETURNTYPE_MAXSIZE);
 #endif // ENREGISTERED_RETURNTYPE_MAXSIZE
-                pLargeStructRetVal = (BYTE*)_alloca(retBuffSize);
+                pLargeStructRetVal = (BYTE*)Alloca(retBuffSize);
 
                 // Clear this in case a GC happens.
                 for (unsigned i = 0; i < retTypeSz; i++)
@@ -10716,7 +10716,7 @@ void Interpreter::VerificationError(const char* msg)
     // TODO: Should raise an exception eventually; for now:
     const char* const msgPrefix = "Verification Error: ";
     size_t len = strlen(msgPrefix) + strlen(msg) + 1;
-    char* msgFinal = (char*)_alloca(len);
+    char* msgFinal = (char*)Alloca(len);
     strcpy_s(msgFinal, len, msgPrefix);
     strcat_s(msgFinal, len, msg);
     _ASSERTE_MSG(false, msgFinal);

--- a/src/vm/invokeutil.cpp
+++ b/src/vm/invokeutil.cpp
@@ -565,7 +565,7 @@ OBJECTREF InvokeUtil::GetBoxedObject(TypeHandle th, void* pData) {
     // Save off the data.  We are going to create and object
     //  which may cause GC to occur.
     int size = pMethTable->GetNumInstanceFieldBytes();
-    void *p = _alloca(size);
+    void *p = Alloca(size);
     memcpy(p, pData, size);
     OBJECTREF retO = pMethTable->Box(p);
     return retO;
@@ -1170,7 +1170,7 @@ void InvokeUtil::SetValidField(CorElementType fldType,
             else if (val == NULL) {
                 // Null is the universal null object.  (Is this a good idea?)
                 int size = pMT->GetNumInstanceFieldBytes();
-                valueData = _alloca(size);
+                valueData = Alloca(size);
                 memset(valueData, 0, size);
             }
             else 

--- a/src/vm/jithelpers.cpp
+++ b/src/vm/jithelpers.cpp
@@ -3413,7 +3413,7 @@ OBJECTREF allocNewMDArr(TypeHandle typeHnd, unsigned dwNumArgs, va_list args)
     }
 #else
     // create an array where fwdArgList[0] == arg[0] ...
-    fwdArgList = (INT32*) _alloca(dwNumArgs * sizeof(INT32));
+    fwdArgList = (INT32*) Alloca(dwNumArgs * sizeof(INT32));
     for (unsigned i = 0; i < dwNumArgs; i++)
     {
         fwdArgList[i] = va_arg(args, INT32);
@@ -6822,7 +6822,7 @@ void F_CALL_VA_CONV JIT_TailCall(PCODE copyArgs, PCODE target, ...)
         //     where our buffer 'starts' is off by 8, so make sure our buffer is
         //     off by 8.
         //
-        pvTempStack = (BYTE*)_alloca(cbTempStack + STACK_ADJUST_FOR_RETURN_ADDRESS) + STACK_ADJUST_FOR_RETURN_ADDRESS;
+        pvTempStack = (BYTE*)Alloca(cbTempStack + STACK_ADJUST_FOR_RETURN_ADDRESS) + STACK_ADJUST_FOR_RETURN_ADDRESS;
     }
 
     _ASSERTE(((size_t)pvTempStack & STACK_ALIGN_MASK) == STACK_ADJUST_FOR_RETURN_ADDRESS);

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -13280,7 +13280,7 @@ BOOL TypeLayoutCheck(MethodTable * pMT, PCCOR_SIGNATURE pBlob)
             size_t cbGCRefMap = (dwActualSize / sizeof(TADDR) + 7) / 8;
             _ASSERTE(cbGCRefMap > 0);
 
-            BYTE * pGCRefMap = (BYTE *)_alloca(cbGCRefMap);
+            BYTE * pGCRefMap = (BYTE *)Alloca(cbGCRefMap);
 
             ComputeGCRefMap(pMT, pGCRefMap, cbGCRefMap);
 

--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -5211,7 +5211,7 @@ LPVOID NDirectMethodDesc::FindEntryPoint(HINSTANCE hMod) const
 
     // Allocate a single character before the start of this string to enable quickly
     // prepending a '_' character if we look for a stdcall entrypoint later on.
-    LPSTR szAnsiEntrypointName = ((LPSTR)_alloca(dstbufsize + 1)) + 1;
+    LPSTR szAnsiEntrypointName = ((LPSTR)Alloca(dstbufsize + 1)) + 1;
 
     // Copy the name so we can mangle it.
     strcpy_s(szAnsiEntrypointName,dstbufsize,GetEntrypointName());

--- a/src/vm/methodtablebuilder.cpp
+++ b/src/vm/methodtablebuilder.cpp
@@ -6867,7 +6867,7 @@ VOID MethodTableBuilder::PlaceInterfaceDeclaration(
         
         // We have to MethodImpl all interface duplicates as all duplicates are 'declared on type' (see 
         // code:#InjectInterfaceDuplicates_ApproxInterfaces)
-        DispatchMapTypeID * rgDispatchMapTypeIDs = (DispatchMapTypeID *)_alloca(sizeof(DispatchMapTypeID) * cInterfaceDuplicates);
+        DispatchMapTypeID * rgDispatchMapTypeIDs = (DispatchMapTypeID *)Alloca(sizeof(DispatchMapTypeID) * cInterfaceDuplicates);
         ComputeDispatchMapTypeIDs(
             pDeclMT, 
             &pDecl->GetMethodSignature().GetSubstitution(), 
@@ -9428,7 +9428,7 @@ MethodTableBuilder::LoadExactInterfaceMap(MethodTable *pMT)
     // (d) If no duplicates then we can use the computed interface map we've created
     // (e) If duplicates found then use the slow metadata-based technique code:#LoadExactInterfaceMap_Algorithm2
     DWORD nInterfacesCount = pMT->GetNumInterfaces();
-    MethodTable **pExactMTs = (MethodTable**) _alloca(sizeof(MethodTable *) * nInterfacesCount);
+    MethodTable **pExactMTs = (MethodTable**) Alloca(sizeof(MethodTable *) * nInterfacesCount);
     DWORD nAssigned = 0;
     BOOL duplicates = false;
     if (pParentMT != NULL)

--- a/src/vm/objectclone.cpp
+++ b/src/vm/objectclone.cpp
@@ -1002,7 +1002,7 @@ OBJECTREF ObjectClone::Clone(OBJECTREF refObj, TypeHandle expectedType, AppDomai
                 DWORD size = sizeof(IObjRefInstanceInfo) + (currObjFixupInfo ? currObjFixupInfo->GetSize() : 0);
                 if (size > dwCurrStackSpaceSize)
                 {
-                    pTempStackSpace = _alloca(size);
+                    pTempStackSpace = Alloca(size);
                     dwCurrStackSpaceSize = size;
                 }
                 IObjRefInstanceInfo *pIORInfo = new (pTempStackSpace) IObjRefInstanceInfo(currID, 0, 0);
@@ -1040,7 +1040,7 @@ OBJECTREF ObjectClone::Clone(OBJECTREF refObj, TypeHandle expectedType, AppDomai
                 DWORD size = sizeof(ValueTypeInfo) + currObjFixupInfo->GetSize();
                 if (size > dwCurrStackSpaceSize)
                 {
-                    pTempStackSpace = _alloca(size);
+                    pTempStackSpace = Alloca(size);
                     dwCurrStackSpaceSize = size;
                 }
                 ValueTypeInfo *valInfo = new (pTempStackSpace) ValueTypeInfo(currID, currObjFixupInfo);
@@ -1496,7 +1496,7 @@ void ObjectClone::AllocateArray()
     TypeHandle __arrayTh = ClassLoader::LoadArrayTypeThrowing(__elemTh, __rank == 1 ? ELEMENT_TYPE_SZARRAY : ELEMENT_TYPE_ARRAY, __rank);
 
     DWORD __numArgs =  __rank*2;
-    INT32* __args = (INT32*) _alloca(sizeof(INT32)*__numArgs);
+    INT32* __args = (INT32*) Alloca(sizeof(INT32)*__numArgs);
 
     if (__arrayTh.AsArray()->GetInternalCorElementType() == ELEMENT_TYPE_ARRAY)
     {
@@ -2743,8 +2743,8 @@ void ObjectClone::ScanArrayMembers()
     DWORD rank                   = pArrayMT->GetRank();
     DWORD dwOffset               = 0;
 
-    DWORD *pIndices = (DWORD*) _alloca(sizeof(DWORD) * rank);
-    VOID *pTemp = _alloca(sizeof(NDimArrayMemberInfo) + rank * sizeof(DWORD));
+    DWORD *pIndices = (DWORD*) Alloca(sizeof(DWORD) * rank);
+    VOID *pTemp = Alloca(sizeof(NDimArrayMemberInfo) + rank * sizeof(DWORD));
     NDimArrayMemberInfo *pArrInfo = new (pTemp) NDimArrayMemberInfo(rank);
     
     bool boxingObjects = (pArrayMT->GetArrayElementType() == ELEMENT_TYPE_VALUETYPE);
@@ -3784,7 +3784,7 @@ void ObjectClone::InvokeVtsCallbacks(OBJECTREF refTarget, RemotingVtsInfo::VtsCa
 
     // Allocate an array to hold the methods to invoke (we do this because the invocation order is the opposite way round from the
     // way we can easily scan for the methods). We can easily optimize this for the single callback case though.
-    MethodDesc **pCallbacks = cMethods == 1 ? &pLastCallback : (MethodDesc**)_alloca(cMethods * sizeof(MethodDesc*));
+    MethodDesc **pCallbacks = cMethods == 1 ? &pLastCallback : (MethodDesc**)Alloca(cMethods * sizeof(MethodDesc*));
 
     if (cMethods > 1)
     {

--- a/src/vm/olevariant.cpp
+++ b/src/vm/olevariant.cpp
@@ -4506,7 +4506,7 @@ BASEARRAYREF OleVariant::CreateArrayRefForSafeArray(SAFEARRAY *pSafeArray, VARTY
         // and element pairs are presented before we call AllocateArrayEx().
         Rank = pSafeArray->cDims;
         cAllocateArrayArgs = Rank * 2;
-        pAllocateArrayArgs = (INT32*)_alloca(sizeof(INT32) * Rank * 2);
+        pAllocateArrayArgs = (INT32*)Alloca(sizeof(INT32) * Rank * 2);
         INT32 * pBoundsPtr = pAllocateArrayArgs;
 
         // Copy the lower bounds and count of elements for the dimensions. These
@@ -4758,10 +4758,10 @@ void OleVariant::TransposeArrayData(BYTE *pDestData, BYTE *pSrcData, SIZE_T dwNu
     CONTRACTL_END;
 
     int iDims;
-    DWORD *aDestElemCount = (DWORD*)_alloca(pSafeArray->cDims * sizeof(DWORD));
-    DWORD *aDestIndex = (DWORD*)_alloca(pSafeArray->cDims * sizeof(DWORD));
-    BYTE **aDestDataPos = (BYTE **)_alloca(pSafeArray->cDims * sizeof(BYTE *));
-    SIZE_T *aDestDelta = (SIZE_T*)_alloca(pSafeArray->cDims * sizeof(SIZE_T));
+    DWORD *aDestElemCount = (DWORD*)Alloca(pSafeArray->cDims * sizeof(DWORD));
+    DWORD *aDestIndex = (DWORD*)Alloca(pSafeArray->cDims * sizeof(DWORD));
+    BYTE **aDestDataPos = (BYTE **)Alloca(pSafeArray->cDims * sizeof(BYTE *));
+    SIZE_T *aDestDelta = (SIZE_T*)Alloca(pSafeArray->cDims * sizeof(SIZE_T));
     CQuickArray<BYTE> TmpArray;
 
     // If there are no components, then there we are done.
@@ -4917,7 +4917,7 @@ BASEARRAYREF OleVariant::ExtractWrappedObjectsFromArray(BASEARRAYREF *pArray)
 
     // Set up the bounds arguments.
     DWORD numArgs =  rank*2;
-        INT32* args = (INT32*) _alloca(sizeof(INT32)*numArgs);
+        INT32* args = (INT32*) Alloca(sizeof(INT32)*numArgs);
     
     if (bIsMDArray)
     {

--- a/src/vm/proftoeeinterfaceimpl.cpp
+++ b/src/vm/proftoeeinterfaceimpl.cpp
@@ -1123,7 +1123,7 @@ BOOL HeapWalkHelper(Object * pBO, void * pvContext)
             if (bOnStack)
             {
                 // It's small enough, so just allocate on the stack
-                arrObjRef = (OBJECTREF *)_alloca(cNumRefs * sizeof(OBJECTREF));
+                arrObjRef = (OBJECTREF *)Alloca(cNumRefs * sizeof(OBJECTREF));
             }
             else
             {
@@ -9716,7 +9716,7 @@ HCIMPL2(EXTERN_C void, ProfileEnter, UINT_PTR clientData, void * platformSpecifi
             }
             
             ulArgInfoSize = sizeof(COR_PRF_FUNCTION_ARGUMENT_INFO) + count * sizeof(COR_PRF_FUNCTION_ARGUMENT_RANGE);
-            pArgumentInfo = (COR_PRF_FUNCTION_ARGUMENT_INFO *)_alloca(ulArgInfoSize);
+            pArgumentInfo = (COR_PRF_FUNCTION_ARGUMENT_INFO *)Alloca(ulArgInfoSize);
         }
 
         HRESULT hr = ProfilingGetFunctionEnter3Info(functionId, (COR_PRF_ELT_INFO)&eltInfo, &frameInfo, &ulArgInfoSize, pArgumentInfo);

--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -543,7 +543,7 @@ FCIMPL6(Object*, RuntimeTypeHandle::CreateInstance, ReflectClassBaseObject* refT
         }
  
         INT32 rank = atd->GetRank();
-        INT32* lengths = (INT32*) _alloca(sizeof(INT32) * rank);
+        INT32* lengths = (INT32*) Alloca(sizeof(INT32) * rank);
         for (INT32 i = 0; i < rank; ++i)
         {
             lengths[i] = 0;
@@ -1076,7 +1076,7 @@ OBJECTREF InvokeArrayConstructor(ArrayTypeDesc* arrayDesc, MethodDesc* pMeth, PT
     if (!ClrSafeInt<int>::multiply(sizeof(INT32), argCnt, allocSize))
         COMPlusThrow(kArgumentException, IDS_EE_SIGTOOCOMPLEX);
         
-    INT32* indexes = (INT32*) _alloca((size_t)allocSize);
+    INT32* indexes = (INT32*) Alloca((size_t)allocSize);
     ZeroMemory(indexes, allocSize);
 
     for (i=0; i<(DWORD)argCnt; i++)
@@ -1446,7 +1446,7 @@ FCIMPL4(Object*, RuntimeMethodHandle::InvokeMethod,
     // and second time to actually make the call.
     INTERIOR_STACK_PROBE_FOR(pThread, 1 + static_cast<UINT>((2 * nAllocaSize) / OS_PAGE_SIZE) + static_cast<UINT>(HOLDER_CODE_NORMAL_STACK_LIMIT));
 
-    LPBYTE pAlloc = (LPBYTE)_alloca(nAllocaSize);
+    LPBYTE pAlloc = (LPBYTE)Alloca(nAllocaSize);
 
     LPBYTE pTransitionBlock = pAlloc + TransitionBlock::GetNegSpaceSize();
 
@@ -1559,10 +1559,10 @@ FCIMPL4(Object*, RuntimeMethodHandle::InvokeMethod,
         if (pMT->IsStructRequiringStackAllocRetBuf())
         {
             SIZE_T sz = pMT->GetNumInstanceFieldBytes();
-            pRetBufStackCopy = _alloca(sz);
+            pRetBufStackCopy = Alloca(sz);
             memset(pRetBufStackCopy, 0, sz);
 
-            pValueClasses = new (_alloca(sizeof(ValueClassInfo))) ValueClassInfo(pRetBufStackCopy, pMT, pValueClasses);
+            pValueClasses = new (Alloca(sizeof(ValueClassInfo))) ValueClassInfo(pRetBufStackCopy, pMT, pValueClasses);
             *((LPVOID*) (pTransitionBlock + argit.GetRetBuffArgOffset())) = pRetBufStackCopy;
         }
         else
@@ -1628,19 +1628,19 @@ FCIMPL4(Object*, RuntimeMethodHandle::InvokeMethod,
 
             PVOID pArgDst = argDest.GetDestinationAddress();
 
-            PVOID pStackCopy = _alloca(structSize);
+            PVOID pStackCopy = Alloca(structSize);
             *(PVOID *)pArgDst = pStackCopy;
             pArgDst = pStackCopy;
 
             if (!nullableType.IsNull())
             {
-                byRefToNullables = new(_alloca(sizeof(ByRefToNullable))) ByRefToNullable(i, pStackCopy, nullableType, byRefToNullables);
+                byRefToNullables = new(Alloca(sizeof(ByRefToNullable))) ByRefToNullable(i, pStackCopy, nullableType, byRefToNullables);
             }
 
             // save the info into ValueClassInfo
             if (pMT->ContainsPointers()) 
             {
-                pValueClasses = new (_alloca(sizeof(ValueClassInfo))) ValueClassInfo(pStackCopy, pMT, pValueClasses);
+                pValueClasses = new (Alloca(sizeof(ValueClassInfo))) ValueClassInfo(pStackCopy, pMT, pValueClasses);
             }
 
             // We need a new ArgDestination that points to the stack copy

--- a/src/vm/runtimehandles.cpp
+++ b/src/vm/runtimehandles.cpp
@@ -2874,7 +2874,7 @@ FCIMPL3(MethodDesc*, RuntimeMethodHandle::GetStubIfNeeded,
             size_t size = ntypars * sizeof(TypeHandle);
             if ((size / sizeof(TypeHandle)) != ntypars) // uint over/underflow
                 COMPlusThrow(kArgumentException);
-            inst = (TypeHandle*) _alloca(size);        
+            inst = (TypeHandle*) Alloca(size);
 
             for (DWORD i = 0; i < ntypars; i++) 
             {

--- a/src/vm/securityattributes.cpp
+++ b/src/vm/securityattributes.cpp
@@ -373,10 +373,10 @@ Assembly* SecurityAttributes::LoadAssemblyFromToken(IMetaDataAssemblyImport *pIm
     _ASSERTE(SUCCEEDED(hr));
 
     // Allocate the necessary buffers.
-    wszName = (LPWSTR)_alloca(cchName * sizeof(WCHAR));
-    sContext.szLocale = (LPWSTR)_alloca(sContext.cbLocale * sizeof(WCHAR));
-    sContext.rProcessor = (DWORD *)_alloca(sContext.ulProcessor * sizeof(DWORD));
-    sContext.rOS = (OSINFO *)_alloca(sContext.ulOS * sizeof(OSINFO));
+    wszName = (LPWSTR)Alloca(cchName * sizeof(WCHAR));
+    sContext.szLocale = (LPWSTR)Alloca(sContext.cbLocale * sizeof(WCHAR));
+    sContext.rProcessor = (DWORD *)Alloca(sContext.ulProcessor * sizeof(DWORD));
+    sContext.rOS = (OSINFO *)Alloca(sContext.ulOS * sizeof(OSINFO));
 
     // Get the assembly name and rest of naming properties.
     hr = pImport->GetAssemblyRefProps(tkAssemblyRef,
@@ -887,7 +887,7 @@ HRESULT SecurityAttributes::SetAttrField(BYTE** ppbBuffer, SIZE_T* pcbBuffer, DW
 
             DWORD allocLen = cbName + 1;
             // Buffer and nul terminate it.
-            szString = (LPSTR)_alloca(allocLen);
+            szString = (LPSTR)Alloca(allocLen);
             memcpy(szString, pbName, cbName);
             szString[cbName] = '\0';
 
@@ -1043,7 +1043,7 @@ HRESULT SecurityAttributes::SetAttrProperty(BYTE** ppbBuffer, SIZE_T* pcbBuffer,
 
             if ((pbName - *ppbBuffer) < 4) {
                 // Buffer and nul terminate it.
-                szString = (LPSTR)_alloca(allocLen);
+                szString = (LPSTR)Alloca(allocLen);
             } else {
                 tmpLargeStringHolder = new BYTE[allocLen];                
                 szString = (LPSTR) ((BYTE*)tmpLargeStringHolder);
@@ -1145,7 +1145,7 @@ void SecurityAttributes::AttrSetBlobToPermissionSets(
     GCPROTECT_BEGIN(throwable);
     {
         // allocate and GC-protect an array of objectrefs to reference the permissions
-        OBJECTREF* attrArray = (OBJECTREF*)_alloca(pset.dwAttrCount * sizeof(OBJECTREF));
+        OBJECTREF* attrArray = (OBJECTREF*)Alloca(pset.dwAttrCount * sizeof(OBJECTREF));
         memset(attrArray, 0, pset.dwAttrCount * sizeof(OBJECTREF));
         GCPROTECT_ARRAY_BEGIN(*attrArray, pset.dwAttrCount);
         {
@@ -1223,7 +1223,7 @@ HRESULT SecurityAttributes::TranslateSecurityAttributesHelper(
                 SetupRestrictSecAttributes();
 
                 // allocate and protect an array of objectrefs to reference the permissions
-                attrArray = (OBJECTREF*)_alloca(pAttrSet->dwAttrCount * sizeof(OBJECTREF));
+                attrArray = (OBJECTREF*)Alloca(pAttrSet->dwAttrCount * sizeof(OBJECTREF));
                 memset(attrArray, 0, pAttrSet->dwAttrCount * sizeof(OBJECTREF));
                 GCPROTECT_ARRAY_BEGIN(*attrArray, pAttrSet->dwAttrCount);
                 {
@@ -1900,7 +1900,7 @@ bool SecurityAttributes::IsUnrestrictedPermissionSetAttribute(CORSEC_ATTRIBUTE* 
     if (allocLen < cbName)
         return false;
 
-    LPSTR szName = (LPSTR)_alloca(allocLen);
+    LPSTR szName = (LPSTR)Alloca(allocLen);
     memcpy(szName, pbName, cbName);
     szName[cbName] = '\0';
 
@@ -1965,7 +1965,7 @@ HRESULT SecurityAttributes::FixUpPermissionSetAttribute(CORSEC_ATTRIBUTE* pPerm)
 
     // Buffer the name of the property and null terminate it.
     DWORD allocLen = cbName + 1;
-    LPSTR szName = (LPSTR)_alloca(allocLen);
+    LPSTR szName = (LPSTR)Alloca(allocLen);
     memcpy(szName, pbName, cbName);
     szName[cbName] = '\0';
 
@@ -2098,7 +2098,7 @@ HRESULT GetFullyQualifiedTypeName(SString* pString, mdAssemblyRef tkAssemblyRef,
             return hr;
 
         // Get the assembly name other naming properties
-        wszAssemblyName = (LPWSTR)_alloca(cchName * sizeof(WCHAR));
+        wszAssemblyName = (LPWSTR)Alloca(cchName * sizeof(WCHAR));
         hr = pImport->GetAssemblyProps(tkAssemblyRef,
                                             (const void **)&pbPublicKeyOrToken,
                                             &cbPublicKeyOrToken,
@@ -2128,7 +2128,7 @@ HRESULT GetFullyQualifiedTypeName(SString* pString, mdAssemblyRef tkAssemblyRef,
             return hr;
 
         // Get the assembly name other naming properties
-        wszAssemblyName = (LPWSTR)_alloca(cchName * sizeof(WCHAR));
+        wszAssemblyName = (LPWSTR)Alloca(cchName * sizeof(WCHAR));
         hr = pImport->GetAssemblyRefProps(tkAssemblyRef,
                                             (const void **)&pbPublicKeyOrToken,
                                             &cbPublicKeyOrToken,

--- a/src/vm/siginfo.cpp
+++ b/src/vm/siginfo.cpp
@@ -1349,7 +1349,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
             {
                 DO_INTERIOR_STACK_PROBE_FOR_NOTHROW_CHECK_THREAD((10+dwAllocaSize/PAGE_SIZE+1), NO_FORBIDGC_LOADER_USE_ThrowSO(););
             }
-            TypeHandle *thisinst = (TypeHandle*) _alloca(dwAllocaSize);
+            TypeHandle *thisinst = (TypeHandle*) Alloca(dwAllocaSize);
 
             // Finally we gather up the type arguments themselves, loading at the level specified for generic arguments
             for (unsigned i = 0; i < ntypars; i++)
@@ -1636,7 +1636,7 @@ TypeHandle SigPointer::GetTypeHandleThrowing(
                     DO_INTERIOR_STACK_PROBE_FOR_NOTHROW_CHECK_THREAD((10+cAllocaSize/PAGE_SIZE+1), NO_FORBIDGC_LOADER_USE_ThrowSO(););
                 }
 
-                TypeHandle *retAndArgTypes = (TypeHandle*) _alloca(cAllocaSize);
+                TypeHandle *retAndArgTypes = (TypeHandle*) Alloca(cAllocaSize);
                 bool fReturnTypeOrParameterNotLoaded = false;
 
                 for (unsigned i = 0; i <= cArgs; i++)

--- a/src/vm/stackbuildersink.cpp
+++ b/src/vm/stackbuildersink.cpp
@@ -294,7 +294,7 @@ void CallDescrWithObjectArray(OBJECTREF& pServer,
     if (!ClrSafeInt<UINT32>::addition(cbAlloc, nStackBytes, cbAlloc))
         COMPlusThrow(kArgumentException);
 
-    pAlloc = (LPBYTE)_alloca(cbAlloc);
+    pAlloc = (LPBYTE)Alloca(cbAlloc);
     pTransitionBlock = pAlloc + TransitionBlock::GetNegSpaceSize();
 
     // cycle through the parameters and see if there are byrefs
@@ -385,7 +385,7 @@ void CallDescrWithObjectArray(OBJECTREF& pServer,
     int    ofs = 0;
 
     // REVIEW: need to use actual arg count if VarArgs are supported
-    ArgInfo* pArgInfoStart = (ArgInfo*) _alloca(nFixedArgs*sizeof(ArgInfo));
+    ArgInfo* pArgInfoStart = (ArgInfo*) Alloca(nFixedArgs*sizeof(ArgInfo));
 
 #ifdef _DEBUG
     // We expect to write useful data over every part of this so need
@@ -434,7 +434,7 @@ void CallDescrWithObjectArray(OBJECTREF& pServer,
                 numByRef ++;
             }
 
-            ByRefInfo *brInfo = (ByRefInfo *) _alloca(offsetof(ByRefInfo,data) + pArgInfo->dataSize);
+            ByRefInfo *brInfo = (ByRefInfo *) Alloca(offsetof(ByRefInfo,data) + pArgInfo->dataSize);
             brInfo->argIndex = arg;
             brInfo->typ = brType;
             brInfo->typeHandle = ty;
@@ -478,9 +478,9 @@ void CallDescrWithObjectArray(OBJECTREF& pServer,
         if (pStructRetTypeMT->IsStructRequiringStackAllocRetBuf())
         {
             SIZE_T sz = pStructRetTypeMT->GetNumInstanceFieldBytes();
-            pRetBufData = pRetBufStackData = _alloca(sz);
+            pRetBufData = pRetBufStackData = Alloca(sz);
             memset(pRetBufData, 0, sz);
-            pValueClasses = new (_alloca(sizeof(ValueClassInfo))) ValueClassInfo(pRetBufStackData, pStructRetTypeMT, pValueClasses);
+            pValueClasses = new (Alloca(sizeof(ValueClassInfo))) ValueClassInfo(pRetBufStackData, pStructRetTypeMT, pValueClasses);
         }
         else
         {
@@ -581,11 +581,11 @@ void CallDescrWithObjectArray(OBJECTREF& pServer,
                     // We do not need to allocate a buffer if the argument is already passed by reference.
                     if (!pArgInfo->byref && ArgIterator::IsArgPassedByRef(dataTypeHandle))
                     {
-                        PVOID pvArg = _alloca(dataSize);
+                        PVOID pvArg = Alloca(dataSize);
                         pMT->UnBoxIntoUnchecked(pvArg, pArguments[i]);
                         *(PVOID*)dataLocation = pvArg;
 
-                        pValueClasses = new (_alloca(sizeof(ValueClassInfo))) ValueClassInfo(pvArg, pMT, pValueClasses);
+                        pValueClasses = new (Alloca(sizeof(ValueClassInfo))) ValueClassInfo(pvArg, pMT, pValueClasses);
                     }
                     else
 #endif

--- a/src/vm/stringliteralmap.cpp
+++ b/src/vm/stringliteralmap.cpp
@@ -448,7 +448,7 @@ static void LogStringLiteral(__in_z const char* action, EEStringData *pStringDat
 
     int length = pStringData->GetCharCount();
     length = min(length, 100);
-    WCHAR *szString = (WCHAR *)_alloca((length + 1) * sizeof(WCHAR));
+    WCHAR *szString = (WCHAR *)Alloca((length + 1) * sizeof(WCHAR));
     memcpyNoGCRefs((void*)szString, (void*)pStringData->GetStringBuffer(), length * sizeof(WCHAR));
     szString[length] = '\0';
     LOG((LF_APPDOMAIN, LL_INFO10000, "String literal \"%S\" %s to Global map, size %d bytes\n", szString, action, pStringData->GetCharCount()));

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -2847,7 +2847,7 @@ DWORD __stdcall Thread::intermediateThreadProc(PVOID arg)
     if (m_offset_counter * offset_multiplier > PAGE_SIZE)
         m_offset_counter = 0;
 
-    (void)_alloca(m_offset_counter * offset_multiplier);
+    (void)Alloca(m_offset_counter * offset_multiplier);
 
     intermediateThreadParam* param = (intermediateThreadParam*)arg;
 
@@ -7661,7 +7661,7 @@ __declspec(noinline) void AllocateSomeStack(){
     const size_t size = 0x400;
 #endif  //_TARGET_X86_
 
-    INT8* mem = (INT8*)_alloca(size);
+    INT8* mem = (INT8*)Alloca(size);
     // Actually touch the memory we just allocated so the compiler can't
     // optimize it away completely.
     // NOTE: this assumes the stack grows down (towards 0).

--- a/src/vm/threadsuspend.cpp
+++ b/src/vm/threadsuspend.cpp
@@ -4275,7 +4275,7 @@ void __stdcall Thread::RedirectedHandledJITCase(RedirectReason reason)
             // Free the context struct if we already have one cached
             if (pThread->GetSavedRedirectContext())
             {
-                CONTEXT* pCtxTemp = (CONTEXT*)_alloca(sizeof(CONTEXT));
+                CONTEXT* pCtxTemp = (CONTEXT*)Alloca(sizeof(CONTEXT));
                 memcpy(pCtxTemp, pCtx, sizeof(CONTEXT));
                 delete pCtx;
                 pCtx = pCtxTemp;
@@ -6736,7 +6736,7 @@ void Thread::SetSafeEvent()
  * WaitSuspendEventsHelper
  *
  * This function is a simple helper function for WaitSuspendEvents.  It is needed
- * because of the EX_TRY macro.  This macro does an alloca(), which allocates space
+ * because of the EX_TRY macro.  This macro does an Alloca(), which allocates space
  * off the stack, not free'ing it.  Thus, doing a EX_TRY in a loop can easily result
  * in a stack overflow error.  By factoring out the EX_TRY into a separate function,
  * we recover that stack space.

--- a/src/vm/util.cpp
+++ b/src/vm/util.cpp
@@ -3913,7 +3913,7 @@ INT32 InternalCasingHelper::InvariantToLowerHelper(__out_bcount_opt(cMaxBytes) L
     __lszInWide = WszMultiByteToWideChar(CP_UTF8, 0, szInSave, -1, 0, 0);
     if (__lszInWide > MAKE_MAX_LENGTH)
          RaiseException(EXCEPTION_INT_OVERFLOW, EXCEPTION_NONCONTINUABLE, 0, 0);
-    szInWide = (LPWSTR) alloca(__lszInWide*sizeof(WCHAR));
+    szInWide = (LPWSTR) Alloca(__lszInWide*sizeof(WCHAR));
     if (szInWide == NULL) {
         if (fAllowThrow) {
             COMPlusThrowOM();
@@ -4066,8 +4066,8 @@ HRESULT GetFileVersion(                     // S_OK or error
     }
 
     // Allocate the buffer for the version info structure
-    // _alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
-    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(_alloca(bufSize));
+    // Alloca() can't return NULL -- raises STATUS_STACK_OVERFLOW.
+    BYTE* pVersionInfoBuffer = reinterpret_cast< BYTE* >(Alloca(bufSize));
 
     ret = GetFileVersionInfoW(wszFilePath, dwHandle, bufSize, pVersionInfoBuffer);
     if (!ret)

--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -2088,7 +2088,7 @@ DWORD __stdcall ThreadpoolMgr::intermediateThreadProc(PVOID arg)
     if (offset_counter * offset_multiplier > PAGE_SIZE)
         offset_counter = 0;
 
-    (void)_alloca(offset_counter * offset_multiplier);
+    (void)Alloca(offset_counter * offset_multiplier);
 
     intermediateThreadParam* param = (intermediateThreadParam*)arg;
 
@@ -4539,7 +4539,7 @@ DWORD __stdcall ThreadpoolMgr::GateThreadStart(LPVOID lpArgs)
                                                   prevCPUInfo.usageBufferSize))
         return 0;
 
-    prevCPUInfo.usageBuffer = (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *)alloca(prevCPUInfo.usageBufferSize);
+    prevCPUInfo.usageBuffer = (SYSTEM_PROCESSOR_PERFORMANCE_INFORMATION *)Alloca(prevCPUInfo.usageBufferSize);
     if (prevCPUInfo.usageBuffer == NULL)
         return 0;
 

--- a/src/vm/zapsig.cpp
+++ b/src/vm/zapsig.cpp
@@ -915,7 +915,7 @@ MethodDesc *ZapSig::DecodeMethod(Module *pReferencingModule,
         if (!ClrSafeInt<SIZE_T>::multiply(nargs, sizeof(TypeHandle), cbMem/* passed by ref */))
             ThrowHR(COR_E_OVERFLOW);
                         
-        TypeHandle * pInst = (TypeHandle*) _alloca(cbMem);
+        TypeHandle * pInst = (TypeHandle*) Alloca(cbMem);
 
         for (DWORD i = 0; i < nargs; i++)
         {

--- a/src/zap/zapcode.cpp
+++ b/src/zap/zapcode.cpp
@@ -1902,7 +1902,7 @@ void ZapHelperThunk::Save(ZapWriter * pZapWriter)
     DWORD pad = GetSize() - sizeof(DWORD);
     if (pad > 0)
     {
-        void * pPad = _alloca(pad);
+        void * pPad = Alloca(pad);
         memset(pPad, DEFAULT_CODE_BUFFER_INIT, pad);
         pZapWriter->Write(pPad, pad);
     }

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -1711,10 +1711,10 @@ IAssemblyName *Zapper::GetAssemblyFusionName(IMetaDataAssemblyImport *pImport)
                                           &md,
                                           NULL));
 
-    szName = (LPWSTR) _alloca(cbName * sizeof(WCHAR));
-    md.szLocale = (LPWSTR) _alloca(md.cbLocale * sizeof(WCHAR));
-    md.rProcessor = (DWORD *) _alloca(md.ulProcessor * sizeof(DWORD));
-    md.rOS = (OSINFO *) _alloca(md.ulOS * sizeof(OSINFO));
+    szName = (LPWSTR) Alloca(cbName * sizeof(WCHAR));
+    md.szLocale = (LPWSTR) Alloca(md.cbLocale * sizeof(WCHAR));
+    md.rProcessor = (DWORD *) Alloca(md.ulProcessor * sizeof(DWORD));
+    md.rOS = (OSINFO *) Alloca(md.ulOS * sizeof(OSINFO));
 
     IfFailThrow(pImport->GetAssemblyProps(a,
                                           &pbPublicKeyToken, &cbPublicKeyToken, NULL,
@@ -1788,10 +1788,10 @@ IAssemblyName *Zapper::GetAssemblyRefFusionName(IMetaDataAssemblyImport *pImport
                                              NULL, NULL,
                                              NULL));
 
-    szName = (LPWSTR) _alloca(cbName * sizeof(WCHAR));
-    md.szLocale = (LPWSTR) _alloca(md.cbLocale * sizeof(WCHAR));
-    md.rProcessor = (DWORD *) _alloca(md.ulProcessor * sizeof(DWORD));
-    md.rOS = (OSINFO *) _alloca(md.ulOS * sizeof(OSINFO));
+    szName = (LPWSTR) Alloca(cbName * sizeof(WCHAR));
+    md.szLocale = (LPWSTR) Alloca(md.cbLocale * sizeof(WCHAR));
+    md.rProcessor = (DWORD *) Alloca(md.ulProcessor * sizeof(DWORD));
+    md.rOS = (OSINFO *) Alloca(md.ulOS * sizeof(OSINFO));
 
     IfFailThrow(pImport->GetAssemblyRefProps(ar,
                                              &pbPublicKeyOrToken, &cbPublicKeyOrToken,


### PR DESCRIPTION
Go for forceful solution of the enforcement of using compiler version of
the `alloca`(3) function.

This solves a long list of issues like this:

```
../../../../../src/libcoreclrpal.a(path.cpp.o): In function `GetFullPathNameW':
/tmp/pkgsrc-tmp/wip/coreclr-git/work/coreclr/src/pal/src/file/path.cpp:227:
warning: Warning: reference to the libc supplied alloca(3); this most likely
will not work. Please use the compiler provided version of alloca(3), by
supplying the appropriate compiler flags (e.g. not -std=c89).
```

*This patch reduces the number of failing PAL tests by 29. * `alloca`(3) from libc
was damaging stack and there isn't doable implementation without compiler
assistance.

Solution:
- Rename most calls of `alloca` (`GCC`) and `_alloca` (`MSVC`) to `Alloca`.
- Declare `Alloca` as `__builtin_alloca` (`GCC`) or `_alloca` (`MSVC`)

Several attempts as `#undef alloca` `#define alloca __buildin_alloca` don't
work with NetBSD's version the Standard C Library

Most Unix compilers define GCC-compatiblity (`__GNUC__`), like:
- `Clang`/`LLVM`,
- `ICC`,
- `PCC`.

Known exception is `TinyCC`, which has other builtin for `alloca`(3), but it's reduced
to the C programming language.