### PR TITLE
[Do Not Merge] Move coreclr to branch model

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -2,7 +2,11 @@
 
 import jobs.generation.Utilities;
 
+// The input project name (e.g. dotnet/coreclr)
 def project = GithubProject
+// The input branch name (e.g. master)
+def branch = GithubBranchName
+def projectFolder = Utilities.getFolderName(project) + '/' + Utilities.getFolderName(branch)
                        
 def static getOSGroup(def os) {
     def osGroupMap = ['Ubuntu':'Linux',
@@ -17,15 +21,6 @@ def static getOSGroup(def os) {
     def osGroup = osGroupMap.get(os, null) 
     assert osGroup != null : "Could not find os group for ${os}"
     return osGroupMap[os]
-}
-
-def static getFullBranchName(def branch) {
-    def branchMap = ['master':'*/master',
-        'rc2':'*/release/1.0.0-rc2',
-        'pr':'*/master']
-    def fullBranchName = branchMap.get(branch, null)
-    assert fullBranchName != null : "Could not find a full branch name for ${branch}"
-    return branchMap[branch]
 }
 
 // We use this class (vs variables) so that the static functions can access data here.
@@ -76,8 +71,6 @@ class Constants {
     def static configurationList = ['Debug', 'Checked', 'Release']
     // This is the set of architectures
     def static architectureList = ['arm', 'arm64', 'x64', 'x86']
-    // This is the set of branches
-    def static branchList = ['master', 'rc2', 'pr']
 }
 
 def static setMachineAffinity(def job, def os, def architecture) {
@@ -167,7 +160,7 @@ def static genStressModeScriptStep(def os, def stressModeName, def stressModeVar
 
 // Calculates the name of the build job based on some typical parameters.
 //
-def static getJobName(def configuration, def architecture, def os, def scenario, def isBuildOnly, def branchName) {
+def static getJobName(def configuration, def architecture, def os, def scenario, def isBuildOnly) {
     // If the architecture is x64, do not add that info into the build name.
     // Need to change around some systems and other builds to pick up the right builds
     // to do that.
@@ -175,9 +168,6 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
     def suffix = scenario != 'default' ? "_${scenario}" : '';
     if (isBuildOnly) {
         suffix += '_bld'
-    }
-    if (branchName == 'rc2'){
-        suffix += '_rc2'
     }
     def baseName = ''
     switch (architecture) {
@@ -216,7 +206,7 @@ def static getJobName(def configuration, def architecture, def os, def scenario,
 // Adds a trigger for the PR build if one is needed.  If isFlowJob is true, then this is the
 // flow job that rolls up the build and test for non-windows OS's.  // If the job is a windows build only job,
 // it's just used for internal builds
-def static addTriggers(def job, def isPR, def architecture, def os, def configuration, def scenario, def isFlowJob, def isWindowsBuildOnlyJob) {
+def static addTriggers(def job, def branch, def isPR, def architecture, def os, def configuration, def scenario, def isFlowJob, def isWindowsBuildOnlyJob) {
     if (isWindowsBuildOnlyJob) {
         return
     }
@@ -332,22 +322,22 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                 case 'OpenSUSE13.2':
                     assert !isFlowJob
                     assert scenario == 'default'
-                    Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+suse.*')
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+suse.*')
                     break
                 case 'Debian8.2':
                     assert !isFlowJob
                     assert scenario == 'default'
-                    Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+debian.*')
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+debian.*')
                     break
                 case 'Ubuntu15.10':
                     assert !isFlowJob
                     assert scenario == 'default'
-                    Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+Ubuntu15\\.10.*')
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+Ubuntu15\\.10.*')
                     break
                 case 'RHEL7.2':
                     assert !isFlowJob
                     assert scenario == 'default'
-                    Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+RHEL7\\.2.*')
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build", '(?i).*test\\W+RHEL7\\.2.*')
                     break
                 case 'Ubuntu':
                 case 'OSX':
@@ -361,71 +351,71 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                             // Ubuntu uses checked for default PR tests
                             if (configuration == 'Checked') {
                                 // Default trigger
-                                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test")
+                                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test")
                             }
                             break
                         case 'pri1':
                             if (configuration == 'Release') {
-                                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Priority 1 Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
+                                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Priority 1 Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
                             }
                             break
                         case 'ilrt':
                             if (configuration == 'Release') {
-                                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} IL RoundTrip Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
+                                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} IL RoundTrip Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
                             }
                             break
                         case 'minopts':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - MinOpts)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - MinOpts)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstress1':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=1)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=1)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstress2':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=2)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=2)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                           
                         case 'forcerelocs':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - ForceRelocs)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ForceRelocs)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                         case 'jitstressregs1':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=1)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=1)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                           
                         case 'jitstressregs2':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=2)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=2)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                                                   
                         case 'jitstressregs3':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=3)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=3)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                                                   
                         case 'jitstressregs4':      
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=4)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=4)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                                                   
                         case 'jitstressregs8':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=8)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=8)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstressregs0x10':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x10)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x10)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstressregs0x80':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x80)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x80)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstress2_jitstressregs1':
