### PR TITLE
Remove need for mono resgen

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00157
+1.0.25-prerelease-00171

--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ usage()
     echo "configureonly - do not perform any builds; just configure the build."
     echo "skipconfigure - skip build configuration."
     echo "skipnative - do not build native components."
-    echo "skipmscorlib - do not build mscorlib.dll even if mono is installed."
+    echo "skipmscorlib - do not build mscorlib.dll."
     echo "skiptests - skip the tests in the 'tests' subdirectory."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
 
@@ -222,8 +222,6 @@ build_mscorlib()
        echo "Skipping building mscorlib."
        return
     fi
-
-    hash mono 2> /dev/null || { echo >&2 "Skipping mscorlib.dll build since Mono is not installed."; __SkipMSCorLib=1; return; }
 
     # Restore buildTools
 

--- a/src/mscorlib/GenerateSplitStringResources.targets
+++ b/src/mscorlib/GenerateSplitStringResources.targets
@@ -1,28 +1,33 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ResGenCommand Condition="'$(ResGenCommand)'=='' and '$(OsEnvironment)'=='Windows_NT'">$(SDK40ToolsPath)ResGen.exe</ResGenCommand>
-    <ResGenCommand Condition="'$(ResGenCommand)'=='' and '$(OsEnvironment)'=='Unix'">resgen</ResGenCommand>
     <PrepareResourcesDependsOn>GenerateSplitStringResources;$(PrepareResourcesDependsOn)</PrepareResourcesDependsOn>
   </PropertyGroup>
-    
+
+  <UsingTask TaskName="PreprocessFile" AssemblyFile="$(BuildToolsTaskDir)Microsoft.DotNet.Build.Tasks.dll" />
+
   <Target Name="GenerateSplitStringResources"
-          Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFile);$(BclSourcesRoot)\mscorlib.txt"
-          Outputs="@(SplitTextStringResource->'$(IntermediateOutputPath)%(Filename).resources')">
+          Inputs="@(SplitTextStringResource)"
+          Outputs="@(SplitTextStringResource->'$(IntermediateOutputPath)%(Filename).txt')">
          
-    <ItemGroup Condition="'$(OsEnvironment)'=='Windows_NT'">
+    <ItemGroup>
       <Internal_ResGenDefines Remove="" />
       <Internal_ResGenDefines Include="INCLUDE_DEBUG" />
       <Internal_ResGenDefines Include="INCLUDE_RUNTIME" />
       <Internal_ResGenDefines Include="%(SplitTextStringResource.ResGenDefines)" />
     </ItemGroup>    
 
-    <Exec Command="&quot;$(ResGenCommand)&quot; &quot;%(SplitTextStringResource.Identity)&quot; &quot;$(IntermediateOutputPath)%(SplitTextStringResource.Filename).resources&quot; @(Internal_ResGenDefines->'/D:%(Identity)', ' ')" />
+    <PreprocessFile SourceFile="%(SplitTextStringResource.Identity)" OutputFile="$(IntermediateOutputPath)%(SplitTextStringResource.Filename).txt" Defines="@(Internal_ResGenDefines)" />
+
+    <GenerateResource Sources="$(IntermediateOutputPath)%(SplitTextStringResource.Filename).txt"
+                      OutputResources="$(IntermediateOutputPath)%(SplitTextStringResource.Filename).resources"
+                      ExecuteAsTool="false" />
 
     <ItemGroup>
       <EmbeddedResource Include="@(SplitTextStringResource->'$(IntermediateOutputPath)%(Filename).resources')">
-        <WithCulture>false</WithCulture>           
+        <WithCulture>false</WithCulture>
         <ManifestResourceName>%(Filename)</ManifestResourceName>
       </EmbeddedResource>
+      <Clean Include="$(IntermediateOutputPath)%(SplitTextStringResource.Filename).txt" />
       <Clean Include="$(IntermediateOutputPath)%(SplitTextStringResource.Filename).resources" />
     </ItemGroup>
 

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -8,7 +8,9 @@
 
 ; For resource info, see the ResourceManager documentation and the ResGen tool,
 ; which is a managed app using ResourceWriter.
-; ResGen now supports C++ & C# style #ifdef's, like #ifndef FOO and #if BAR
+; ResGen now supports limited preprocessing of txt files, you can use
+; #if SYMBOL and #if !SYMBOL to control what sets of resources are included in
+; the resulting resources.
 
 ; The naming scheme is: [Namespace.] ExceptionName _ Reason
 ; We'll suppress "System." where possible.


### PR DESCRIPTION
The last remaining dependency on mono was to use the resgen
implementation since cross platform we don't have a version of
ResGen.exe. While MSBuild and dotnet-resgen can both convert txt files
into resources, neither of them understand the #if syntax we use in
mscorlib.txt to allow us to remove resources if features of the runtime
are not enabled.

Since we already have a dependency on Python, I've added a dead simple
script that understands the limited preprocessor features we support
and pre-processes the text file. We can then pass that preprocessed file
to MSBuild which will handle converting it to a .resources file.