### PR TITLE
Inline refactoring: add candidate observations

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4994,8 +4994,8 @@ TOO_FAR:
                 if (verbose)
                 {
                     printf("\n\nInline expansion aborted because of impCanInlineNative: %s %s\n",
-                       compInlineResult->isNever() ? "INLINE_NEVER" : "INLINE_FAIL",
-                       compInlineResult->reason());
+                       compInlineResult->resultString(),
+                       compInlineResult->reasonString());
                 }
 #endif
 
@@ -5009,7 +5009,7 @@ TOO_FAR:
        {
           // This method's IL was small enough that we didn't use the size model to estimate
           // inlinability. Note that as the latest candidate reason.
-          compInlineResult->setCandidate("below ALWAYS_INLINE size");
+          compInlineResult->noteCandidate(InlineObservation::CALLEE_BELOW_ALWAYS_INLINE_SIZE);
        }
     }
 
@@ -22064,7 +22064,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
                inlineCandidateInfo->methInfo.ILCodeSize,
                inlineDepth,
                info.compFullName,
-               inlineResult->reason());
+               inlineResult->reasonString());
     }
 
     if (verbose)
@@ -22078,7 +22078,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
 #endif
 
     // We inlined...
-    inlineResult->setSuccess();
+    inlineResult->noteSuccess();
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -15777,7 +15777,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
                  threshold / NATIVE_CALL_SIZE_MULTIPLIER, multiplier));
 
        // Still a viable candidate....update status
-       inlineResult->setCandidate("Native size estimate within threshold");
+       inlineResult->noteCandidate(InlineObservation::CALLSITE_NATIVE_SIZE_ESTIMATE_OK);
     }
 
 #undef NATIVE_CALL_SIZE_MULTIPLIER
@@ -15847,8 +15847,10 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE    fncHandle,
 
     if (forceInline) 
     {
+        // This looks a bit redundant; it's because we haven't yet
+        // extracted policy from observation....
         inlineResult->note(InlineObservation::CALLEE_HAS_FORCE_INLINE);
-        inlineResult->setCandidate("Inline is a force inline");
+        inlineResult->noteCandidate(InlineObservation::CALLEE_HAS_FORCE_INLINE);
         return;
     }       
  
@@ -15919,7 +15921,7 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE    fncHandle,
 #endif // FEATURE_LEGACYNETCF
 
     // Still a viable candidate...
-    inlineResult->setCandidate("impCanInlineIL");
+    inlineResult->noteCandidate(InlineObservation::CALLEE_CAN_INLINE_IL);
 }
 
 /*****************************************************************************
@@ -16105,7 +16107,7 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
 
         *(pParam->ppInlineCandidateInfo) = pInfo;
 
-        pParam->result->setCandidate("impCheckCanInline");
+        pParam->result->noteCandidate(InlineObservation::CALLEE_CHECK_CAN_INLINE_IL);
   
 _exit:
         ;
@@ -16218,7 +16220,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo *  pInlineInfo,
     // This doesn't mean that other information or other args
     // will not prevent inlining of this method.
     //
-    inlineResult->setCandidate("impInlineRecordArgInfo");
+    inlineResult->noteCandidate(InlineObservation::CALLSITE_ARGS_OK);
 }
 
 /*****************************************************************************
@@ -16563,7 +16565,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
     pInlineInfo->hasSIMDTypeArgLocalOrReturn = foundSIMDType;
 #endif // FEATURE_SIMD
 
-    inlineResult->setCandidate("impInlineInitVars");
+    inlineResult->noteCandidate(InlineObservation::CALLSITE_LOCALS_OK);
 }
 
 

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -184,7 +184,7 @@ void InlineResult::report()
         const char* caller = (inlInliner == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlInliner);
         const char* callee = (inlInlinee == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlInlinee);
 
-        JITDUMP(format, inlContext, resultString(), inlReason, caller, callee);
+        JITDUMP(format, inlContext, resultString(), reasonString(), caller, callee);
     }
 
 #endif // DEBUG
@@ -192,8 +192,8 @@ void InlineResult::report()
     if (isDecided()) 
     {
         const char* format = "INLINER: during '%s' result '%s' reason '%s'\n";
-        JITLOG_THIS(inlCompiler, (LL_INFO100000, format, inlContext, resultString(), inlReason));
+        JITLOG_THIS(inlCompiler, (LL_INFO100000, format, inlContext, resultString(), reasonString()));
         COMP_HANDLE comp = inlCompiler->info.compCompHnd;
-        comp->reportInliningDecision(inlInliner, inlInlinee, result(), inlReason);
+        comp->reportInliningDecision(inlInliner, inlInlinee, result(), reasonString());
     }
 }

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -87,7 +87,10 @@ INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",      
 
 // ------ Callee Information ------- 
 
-INLINE_OBSERVATION(HAS_FORCE_INLINE,          bool,   "has aggressive inline attr",    INFORMATION, CALLEE)
+INLINE_OBSERVATION(BELOW_ALWAYS_INLINE_SIZE,  bool,   "below ALWAYS_INLINE size",      INFORMATION, CALLEE)
+INLINE_OBSERVATION(CAN_INLINE_IL,             bool,   "IL passes basic checks",        INFORMATION, CALLEE)
+INLINE_OBSERVATION(CHECK_CAN_INLINE_IL,       bool,   "IL passes detailed checks",     INFORMATION, CALLEE)
+INLINE_OBSERVATION(HAS_FORCE_INLINE,          bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",           INFORMATION, CALLEE)
@@ -139,13 +142,16 @@ INLINE_OBSERVATION(RETURN_TYPE_MISMATCH,      bool,   "return type mismatch",   
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLSITE)
 INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",               FATAL,       CALLSITE)
 
-// ------ Call Site Peformance ------- 
+// ------ Call Site Performance ------- 
 
 
 // ------ Call Site Information ------- 
 
+INLINE_OBSERVATION(ARGS_OK,                   bool,   "arguments suitable",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(BENEFIT_MULTIPLIER,        double, "benefit multiplier",            INFORMATION, CALLSITE)
+INLINE_OBSERVATION(LOCALS_OK,                 bool,   "locals suitable",               INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLSITE)
+INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE_OK,   bool,   "native size estimate ok",       INFORMATION, CALLSITE)
 
 // ------ Final Sentinel ------- 
 


### PR DESCRIPTION
Add candidate observations and update the InlineResult to hold
onto the observation rather than the reason string.