@@ -447,7 +437,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                         case 'gcstress0xc_minopts_heapverify1':                                 
                             def displayStr = getStressModeDisplayName(scenario)  
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayStr})",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayStr})",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'corefx_baseline':
@@ -463,7 +453,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                         case 'corefx_jitstressregs0x80':
                             def displayName = 'CoreFx' + getStressModeDisplayName(scenario)                                                    
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayName})",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayName})",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                          
                         default:
@@ -474,11 +464,11 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                     break
                 case 'CentOS7.1':
                     if (configuration == 'Checked' && isFlowJob && scenario == 'pri1' && architecture == 'x64') {
-                        Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Priority 1 Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
+                        Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Priority 1 Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
                     }
                 case 'OpenSUSE13.2':
                     if (configuration == 'Checked' && !isFlowJob && scenario == 'default') {
-                        Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build")
+                        Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build")
                     }
                     break
                 case 'Windows_NT':
@@ -486,72 +476,72 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                         case 'default':
                             // Default trigger
                             if (configuration != 'Checked') {
-                                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test")
+                                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test")
                             }
                             break
                         case 'pri1':
                             if (configuration == 'Release') {
-                                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Priority 1 Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
+                                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Priority 1 Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
                             }
                             break
                         case 'ilrt':
                             if (configuration == 'Release') {
-                                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} IL RoundTrip Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
+                                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} IL RoundTrip Build and Test", "(?i).*test\\W+${os}\\W+${scenario}.*")
                             }
                             break
                         case 'minopts':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - MinOpts)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - MinOpts)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'forcerelocs':                         
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - ForceRelocs)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ForceRelocs)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                           
                         case 'jitstress1':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=1)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=1)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstress2':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=2)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStress=2)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break
                         case 'jitstressregs1':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=1)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=1)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         case 'jitstressregs2':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=2)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=2)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         case 'jitstressregs3':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=3)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=3)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         case 'jitstressregs4':      
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=4)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=4)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         case 'jitstressregs8':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=8)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=8)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         case 'jitstressregs0x10':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x10)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x10)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         case 'jitstressregs0x80':
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x80)",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - JitStressRegs=0x80)",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break       
                         case 'jitstress2_jitstressregs1':
@@ -573,7 +563,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                         case 'gcstress0xc_minopts_heapverify1':                                 
                             def displayStr = getStressModeDisplayName(scenario)
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayStr})",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayStr})",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                                   
                         case 'corefx_baseline':
@@ -589,7 +579,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                         case 'corefx_jitstressregs0x80':
                             def displayName = 'CoreFx ' + getStressModeDisplayName(scenario)
                             assert (os == 'Windows_NT') || (os in Constants.crossList)
-                            Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayName})",
+                            Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build and Test (Jit - ${displayName})",
                                "(?i).*test\\W+${os}\\W+${scenario}.*")
                             break                       
                         default:
@@ -601,7 +591,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                 case 'FreeBSD':
                     assert scenario == 'default'
                     if (configuration == 'Checked') {
-                        Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build")
+                        Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build")
                     }
                     break
                 default:
