### PR TITLE
Fix debugger attach to process on OSX

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -2374,7 +2374,7 @@ CreateProcessModules(
     ssize_t read;
 
     char vmmapCommand[100];
-    int chars = snprintf(vmmapCommand, sizeof(vmmapCommand), "/usr/bin/vmmap -interleaved %d", dwProcessId);
+    int chars = snprintf(vmmapCommand, sizeof(vmmapCommand), "/usr/bin/vmmap -interleaved %d -wide", dwProcessId);
     _ASSERTE(chars > 0 && chars <= sizeof(vmmapCommand));
 
     FILE *vmmapFile = popen(vmmapCommand, "r");


### PR DESCRIPTION
Attaching to processes on OSX was broken with the way the .NET CLI is installing CoreCLR. The issue is that the vmmap executable that dbgshim is using will, by default, truncate paths. This caused it to be unable to find the real path to DBI.

Fix: pass the '-wide' argument to vmmap