### PR TITLE
Inline refactoring: capture failing observation for non-candidates

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4970,7 +4970,7 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
             if (opts.eeFlags & CORJIT_FLG_PREJIT)
             {
                 // Cache inlining hint during NGen to avoid touching bodies of non-inlineable methods at runtime
-                InlineResult trialResult(this, nullptr, methodHnd, "prejit1");
+                InlineResult trialResult(this, methodHnd, "prejit1");
                 impCanInlineIL(methodHnd, methodInfo, forceInline, &trialResult);
                 if (trialResult.isFailure())
                 {
@@ -5016,7 +5016,7 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
             assert(compNativeSizeEstimate != NATIVE_SIZE_INVALID); 
 
             int callsiteNativeSizeEstimate = impEstimateCallsiteNativeSize(methodInfo);
-            InlineResult trialResult(this, nullptr, methodHnd, "prejit2");
+            InlineResult trialResult(this, methodHnd, "prejit2");
             
             impCanInlineNative(callsiteNativeSizeEstimate, 
                                compNativeSizeEstimate,

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2507,6 +2507,12 @@ struct GenTreeCall final : public GenTree
     CORINFO_CONST_LOOKUP gtEntryPoint;
 #endif
 
+#ifdef DEBUG
+    // For non-inline candidates, track the first observation
+    // that blocks candidacy.
+    unsigned gtInlineObservation;
+#endif
+
     GenTreeCall(var_types type) : 
         GenTree(GT_CALL, type) 
     {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -15762,7 +15762,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
         }
         else 
         {
-            // Static hint case.... here the "callee" is the function being assessed. (PLS VERIFY)
+            // Static hint case.... here the "callee" is the function being assessed.
             inlineResult->noteFatal(InlineObservation::CALLEE_EXCEEDS_THRESHOLD);
         }
     }
@@ -16816,9 +16816,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
     }
     
     GenTreeCall* call = callNode->AsCall();
-    CORINFO_METHOD_HANDLE callerHandle = info.compMethodHnd;
-    CORINFO_METHOD_HANDLE calleeHandle = call->gtCall.gtCallType == CT_USER_FUNC ? call->gtCall.gtCallMethHnd : nullptr;
-    InlineResult inlineResult(this, callerHandle, calleeHandle, "impMarkInlineCandidate");
+    InlineResult inlineResult(this, call, "impMarkInlineCandidate");
     
     /* Don't inline if not optimized code */
     if  (opts.compDbgCode)


### PR DESCRIPTION
Refactor the InlineResult to take a `GenTreeCall` instead of artifacts
derived from the call. Use this to decorate the call (in DEBUG) if
an inline fails with the observation that lead to the failure. Move
this constructor out of the header since we now need it to invoke
methods on types that are header-opaque.

Try and pick this reason up later on when non-candidate call sites are
encountered during inlining.

Introduce a second constructor for the pre-jit use case, where we are
evaulating a method to see if we can mark it as never inline to save
work in any subsequent compilation. Put this into the cpp file too for
symmetry.

Type the backing field in GenTreeCall as unsigned to avoid creating
more deeply entangled include circularities. Happy to reconsider if
this seems ill-advised.

Reword a few more uses of inlinee to callee (similarly inliner to
caller). Make `inlIsValidObservation` globally visible and enable
a prior commented-out assert.