### PR TITLE
Benchstones: Adjust iteration count

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.cs
@@ -17,7 +17,7 @@ public static class Adams
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 200000;
+    public const int Iterations = 20000000;
 #endif
 
     public static volatile object VolatileObject;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMk2/BenchMk2.cs
@@ -16,7 +16,7 @@ public static class BenchMk2
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 4000000;
+    public const int Iterations = 40000000;
 #endif
 
     private static int s_i, s_n;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/BenchMrk/BenchMrk.cs
@@ -16,7 +16,7 @@ public static class BenchMrk
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 4000000;
+    public const int Iterations = 40000000;
 #endif
 
     private static int s_i, s_n;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.cs
@@ -17,7 +17,7 @@ public static class Bisect
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 400000;
+    public const int Iterations = 4000000;
 #endif
 
     public static volatile object VolatileObject;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/DMath/DMath.cs
@@ -16,7 +16,7 @@ public static class DMath
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 100000;
+    public const int Iterations = 500000;
 #endif
 
     private const double Deg2Rad = 57.29577951;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.cs
@@ -18,7 +18,7 @@ public static class FFT
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 300000;
+    public const int Iterations = 3000000;
 #endif
 
     private static readonly int s_points = 16;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InProd/InProd.cs
@@ -16,7 +16,7 @@ public static class InProd
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 70;
+    public const int Iterations = 100;
 #endif
 
     private const int RowSize = 10 * Iterations;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.cs
@@ -17,7 +17,7 @@ public static class InvMt
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 80;
+    public const int Iterations = 800;
 #endif
 
     private const int MatSize = Iterations;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.cs
@@ -65,7 +65,7 @@ public class LLoops
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 4000;
+    public const int Iterations = 40000;
 #endif
 
     private const double MaxErr = 1.0e-6;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.cs
@@ -17,7 +17,7 @@ public static class Lorenz
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 8000000;
+    public const int Iterations = 100000000;
 #endif
 
     private static double s_t = 0.0;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
@@ -15,7 +15,7 @@ public static class LLoops
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 60;
+    public const int Iterations = 750;
 #endif
 
     private static float s_det;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.cs
@@ -18,7 +18,7 @@ public static class NewtE
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 1000000;
+    public const int Iterations = 5000000;
 #endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.cs
@@ -17,7 +17,7 @@ public static class NewtR
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 80000000;
+    public const int Iterations = 1000000000;
 #endif
 
     public static volatile object VolatileObject;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
@@ -17,7 +17,7 @@ public static class Adams
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 4000000;
+    public const int Iterations = 50000000;
 #endif
 
     public static volatile object VolatileObject;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.cs
@@ -17,7 +17,7 @@ public static class Romber
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 640000;
+    public const int Iterations = 7500000;
 #endif
 
     private static T[][] AllocArray<T>(int n1, int n2)

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.cs
@@ -17,7 +17,7 @@ public static class Secant
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 3000000;
+    public const int Iterations = 50000000;
 #endif
 
     public static volatile object VolatileObject;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.cs
@@ -17,7 +17,7 @@ public static class Simpsn
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 90000;
+    public const int Iterations = 900000;
 #endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.cs
@@ -16,7 +16,7 @@ public static class SqMtx
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 4000;
+    public const int Iterations = 40000;
 #endif
 
     private const int MatrixSize = 40;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.cs
@@ -17,7 +17,7 @@ public static class Trap
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 240000;
+    public const int Iterations = 2400000;
 #endif
 
     [MethodImpl(MethodImplOptions.NoInlining)]

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.cs
@@ -17,7 +17,7 @@ public static class Whetsto
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 50000;
+    public const int Iterations = 250000;
 #endif
 
     private static int s_j, s_k, s_l;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/8Queens/8Queens.cs
