### PR TITLE
Add libraries for tests that reference them.

### DIFF
--- a/tests/src/JIT/Methodical/Boxing/xlang/sinlib.il
+++ b/tests/src/JIT/Methodical/Boxing/xlang/sinlib.il
@@ -1,0 +1,161 @@
+.module 'sinlib_il.dll'
+.assembly extern legacy library mscorlib { auto }
+.assembly 'sinlib_il' {}
+.namespace SinCalcLib
+{
+  .class value public auto ansi sealed PiVal extends [mscorlib]System.ValueType
+  {
+    .field public float64 Value
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(float64 v) il managed
+    {
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  initobj    SinCalcLib.PiVal
+      IL_0007:  ldarg.0
+      IL_0008:  ldarg.1
+      IL_0009:  stfld      float64 SinCalcLib.PiVal::Value
+      IL_000e:  ret
+    } 
+
+  } 
+
+  .class public auto ansi SinCalcLib extends [mscorlib]System.Object
+  {
+    .field public static class System.Object PI
+    .method public hidebysig static class System.Object 
+            mySin(class System.Object Angle) il managed
+    {
+      .maxstack  3
+      .locals (class System.Object V_0,
+               class System.Object V_1,
+               class System.Object V_2,
+               class System.Object V_3,
+               class System.Object V_4,
+               float64 V_5,
+               int32 V_6)
+      IL_0000:  ldc.r8     1.
+      IL_0009:  stloc.s    V_5
+      IL_000b:  ldloc.s   V_5
+      IL_000d:  box  [mscorlib]System.Double
+      IL_0012:  stloc.3
+      IL_0013:  ldarg.0
+      IL_0014:  dup
+      IL_0015:  stloc.2
+      IL_0016:  stloc.0
+      IL_0017:  ldc.r8     0.
+      IL_0020:  stloc.s    V_5
+      IL_0022:  ldloc.s   V_5
+      IL_0024:  box  [mscorlib]System.Double
+      IL_0029:  stloc.1
+      IL_002a:  ldc.i4.1
+      IL_002b:  stloc.s    V_6
+      IL_002d:  ldloc.s   V_6
+      IL_002f:  box  [mscorlib]System.Int32
+      IL_0034:  stloc.s    V_4
+      IL_0036:  br         IL_00cd
+
+      IL_003b:  ldloc.1
+      IL_003c:  unbox      [mscorlib]System.Double
+      IL_0041:  ldind.r8
+      IL_0042:  ldloc.2
+      IL_0043:  unbox      [mscorlib]System.Double
+      IL_0048:  ldind.r8
+      IL_0049:  add
+      IL_004a:  stloc.s    V_5
+      IL_004c:  ldloc.s   V_5
+      IL_004e:  box  [mscorlib]System.Double
+      IL_0053:  stloc.1
+      IL_0054:  ldloc.0
+      IL_0055:  unbox      [mscorlib]System.Double
+      IL_005a:  ldind.r8
+      IL_005b:  ldarg.0
+      IL_005c:  unbox      [mscorlib]System.Double
+      IL_0061:  ldind.r8
+      IL_0062:  neg
+      IL_0063:  ldarg.0
+      IL_0064:  unbox      [mscorlib]System.Double
+      IL_0069:  ldind.r8
+      IL_006a:  mul
+      IL_006b:  mul
+      IL_006c:  stloc.s    V_5
+      IL_006e:  ldloc.s   V_5
+      IL_0070:  box  [mscorlib]System.Double
+      IL_0075:  stloc.0
+      IL_0076:  ldloc.3
+      IL_0077:  unbox      [mscorlib]System.Double
+      IL_007c:  ldind.r8
+      IL_007d:  ldloc.s    V_4
+      IL_007f:  unbox      [mscorlib]System.Int32
+      IL_0084:  ldind.i4
+      IL_0085:  ldc.i4.1
+      IL_0086:  add
+      IL_0087:  conv.r8
+      IL_0088:  mul
+      IL_0089:  ldloc.s    V_4
+      IL_008b:  unbox      [mscorlib]System.Int32
+      IL_0090:  ldind.i4
+      IL_0091:  ldc.i4.2
+      IL_0092:  add
+      IL_0093:  conv.r8
+      IL_0094:  mul
+      IL_0095:  stloc.s    V_5
+      IL_0097:  ldloc.s   V_5
+      IL_0099:  box  [mscorlib]System.Double
+      IL_009e:  stloc.3
+      IL_009f:  ldloc.0
+      IL_00a0:  unbox      [mscorlib]System.Double
+      IL_00a5:  ldind.r8
+      IL_00a6:  ldloc.3
+      IL_00a7:  unbox      [mscorlib]System.Double
+      IL_00ac:  ldind.r8
+      IL_00ad:  div
+      IL_00ae:  stloc.s    V_5
+      IL_00b0:  ldloc.s   V_5
+      IL_00b2:  box  [mscorlib]System.Double
+      IL_00b7:  stloc.2
+      IL_00b8:  ldloc.s    V_4
+      IL_00ba:  unbox      [mscorlib]System.Int32
+      IL_00bf:  ldind.i4
+      IL_00c0:  ldc.i4.2
+      IL_00c1:  add
+      IL_00c2:  stloc.s    V_6
+      IL_00c4:  ldloc.s   V_6
+      IL_00c6:  box  [mscorlib]System.Int32
+      IL_00cb:  stloc.s    V_4
+      IL_00cd:  ldloc.s    V_4
+      IL_00cf:  unbox      [mscorlib]System.Int32
+      IL_00d4:  ldind.i4
+      IL_00d5:  ldc.i4     0xc8
+      IL_00da:  ble        IL_003b
+
+      IL_00df:  ldloc.1
+      IL_00e0:  ret
+    } 
+
+    .method public hidebysig specialname rtspecialname static 
+            void .cctor() il managed
+    {
+      .maxstack  2
+      .locals (value class SinCalcLib.PiVal V_0)
+      IL_0000:  ldc.r8     3.1415926535897931
+      IL_0009:  newobj     instance void SinCalcLib.PiVal::.ctor(float64)
+      IL_000e:  stloc.0
+      IL_000f:  ldloc.s   V_0
+      IL_0011:  box  SinCalcLib.PiVal
+      IL_0016:  stsfld     class System.Object SinCalcLib.SinCalcLib::PI
+      IL_001b:  ret
+    } 
+
+    .method public hidebysig specialname rtspecialname 
+            instance void .ctor() il managed
+    {
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } 
+
+  } 
+
+} 

