### PR TITLE
Revert "Revert "Remove useless security checks""

### DIFF
--- a/src/mscorlib/src/System/Reflection/ConstructorInfo.cs
+++ b/src/mscorlib/src/System/Reflection/ConstructorInfo.cs
@@ -626,15 +626,15 @@ namespace System.Reflection
 
             }
 
+#if !FEATURE_CORECLR
             if ((invocationFlags &(INVOCATION_FLAGS.INVOCATION_FLAGS_RISKY_METHOD | INVOCATION_FLAGS.INVOCATION_FLAGS_NEED_SECURITY)) != 0) 
             {
-#if !FEATURE_CORECLR
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_RISKY_METHOD) != 0)
                     CodeAccessPermission.Demand(PermissionType.ReflectionMemberAccess);
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NEED_SECURITY) != 0)
-#endif // !FEATURE_CORECLR
                     RuntimeMethodHandle.PerformSecurityCheck(obj, this, m_declaringType, (uint)m_invocationFlags);
             }
+#endif // !FEATURE_CORECLR
 
             Signature sig = Signature;
 
@@ -719,19 +719,17 @@ namespace System.Reflection
             }
 #endif
 
+#if !FEATURE_CORECLR
             if ((invocationFlags & (INVOCATION_FLAGS.INVOCATION_FLAGS_RISKY_METHOD | INVOCATION_FLAGS.INVOCATION_FLAGS_NEED_SECURITY | INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR)) != 0) 
             {
-#if !FEATURE_CORECLR
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_RISKY_METHOD) != 0) 
                     CodeAccessPermission.Demand(PermissionType.ReflectionMemberAccess);
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NEED_SECURITY)  != 0) 
-#endif // !FEATURE_CORECLR
                     RuntimeMethodHandle.PerformSecurityCheck(null, this, m_declaringType, (uint)(m_invocationFlags | INVOCATION_FLAGS.INVOCATION_FLAGS_CONSTRUCTOR_INVOKE));
-#if !FEATURE_CORECLR
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_IS_DELEGATE_CTOR) != 0)
                     new SecurityPermission(SecurityPermissionFlag.UnmanagedCode).Demand();
-#endif // !FEATURE_CORECLR
             }
+#endif // !FEATURE_CORECLR
 
             // get the signature
             Signature sig = Signature;

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -438,10 +438,10 @@ namespace System.Reflection.Emit
         [System.Security.SecurityCritical]  // auto-generated
         private void PerformSecurityCheck(Module m, ref StackCrawlMark stackMark, bool skipVisibility)
         {
-#if !FEATURE_CORECLR
             if (m == null) 
                 throw new ArgumentNullException("m");
             Contract.EndContractBlock();
+#if !FEATURE_CORECLR
 
             RuntimeModule rtModule;
             ModuleBuilder mb = m as ModuleBuilder;
@@ -484,9 +484,9 @@ namespace System.Reflection.Emit
         [System.Security.SecurityCritical]  // auto-generated
         private void PerformSecurityCheck(Type owner, ref StackCrawlMark stackMark, bool skipVisibility)
         {
-#if !FEATURE_CORECLR
             if (owner == null)
                 throw new ArgumentNullException("owner");
+#if !FEATURE_CORECLR
 
             RuntimeType rtOwner = owner as RuntimeType;
             if (rtOwner == null)

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -438,6 +438,7 @@ namespace System.Reflection.Emit
         [System.Security.SecurityCritical]  // auto-generated
         private void PerformSecurityCheck(Module m, ref StackCrawlMark stackMark, bool skipVisibility)
         {
+#if !FEATURE_CORECLR
             if (m == null) 
                 throw new ArgumentNullException("m");
             Contract.EndContractBlock();
@@ -477,11 +478,13 @@ namespace System.Reflection.Emit
                 new SecurityPermission(SecurityPermissionFlag.ControlEvidence).Demand();
 #pragma warning restore 618
 #endif //FEATURE_CORECLR
+#endif //!FEATURE_CORECLR
         }
 
         [System.Security.SecurityCritical]  // auto-generated
         private void PerformSecurityCheck(Type owner, ref StackCrawlMark stackMark, bool skipVisibility)
         {
+#if !FEATURE_CORECLR
             if (owner == null)
                 throw new ArgumentNullException("owner");
 
@@ -519,6 +522,7 @@ namespace System.Reflection.Emit
                 new SecurityPermission(SecurityPermissionFlag.ControlEvidence).Demand();
 #pragma warning restore 618
 #endif //FEATURE_CORECLR
+#endif //!FEATURE_CORECLR
         }
 
         //

--- a/src/mscorlib/src/System/Reflection/MethodInfo.cs
+++ b/src/mscorlib/src/System/Reflection/MethodInfo.cs
@@ -721,16 +721,16 @@ namespace System.Reflection
             }
 #endif
 
+#if !FEATURE_CORECLR
             if ((invocationFlags & (INVOCATION_FLAGS.INVOCATION_FLAGS_RISKY_METHOD | INVOCATION_FLAGS.INVOCATION_FLAGS_NEED_SECURITY)) != 0)
             {
-#if !FEATURE_CORECLR
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_RISKY_METHOD) != 0)
                     CodeAccessPermission.Demand(PermissionType.ReflectionMemberAccess);
 
                 if ((invocationFlags & INVOCATION_FLAGS.INVOCATION_FLAGS_NEED_SECURITY) != 0)
