### PR TITLE
Enforce compiler version of alloca(3) on NetBSD

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.h
+++ b/src/ToolBox/SOS/Strike/strike.h
@@ -76,6 +76,16 @@
 #ifndef PAL_STDCPP_COMPAT
 #include <malloc.h>
 #endif
+
+#ifdef FEATURE_PAL
+#ifndef alloca
+#define alloca  __builtin_alloca
+#endif
+#ifndef _alloca
+#define _alloca __builtin_alloca
+#endif
+#endif // FEATURE_PAL
+
 #include <stddef.h>
 
 #ifndef FEATURE_PAL
@@ -128,4 +138,3 @@ HRESULT SetNGENCompilerFlags(DWORD flags);
 
 
 #endif // __strike_h__
-

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6340,11 +6340,6 @@ PALIMPORT char * __cdecl _strdup(const char *);
 #endif //_MSC_VER
 
 #if defined(__GNUC__) && defined(PLATFORM_UNIX)
-// we set -fno-builtin on the command line. This requires that if
-// we use alloca, with either have to call __builtin_alloca, or
-// ensure that the alloca call doesn't happen in code which is
-// modifying the stack (such as "memset (alloca(x), y, z)"
-
 #define alloca  __builtin_alloca
 #endif // __GNUC__
 

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -68,7 +68,6 @@ endif()
 # turn off capability to remove unused functions (which was enabled in debug build with sanitizers)
 set(CMAKE_SHARED_LINKER_FLAGS_DEBUG "${CMAKE_SHARED_LINKER_FLAGS_DEBUG} -Wl,--no-gc-sections")
 
-add_compile_options(-fno-builtin)
 add_compile_options(-fPIC)
 
 if(PAL_CMAKE_PLATFORM_ARCH_AMD64)

--- a/src/pal/src/include/pal/palinternal.h
+++ b/src/pal/src/include/pal/palinternal.h
@@ -337,15 +337,15 @@ function_name() to call the system's implementation
 #undef _BitScanForward64
 #endif 
 
-/* pal.h does "#define alloca _alloca", but we need access to the "real"
-   alloca */
-#undef alloca
+/* pal.h defines alloca(3) as a compiler builtin.
+   Redefining it to native libc will result in undefined breakage because
+   a compiler is allowed to make assumptions about the stack and frame
+   pointers. */
 
 /* Undef all functions and types previously defined so those functions and
    types could be mapped to the C runtime and socket implementation of the 
    native OS */
 #undef exit
-#undef alloca
 #undef atexit
 #undef div
 #undef div_t


### PR DESCRIPTION
The documentation of `alloca`(3) says:

```
     o   The alloca() function should be supplied by the compiler because the
         compiler is allowed to make assumptions about the stack and frame
         pointers.  The libc alloca() implementation cannot account for those
         assumptions.  While there is a machine dependent implementation of
         alloca() in libc, its use is discouraged and in most cases it will
         not work.  Using this implementation will produce linker warnings.
```

This is true for CoreCLR - `alloca`(3) was breaking 30 PAL tests.

Enforce on this operating system a compiler version.

Thanks Jan Kotas (Microsoft) for inspiration what may go wrong.