--- a/tests/src/JIT/Methodical/Boxing/xlang/sinlib.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/xlang/sinlib.ilproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="sinlib.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Methodical/Boxing/xlang/sinlib.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/xlang/sinlib.ilproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/Methodical/acceptance/ca/app.config
+++ b/tests/src/JIT/Methodical/acceptance/ca/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Methodical/acceptance/ca/csattr.cs
+++ b/tests/src/JIT/Methodical/acceptance/ca/csattr.cs
@@ -1,0 +1,72 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+public enum SomeStuff { e1 = 1, e17 = 17 }
+
+[System.AttributeUsageAttribute(System.AttributeTargets.Class | System.AttributeTargets.Struct, AllowMultiple = true)]
+public class Attr : System.Attribute
+{
+    public Attr() { name = "default"; num = 0; }
+
+    public Attr(int[] up0)
+    {
+        name = "intgcarray";
+        unnamed_list = up0[0].ToString();
+    }
+    public Attr(System.Type[] up0)
+    {
+        name = "typegcarray";
+        unnamed_list = up0[0].ToString();
+    }
+    public Attr(int up0)
+    {
+        name = "int";
+        unnamed_list = up0.ToString();
+    }
+    public Attr(int up0, float up1)
+    {
+        name = "int_float";
+        unnamed_list = up0.ToString() + "\t|" + String.Format("{0:N2}", up1);
+    }
+    public Attr(SomeStuff up0)
+    {
+        name = "enum";
+        unnamed_list = up0.ToString();
+    }
+    public Attr(String up0)
+    {
+        name = "String";
+        unnamed_list = up0;
+    }
+    public Attr(int[] up0, System.Type[] up1, int up2, float up3, SomeStuff up4, String up5)
+    {
+        name = "multiple1";
+        unnamed_list = up0[0].ToString() + "\t|" +
+                up1[0].ToString() + "\t|" +
+                up2.ToString() + "\t|" +
+                String.Format("{0:N2}", up3) + "\t|" +
+                up4.ToString() + "\t|" +
+                up5;
+    }
+    public Attr(int[] up0, ulong up1, int up2, double up3, SomeStuff up4, String up5)
+    {
+        name = "multiple2";
+        unnamed_list = up0[0].ToString() + "\t|" +
+                up1.ToString() + "\t|" +
+                up2.ToString() + "\t|" +
+                String.Format("{0:N2}", up3) + "\t|" +
+                up4.ToString() + "\t|" +
+                up5;
+    }
+
+    public int[] np0;
+    public String[] np1;
+    public System.Type np2;
+    public double np3;
+    public String name;
+    public int num;
+    public String unnamed_list;
+}

