### PR TITLE
Save/restore floating point arguments in asm macros on Linux arm and arm64

### DIFF
--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -125,7 +125,7 @@ C_FUNC(\Name\()_End):
 // d2
 // d1
 // d0                          <- __PWTB_FloatArgumentRegisters
-.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, saveFpArgs = 0, pushArgRegs = 0
+.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, saveFpArgs = 1, pushArgRegs = 0
 
         __PWTB_FloatArgumentRegisters = \extraLocals
         __PWTB_SaveFPArgs = \saveFpArgs
@@ -134,13 +134,13 @@ C_FUNC(\Name\()_End):
                 .if ((__PWTB_FloatArgumentRegisters % 8) != 0)
                 __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 4
                 .endif
-                
-                __PWTB_TransitionBlock = __PWTB_FloatArgumentRegisters + 8 * 8 + 8 // 8 floating point registers
-        .else                
+
+                __PWTB_TransitionBlock = __PWTB_FloatArgumentRegisters + 8 * 8 + 4 // 8 floating point registers + padding
+        .else
                 .if ((__PWTB_FloatArgumentRegisters % 8) == 0)
                 __PWTB_FloatArgumentRegisters = __PWTB_FloatArgumentRegisters + 4
                 .endif
-                
+
                 __PWTB_TransitionBlock = __PWTB_FloatArgumentRegisters
         .endif
 
@@ -153,12 +153,12 @@ C_FUNC(\Name\()_End):
         PUSH_CALLEE_SAVED_REGISTERS
         
         alloc_stack     __PWTB_StackAlloc
-        
+
         .if (__PWTB_SaveFPArgs == 1)
                 add r6, sp, #(__PWTB_FloatArgumentRegisters)
                 vstm r6, {d0-d7}
         .endif
-        
+
         CHECK_STACK_ALIGNMENT
         
         END_PROLOGUE
@@ -171,7 +171,7 @@ C_FUNC(\Name\()_End):
         POP_CALLEE_SAVED_REGISTERS
         free_stack 16
         bx lr
-                
+
 .endm
 
 .macro EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
@@ -180,10 +180,10 @@ C_FUNC(\Name\()_End):
                 add r6, sp, #(__PWTB_FloatArgumentRegisters)
                 vldm r6, {d0-d7}
         .endif
-        
+
         free_stack __PWTB_StackAlloc
         POP_CALLEE_SAVED_REGISTERS
-        POP_ARGUMENT_REGISTERS        
+        POP_ARGUMENT_REGISTERS
         
 .endm
 

--- a/src/pal/inc/unixasmmacrosarm64.inc
+++ b/src/pal/inc/unixasmmacrosarm64.inc
@@ -125,7 +125,7 @@ C_FUNC(\Name\()_End):
 // FloatRegisters::d2
 // FloatRegisters::d1
 // FloatRegisters::d0
-.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals, SaveFPArgs
+.macro PROLOG_WITH_TRANSITION_BLOCK extraLocals = 0, SaveFPArgs = 1
 
         __PWTB_FloatArgumentRegisters = \extraLocals
 
@@ -215,7 +215,7 @@ C_FUNC(\Name\()_End):
 // Provides a matching epilog to PROLOG_WITH_TRANSITION_BLOCK and ends by preparing for tail-calling.
 // Since this is a tail call argument registers are restored.
 //
-.macro EPILOG_WITH_TRANSITION_BLOCK_TAILCALL extraLocals, SaveFPArgs
+.macro EPILOG_WITH_TRANSITION_BLOCK_TAILCALL extraLocals = 0, SaveFPArgs =1
 
         __PWTB_FloatArgumentRegisters = \extraLocals
 

--- a/src/vm/arm/asmhelpers.S
+++ b/src/vm/arm/asmhelpers.S
@@ -1311,7 +1311,7 @@ DelayLoad_Helper\suffix:
 
         push         {r0}
 
-        PROLOG_WITH_TRANSITION_BLOCK 0x4, 1, DoNotPushArgRegs
+        PROLOG_WITH_TRANSITION_BLOCK 0x4, 0, DoNotPushArgRegs
 
         // Load the helper arguments
         ldr         r5, [sp,#(__PWTB_TransitionBlock+10*4)] // pModule

--- a/src/vm/arm/asmhelpers.asm
+++ b/src/vm/arm/asmhelpers.asm
@@ -2708,7 +2708,7 @@ $__RealName
 
         PROLOG_PUSH         {r0}
 
-        PROLOG_WITH_TRANSITION_BLOCK 0x4, {true}, DoNotPushArgRegs
+        PROLOG_WITH_TRANSITION_BLOCK 0x4, {false}, DoNotPushArgRegs
 
         ; Load the helper arguments
         ldr         r5, [sp,#(__PWTB_TransitionBlock+10*4)] ; pModule

--- a/src/vm/arm64/asmhelpers.S
+++ b/src/vm/arm64/asmhelpers.S
@@ -149,7 +149,7 @@ NESTED_END PrecodeFixupThunk, _TEXT
 
 NESTED_ENTRY ThePreStub, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK 0, 0
+    PROLOG_WITH_TRANSITION_BLOCK
 
     add x0, sp, #__PWTB_TransitionBlock // pTransitionBlock
     mov x1, METHODDESC_REGISTER // pMethodDesc
@@ -158,7 +158,7 @@ NESTED_ENTRY ThePreStub, _TEXT, NoHandler
 
     mov x9, x0
 
-    EPILOG_WITH_TRANSITION_BLOCK_TAILCALL 0, 0
+    EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
     EPILOG_BRANCH_REG  x9
 
 NESTED_END ThePreStub, _TEXT
@@ -180,7 +180,7 @@ LEAF_END ThePreStubPatch, _TEXT
 // The stub dispatch thunk which transfers control to VSD_ResolveWorker.
 NESTED_ENTRY ResolveWorkerAsmStub, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK 0, 0
+    PROLOG_WITH_TRANSITION_BLOCK
 
     add x0, sp, #__PWTB_TransitionBlock // pTransitionBlock
     and x1, x11, #-4 // Indirection cell
@@ -189,7 +189,7 @@ NESTED_ENTRY ResolveWorkerAsmStub, _TEXT, NoHandler
     bl C_FUNC(VSD_ResolveWorker)
     mov x9, x0
    
-    EPILOG_WITH_TRANSITION_BLOCK_TAILCALL 0, 0
+    EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
 
     EPILOG_BRANCH_REG x9
 
@@ -390,7 +390,7 @@ NESTED_END VirtualMEthodFixupStub, _TEXT
 
 NESTED_ENTRY ExternalMethodFixupStub, _TEXT, NoHandler
 
-    PROLOG_WITH_TRANSITION_BLOCK 0, 0
+    PROLOG_WITH_TRANSITION_BLOCK
 
     add x0, sp, #__PWTB_TransitionBlock // pTransitionBlock
     mov x1, x12 // pThunk
@@ -400,7 +400,7 @@ NESTED_ENTRY ExternalMethodFixupStub, _TEXT, NoHandler
     // mov the address we patched to in x12 so that we can tail call to it
     mov x12, x0
 
-    EPILOG_WITH_TRANSITION_BLOCK_TAILCALL 0, 0
+    EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
     PATCH_LABEL ExternalMethodFixupPatchLabel
     EPILOG_BRANCH_REG   x12
 


### PR DESCRIPTION
The transition block prolog/epilog macros were not correctly saving and restoring the floating point arguments on arm and arm64 on Unix.