-#endif // !FEATURE_CORECLR
                     RuntimeMethodHandle.PerformSecurityCheck(obj, this, m_declaringType, (uint)m_invocationFlags);
             }
+#endif // !FEATURE_CORECLR
             #endregion
 
             return UnsafeInvokeInternal(obj, parameters, arguments);

--- a/src/mscorlib/src/System/RtType.cs
+++ b/src/mscorlib/src/System/RtType.cs
@@ -5413,6 +5413,9 @@ namespace System
                 bCanBeCached = false;
             }
 #endif
+#if FEATURE_CORECLR
+            bSecurityCheckOff = true;       // CoreCLR does not use security at all.   
+#endif
 
             Object instance = RuntimeTypeHandle.CreateInstance(this, publicOnly, bSecurityCheckOff, ref bCanBeCached, ref runtime_ctor, ref bNeedSecurityCheck);
 
@@ -5467,9 +5470,11 @@ namespace System
 
                     if (ace.m_ctor != null)
                     {
+#if !FEATURE_CORECLR
                         // Perform security checks if needed
                         if (ace.m_bNeedSecurityCheck)
                             RuntimeMethodHandle.PerformSecurityCheck(instance, ace.m_hCtorMethodHandle, this, (uint)INVOCATION_FLAGS.INVOCATION_FLAGS_CONSTRUCTOR_INVOKE);
+#endif
 
                         // Call ctor (value types wont have any)
                         try

--- a/src/mscorlib/src/System/RuntimeHandles.cs
+++ b/src/mscorlib/src/System/RuntimeHandles.cs
@@ -1196,6 +1196,7 @@ namespace System
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static extern internal uint GetSpecialSecurityFlags(IRuntimeMethodInfo method);
 
+#if !FEATURE_CORECLR
         [System.Security.SecurityCritical]  // auto-generated
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
         static extern internal void PerformSecurityCheck(Object obj, RuntimeMethodHandleInternal method, RuntimeType parent, uint invocationFlags);
@@ -1207,6 +1208,7 @@ namespace System
             GC.KeepAlive(method);
             return;
         }
+#endif //!FEATURE_CORECLR
         #endregion
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/vm/ecalllist.h
+++ b/src/vm/ecalllist.h
@@ -575,7 +575,9 @@ FCFuncStart(gRuntimeMethodHandle)
     QCFuncElement("GetCallerType", RuntimeMethodHandle::GetCallerType)
     FCFuncElement("GetLoaderAllocator", RuntimeMethodHandle::GetLoaderAllocator)
     FCFuncElement("GetSpecialSecurityFlags", ReflectionInvocation::GetSpecialSecurityFlags)
+#ifndef FEATURE_CORECLR
     FCFuncElement("PerformSecurityCheck", ReflectionInvocation::PerformSecurityCheck)
+#endif // FEATURE_CORECLR
 FCFuncEnd()
 
 FCFuncStart(gCOMDefaultBinderFuncs)

--- a/src/vm/reflectioninvocation.cpp
+++ b/src/vm/reflectioninvocation.cpp
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 //
-
 //
-
 
 #include "common.h"
 #include "reflectioninvocation.h"
@@ -900,6 +898,8 @@ FCIMPL1(DWORD, ReflectionInvocation::GetSpecialSecurityFlags, ReflectMethodObjec
 }
 FCIMPLEND
 
+#ifndef FEATURE_CORECLR
+
 // Can not inline this function.
 #ifdef _MSC_VER
 __declspec(noinline)
@@ -999,6 +999,8 @@ FCIMPL4(void, ReflectionInvocation::PerformSecurityCheck, Object *target, Method
     HELPER_METHOD_FRAME_END();
 }
 FCIMPLEND
+
+#endif // FEATURE_CORECLR
 
 /****************************************************************************/
 /* boxed Nullable<T> are represented as a boxed T, so there is no unboxed


### PR DESCRIPTION
This reverts commit a5e803cf70d861022f3b6cddb9045edb8a222e78.
Remove more calls to PerformSecurityCheck.  

@jkotas @stephentoub 

This was originally checked in as #3027 but then reverted by #3063 because of a Ubuntu failure.  

Issue #3064 is tracking putting this back and this this pull request is trying to do that.

In #3063 the failure gave the following output:

03:21:48 Type: System.Diagnostics.Tests.ProcessTestBase+<>c
 03:21:48 Method: Int32 b__7_0()
 03:21:48 Exception: System.OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.
 03:21:48 at System.RuntimeMethodHandle.PerformSecurityCheck(Object obj, IRuntimeMethodInfo method, RuntimeType parent, UInt32 invocationFlags)
 03:21:48 at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
 03:21:48 at RemoteExecutorConsoleApp.Program.Main(String[] args)

Now interestingly the original OutOfMemory failure seems to come out of the PerformSecurityCheck method which after the change shoudl have been EMPTY.   This suggests that there is something more 'magical' going on and this method just happens to be the point where it happens.

It turns out that  there are only a small number of calls to the empty PerformSecurityCheck function, and in fact removing the calls actually made the #ifdefs simpler, so that is what this change does.

Note that I have not root caused the original failure.   However clearly it can't repro in the same way because the method on the stack above does not event exist.

We should certainly retry the test.  If it does not get run as part of normal pull request validation I will need instructions on doing that run.   