### PR TITLE
Do not define global inline new/delete operators

### DIFF
--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -83,6 +83,17 @@ const UINT kcMaxRevertedRejitData = 10;
 
 #ifndef FEATURE_PAL
 
+// ensure we always allocate on the process heap
+void* __cdecl operator new(size_t size) throw()
+{ return HeapAlloc(GetProcessHeap(), 0, size); }
+void __cdecl operator delete(void* pObj) throw()
+{ HeapFree(GetProcessHeap(), 0, pObj); }
+
+void* __cdecl operator new[](size_t size) throw()
+{ return HeapAlloc(GetProcessHeap(), 0, size); }
+void __cdecl operator delete[](void* pObj) throw()
+{ HeapFree(GetProcessHeap(), 0, pObj); }
+
 /**********************************************************************\
 * Here we define types and functions that support custom COM           *
 * activation rules, as defined by the CIOptions enum.                  *

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -1632,19 +1632,6 @@ WCHAR *CreateMethodTableName(TADDR mt, TADDR cmt = NULL);
 void isRetAddr(DWORD_PTR retAddr, DWORD_PTR* whereCalled);
 DWORD_PTR GetValueFromExpression (___in __in_z const char *const str);
 
-#ifndef FEATURE_PAL
-// ensure we always allocate on the process heap
-FORCEINLINE void* __cdecl operator new(size_t size) throw()
-{ return HeapAlloc(GetProcessHeap(), 0, size); }
-FORCEINLINE void __cdecl operator delete(void* pObj) throw()
-{ HeapFree(GetProcessHeap(), 0, pObj); }
-
-FORCEINLINE void* __cdecl operator new[](size_t size) throw()
-{ return HeapAlloc(GetProcessHeap(), 0, size); }
-FORCEINLINE void __cdecl operator delete[](void* pObj) throw()
-{ HeapFree(GetProcessHeap(), 0, pObj); }
-#endif
-
 enum ModuleHeapType
 {
     ModuleHeapType_ThunkHeap,


### PR DESCRIPTION
VS2015 Update 2 generates C4595 for such code and the build fails due to /WX