@@ -615,11 +605,11 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
             assert scenario == 'default'
             switch (os) {
                 case 'Ubuntu':
-                    Utilities.addGithubPRTrigger(job, "${os} ${architecture} Cross ${configuration} Build", "(?i).*test\\W+${os}\\W+${architecture}.*")
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build", "(?i).*test\\W+${os}\\W+${architecture}.*")
                     break
                 case 'Windows_NT':
                     // Set up a private trigger
-                    Utilities.addPrivateGithubPRTrigger(job, "${os} ${architecture} Cross ${configuration} Build",
+                    Utilities.addPrivateGithubPRTriggerForBranch(job, branch, "${os} ${architecture} Cross ${configuration} Build",
                         "(?i).*test\\W+${os}\\W+${architecture}.*", null, ['erozenfeld', 'kyulee1', 'pgavlin', 'russellhadley', 'swaroop-sridhar', 'JosephTremoulet', 'jashook', 'RussKeldorph', 'gkhanna79', 'briansul', 'cmckinsey', 'jkotas', 'ramarag', 'markwilkie', 'rahku', 'tzwlai', 'weshaggard', 'LLITCHEV'])
                     break
             }
@@ -629,12 +619,12 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
             // For windows, x86 runs by default
             if (os == 'Windows_NT') {
                 if (configuration != 'Checked') {
-                    Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Legacy Backend Build and Test")
+                    Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Legacy Backend Build and Test")
                 }
             }
             else {
                 // default trigger
-                Utilities.addGithubPRTrigger(job, "${os} ${architecture} ${configuration} Build", "(?i).*test\\W+${architecture}\\W+${osGroup}.*")
+                Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Build", "(?i).*test\\W+${architecture}\\W+${osGroup}.*")
             }
             break
         default:
@@ -648,7 +638,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
 
 def combinedScenarios = Constants.basicScenarios + Constants.jitStressModeScenarios.keySet()
 combinedScenarios.each { scenario ->
-    Constants.branchList.each { branchName ->
+    [true, false].each { isPR ->
         Constants.architectureList.each { architecture ->
             Constants.configurationList.each { configuration ->
                 Constants.osList.each { os ->
@@ -659,9 +649,8 @@ combinedScenarios.each { scenario ->
                         isBuildOnly = true
                         os = 'Windows_NT'
                     }
-                    def isPR = (branchName == 'pr');
                     
-                    // Skip totally unimplemented (in CI) configurations.
+					// Skip totally unimplemented (in CI) configurations.
                     switch (architecture) {
                         case 'arm64':
                             // Windows or cross compiled Ubuntu
@@ -747,7 +736,7 @@ combinedScenarios.each { scenario ->
                 
                     // Calculate names
                     def lowerConfiguration = configuration.toLowerCase()
-                    def jobName = getJobName(configuration, architecture, os, scenario, isBuildOnly, branchName)
+                    def jobName = getJobName(configuration, architecture, os, scenario, isBuildOnly)
                     
                     // Create the new job
                     def newJob = job(Utilities.getFullJobName(project, jobName, isPR)) {}
@@ -755,8 +744,8 @@ combinedScenarios.each { scenario ->
                     setMachineAffinity(newJob, os, architecture)
 
                     // Add all the standard options
-                    Utilities.standardJobSetup(newJob, project, isPR, getFullBranchName(branchName))
-                    addTriggers(newJob, isPR, architecture, os, configuration, scenario, false, isBuildOnly)
+                    Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
+                    addTriggers(newJob, branch, isPR, architecture, os, configuration, scenario, false, isBuildOnly)
                 
                     def buildCommands = [];
                     def osGroup = getOSGroup(os)
@@ -995,14 +984,12 @@ combinedScenarios.each { scenario ->
 
 // Create the Linux/OSX coreclr test leg for debug and release and each scenario
 combinedScenarios.each { scenario ->
-    Constants.branchList.each { branchName ->
+    [true, false].each { isPR ->
         // Architectures.  x64 only at this point
         ['x64'].each { architecture ->
             // Put the OS's supported for coreclr cross testing here
             Constants.crossList.each { os ->
                 Constants.configurationList.each { configuration ->
-
-                    def isPR = (branchName == 'pr');
 
                     if (Constants.jitStressModeScenarios.containsKey(scenario)) {
                         if (configuration != 'Checked') {
@@ -1042,20 +1029,20 @@ combinedScenarios.each { scenario ->
                     
                     def lowerConfiguration = configuration.toLowerCase()
                     def osGroup = getOSGroup(os)
-                    def jobName = getJobName(configuration, architecture, os, scenario, false, branchName) + "_tst"
-                    def inputCoreCLRBuildName = Utilities.getFolderName(project) + '/' + 
-                        Utilities.getFullJobName(project, getJobName(configuration, architecture, os, 'default', false, branchName), isPR)
+                    def jobName = getJobName(configuration, architecture, os, scenario, false) + "_tst"
+                    def inputCoreCLRBuildName = projectFolder + '/' + 
+                        Utilities.getFullJobName(project, getJobName(configuration, architecture, os, 'default', false), isPR)
                     // If this is a stress scenario, there isn't any difference in the build job
                     // so we didn't create a build only job for windows_nt specific to that stress mode.  Just copy
                     // from the default scenario
                     def inputWindowTestsBuildName = ''
                     if (Constants.jitStressModeScenarios.containsKey(scenario)) {
-                        inputWindowTestsBuildName = Utilities.getFolderName(project) + '/' + 
-                            Utilities.getFullJobName(project, getJobName(configuration, architecture, 'windows_nt', 'default', true, branchName), isPR)
+                        inputWindowTestsBuildName = projectFolder + '/' + 
+                            Utilities.getFullJobName(project, getJobName(configuration, architecture, 'windows_nt', 'default', true), isPR)
                     }
                     else {
-                        inputWindowTestsBuildName = Utilities.getFolderName(project) + '/' + 
-                            Utilities.getFullJobName(project, getJobName(configuration, architecture, 'windows_nt', scenario, true, branchName), isPR)
+                        inputWindowTestsBuildName = projectFolder + '/' + 
+                            Utilities.getFullJobName(project, getJobName(configuration, architecture, 'windows_nt', scenario, true), isPR)
                     }
                     // Enable Server GC for Ubuntu PR builds
                     def serverGCString = ''
@@ -1094,9 +1081,10 @@ combinedScenarios.each { scenario ->
                                 }
                             }
                         
-                            // Corefx native components
-                            def corefxNativeCompBinaries = 
-                            copyArtifacts("dotnet_corefx/nativecomp_${os.toLowerCase()}_release") {
+                            // Corefx native component.
+							// Pull from main folder in corefx for now, once the corefx branchify PR gets merged this will chnage
+                            def corefxFolder = Utilities.getFolderName('dotnet/corefx')
+                            copyArtifacts("${corefxFolder}/nativecomp_${os.toLowerCase()}_release") {
                                 includePatterns('bin/**')
                                 buildSelector {
                                     latestSuccessful(true)
@@ -1104,7 +1092,7 @@ combinedScenarios.each { scenario ->
                             }
                         
                             // CoreFX Linux binaries
-                            copyArtifacts("dotnet_corefx/${os.toLowerCase()}_release_bld") {
+                            copyArtifacts("${corefxFolder}/${os.toLowerCase()}_release_bld") {
                                 includePatterns('bin/build.pack')
                                 buildSelector {
                                     latestSuccessful(true)
@@ -1141,7 +1129,7 @@ combinedScenarios.each { scenario ->
                     }
 
                     setMachineAffinity(newJob, os, architecture)
-                    Utilities.standardJobSetup(newJob, project, isPR, getFullBranchName(branchName))
+                    Utilities.standardJobSetup(newJob, project, isPR, "*/${branch}")
                     // Set timeouts to 240.
                     setTestJobTimeOut(newJob, scenario)
                     Utilities.addXUnitDotNETResults(newJob, '**/coreclrtests.xml')
@@ -1150,8 +1138,8 @@ combinedScenarios.each { scenario ->
                     // test.
                     // Windows CoreCLR build and Linux CoreCLR build (in parallel) ->
                     // Linux CoreCLR test
-                    def flowJobName = getJobName(configuration, architecture, os, scenario, false, branchName) + "_flow"
-                    def fullTestJobName = Utilities.getFolderName(project) + '/' + newJob.name
+                    def flowJobName = getJobName(configuration, architecture, os, scenario, false) + "_flow"
+                    def fullTestJobName = projectFolder + '/' + newJob.name
                     def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, flowJobName, isPR)) {
                         buildFlow("""
 // Build the input jobs in parallel
@@ -1164,15 +1152,10 @@ parallel (
 build(params + [CORECLR_BUILD: coreclrBuildJob.build.number, 
                 CORECLR_WINDOWS_BUILD: windowsBuildJob.build.number], '${fullTestJobName}')    
 """)
-                        // Needs a workspace
-                        configure {
-                            def buildNeedsWorkspace = it / 'buildNeedsWorkspace'
-                            buildNeedsWorkspace.setValue('true')
-                        }
                     }
 
-                    Utilities.standardJobSetup(newFlowJob, project, isPR, getFullBranchName(branchName))
-                    addTriggers(newFlowJob, isPR, architecture, os, configuration, scenario, true, false)
+                    Utilities.standardJobSetup(newFlowJob, project, isPR, "*/${branch}")
+                    addTriggers(newFlowJob, branch, isPR, architecture, os, configuration, scenario, true, false)
                 } // configuration
             } // os
         } // architecture


### PR DESCRIPTION
This moves coreclr to the branch-based CI model.  In this model, instead of having the CI generate jobs out of dotnet/coreclr's master branch for all branches (using all sorts of odd naming suffixes of course), the master CI lists tell the CI which branches it should look at for CI config info.  It passes the branch name to the netci file, which then can use it to tell the SCM to pull code from specific branches or set branch specific PR triggers.