### PR TITLE
Fix INVALIDGCVALUE on Unix

### DIFF
--- a/src/pal/inc/unixasmmacros.inc
+++ b/src/pal/inc/unixasmmacros.inc
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-#define INVALIDGCVALUE -0x33333333 // 0CCCCCCCDh - the assembler considers it to be a signed integer constant
+#define INVALIDGCVALUE 0CCCCCCCDh
 
 #if defined(__APPLE__)
 #define C_FUNC(name) _##name

--- a/src/vm/amd64/jithelpers_fast.S
+++ b/src/vm/amd64/jithelpers_fast.S
@@ -186,7 +186,7 @@ LEAF_ENTRY JIT_ByRefWriteBarrier, _TEXT
         mov     rax, [r10]
         cmp     rax, r11
         je      DoneShadow_ByRefWriteBarrier
-        mov     r11, INVALIDGCVALUE
+        movabs  r11, INVALIDGCVALUE
         mov     [r10], r11
 
         jmp     DoneShadow_ByRefWriteBarrier

--- a/src/vm/amd64/jithelpers_slow.S
+++ b/src/vm/amd64/jithelpers_slow.S
@@ -45,7 +45,7 @@ LEAF_ENTRY JIT_WriteBarrier_Debug, _TEXT
         mov     rax, [r10]
         cmp     rax, r11
         je      DoneShadow
-        mov     r11, INVALIDGCVALUE
+        movabs  r11, INVALIDGCVALUE
         mov     [r10], r11
 
         jmp     DoneShadow


### PR DESCRIPTION
The INVALIDGCVALUE value loaded into the R11 in the JIT_WriteBarrier_Debug
and JIT_ByRefWriteBarrier is sign extended to 0xFFFFFFFFCCCCCCCD instead of
being the 0x00000000CCCCCCCD.
It was introduced during the early days of CoreCLR porting when I have
misread the error message that I was getting from Clang when compiling
mov R11, 0xCCCCCCCD and didn't know yet that loading 64 bit number requires
using the movabs mnemonics.