--- a/tests/src/JIT/Methodical/acceptance/ca/csattr.csproj
+++ b/tests/src/JIT/Methodical/acceptance/ca/csattr.csproj
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="csattr.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Methodical/acceptance/ca/csattr.csproj
+++ b/tests/src/JIT/Methodical/acceptance/ca/csattr.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/Methodical/cctor/misc/testlib.cs
+++ b/tests/src/JIT/Methodical/cctor/misc/testlib.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Threading;
+using System.Reflection;
+
+namespace Precise
+{
+    public class measure
+    {
+        public static int a = 0xCC;
+    }
+    public class test
+    {
+        public static byte b = 0xC;
+        public static void f()
+        {
+        }
+        public static void f(ref byte b)
+        {
+            return;
+        }
+
+        static test()
+        {
+            if (measure.a != 0xCC)
+            {
+                Console.WriteLine("in .cctor(), measure.a is {0}", measure.a);
+                Console.WriteLine("FAILED");
+                throw new Exception();
+            }
+            Console.WriteLine("in .cctor(), measure.a is {0}", measure.a);
+            Console.WriteLine("Current thread is {0}", Thread.CurrentThread.Name);
+            // Following two lines commented because not available in .Net Core
+            // Console.WriteLine("Calling assembly is {0}", Assembly.GetCallingAssembly().FullName);
+            // Console.WriteLine("This assembly is {0}", Assembly.GetExecutingAssembly().FullName);
+            measure.a += 8;
+            if (measure.a != 212)
+            {
+                Console.WriteLine("in .cctor() after measure.a+=8, measure.a is {0}", measure.a);
+                Console.WriteLine("FAILED");
+                throw new Exception();
+            }
+            Console.WriteLine("in .cctor() after measure.a+=8, measure.a is {0}", measure.a);
+        }
+    }
+}
+

