### PR TITLE
Refactor of conditional branches for the ARM architecture

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -92,7 +92,7 @@ private:
 
     static emitJumpKind genJumpKindForOper(genTreeOps cmp, bool isUnsigned);
 
-#ifdef _TARGET_XARCH_
+
     // For a given compare oper tree, returns the conditions to use with jmp/set in 'jmpKind' array. 
     // The corresponding elements of jmpToTrueLabel indicate whether the target of the jump is to the
     // 'true' label or a 'false' label.  
@@ -101,11 +101,11 @@ private:
     // branch to on compare condition being true.  'false' label corresponds to the target to
     // branch to on condition being false.
     static void genJumpKindsForTree(GenTreePtr cmpTree, emitJumpKind jmpKind[2], bool jmpToTrueLabel[2]);
+
 #if !defined(_TARGET_64BIT_)
     static void genJumpKindsForTreeLongHi(GenTreePtr cmpTree, emitJumpKind jmpKind[2], bool jmpToTrueLabel[2]);
     static void genJumpKindsForTreeLongLo(GenTreePtr cmpTree, emitJumpKind jmpKind[2], bool jmpToTrueLabel[2]);
 #endif //!defined(_TARGET_64BIT_)
-#endif // _TARGET_XARCH_
 
     static bool         genShouldRoundFP();
 

--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -90,8 +90,8 @@ private:
                                                         else
                                                             return REG_SPBASE; }
 
-    static emitJumpKind genJumpKindForOper(genTreeOps cmp, bool isUnsigned);
-
+    enum CompareKind { CK_SIGNED, CK_UNSIGNED, CK_LOGICAL };
+    static emitJumpKind genJumpKindForOper(genTreeOps cmp, CompareKind compareKind);
 
     // For a given compare oper tree, returns the conditions to use with jmp/set in 'jmpKind' array. 
     // The corresponding elements of jmpToTrueLabel indicate whether the target of the jump is to the

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -1448,8 +1448,9 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
             // Get the "kind" and type of the comparison.  Note that whether it is an unsigned cmp
             // is governed by a flag NOT by the inherent type of the node
             // TODO-ARM-CQ: Check if we can use the currently set flags.
