### PR TITLE
Fix issue with excessive memory use by debug and checked jits

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -9859,21 +9859,22 @@ void JitInlineResult::report()
 
 #ifdef DEBUG
 
-    const char* format = "INLINER: during '%s' result '%s' reason '%s' for '%s' calling '%s'\n";
-    const char* caller = (inlInliner == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlInliner);
-    const char* callee = (inlInlinee == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlInlinee);
+    if (VERBOSE)
+    {
+        const char* format = "INLINER: during '%s' result '%s' reason '%s' for '%s' calling '%s'\n";
+        const char* caller = (inlInliner == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlInliner);
+        const char* callee = (inlInlinee == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlInlinee);
 
-    JITDUMP(format, inlContext, resultString(), inlReason, caller, callee);
+        JITDUMP(format, inlContext, resultString(), inlReason, caller, callee);
+    }
 
 #endif // DEBUG
 
     if (isDecided()) 
     {
-        JITLOG_THIS(inlCompiler, (LL_INFO100000, format, inlContext, resultString(), inlReason, caller, callee));
+        const char* format = "INLINER: during '%s' result '%s' reason '%s'\n";
+        JITLOG_THIS(inlCompiler, (LL_INFO100000, format, inlContext, resultString(), inlReason));
         COMP_HANDLE comp = inlCompiler->info.compCompHnd;
         comp->reportInliningDecision(inlInliner, inlInlinee, result(), inlReason);
     }
 }
-
-    
-


### PR DESCRIPTION
In #3051 the jit started calling `eeGetClassFullName` for both caller and callee handles
even when dumping was disabled, passed this information to
the logging messages where previously the caller and callee were
identified via other context, and prepared the full name dump artifacts
for all inline decisions rather than the selective cases handled
previously.

This change caused excessive memory use in some tests.

This change makes the calls to `eeGetClassFullName` conditional on
whether dumping is enabled, and does not require these calls for logging
messages.