--- a/tests/src/JIT/Methodical/cctor/misc/testlib.csproj
+++ b/tests/src/JIT/Methodical/cctor/misc/testlib.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="testlib.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)threading+thread\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)threading+thread\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)threading+thread\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Methodical/cctor/misc/testlib.csproj
+++ b/tests/src/JIT/Methodical/cctor/misc/testlib.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/helper.il
+++ b/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/helper.il
@@ -1,0 +1,121 @@
+
+.assembly extern mscorlib
+{
+  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
+  .ver 4:0:0:0
+}
+.assembly helper
+{
+  .custom instance void [mscorlib]System.Runtime.CompilerServices.CompilationRelaxationsAttribute::.ctor(int32) = ( 01 00 08 00 00 00 00 00 ) 
+}
+
+.class public abstract auto ansi sealed beforefieldinit Helper
+       extends [mscorlib]System.Object
+{
+  .class auto ansi nested private beforefieldinit ExceptionHelper`1<T>
+         extends [mscorlib]System.Exception
+  {
+    .field public !T payload
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor() cil managed
+    {
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
+      IL_0006:  ret
+    } 
+
+    .method public hidebysig specialname rtspecialname 
+            instance void  .ctor(!T t) cil managed
+    {
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Exception::.ctor()
+      IL_0006:  ldarg.0
+      IL_0007:  ldarg.1
+      IL_0008:  stfld      !0 class Helper/ExceptionHelper`1<!T>::payload
+      IL_000d:  ret
+    } 
+
+  } 
+
+  .method private hidebysig static void OverwriteRDX<SrcType>(!!SrcType src) cil managed noinlining
+  {
+    ret
+  }
+
+  .method public hidebysig static !!DestType 
+          RetypeObject<DestType,SrcType>(!!SrcType src) cil managed noinlining
+  {
+    .maxstack  2
+    .locals init (!!DestType retVal)
+    .try
+    {
+      newobj     instance void class Helper/ExceptionHelper`1<!!DestType>::.ctor()
+      throw
+    }
+    catch class Helper/ExceptionHelper`1<!!DestType> 
+    {
+      ldarg.0
+      newobj     instance void class Helper/ExceptionHelper`1<!!SrcType>::.ctor(!0)
+      call       void Helper::OverwriteRDX<class Helper/ExceptionHelper`1<!!SrcType>>(!!0)
+      ldfld      !0 class Helper/ExceptionHelper`1<!!DestType>::payload
+      stloc.0
+      leave      END_CATCH
+
+    }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+    .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH } .try { leave END_CATCH } catch class [mscorlib]System.Exception { leave END_CATCH }
+  END_CATCH:
+    ldloc.0
+    ret
+  } 
+
+} 
+

--- a/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/helper.ilproj
+++ b/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/helper.ilproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="helper.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/helper.ilproj
+++ b/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/helper.ilproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/app.config
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.cs
@@ -1,0 +1,585 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Diagnostics;
+
+public class Utils
+{
+    public static int failures = 0;
+
+    public static void Fail(string outputString)
+    {
+        failures++;
+        // Console.WriteLine(outputString + new StackTrace(true).ToString());
+        Console.WriteLine(outputString);
+    }
+
+    public static void CheckType<U>(U parameterToCheck, Type typeToCheckAgainst)
+    {
+        if (!typeToCheckAgainst.Equals(typeof(U)))
+        {
+            Fail("Expected typeof generic method Type Parameter for parameter, '" + parameterToCheck + "', to be '" + typeToCheckAgainst + "', but found '" + typeof(U) + "'");
+        }
+
+        if (!typeToCheckAgainst.Equals(parameterToCheck.GetType()))
+        {
+            Fail("Expected Type.GetType parameter, '" + parameterToCheck + "', to be '" + typeToCheckAgainst + "', but found '" + parameterToCheck.GetType() + "'");
+        }
+    }
+
+    public static bool CompareArray<U>(U[] arrayOne, U[] arrayTwo)
+    {
+        for (int i = arrayOne.GetUpperBound(0); i >= 0; i--)
+        {
+            if (arrayOne[i].Equals(arrayTwo[i]))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static string BuildArrayString<U>(U[] arrayToPrint)
+    {
+        string stringToReturn = typeof(U) + " {";
+        int i;
+
+        for (i = 0; i <= arrayToPrint.GetUpperBound(0); i++)
+        {
+            stringToReturn = stringToReturn + arrayToPrint[i] + ", ";
+        }
+
+        stringToReturn.Remove(stringToReturn.Length - 2, 2);
+        stringToReturn = stringToReturn + "}";
+        return stringToReturn;
+    }
+}
+
+public class GenericClass<T>
+{
+    public static Type classParameterType;
+    public bool usingBaseVirtualProperty;
+
+    public static U StaticGenericMethod<U>(U methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public static int StaticNonGenericMethodInt(int methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public static string StaticNonGenericMethodString(string methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public static int[] StaticNonGenericMethodIntArray(int[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public static string[] StaticNonGenericMethodStringArray(string[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public static U StaticGenericMethodUsesClassTypeParam<U>(T classParameter, U methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public static int StaticNonGenericMethodIntUsesClassTypeParam(T classParameter, int methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public static string StaticNonGenericMethodStringUsesClassTypeParam(T classParameter, string methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public static int[] StaticNonGenericMethodIntArrayUsesClassTypeParam(T classParameter, int[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public static string[] StaticNonGenericMethodStringArrayUsesClassTypeParam(T classParameter, string[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public U GenericMethod<U>(U methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public int NonGenericMethodInt(int methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public string NonGenericMethodString(string methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public int[] NonGenericMethodIntArray(int[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public string[] NonGenericMethodStringArray(string[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        return methodParameter;
+    }
+
+    public U GenericMethodUsesClassTypeParam<U>(T classParameter, U methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public int NonGenericMethodIntUsesClassTypeParam(T classParameter, int methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public string NonGenericMethodStringUsesClassTypeParam(T classParameter, string methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public int[] NonGenericMethodIntArrayUsesClassTypeParam(T classParameter, int[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public string[] NonGenericMethodStringArrayUsesClassTypeParam(T classParameter, string[] methodParameter, Type methodParameterType)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public virtual U VirtualGenericMethod<U>(U methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        return methodParameter;
+    }
+
+    public virtual int VirtualNonGenericMethodInt(int methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        return methodParameter;
+    }
+
+    public virtual string VirtualNonGenericMethodString(string methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        return methodParameter;
+    }
+
+    public virtual int[] VirtualNonGenericMethodIntArray(int[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        return methodParameter;
+    }
+
+    public virtual string[] VirtualNonGenericMethodStringArray(string[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        return methodParameter;
+    }
+
+    public virtual U VirtualGenericMethodUsesClassTypeParam<U>(T classParameter, U methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public virtual int VirtualNonGenericMethodIntUsesClassTypeParam(T classParameter, int methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public virtual string VirtualNonGenericMethodStringUsesClassTypeParam(T classParameter, string methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public virtual int[] VirtualNonGenericMethodIntArrayUsesClassTypeParam(T classParameter, int[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public virtual string[] VirtualNonGenericMethodStringArrayUsesClassTypeParam(T classParameter, string[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        if (isBase == false) { Utils.Fail("Expected to be true, but found it to be false."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public T genericField;
+    public int nongenericIntField;
+    public string nongenericStringField;
+    public int[] nongenericIntArrayField;
+    public string[] nongenericStringArrayField;
+
+    public T genericProperty
+    {
+        get
+        {
+            Utils.CheckType<T>(genericField, classParameterType);
+            return genericField;
+        }
+
+        set
+        {
+            Utils.CheckType<T>(value, classParameterType);
+            genericField = value;
+        }
+    }
+
+    public int nongenericIntProperty
+    {
+        get
+        {
+            return nongenericIntField;
+        }
+
+        set
+        {
+            nongenericIntField = value;
+        }
+    }
+
+    public string nongenericStringProperty
+    {
+        get
+        {
+            return nongenericStringField;
+        }
+
+        set
+        {
+            nongenericStringField = value;
+        }
+    }
+
+    public int[] nongenericIntArrayProperty
+    {
+        get
+        {
+            return nongenericIntArrayField;
+        }
+
+        set
+        {
+            nongenericIntArrayField = value;
+        }
+    }
+
+    public string[] nongenericStringArrayProperty
+    {
+        get
+        {
+            return nongenericStringArrayField;
+        }
+
+        set
+        {
+            nongenericStringArrayField = value;
+        }
+    }
+
+    public virtual T genericVirtualProperty
+    {
+        get
+        {
+            Utils.CheckType<T>(genericField, classParameterType);
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            return genericField;
+        }
+
+        set
+        {
+            Utils.CheckType<T>(value, classParameterType);
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            genericField = value;
+        }
+    }
+
+    public virtual int nongenericIntVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            return nongenericIntField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            nongenericIntField = value;
+        }
+    }
+
+    public virtual string nongenericStringVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            return nongenericStringField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            nongenericStringField = value;
+        }
+    }
+
+    public virtual int[] nongenericIntArrayVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            return nongenericIntArrayField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            nongenericIntArrayField = value;
+        }
+    }
+
+    public virtual string[] nongenericStringArrayVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            return nongenericStringArrayField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == false) { Utils.Fail("Expected usingBaseVirtualProperty to be true, but found it to be false."); }
+            nongenericStringArrayField = value;
+        }
+    }
+
+    public delegate U genericDelegate<U>(U delegateParameter, Type typeOfDelegateParameter);
+    public delegate int nongenericDelegateInt(int delegateParameter, Type typeOfDelegateParameter);
+    public delegate string nongenericDelegateString(string delegateParameter, Type typeOfDelegateParameter);
+    public delegate int[] nongenericDelegateIntArray(int[] delegateParameter, Type typeOfDelegateParameter);
+    public delegate string[] nongenericDelegateStringArray(string[] delegateParameter, Type typeOfDelegateParameter);
+    public delegate U genericDelegateUsesClassTypeParam<U>(T classParameter, U delegateParameter, Type typeOfDelegateParameter);
+    public delegate int nongenericDelegateIntUsesClassTypeParam(T classParameter, int delegateParameter, Type typeOfDelegateParameter);
+    public delegate string nongenericDelegateStringUsesClassTypeParam(T classParameter, string delegateParameter, Type typeOfDelegateParameter);
+    public delegate int[] nongenericDelegateIntArrayUsesClassTypeParam(T classParameter, int[] delegateParameter, Type typeOfDelegateParameter);
+    public delegate string[] nongenericDelegateStringArrayUsesClassTypeParam(T classParameter, string[] delegateParameter, Type typeOfDelegateParameter);
+}
+
+public class GenericClassInheritsFromGenericClass<T> : GenericClass<T>
+{
+    public override U VirtualGenericMethod<U>(U methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        return methodParameter;
+    }
+
+    public override int VirtualNonGenericMethodInt(int methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        return methodParameter;
+    }
+
+    public override string VirtualNonGenericMethodString(string methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        return methodParameter;
+    }
+
+    public override int[] VirtualNonGenericMethodIntArray(int[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        return methodParameter;
+    }
+
+    public override string[] VirtualNonGenericMethodStringArray(string[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        return methodParameter;
+    }
+
+    public override U VirtualGenericMethodUsesClassTypeParam<U>(T classParameter, U methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<U>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public override int VirtualNonGenericMethodIntUsesClassTypeParam(T classParameter, int methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public override string VirtualNonGenericMethodStringUsesClassTypeParam(T classParameter, string methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public override int[] VirtualNonGenericMethodIntArrayUsesClassTypeParam(T classParameter, int[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<int[]>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public override string[] VirtualNonGenericMethodStringArrayUsesClassTypeParam(T classParameter, string[] methodParameter, Type methodParameterType, bool isBase)
+    {
+        Utils.CheckType<string[]>(methodParameter, methodParameterType);
+        if (isBase == true) { Utils.Fail("Expected to be false, but found it to be true."); }
+        Utils.CheckType<T>(classParameter, classParameterType);
+        return methodParameter;
+    }
+
+    public override T genericVirtualProperty
+    {
+        get
+        {
+            Utils.CheckType<T>(genericField, classParameterType);
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            return genericField;
+        }
+
+        set
+        {
+            Utils.CheckType<T>(value, classParameterType);
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            genericField = value;
+        }
+    }
+
+    public override int nongenericIntVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            return nongenericIntField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            nongenericIntField = value;
+        }
+    }
+
+    public override string nongenericStringVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            return nongenericStringField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            nongenericStringField = value;
+        }
+    }
+
+    public override int[] nongenericIntArrayVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            return nongenericIntArrayField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            nongenericIntArrayField = value;
+        }
+    }
+
+    public override string[] nongenericStringArrayVirtualProperty
+    {
+        get
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            return nongenericStringArrayField;
+        }
+
+        set
+        {
+            if (usingBaseVirtualProperty == true) { Utils.Fail("Expected usingBaseVirtualProperty to be false, but found it to be true."); }
+            nongenericStringArrayField = value;
+        }
+    }
+}

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="csharpgenerictypes.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b210352/csharpgenerictypes.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_132534/app.config
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_132534/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.il
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.il
@@ -1,0 +1,296 @@
+
+.assembly extern mscorlib
+{
+    .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
+    .ver 4:0:0:0
+}
+
+.assembly extern CSharpPart {}
+
+.assembly ILPart {}
+
+.module ILPart.dll
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       
+.corflags 0x00000001    
+
+
+
+.class
+    public abstract auto ansi sealed beforefieldinit
+    Test.ILJmpWrappers
+        extends [mscorlib]System.Object
+{
+    .method public static void Pass6Args_Maxstack_2
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 2
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_2(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_3
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 3
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_3(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_4
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 4
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_4(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_5
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 5
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_5(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_6
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 6
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_6(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_7
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 7
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_7(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_8
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 8
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_8(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_9
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 9
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_9(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+    .method public static void Pass6Args_Maxstack_10
+        (
+            int32 A_0,
+            int64 A_1,
+            float32 A_2,
+            float64 A_3,
+            valuetype [CSharpPart]Test.BasicStruct A_4,
+            string A_5
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 10
+
+        ldarg       A_0
+        starg       A_0
+
+        jmp
+            void
+            [CSharpPart]Test.CalleeSide::Pass6Args_Maxstack_10(
+                int32,
+                int64,
+                float32,
+                float64,
+                valuetype [CSharpPart]Test.BasicStruct,
+                string
+            )
+
+        ret
+    }
+}

--- a/tests/src/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.ilproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.ilproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="jmpwrappers.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.ilproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_132534/jmpwrappers.ilproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_145295/app.config
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_145295/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_145295/ilpart.il
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_145295/ilpart.il
@@ -1,0 +1,214 @@
+
+.module extern CSharpPart.netmodule
+
+
+.assembly extern mscorlib
+{
+    .publickeytoken = (B7 7A 5C 56 19 34 E0 89)
+    .ver 4:0:0:0
+}
+
+
+.assembly extern CSharpPart {}
+
+
+.assembly ILPart {}
+
+
+.module ILPart.dll
+.imagebase 0x00400000
+.file alignment 0x00000200
+.stackreserve 0x00100000
+.subsystem 0x0003       
+.corflags 0x00000001    
+
+
+
+.class
+    public abstract auto ansi sealed beforefieldinit
+    Test.ILPart
+        extends [mscorlib]System.Object
+{
+
+    .method
+        public hidebysig
+        static int32 CallThroughFrameWithMultipleEndfinallyOps_TopLevel
+        (
+            int32 calloutIndex
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 8
+
+        .locals init (int32 computedValue)
+
+
+        ldc.i4      100
+        stloc       computedValue
+
+
+        .try
+        {
+
+            leave       END_OF_METHOD_BODY
+
+        }
+        finally
+        {
+
+            ldarg       calloutIndex
+
+            switch      (RUN_CALLOUT_0,
+                         RUN_CALLOUT_1,
+                         RUN_CALLOUT_2,
+                         RUN_CALLOUT_3,
+                         RUN_CALLOUT_4,
+                         RUN_CALLOUT_5,
+                         RUN_CALLOUT_6)
+
+
+        RUN_CALLOUT_0:
+            ldc.i4      0
+            stloc       computedValue
+            endfinally
+
+        RUN_CALLOUT_1:
+            ldc.i4      1
+            stloc       computedValue
+            endfinally
+
+        RUN_CALLOUT_2:
+            ldc.i4      2
+            stloc       computedValue
+            endfinally
+
+        RUN_CALLOUT_3:
+            call        void [CSharpPart]Test.Helpers::Callout3()
+            endfinally
+
+        RUN_CALLOUT_4:
+            ldc.i4      4
+            stloc       computedValue
+            call        void [CSharpPart]Test.Helpers::Callout4()
+            endfinally
+
+        RUN_CALLOUT_5:
+            call        void [CSharpPart]Test.Helpers::Callout5()
+            endfinally
+
+        RUN_CALLOUT_6:
+            call        void [CSharpPart]Test.Helpers::Callout6()
+            endfinally
+
+        }
+
+
+    END_OF_METHOD_BODY:
+
+        ldloc       computedValue
+        ret
+    }
+
+
+
+    .method
+        public hidebysig
+        static int32 CallThroughFrameWithMultipleEndfinallyOps_Nested
+        (
+            int32 calloutIndex
+        )
+        cil managed noinlining
+    {
+
+        .maxstack 8
+
+        .locals init (int32 computedValue)
+
+
+        ldc.i4      100
+        stloc       computedValue
+
+
+        .try
+        {
+
+            call        void [CSharpPart]Test.Helpers::Throw()
+            leave       END_OF_METHOD_BODY
+
+        }
+        catch [mscorlib]System.Exception
+        {
+
+            pop
+
+
+            .try
+            {
+
+                leave       END_OF_CATCH_BLOCK
+
+            }
+            finally
+            {
+
+                ldarg       calloutIndex
+
+                switch      (RUN_CALLOUT_0,
+                             RUN_CALLOUT_1,
+                             RUN_CALLOUT_2,
+                             RUN_CALLOUT_3,
+                             RUN_CALLOUT_4,
+                             RUN_CALLOUT_5,
+                             RUN_CALLOUT_6)
+
+
+            RUN_CALLOUT_0:
+                ldc.i4      0
+                stloc       computedValue
+                endfinally
+
+            RUN_CALLOUT_1:
+                ldc.i4      1
+                stloc       computedValue
+                endfinally
+
+            RUN_CALLOUT_2:
+                ldc.i4      2
+                stloc       computedValue
+                endfinally
+
+            RUN_CALLOUT_3:
+                call        void [CSharpPart]Test.Helpers::Callout3()
+                endfinally
+
+            RUN_CALLOUT_4:
+                call        void [CSharpPart]Test.Helpers::Callout4()
+                endfinally
+
+            RUN_CALLOUT_5:
+                call        void [CSharpPart]Test.Helpers::Callout5()
+                endfinally
+
+            RUN_CALLOUT_6:
+                call        void [CSharpPart]Test.Helpers::Callout6()
+                endfinally
+
+            }
+
+
+        END_OF_CATCH_BLOCK:
+
+            leave       END_OF_METHOD_BODY
+
+        }
+
+
+    END_OF_METHOD_BODY:
+
+        ldloc       computedValue
+        ret
+    }
+
+}
+

--- a/tests/src/JIT/Regression/Dev11/External/dev11_145295/ilpart.ilproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_145295/ilpart.ilproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ilpart.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/Dev11/External/dev11_145295/ilpart.ilproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_145295/ilpart.ilproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/jit64/regress/vsw/568666/app.config
+++ b/tests/src/JIT/jit64/regress/vsw/568666/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/jit64/regress/vsw/568666/dll.cs
+++ b/tests/src/JIT/jit64/regress/vsw/568666/dll.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+public static class Library
+{
+    private static string s_name
+#if NoCCtor
+ = "Library";
+#else
+    ;
+    static Library()
+    {
+        s_name = "Library";
+    }
+#endif
+
+    public static string Name { get { return s_name; } }
+}

--- a/tests/src/JIT/jit64/regress/vsw/568666/dll.csproj
+++ b/tests/src/JIT/jit64/regress/vsw/568666/dll.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="dll.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/jit64/regress/vsw/568666/dll.csproj
+++ b/tests/src/JIT/jit64/regress/vsw/568666/dll.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/app.config
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived1.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived1.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived1
+    {
+        public override int GetHashCode() { return 1; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived1.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived1.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived10.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived10.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived10
+    {
+        public override int GetHashCode() { return 10; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived10.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived10.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived11.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived11.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived11
+    {
+        public override int GetHashCode() { return 11; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived11.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived11.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived12.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived12.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived12
+    {
+        public override int GetHashCode() { return 12; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived12.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived12.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived13.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived13.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived13
+    {
+        public override int GetHashCode() { return 13; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived13.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived13.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived14.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived14.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived14
+    {
+        public override int GetHashCode() { return 14; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived14.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived14.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived15.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived15.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived15
+    {
+        public override int GetHashCode() { return 15; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived15.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived15.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived16.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived16.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived16
+    {
+        public override int GetHashCode() { return 16; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived16.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived16.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived17.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived17.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived17
+    {
+        public override int GetHashCode() { return 17; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived17.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived17.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived18.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived18.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived18
+    {
+        public override int GetHashCode() { return 18; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived18.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived18.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived19.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived19.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived19
+    {
+        public override int GetHashCode() { return 19; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived19.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived19.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived2.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived2.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived2
+    {
+        public override int GetHashCode() { return 2; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived2.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived2.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived20.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived20.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived20
+    {
+        public override int GetHashCode() { return 20; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived20.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived20.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived3.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived3.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived3
+    {
+        public override int GetHashCode() { return 3; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived3.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived3.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived4.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived4.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived4
+    {
+        public override int GetHashCode() { return 4; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived4.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived4.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived5.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived5.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived5
+    {
+        public override int GetHashCode() { return 5; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived5.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived5.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived6.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived6.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived6
+    {
+        public override int GetHashCode() { return 6; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived6.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived6.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived7.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived7.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived7
+    {
+        public override int GetHashCode() { return 7; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived7.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived7.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived8.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived8.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived8
+    {
+        public override int GetHashCode() { return 8; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived8.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived8.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived9.cs
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived9.cs
@@ -1,0 +1,13 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+namespace VirtFunc
+{
+    public class CDerived9
+    {
+        public override int GetHashCode() { return 9; }
+    }
+}

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="cderived9.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
+++ b/tests/src/JIT/opt/virtualstubdispatch/hashcode/cderived9.csproj
@@ -8,6 +8,8 @@
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
     <OutputType>Library</OutputType>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+    <GenerateRunScript>false</GenerateRunScript> 
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
This change adds dynamic link libraries that are referenced
by other tests.

It does not add the tests that reference these so we do not expect any new run-time test failures.