### PR TITLE
Change MAPMapPEFile to use ExecutableAllcator instead of mmap to reserve VA

### DIFF
--- a/src/pal/src/include/pal/virtual.h
+++ b/src/pal/src/include/pal/virtual.h
@@ -201,6 +201,16 @@ private:
 
 #endif // __cplusplus
 
+/*++
+Function :
+    ReserveMemoryFromExecutableAllocator
+
+    This function is used to reserve a region of virual memory (not commited)
+    that is located close to the coreclr library. The memory comes from the virtual
+    address range that is managed by ExecutableMemoryAllocator.
+--*/
+void* ReserveMemoryFromExecutableAllocator(SIZE_T allocationSize);
+
 #endif /* _PAL_VIRTUAL_H_ */
 
 

--- a/src/pal/src/map/virtual.cpp
+++ b/src/pal/src/map/virtual.cpp
@@ -2353,6 +2353,19 @@ ResetWriteWatch(
 }
 
 /*++
+Function :
+    ReserveMemoryFromExecutableAllocator
+
+    This function is used to reserve a region of virual memory (not commited)
+    that is located close to the coreclr library. The memory comes from the virtual
+    address range that is managed by ExecutableMemoryAllocator.
+--*/
+void* ReserveMemoryFromExecutableAllocator(SIZE_T allocationSize)
+{
+    return g_executableMemoryAllocator.AllocateMemory(allocationSize);
+}
+
+/*++
 Function:
     ExecutableMemoryAllocator::Initialize()
 


### PR DESCRIPTION
This change modifies the MAPMapPEFile in PAL to use ExecutableAllcator
instead of mmap in order to reserve VA for managed executable images. This
allows all NI images to be located near each other and close to the
coreclr library, which also allows the runtime to generate code that is
more efficient (by avoiding usage of jump stubs).

It also fixes an issue (https://github.com/dotnet/cli/issues/652) where
CLI fails with OutOfMemoryException which turned out to be related to
loading NI files. Due to a certain allocation pattern, mmap can place an
NI file at a region of virtual address space that does not have any free
memory around the NI images. As a result, when the runtime needs to
allocate memory for jump stubs for the image it cannot find any available
memory near the image and fails with OutOfMemoryException.