### PR TITLE
Fix issue unveiled on NetBSD: Add PAL__vsnprintf shadow in PAL

### DIFF
--- a/src/ToolBox/SOS/Strike/strike.h
+++ b/src/ToolBox/SOS/Strike/strike.h
@@ -44,6 +44,10 @@
 #define _wcsstr     wcsstr
 #endif // !PAL_STDCPP_COMPAT
 
+#ifdef PLATFORM_UNIX
+#define  _vsnprintf vsnprintf
+#endif
+
 #define ___in       _SAL1_Source_(__in, (), _In_)
 #define ___out      _SAL1_Source_(__out, (), _Out_)
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -5790,6 +5790,7 @@ CoCreateGuid(OUT GUID * pguid);
 #define _close        PAL__close
 #define _wcstoui64    PAL__wcstoui64
 #define _flushall     PAL__flushall
+#define _vsnprintf    PAL__vsnprintf
 
 #ifdef _AMD64_ 
 #define _mm_getcsr    PAL__mm_getcsr

--- a/src/pal/src/cruntime/printf.cpp
+++ b/src/pal/src/cruntime/printf.cpp
@@ -295,7 +295,7 @@ wsprintfA(
     ENTRY("wsprintfA (buffer=%p, format=%p (%s))\n", buffer, format, format);
 
     va_start(ap, format);
-    Length = PAL__vsnprintf(buffer, 1024, format, ap);
+    Length = InternalVsnprintf(CorUnix::InternalGetCurrentThread(), buffer, 1024, format, ap);
     va_end(ap);
 
     LOGEXIT("wsprintfA returns int %d\n", Length);
@@ -354,7 +354,7 @@ _snprintf(
           buffer, (unsigned long) count, format, format);
 
     va_start(ap, format);
-    Length = PAL__vsnprintf(buffer, count, format, ap);
+    Length = InternalVsnprintf(CorUnix::InternalGetCurrentThread(), buffer, count, format, ap);
     va_end(ap);
 
     LOGEXIT("_snprintf returns int %d\n", Length);
@@ -1529,7 +1529,7 @@ PAL_sprintf(
     ENTRY("PAL_sprintf (buffer=%p, format=%p (%s))\n", buffer, format, format);
 
     va_start(ap, format);
-    Length = PAL__vsnprintf(buffer, 0x7fffffff, format, ap);
+    Length = InternalVsnprintf(CorUnix::InternalGetCurrentThread(), buffer, 0x7fffffff, format, ap);
     va_end(ap);
 
     LOGEXIT("PAL_sprintf returns int %d\n", Length);
@@ -1613,42 +1613,13 @@ PAL_vsprintf(char *buffer,
     ENTRY("PAL_vsprintf (buffer=%p, format=%p (%s), argptr=%p)\n", 
           buffer, format, format, argptr);
 
-    Length = PAL__vsnprintf(buffer, 0x7fffffff, format, argptr);
+    Length = InternalVsnprintf(CorUnix::InternalGetCurrentThread(), buffer, 0x7fffffff, format, argptr);
 
     LOGEXIT("PAL_vsprintf returns int %d\n", Length);
     PERF_EXIT(vsprintf);
 
     return Length;
 }
-
-
-/*++
-Function:
-  _vsnprintf
-
-See MSDN doc.
---*/
-int 
-__cdecl 
-_vsnprintf(char *buffer, 
-           size_t count, 
-           const char *format, 
-           va_list argptr)
-{
-    LONG Length;
-
-    PERF_ENTRY(_vsnprintf);
-    ENTRY("_vsnprintf (buffer=%p, count=%d, format=%p (%s), argptr=%p)\n", 
-          buffer, count, format, format, argptr);
-
-    Length = PAL__vsnprintf(buffer, count, format, argptr);
-
-    LOGEXIT("_vsnprintf returns int %d\n", Length);
-    PERF_EXIT(_vsnprintf);
-
-    return Length;
-}
-
 
 
 /*++
@@ -1785,4 +1756,3 @@ static int SscanfFloatCheckExponent(LPCSTR buff, LPCSTR floatFmt,
     return ret;
 }
 #endif // SSCANF_CANNOT_HANDLE_MISSING_EXPONENT
-

--- a/src/pal/src/cruntime/printfcpp.cpp
+++ b/src/pal/src/cruntime/printfcpp.cpp
@@ -1068,7 +1068,18 @@ Parameters:
 
 int __cdecl PAL__vsnprintf(LPSTR Buffer, size_t Count, LPCSTR Format, va_list ap)
 {
-    return CoreVsnprintf(InternalGetCurrentThread(), Buffer, Count, Format, ap);
+    LONG Length;
+
+    PERF_ENTRY(PAL__vsnprintf);
+    ENTRY("PAL__vsnprintf (buffer=%p, count=%d, format=%p (%s), argptr=%p)\n",
+          Buffer, Count, Format, Format, ap);
+
+    Length = CoreVsnprintf(InternalGetCurrentThread(), Buffer, Count, Format, ap);
+
+    LOGEXIT("PAL__vsnprintf returns int %d\n", Length);
+    PERF_EXIT(PAL__vsnprintf);
+
+    return Length;
 }
 
 /*******************************************************************************

--- a/src/pal/src/cruntime/silent_printf.cpp
+++ b/src/pal/src/cruntime/silent_printf.cpp
@@ -26,6 +26,7 @@ Revision History:
 #include "pal/cruntime.h"
 #include "pal/locale.h"
 #include "pal/printfcpp.hpp"
+#include "pal/thread.hpp"
 
 /* clip strings (%s, %S) at this number of characters */
 #define MAX_STR_LEN 300
@@ -280,7 +281,7 @@ INT Silent_PAL_vsnprintf(LPSTR Buffer, INT Count, LPCSTR Format, va_list aparg)
                     }                                     
                     va_list apcopy;
                     va_copy(apcopy, ap);
-                    TempInt = PAL__vsnprintf(BufferPtr, TempCount, TempBuff, apcopy);
+                    TempInt = InternalVsnprintf(CorUnix::InternalGetCurrentThread(), BufferPtr, TempCount, TempBuff, apcopy);
                     va_end(apcopy);
                     PAL_printf_arg_remover(&ap, Width, Precision, Type, Prefix);
                 }
@@ -987,4 +988,3 @@ size_t Silent_PAL_wcslen(const wchar_16 *string)
     
     return nChar;
 }
-


### PR DESCRIPTION
NetBSD's libc internally uses a function named `_vsnprintf`. We need to mask
PAL's version of this function to remove clash with the system. With it
`snprintf`(3) calls were jumping out of libc and landing back to PAL.

It was unveiled with many PAL tests.

Detailed documentation about `_symbols` in the NetBSD libc is documented
in the NetBSD sources in a file: `src/lib/libc/README`

Thanks Jan Vorli (Microsoft) for help with debugging.

Fix #3199