### PR TITLE
Added code to clone the structDesc member of GT_CALL.

### DIFF
--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6308,6 +6308,10 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
         }
         copy->gtCall.gtRetClsHnd = tree->gtCall.gtRetClsHnd;
 
+#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
+        copy->gtCall.structDesc.CopyFrom(tree->gtCall.structDesc);
+#endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)  
+
 #ifdef FEATURE_READYTORUN_COMPILER
         copy->gtCall.gtEntryPoint = tree->gtCall.gtEntryPoint;
 #endif

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2358,11 +2358,6 @@ struct GenTreeCall final : public GenTree
     regMaskTP         gtCallRegUsedMask;      // mask of registers used to pass parameters
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
     SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
-
-    void SetRegisterReturningStructState(const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR& structDescIn)
-    {
-        structDesc.CopyFrom(structDescIn);
-    }
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
 #define     GTF_CALL_M_EXPLICIT_TAILCALL       0x0001  // GT_CALL -- the call is "tail" prefixed and importer has performed tail call checks


### PR DESCRIPTION
Adds code to clone the structDesc member of GT_CALL. It modifies the
importer to get the structDesc directly in this field, instead of using a
separate local and eliminates the obsolete SetRegisterReturningStructState
method of GenTreeCall.

Fixes 3239.