@@ -17,7 +17,7 @@ public static class EightQueens
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 100000;
+    public const int Iterations = 1000000;
 #endif
 
     static int[] m_c = new int[15];

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Ackermann/Ackermann.cs
@@ -17,7 +17,7 @@ public static class Ackermann
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 100000;
+    public const int Iterations = 1000000;
 #endif
 
     static int Acker(int m, int n) {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray/AddArray.cs
@@ -17,7 +17,7 @@ public static class AddArray
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 15000;
+    public const int Iterations = 150000;
 #endif
 
     const int Size = 6000;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/AddArray2/AddArray2.cs
@@ -16,7 +16,7 @@ public static class AddArray2
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 50;
+    public const int Iterations = 500;
 #endif
 
     private const int Dim = 200;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array1/Array1.cs
@@ -24,7 +24,7 @@ public static class Array1
     private const int Iterations = 1;
     private const int Maxnum = 100;
 #else
-    private const int Iterations = 125;
+    private const int Iterations = 500;
     private const int Maxnum = 1000;
 #endif
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Array2/Array2.cs
@@ -17,7 +17,7 @@ public static class Array2
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 500000;
+    public const int Iterations = 5000000;
 #endif
 
     static T[][][] AllocArray<T>(int n1, int n2, int n3) {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BenchE/BenchE.cs
@@ -16,7 +16,7 @@ public static class BenchE
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 5000000;
+    public const int Iterations = 50000000;
 #endif
 
     private static int s_position;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort/BubbleSort.cs
@@ -17,7 +17,7 @@ public static class BubbleSort
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 55000;
+    public const int Iterations = 500000;
 #endif
 
     static void SortArray(int[] tab, int last) {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/BubbleSort2/BubbleSort2.cs
@@ -18,7 +18,7 @@ public static class BubbleSort2
     public const int Iterations = 1;
     public const int Bound = 5 * Iterations;
 #else
-    public const int Iterations = 15;
+    public const int Iterations = 40;
     public const int Bound = 500 * Iterations;
 #endif
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/CSieve/CSieve.cs
@@ -18,7 +18,7 @@ public static class CSieve
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 200;
+    public const int Iterations = 500;
 #endif
 
     const int Size = 8190;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Fib/Fib.cs
@@ -17,7 +17,7 @@ public static class Fib
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 3500;
+    public const int Iterations = 30000;
 #endif
 
     const int Number = 24;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/HeapSort/HeapSort.cs
@@ -17,7 +17,7 @@ public static class HeapSort
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 2500;
+    public const int Iterations = 25000;
 #endif
 
     const int ArraySize = 5500;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/IniArray/IniArray.cs
@@ -17,7 +17,7 @@ public static class IniArray
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 10000000;
+    public const int Iterations = 200000000;
 #endif
 
     const int Allotted = 16;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/LogicArray/LogicArray.cs
@@ -17,7 +17,7 @@ public static class LogicArray
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 3000;
+    public const int Iterations = 30000;
 #endif
 
     const int ArraySize = 50;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Midpoint/Midpoint.cs
@@ -17,7 +17,7 @@ public static class Midpoint
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 70000;
+    public const int Iterations = 700000;
 #endif
 
     static T[][] AllocArray<T>(int n1, int n2) {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/MulMatrix/MulMatrix.cs
@@ -17,7 +17,7 @@ public static class MulMatrix
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 100;
+    public const int Iterations = 1000;
 #endif
     
     const int Size = 75;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/NDhrystone/NDhrystone.cs
@@ -22,7 +22,7 @@ public static class NDhrystone
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 7000000;
+    public const int Iterations = 70000000;
 #endif
 
     static T[][] AllocArray<T>(int n1, int n2) {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Permutate/Permutate.cs
@@ -16,7 +16,7 @@ public class Permutate
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 20000;
+    public const int Iterations = 150000;
 #endif
 
     private int[] _permArray = new int[11];

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Pi/Pi.cs
@@ -17,7 +17,7 @@ public static class Pi
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 100;
+    public const int Iterations = 1000;
 #endif
 
     static int[] ComputePi(int[] a) {

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/Puzzle/Puzzle.cs
@@ -16,7 +16,7 @@ public class Puzzle
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 400;
+    public const int Iterations = 4000;
 #endif
 
     private const int PuzzleSize = 511;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/QuickSort/QuickSort.cs
@@ -17,7 +17,7 @@ public static class QuickSort
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 80000;
+    public const int Iterations = 800000;
 #endif
 
     const int MAXNUM = 200;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeInsert/TreeInsert.cs
@@ -16,7 +16,7 @@ public class TreeInsert
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 15000;
+    public const int Iterations = 150000;
 #endif
 
     private struct Node

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/TreeSort/TreeSort.cs
@@ -17,7 +17,7 @@ public static class TreeSort
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 1200;
+    public const int Iterations = 12500;
 #endif
 
     const int SortElements = 5000;

--- a/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchI/XposMatrix/XposMatrix.cs
@@ -18,7 +18,7 @@ public static class XposMatrix
 #if DEBUG
     public const int Iterations = 1;
 #else
-    public const int Iterations = 25000;
+    public const int Iterations = 250000;
 #endif
 
     static T[][] AllocArray<T>(int n1, int n2) {


### PR DESCRIPTION
Increase the iteration count on BenchI/BenchF so that the benchmarks
run for about 10-20 seconds. Previously, most benchmarks ran for less
than a second, making the performance comparison unreliable.
