### PR TITLE
Optimize String.Replace when the chars are the same

### DIFF
--- a/src/classlibnative/bcltype/stringnative.cpp
+++ b/src/classlibnative/bcltype/stringnative.cpp
@@ -686,6 +686,15 @@ FCIMPL3(LPVOID, COMString::Replace, StringObject* thisRefUNSAFE, CLR_CHAR oldCha
     }
 
     //Perf: If no replacements required, return initial reference
+    
+    // Do it if the chars are the same...
+    
+    if ((WCHAR)oldChar == (WCHAR)newChar)
+    {
+        return thisRefUNSAFE;
+    }
+    
+    // Or if the old char isn't found.
     oldBuffer = thisRef->GetBuffer();
     length = thisRef->GetStringLength();
 


### PR DESCRIPTION
Was reading some code recently that went along the lines of this:

```csharp
public static string MakeRelativePath(string here, string there)
{
    return new Uri(here)
        .MakeRelativeUri(new Uri(there))
        .ToString()
        .Replace('/', Path.DirectorySeparatorChar);
}
```

since on Unix systems `/` is the directory separator, I decided to check the code here if it allocated a new string for such a scenario. Apparently it does, so here is the corresponding change.