### PR TITLE
Remove IlasmRoundTrip from these project files

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Adams/Adams.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Bisect/Bisect.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/FFT/FFT.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/InvMt/InvMt.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/LLoops/LLoops.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Lorenz/Lorenz.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtE/NewtE.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/NewtR/NewtR.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Romber/Romber.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Secant/Secant.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Simpsn/Simpsn.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/SqMtx/SqMtx.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Trap/Trap.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.csproj
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Whetsto/Whetsto.csproj
@@ -13,7 +13,6 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <IlasmRoundTrip>true</IlasmRoundTrip>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
We test ilasm/ildasm separately, so no reason to round trip when
building these benchmarks.

Closes #3202.