+            CompareKind compareKind = ((cmp->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
 
-            emitJumpKind jmpKind   = genJumpKindForOper(cmp->gtOper, (cmp->gtFlags & GTF_UNSIGNED) != 0);
+            emitJumpKind jmpKind   = genJumpKindForOper(cmp->gtOper, compareKind);
             BasicBlock * jmpTarget = compiler->compCurBB->bbJumpDest;
 
             inst_JMP(jmpKind, jmpTarget);
@@ -1468,7 +1469,8 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
             BasicBlock* skipLabel = genCreateTempLabel();
 
-            inst_JMP(genJumpKindForOper(GT_EQ, false), skipLabel);
+            emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
+            inst_JMP(jmpEqual, skipLabel);
             // emit the call to the EE-helper that stops for GC (or other reasons)
 
             genEmitHelperCall(CORINFO_HELP_STOP_FOR_GC, 0, EA_UNKNOWN);
@@ -1674,13 +1676,13 @@ CodeGen::genRangeCheck(GenTreePtr  oper)
         //  constant operand in the second position
         src1 = arrLen;
         src2 = arrIdx;
-        jmpKind = genJumpKindForOper(GT_LE, true);  // unsigned compare
+        jmpKind = genJumpKindForOper(GT_LE, CK_UNSIGNED); 
     }
     else
     {
         src1 = arrIdx;
         src2 = arrLen;
-        jmpKind = genJumpKindForOper(GT_GE, true);  // unsigned compare
+        jmpKind = genJumpKindForOper(GT_GE, CK_UNSIGNED); 
     }
 
     genConsumeIfReg(src1);

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -27,6 +27,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #include "gcinfoencoder.h"
 #endif
 
+
 // Get the register assigned to the given node
 
 regNumber CodeGenInterface::genGetAssignedReg(GenTreePtr tree)
@@ -1467,7 +1468,7 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
             BasicBlock* skipLabel = genCreateTempLabel();
 
-            inst_JMP(genJumpKindForOper(GT_EQ, true), skipLabel);
+            inst_JMP(genJumpKindForOper(GT_EQ, false), skipLabel);
             // emit the call to the EE-helper that stops for GC (or other reasons)
 
             genEmitHelperCall(CORINFO_HELP_STOP_FOR_GC, 0, EA_UNKNOWN);
@@ -1669,15 +1670,17 @@ CodeGen::genRangeCheck(GenTreePtr  oper)
 
     if (arrIdx->isContainedIntOrIImmed())
     {
+        // To encode using a cmp immediate, we place the 
+        //  constant operand in the second position
         src1 = arrLen;
         src2 = arrIdx;
-        jmpKind = EJ_jbe;
+        jmpKind = genJumpKindForOper(GT_LE, true);  // unsigned compare
     }
     else
     {
         src1 = arrIdx;
         src2 = arrLen;
-        jmpKind = EJ_jae;
+        jmpKind = genJumpKindForOper(GT_GE, true);  // unsigned compare
     }
 
     genConsumeIfReg(src1);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2457,7 +2457,7 @@ FOUND_AM:
 emitJumpKind         CodeGen::genJumpKindForOper(genTreeOps  cmp, CompareKind compareKind)
 {
     const static
-        BYTE            genJCCinsSgn[] =
+    BYTE            genJCCinsSigned[] =
     {
 #if defined(_TARGET_XARCH_)
         EJ_je,      // GT_EQ
@@ -2477,7 +2477,7 @@ emitJumpKind         CodeGen::genJumpKindForOper(genTreeOps  cmp, CompareKind co
     };
 
     const static
-        BYTE            genJCCinsUns[] =       /* unsigned comparison */
+    BYTE            genJCCinsUnsigned[] =       /* unsigned comparison */
     {
 #if defined(_TARGET_XARCH_)
         EJ_je,      // GT_EQ
@@ -2497,7 +2497,7 @@ emitJumpKind         CodeGen::genJumpKindForOper(genTreeOps  cmp, CompareKind co
     };
 
     const static
-        BYTE            genJCCinsLog[] =       /* logical operation */
+    BYTE            genJCCinsLogical[] =       /* logical operation */
     {
 #if defined(_TARGET_XARCH_)
         EJ_je,      // GT_EQ   (Z == 1)
@@ -2517,43 +2517,43 @@ emitJumpKind         CodeGen::genJumpKindForOper(genTreeOps  cmp, CompareKind co
     };
 
 #if defined(_TARGET_XARCH_)
-    assert(genJCCinsSgn[GT_EQ - GT_EQ] == EJ_je);
-    assert(genJCCinsSgn[GT_NE - GT_EQ] == EJ_jne);
-    assert(genJCCinsSgn[GT_LT - GT_EQ] == EJ_jl);
-    assert(genJCCinsSgn[GT_LE - GT_EQ] == EJ_jle);
-    assert(genJCCinsSgn[GT_GE - GT_EQ] == EJ_jge);
-    assert(genJCCinsSgn[GT_GT - GT_EQ] == EJ_jg);
+    assert(genJCCinsSigned[GT_EQ - GT_EQ] == EJ_je);
+    assert(genJCCinsSigned[GT_NE - GT_EQ] == EJ_jne);
+    assert(genJCCinsSigned[GT_LT - GT_EQ] == EJ_jl);
+    assert(genJCCinsSigned[GT_LE - GT_EQ] == EJ_jle);
+    assert(genJCCinsSigned[GT_GE - GT_EQ] == EJ_jge);
+    assert(genJCCinsSigned[GT_GT - GT_EQ] == EJ_jg);
 
-    assert(genJCCinsUns[GT_EQ - GT_EQ] == EJ_je);
-    assert(genJCCinsUns[GT_NE - GT_EQ] == EJ_jne);
-    assert(genJCCinsUns[GT_LT - GT_EQ] == EJ_jb);
-    assert(genJCCinsUns[GT_LE - GT_EQ] == EJ_jbe);
-    assert(genJCCinsUns[GT_GE - GT_EQ] == EJ_jae);
-    assert(genJCCinsUns[GT_GT - GT_EQ] == EJ_ja);
+    assert(genJCCinsUnsigned[GT_EQ - GT_EQ] == EJ_je);
+    assert(genJCCinsUnsigned[GT_NE - GT_EQ] == EJ_jne);
+    assert(genJCCinsUnsigned[GT_LT - GT_EQ] == EJ_jb);
+    assert(genJCCinsUnsigned[GT_LE - GT_EQ] == EJ_jbe);
+    assert(genJCCinsUnsigned[GT_GE - GT_EQ] == EJ_jae);
+    assert(genJCCinsUnsigned[GT_GT - GT_EQ] == EJ_ja);
 
-    assert(genJCCinsLog[GT_EQ - GT_EQ] == EJ_je);
-    assert(genJCCinsLog[GT_NE - GT_EQ] == EJ_jne);
-    assert(genJCCinsLog[GT_LT - GT_EQ] == EJ_js);
-    assert(genJCCinsLog[GT_GE - GT_EQ] == EJ_jns);
+    assert(genJCCinsLogical[GT_EQ - GT_EQ] == EJ_je);
+    assert(genJCCinsLogical[GT_NE - GT_EQ] == EJ_jne);
+    assert(genJCCinsLogical[GT_LT - GT_EQ] == EJ_js);
+    assert(genJCCinsLogical[GT_GE - GT_EQ] == EJ_jns);
 #elif defined(_TARGET_ARMARCH_)
-    assert(genJCCinsSgn[GT_EQ - GT_EQ] == EJ_eq);
-    assert(genJCCinsSgn[GT_NE - GT_EQ] == EJ_ne);
-    assert(genJCCinsSgn[GT_LT - GT_EQ] == EJ_lt);
-    assert(genJCCinsSgn[GT_LE - GT_EQ] == EJ_le);
-    assert(genJCCinsSgn[GT_GE - GT_EQ] == EJ_ge);
-    assert(genJCCinsSgn[GT_GT - GT_EQ] == EJ_gt);
+    assert(genJCCinsSigned[GT_EQ - GT_EQ] == EJ_eq);
+    assert(genJCCinsSigned[GT_NE - GT_EQ] == EJ_ne);
+    assert(genJCCinsSigned[GT_LT - GT_EQ] == EJ_lt);
+    assert(genJCCinsSigned[GT_LE - GT_EQ] == EJ_le);
+    assert(genJCCinsSigned[GT_GE - GT_EQ] == EJ_ge);
+    assert(genJCCinsSigned[GT_GT - GT_EQ] == EJ_gt);
 
-    assert(genJCCinsUns[GT_EQ - GT_EQ] == EJ_eq);
-    assert(genJCCinsUns[GT_NE - GT_EQ] == EJ_ne);
-    assert(genJCCinsUns[GT_LT - GT_EQ] == EJ_lo);
-    assert(genJCCinsUns[GT_LE - GT_EQ] == EJ_ls);
-    assert(genJCCinsUns[GT_GE - GT_EQ] == EJ_hs);
-    assert(genJCCinsUns[GT_GT - GT_EQ] == EJ_hi);
+    assert(genJCCinsUnsigned[GT_EQ - GT_EQ] == EJ_eq);
+    assert(genJCCinsUnsigned[GT_NE - GT_EQ] == EJ_ne);
+    assert(genJCCinsUnsigned[GT_LT - GT_EQ] == EJ_lo);
+    assert(genJCCinsUnsigned[GT_LE - GT_EQ] == EJ_ls);
+    assert(genJCCinsUnsigned[GT_GE - GT_EQ] == EJ_hs);
+    assert(genJCCinsUnsigned[GT_GT - GT_EQ] == EJ_hi);
 
-    assert(genJCCinsLog[GT_EQ - GT_EQ] == EJ_eq);
-    assert(genJCCinsLog[GT_NE - GT_EQ] == EJ_ne);
-    assert(genJCCinsLog[GT_LT - GT_EQ] == EJ_mi);
-    assert(genJCCinsLog[GT_GE - GT_EQ] == EJ_pl);
+    assert(genJCCinsLogical[GT_EQ - GT_EQ] == EJ_eq);
+    assert(genJCCinsLogical[GT_NE - GT_EQ] == EJ_ne);
+    assert(genJCCinsLogical[GT_LT - GT_EQ] == EJ_mi);
+    assert(genJCCinsLogical[GT_GE - GT_EQ] == EJ_pl);
 #else
     assert(!"unknown arch");
 #endif
@@ -2563,15 +2563,15 @@ emitJumpKind         CodeGen::genJumpKindForOper(genTreeOps  cmp, CompareKind co
 
     if (compareKind == CK_UNSIGNED)
     {
-        result = (emitJumpKind)genJCCinsUns[cmp - GT_EQ];
+        result = (emitJumpKind)genJCCinsUnsigned[cmp - GT_EQ];
     }
     else if (compareKind == CK_SIGNED)
     {
-        result = (emitJumpKind)genJCCinsSgn[cmp - GT_EQ];
+        result = (emitJumpKind)genJCCinsSigned[cmp - GT_EQ];
     }
     else if (compareKind == CK_LOGICAL)
     {
-        result = (emitJumpKind)genJCCinsLog[cmp - GT_EQ];
+        result = (emitJumpKind)genJCCinsLogical[cmp - GT_EQ];
     }
     assert(result != EJ_COUNT);
     return result;

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -3487,10 +3487,12 @@ regMaskTP           CodeGen::WriteBarrier(GenTreePtr tgt,
 void                CodeGen::genJccLongHi(genTreeOps   cmp,
                                           BasicBlock * jumpTrue,
                                           BasicBlock * jumpFalse,
-                                          bool         unsOper )
+                                          bool         isUnsigned )
 {
     if (cmp != GT_NE)
+    {
         jumpFalse->bbFlags |= BBF_JMP_TARGET|BBF_HAS_LABEL;
+    }
 
     switch (cmp)
     {
@@ -3504,7 +3506,7 @@ void                CodeGen::genJccLongHi(genTreeOps   cmp,
 
     case GT_LT:
     case GT_LE:
-        if (unsOper)
+        if (isUnsigned)
         {
             inst_JMP(EJ_ja , jumpFalse);
             inst_JMP(EJ_jb , jumpTrue);
@@ -3518,7 +3520,7 @@ void                CodeGen::genJccLongHi(genTreeOps   cmp,
 
     case GT_GE:
     case GT_GT:
-        if (unsOper)
+        if (isUnsigned)
         {
             inst_JMP(EJ_jb , jumpFalse);
             inst_JMP(EJ_ja , jumpTrue);
@@ -3583,12 +3585,14 @@ void            CodeGen::genJccLongLo(genTreeOps  cmp,
 */
 
 void                CodeGen::genJccLongHi(genTreeOps   cmp,
-    BasicBlock * jumpTrue,
-    BasicBlock * jumpFalse,
-    bool         unsOper)
+                                          BasicBlock * jumpTrue,
+                                          BasicBlock * jumpFalse,
+                                          bool         isUnsigned)
 {
     if (cmp != GT_NE)
+    {
         jumpFalse->bbFlags |= BBF_JMP_TARGET | BBF_HAS_LABEL;
+    }
 
     switch (cmp)
     {
@@ -3602,7 +3606,7 @@ void                CodeGen::genJccLongHi(genTreeOps   cmp,
 
     case GT_LT:
     case GT_LE:
-        if (unsOper)
+        if (isUnsigned)
         {
             inst_JMP(EJ_hi, jumpFalse);
             inst_JMP(EJ_lo, jumpTrue);
@@ -3616,7 +3620,7 @@ void                CodeGen::genJccLongHi(genTreeOps   cmp,
 
     case GT_GE:
     case GT_GT:
-        if (unsOper)
+        if (isUnsigned)
         {
             inst_JMP(EJ_lo, jumpFalse);
             inst_JMP(EJ_hi, jumpTrue);
@@ -3640,8 +3644,8 @@ void                CodeGen::genJccLongHi(genTreeOps   cmp,
 */
 
 void            CodeGen::genJccLongLo(genTreeOps  cmp,
-    BasicBlock* jumpTrue,
-    BasicBlock* jumpFalse)
+                                      BasicBlock* jumpTrue,
+                                      BasicBlock* jumpFalse)
 {
     switch (cmp)
     {
@@ -15326,8 +15330,8 @@ USE_SAR_FOR_CAST:
                     genComputeRegPair(op1, REG_PAIR_NONE, RBM_ALLINT & ~needReg, RegSet::FREE_REG);
                     regPair = op1->gtRegPair;
 
-                    // Do we need to set the sign-flag, or can be check if it
-                    // set, and not do this "test" if so.
+                    // Do we need to set the sign-flag, or can we checked if it is set?
+                    // and not do this "test" if so.
 
                     if (op1->gtFlags & GTF_REG_VAL)
                     {

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -258,7 +258,7 @@ void                CodeGen::genEmitGSCookieCheck(bool pushReg)
     }
 
     BasicBlock  *gsCheckBlk = genCreateTempLabel();
-    inst_JMP(genJumpKindForOper(GT_EQ, true), gsCheckBlk);
+    inst_JMP(genJumpKindForOper(GT_EQ, false), gsCheckBlk);
     genEmitHelperCall(CORINFO_HELP_FAIL_FAST, 0, EA_UNKNOWN);
     genDefineTempLabel(gsCheckBlk);
 }
@@ -2267,7 +2267,7 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
             BasicBlock* skipLabel = genCreateTempLabel();
 
-            inst_JMP(genJumpKindForOper(GT_EQ, true), skipLabel);
+            inst_JMP(genJumpKindForOper(GT_EQ, false), skipLabel);
 
             // emit the call to the EE-helper that stops for GC (or other reasons)
             assert(treeNode->gtRsvdRegs != RBM_NONE);
@@ -2878,7 +2878,7 @@ CodeGen::genLclHeap(GenTreePtr tree)
         getEmitter()->emitIns_S_R(INS_cmp, EA_PTRSIZE, REG_SPBASE, compiler->lvaReturnEspCheck, 0);
 
         BasicBlock  *   esp_check = genCreateTempLabel();
-        inst_JMP(genJumpKindForOper(GT_EQ, true), esp_check);
+        inst_JMP(genJumpKindForOper(GT_EQ, false), esp_check);
         getEmitter()->emitIns(INS_BREAKPOINT);
         genDefineTempLabel(esp_check);
     }

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -258,7 +258,8 @@ void                CodeGen::genEmitGSCookieCheck(bool pushReg)
     }
 
     BasicBlock  *gsCheckBlk = genCreateTempLabel();
-    inst_JMP(genJumpKindForOper(GT_EQ, false), gsCheckBlk);
+    emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
+    inst_JMP(jmpEqual, gsCheckBlk);
     genEmitHelperCall(CORINFO_HELP_FAIL_FAST, 0, EA_UNKNOWN);
     genDefineTempLabel(gsCheckBlk);
 }
@@ -2267,7 +2268,8 @@ CodeGen::genCodeForTreeNode(GenTreePtr treeNode)
 
             BasicBlock* skipLabel = genCreateTempLabel();
 
-            inst_JMP(genJumpKindForOper(GT_EQ, false), skipLabel);
+            emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
+            inst_JMP(jmpEqual, skipLabel);
 
             // emit the call to the EE-helper that stops for GC (or other reasons)
             assert(treeNode->gtRsvdRegs != RBM_NONE);
@@ -2878,7 +2880,8 @@ CodeGen::genLclHeap(GenTreePtr tree)
         getEmitter()->emitIns_S_R(INS_cmp, EA_PTRSIZE, REG_SPBASE, compiler->lvaReturnEspCheck, 0);
 
         BasicBlock  *   esp_check = genCreateTempLabel();
-        inst_JMP(genJumpKindForOper(GT_EQ, false), esp_check);
+        emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
+        inst_JMP(jmpEqual, esp_check);
         getEmitter()->emitIns(INS_BREAKPOINT);
         genDefineTempLabel(esp_check);
     }
@@ -6278,7 +6281,8 @@ void         CodeGen::genJumpKindsForTree(GenTreePtr    cmpTree,
     // For integer comparisons just use genJumpKindForOper
     if (!varTypeIsFloating(cmpTree->gtOp.gtOp1->gtEffectiveVal()))
     {
-        jmpKind[0] = genJumpKindForOper(cmpTree->gtOper, (cmpTree->gtFlags & GTF_UNSIGNED) != 0);
+        CompareKind compareKind = ((cmpTree->gtFlags & GTF_UNSIGNED) != 0) ? CK_UNSIGNED : CK_SIGNED;
+        jmpKind[0] = genJumpKindForOper(cmpTree->gtOper, compareKind);
         jmpKind[1] = EJ_NONE;
     }
     else
@@ -6428,7 +6432,7 @@ void         CodeGen::genJumpKindsForTreeLongLo(GenTreePtr    cmpTree,
     jmpToTrueLabel[1] = true;
 
     assert(cmpTree->OperIsCompare());
-    jmpKind[0] = genJumpKindForOper(cmpTree->gtOper, true);
+    jmpKind[0] = genJumpKindForOper(cmpTree->gtOper, CK_UNSIGNED);
     jmpKind[1] = EJ_NONE;
 }
 

--- a/src/jit/emitarm.cpp
+++ b/src/jit/emitarm.cpp
@@ -31,7 +31,7 @@ const instruction       emitJumpKindInstructions[] =
 {
     INS_nop,
 
-    #define JMP_SMALL(en, rev, ins, condcode) INS_##ins,
+    #define JMP_SMALL(en, rev, ins) INS_##ins,
     #include "emitjmps.h"
 };
 
@@ -39,16 +39,7 @@ const emitJumpKind      emitReverseJumpKinds[] =
 {
     EJ_NONE,
 
-    #define JMP_SMALL(en, rev, ins, condcode) EJ_##rev,
-    #include "emitjmps.h"
-};
-
-
-const unsigned          emitJumpKindCondCodes[] =
-{
-    15, // illegal
-
-    #define JMP_SMALL(en, rev, ins, condcode) condcode,
+    #define JMP_SMALL(en, rev, ins) EJ_##rev,
     #include "emitjmps.h"
 };
 
@@ -89,16 +80,6 @@ const unsigned          emitJumpKindCondCodes[] =
 {
     assert(jumpKind < EJ_COUNT);
     return emitReverseJumpKinds[jumpKind];
-}
-
-/*****************************************************************************
- * Look up the condition code for a give jump kind
- */
-
-/*static*/ unsigned         emitter::emitJumpKindCondCode(emitJumpKind jumpKind)
-{
-    assert(EJ_NONE < jumpKind && jumpKind < EJ_COUNT);
-    return emitJumpKindCondCodes[jumpKind];
 }
 
 /*****************************************************************************

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -33,7 +33,7 @@ const instruction       emitJumpKindInstructions[] =
 {
     INS_nop,
 
-    #define JMP_SMALL(en, rev, ins, condcode) INS_##ins,
+    #define JMP_SMALL(en, rev, ins) INS_##ins,
     #include "emitjmps.h"
 };
 
@@ -41,7 +41,7 @@ const emitJumpKind      emitReverseJumpKinds[] =
 {
     EJ_NONE,
 
-    #define JMP_SMALL(en, rev, ins, condcode) EJ_##rev,
+    #define JMP_SMALL(en, rev, ins) EJ_##rev,
     #include "emitjmps.h"
 };
 

--- a/src/jit/emitjmps.h
+++ b/src/jit/emitjmps.h
@@ -28,43 +28,24 @@ JMP_SMALL(jge   , jl    , jge    )
 JMP_SMALL(jle   , jg    , jle    )
 JMP_SMALL(jg    , jle   , jg     )
 
-#elif defined(_TARGET_ARM_)
+#elif defined(_TARGET_ARMARCH_)
 
 //       jump   reverse instruction condcode
-JMP_SMALL(jmp   , jmp   , b         , 15    )  // illegal condcode
-JMP_SMALL(jo    , jno   , bvs       , 6     )  // VS
-JMP_SMALL(jno   , jo    , bvc       , 7     )  // VC
-JMP_SMALL(jb    , jae   , blo       , 3     )  // LO also CC
-JMP_SMALL(jae   , jb    , bhs       , 2     )  // HS also CS
-JMP_SMALL(je    , jne   , beq       , 0     )  // EQ
-JMP_SMALL(jne   , je    , bne       , 1     )  // NE
-JMP_SMALL(jbe   , ja    , bls       , 9     )  // LS
-JMP_SMALL(ja    , jbe   , bhi       , 8     )  // HI
-JMP_SMALL(js    , jns   , bmi       , 4     )  // MI
-JMP_SMALL(jns   , js    , bpl       , 5     )  // PL
-JMP_SMALL(jl    , jge   , blt       , 11    )  // LT
-JMP_SMALL(jge   , jl    , bge       , 10    )  // GE
-JMP_SMALL(jle   , jg    , ble       , 13    )  // LE
-JMP_SMALL(jg    , jle   , bgt       , 12    )  // GT
-
-#elif defined(_TARGET_ARM64_)
-
-//       jump   reverse instruction condcode
-JMP_SMALL(jmp   , jmp   , b         , 15    )  // illegal condcode
-JMP_SMALL(jo    , jno   , bvs       , 6     )  // VS
-JMP_SMALL(jno   , jo    , bvc       , 7     )  // VC
-JMP_SMALL(jb    , jae   , blo       , 3     )  // LO also CC
-JMP_SMALL(jae   , jb    , bhs       , 2     )  // HS also CS
-JMP_SMALL(je    , jne   , beq       , 0     )  // EQ
-JMP_SMALL(jne   , je    , bne       , 1     )  // NE
-JMP_SMALL(jbe   , ja    , bls       , 9     )  // LS
-JMP_SMALL(ja    , jbe   , bhi       , 8     )  // HI
-JMP_SMALL(js    , jns   , bmi       , 4     )  // MI
-JMP_SMALL(jns   , js    , bpl       , 5     )  // PL
-JMP_SMALL(jl    , jge   , blt       , 11    )  // LT
-JMP_SMALL(jge   , jl    , bge       , 10    )  // GE
-JMP_SMALL(jle   , jg    , ble       , 13    )  // LE
-JMP_SMALL(jg    , jle   , bgt       , 12    )  // GT
+JMP_SMALL(jmp   , jmp   , b      )  // AL always
+JMP_SMALL(eq    , ne    , beq    )  // EQ
+JMP_SMALL(ne    , eq    , bne    )  // NE
+JMP_SMALL(hs    , lo    , bhs    )  // HS also CS
+JMP_SMALL(lo    , hs    , blo    )  // LO also CC
+JMP_SMALL(mi    , pl    , bmi    )  // MI
+JMP_SMALL(pl    , mi    , bpl    )  // PL
+JMP_SMALL(vs    , vc    , bvs    )  // VS
+JMP_SMALL(vc    , vs    , bvc    )  // VC
+JMP_SMALL(hi    , ls    , bhi    )  // HI
+JMP_SMALL(ls    , hi    , bls    )  // LS
+JMP_SMALL(ge    , lt    , bge    )  // GE
+JMP_SMALL(lt    , ge    , blt    )  // LT
+JMP_SMALL(gt    , le    , bgt    )  // GT
+JMP_SMALL(le    , gt    , ble    )  // LE
 
 #else
   #error Unsupported or unset target architecture

--- a/src/jit/instr.cpp
+++ b/src/jit/instr.cpp
@@ -284,20 +284,23 @@ void                CodeGen::inst_SET(emitJumpKind   condition,
     /* Convert the condition to an insCond value */
     switch (condition)
     {
-    case EJ_je  : cond = INS_COND_EQ; break;
-    case EJ_jne : cond = INS_COND_NE; break;
-    case EJ_jae : cond = INS_COND_HS; break;
-    case EJ_jb  : cond = INS_COND_LO; break;
+    case EJ_eq  : cond = INS_COND_EQ; break;
+    case EJ_ne  : cond = INS_COND_NE; break;
+    case EJ_hs  : cond = INS_COND_HS; break;
+    case EJ_lo  : cond = INS_COND_LO; break;
 
-    case EJ_js  : cond = INS_COND_MI; break;
-    case EJ_jns : cond = INS_COND_PL; break;
-    case EJ_ja  : cond = INS_COND_HI; break;
-    case EJ_jbe : cond = INS_COND_LS; break;
+    case EJ_mi  : cond = INS_COND_MI; break;
+    case EJ_pl  : cond = INS_COND_PL; break;
+    case EJ_vs  : cond = INS_COND_VS; break;
+    case EJ_vc  : cond = INS_COND_VC; break;
 
-    case EJ_jge : cond = INS_COND_GE; break;
-    case EJ_jl  : cond = INS_COND_LT; break;
-    case EJ_jg  : cond = INS_COND_GT; break;
-    case EJ_jle : cond = INS_COND_LE; break;
+    case EJ_hi  : cond = INS_COND_HI; break;
+    case EJ_ls  : cond = INS_COND_LS; break;
+    case EJ_ge  : cond = INS_COND_GE; break;
+    case EJ_lt  : cond = INS_COND_LT; break;
+
+    case EJ_gt  : cond = INS_COND_GT; break;
+    case EJ_le  : cond = INS_COND_LE; break;
  
     default:      NO_WAY("unexpected condition type"); return;
     }

--- a/src/jit/instr.h
+++ b/src/jit/instr.h
@@ -70,11 +70,7 @@ enum emitJumpKind
 {
     EJ_NONE,
 
-#if defined(_TARGET_XARCH_)
     #define JMP_SMALL(en, rev, ins)           EJ_##en,
-#elif defined(_TARGET_ARMARCH_)
-    #define JMP_SMALL(en, rev, ins, condcode) EJ_##en,
-#endif
     #include "emitjmps.h"
 
     EJ_COUNT

--- a/src/jit/registerfp.cpp
+++ b/src/jit/registerfp.cpp
@@ -314,7 +314,8 @@ void CodeGen::genFloatCheckFinite(GenTree *tree, RegSet::RegisterPreference *pre
     inst_RV_IV(INS_cmp, reg, expMask, EA_4BYTE);
 
     // If exponent was all 1's, we need to throw ArithExcep
-    genJumpToThrowHlpBlk(EJ_eq, SCK_ARITH_EXCPN);
+    emitJumpKind jmpEqual = genJumpKindForOper(GT_EQ, CK_SIGNED);
+    genJumpToThrowHlpBlk(jmpEqual, SCK_ARITH_EXCPN);
 
     genCodeForTreeFloat_DONE(tree, op1->gtRegNum);
 }

--- a/src/jit/registerfp.cpp
+++ b/src/jit/registerfp.cpp
@@ -314,7 +314,7 @@ void CodeGen::genFloatCheckFinite(GenTree *tree, RegSet::RegisterPreference *pre
     inst_RV_IV(INS_cmp, reg, expMask, EA_4BYTE);
 
     // If exponent was all 1's, we need to throw ArithExcep
-    genJumpToThrowHlpBlk(EJ_je, SCK_ARITH_EXCPN);
+    genJumpToThrowHlpBlk(EJ_eq, SCK_ARITH_EXCPN);
 
     genCodeForTreeFloat_DONE(tree, op1->gtRegNum);
 }

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -1684,7 +1684,7 @@ WorkingDir=JIT\Methodical\NaN\cond32_il_d
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [operandtypeinlinetype.exe_1907]
 RelativePath=CoreMangLib\cti\system\reflection\emit\operandtype\OperandTypeInlineType\OperandTypeInlineType.exe
 WorkingDir=CoreMangLib\cti\system\reflection\emit\operandtype\OperandTypeInlineType
@@ -5807,7 +5807,7 @@ WorkingDir=JIT\Methodical\NaN\cond64_il_d
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [_reltailjump_cs.exe_3683]
 RelativePath=JIT\Methodical\Boxing\misc\_reltailjump_cs\_reltailjump_cs.exe
 WorkingDir=JIT\Methodical\Boxing\misc\_reltailjump_cs
@@ -7396,7 +7396,7 @@ WorkingDir=CoreMangLib\cti\system\math\MathSinh
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=RT;EXPECTED_PASS;ISSUE_3105
 [opcodesthrow.exe_1883]
 RelativePath=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesThrow\OpCodesThrow.exe
 WorkingDir=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesThrow
@@ -10476,7 +10476,7 @@ WorkingDir=JIT\Methodical\NaN\cond32_il_r
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [b85317.exe_5669]
 RelativePath=JIT\Regression\VS-ia64-JIT\M00\b85317\b85317\b85317.exe
 WorkingDir=JIT\Regression\VS-ia64-JIT\M00\b85317\b85317
@@ -11225,7 +11225,7 @@ WorkingDir=JIT\Methodical\NaN\cond64_il_r
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [seq_funcptr_gc_r.exe_3964]
 RelativePath=JIT\Methodical\explicit\funcptr\seq_funcptr_gc_r\seq_funcptr_gc_r.exe
 WorkingDir=JIT\Methodical\explicit\funcptr\seq_funcptr_gc_r
@@ -13703,7 +13703,7 @@ WorkingDir=Regressions\common\AboveStackLimit
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_PASS;ISSUE_3032
+Categories=RT;EXPECTED_PASS;ISSUE_3032;DBG_FAIL;ISSUE_5814
 [b14617.exe_5517]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1.2-M01\b14617\b14617\b14617.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1.2-M01\b14617\b14617
@@ -15278,7 +15278,7 @@ WorkingDir=CoreMangLib\cti\system\math\MathSin
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=RT;EXPECTED_PASS;ISSUE_3105
 [sbyte_cs_d.exe_4376]
 RelativePath=JIT\Methodical\MDArray\DataTypes\sbyte_cs_d\sbyte_cs_d.exe
 WorkingDir=JIT\Methodical\MDArray\DataTypes\sbyte_cs_d
@@ -21109,7 +21109,7 @@ WorkingDir=JIT\Methodical\NaN\comp32_il_r
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [b57492.exe_5294]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57492\b57492\b57492.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57492\b57492
@@ -23531,7 +23531,7 @@ WorkingDir=JIT\Methodical\NaN\comp64_il_r
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [_relexplicit3.exe_3995]
 RelativePath=JIT\Methodical\explicit\misc\_relexplicit3\_relexplicit3.exe
 WorkingDir=JIT\Methodical\explicit\misc\_relexplicit3
@@ -26030,7 +26030,7 @@ WorkingDir=CoreMangLib\cti\system\math\MathSign7
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=RT;EXPECTED_PASS;ISSUE_3105
 [booleaniconvertibletosbyte.exe_387]
 RelativePath=CoreMangLib\cti\system\boolean\BooleanIConvertibleToSByte\BooleanIConvertibleToSByte.exe
 WorkingDir=CoreMangLib\cti\system\boolean\BooleanIConvertibleToSByte
@@ -32141,7 +32141,7 @@ WorkingDir=CoreMangLib\cti\system\double\DoubleCompareTo1
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=RT;EXPECTED_PASS;ISSUE_3105
 [b70808.exe_5371]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70808\b70808\b70808.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70808\b70808
@@ -34199,7 +34199,7 @@ WorkingDir=JIT\Methodical\NaN\comp32_il_d
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [textelementenumeratorelementindex.exe_1217]
 RelativePath=CoreMangLib\cti\system\globalization\textelementenumerator\TextElementEnumeratorElementIndex\TextElementEnumeratorElementIndex.exe
 WorkingDir=CoreMangLib\cti\system\globalization\textelementenumerator\TextElementEnumeratorElementIndex
@@ -35641,7 +35641,7 @@ WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53994\b53994
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [b07411.exe_5023]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M10\b07411\b07411\b07411.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M10\b07411\b07411
@@ -40163,7 +40163,7 @@ WorkingDir=JIT\Methodical\NaN\comp64_il_d
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3105
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [tailcall_av.exe_4593]
 RelativePath=JIT\Methodical\tailcall_v4\tailcall_AV\tailcall_AV.exe
 WorkingDir=JIT\Methodical\tailcall_v4\tailcall_AV
@@ -40499,7 +40499,7 @@ WorkingDir=Regressions\coreclr\0099\AboveStackLimit
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_PASS;ISSUE_3032
+Categories=RT;EXPECTED_PASS;ISSUE_3032;DBG_FAIL;ISSUE_5814
 [b565808.exe_5560]
 RelativePath=JIT\Regression\CLR-x86-JIT\v2.1\b565808\b565808\b565808.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\v2.1\b565808\b565808
@@ -40849,7 +40849,7 @@ WorkingDir=CoreMangLib\cti\system\math\MathSign2
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=RT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=RT;EXPECTED_PASS;ISSUE_3105
 [threadstartdouble_2.exe_198]
 RelativePath=baseservices\threading\paramthreadstart\ThreadStartDouble_2\ThreadStartDouble_2.exe
 WorkingDir=baseservices\threading\paramthreadstart\ThreadStartDouble_2

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -8075,7 +8075,7 @@ WorkingDir=JIT\Directed\StructPromote\SP2c
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3151
+Categories=JIT;EXPECTED_FAIL;ISSUE_3151;REL_PASS
 [attributector.exe_2053]
 RelativePath=CoreMangLib\cti\system\resources\satellitecontractversionattribute\AttributeCtor\AttributeCtor.exe
 WorkingDir=CoreMangLib\cti\system\resources\satellitecontractversionattribute\AttributeCtor
@@ -13836,7 +13836,7 @@ WorkingDir=JIT\Directed\StructPromote\SP2b
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3151
+Categories=JIT;EXPECTED_FAIL;ISSUE_3151;REL_PASS
 [ldfldahack.exe_5577]
 RelativePath=JIT\Regression\CLR-x86-JIT\v2.1\DDB\B168384\LdfldaHack\LdfldaHack.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\v2.1\DDB\B168384\LdfldaHack
@@ -19177,7 +19177,7 @@ WorkingDir=JIT\Methodical\Invoke\25params\25param2a_cs_do
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988;ISSUE_2987
+Categories=JIT;EXPECTED_FAIL;ISSUE_2988;ISSUE_2987;REL_PASS
 [_il_relconv_i8_i.exe_3892]
 RelativePath=JIT\Methodical\ELEMENT_TYPE_IU\_il_relconv_i8_i\_il_relconv_i8_i.exe
 WorkingDir=JIT\Methodical\ELEMENT_TYPE_IU\_il_relconv_i8_i
@@ -20654,7 +20654,7 @@ WorkingDir=JIT\Methodical\Invoke\25params\25param2a_cs_ro
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2988;ISSUE_2987
+Categories=JIT;EXPECTED_FAIL;ISSUE_2988;ISSUE_2987;REL_PASS
 [weakreferenceisaliveb_psc.exe_2559]
 RelativePath=CoreMangLib\cti\system\weakreference\WeakReferenceIsAliveb_PSC\WeakReferenceIsAliveb_PSC.exe
 WorkingDir=CoreMangLib\cti\system\weakreference\WeakReferenceIsAliveb_PSC
@@ -26450,7 +26450,7 @@ WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b12399\b12399
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_PASS;ISSUE_3105
 [int16iconvertibletoboolean.exe_1323]
 RelativePath=CoreMangLib\cti\system\int16\Int16IConvertibleToBoolean\Int16IConvertibleToBoolean.exe
 WorkingDir=CoreMangLib\cti\system\int16\Int16IConvertibleToBoolean
@@ -34234,7 +34234,7 @@ WorkingDir=JIT\Directed\StructPromote\SP2a
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_3151
+Categories=JIT;EXPECTED_FAIL;ISSUE_3151;REL_PASS
 [b15222.exe_4865]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15222\b15222\b15222.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15222\b15222


### PR DESCRIPTION
Conditional branches on Arm now match the Arm condition codes instead of using x86 branches.

Updated the enum emitJumpKind to use Arm condition codes rather than x86 conditional branches

Implemented and tested for Arm64 the full set of ordered and unordered floating point branches
Implemented and tested for Arm64 genSetRegToCond for ordered and unordered floating point compares

On Arm64 we now use the genJumpKindsForTree to return up to two conditional branches for floating point compares

Changed genJumpKindForOper to use an new enum CompareKind to specify a signed, unsigned or logical compare operation 

Cleanup we now use genJumpKindForOper to select conditional branches and prefer
 using CK_SIGNED for creating branches for GT_EQ and GT_NE

Removed the unused fourth 'condcode' portion of the JMP_SMALL macro and
the fourth column from the Arm/Arm64 part of "emitjmps.cpp"

Unified Arm32 and Arm64 conditionals in "emitjmps.cpp"
Reordered the Arm32 and Arm64 conditionals in "emitjmps.cpp" to match the ARMV8 docs

This change  impacts the Arm32  and x86 JIT's and was verified to have no asm diffs for them
