### PR TITLE
Disambiguate debug pipe names with more than just PID

### DIFF
--- a/src/debug/debug-pal/unix/twowaypipe.cpp
+++ b/src/debug/debug-pal/unix/twowaypipe.cpp
@@ -13,19 +13,19 @@
 
 #include "twowaypipe.h"
 
-#define PIPE_NAME_FORMAT_STR "/tmp/clr-debug-pipe-%llu-%d-%s"
+static const char* PipeNameFormat = "/tmp/clr-debug-pipe-%d-%llu-%s";
 
 static void GetPipeName(char *name, DWORD id, const char *suffix)
 {
-    UINT64 uniqueTimeValue;
-    BOOL ret = GetUniqueTimeValueForProcess(id, &uniqueTimeValue);
+    UINT64 disambiguationKey;
+    BOOL ret = GetProcessIdDisambiguationKey(id, &disambiguationKey);
 
-    // If GetUniqueTimeValueForProcess failed for some reason, it shouldn't have
-    // modified uniqueTimeValue. We expect that anyone else making the pipe name
-    // will also fail and thus will also try to use 0 as the time value.
-    _ASSERTE(ret == TRUE || uniqueTimeValue == 0);
+    // If GetProcessIdDisambiguationKey failed for some reason, it should set the value 
+    // to 0. We expect that anyone else making the pipe name will also fail and thus will
+    // also try to use 0 as the value.
+    _ASSERTE(ret == TRUE || disambiguationKey == 0);
 
-    int chars = _snprintf(name, PATH_MAX, PIPE_NAME_FORMAT_STR, uniqueTimeValue, id, suffix);
+    int chars = _snprintf(name, PATH_MAX, PipeNameFormat, id, disambiguationKey, suffix);
     _ASSERTE(chars > 0 && chars < PATH_MAX);
 }
 

--- a/src/debug/debug-pal/unix/twowaypipe.cpp
+++ b/src/debug/debug-pal/unix/twowaypipe.cpp
@@ -13,11 +13,19 @@
 
 #include "twowaypipe.h"
 
-#define PIPE_NAME_FORMAT_STR "/tmp/clr-debug-pipe-%d-%s"
+#define PIPE_NAME_FORMAT_STR "/tmp/clr-debug-pipe-%llu-%d-%s"
 
 static void GetPipeName(char *name, DWORD id, const char *suffix)
 {
-    int chars = _snprintf(name, PATH_MAX, PIPE_NAME_FORMAT_STR, id, suffix);
+    UINT64 uniqueTimeValue;
+    BOOL ret = GetUniqueTimeValueForProcess(id, &uniqueTimeValue);
+
+    // If GetUniqueTimeValueForProcess failed for some reason, it shouldn't have
+    // modified uniqueTimeValue. We expect that anyone else making the pipe name
+    // will also fail and thus will also try to use 0 as the time value.
+    _ASSERTE(ret == TRUE || uniqueTimeValue == 0);
+
+    int chars = _snprintf(name, PATH_MAX, PIPE_NAME_FORMAT_STR, uniqueTimeValue, id, suffix);
     _ASSERTE(chars > 0 && chars < PATH_MAX);
 }
 

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1864,9 +1864,9 @@ GetProcessTimes(
 PALIMPORT
 BOOL
 PALAPI
-GetUniqueTimeValueForProcess(
+GetProcessIdDisambiguationKey(
         IN DWORD processId,
-        OUT UINT64 *uniqueTimeValue);
+        OUT UINT64 *disambiguationKey);
 
 #define MAXIMUM_WAIT_OBJECTS  64
 #define WAIT_OBJECT_0 0

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -1861,6 +1861,13 @@ GetProcessTimes(
         OUT LPFILETIME lpKernelTime,
         OUT LPFILETIME lpUserTime);
 
+PALIMPORT
+BOOL
+PALAPI
+GetUniqueTimeValueForProcess(
+        IN DWORD processId,
+        OUT UINT64 *uniqueTimeValue);
+
 #define MAXIMUM_WAIT_OBJECTS  64
 #define WAIT_OBJECT_0 0
 #define WAIT_ABANDONED   0x00000080

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1379,9 +1379,6 @@ PAL_SetShutdownCallback(
     g_shutdownCallback = callback;
 }
 
-#define RuntimeStartupSemaphoreName "/RuntimeStartupEvent%08x"
-#define RuntimeContinueSemaphoreName "/RuntimeContinueEvent%08x"
-
 static bool IsCoreClrModule(const char* pModulePath)
 {
     // Strip off everything up to and including the last slash in the path to get name
@@ -1395,15 +1392,27 @@ static bool IsCoreClrModule(const char* pModulePath)
     return _stricmp(pModuleName, MAKEDLLNAME_A("coreclr")) == 0;
 }
 
+// Build the semaphore names using the PID and a value that can be used for distinguishing
+// between processes with the same PID (which ran at different times). This is to avoid
+// cases where a prior process with the same PID exited abnormally without having a chance
+// to clean up its semaphore. 
+static const char* RuntimeStartupSemaphoreName = "/RuntimeStartupEvent%08x-%llu";
+static const char* RuntimeContinueSemaphoreName = "/RuntimeContinueEvent%08x-%llu";
+
 class PAL_RuntimeStartupHelper
 {
     LONG m_ref;
     bool m_canceled;
-    DWORD m_processId;
     PPAL_STARTUP_CALLBACK m_callback;
     PVOID m_parameter;
     DWORD m_threadId;
     HANDLE m_threadHandle;
+
+    DWORD m_processId;
+
+    // A value that, used in conjunction with the process ID, uniquely identifies a process.
+    // See the format we use for debugger semaphore names for why this is necessary.
+    UINT64 m_processIdDisambiguationKey;
 
     // Debugger waits on this semaphore and the runtime signals it on startup.
     sem_t *m_startupSem;
@@ -1415,11 +1424,11 @@ public:
     PAL_RuntimeStartupHelper(DWORD dwProcessId, PPAL_STARTUP_CALLBACK pfnCallback, PVOID parameter) :
         m_ref(1),
         m_canceled(false),
-        m_processId(dwProcessId),
         m_callback(pfnCallback),
         m_parameter(parameter),
         m_threadId(0),
         m_threadHandle(NULL),
+        m_processId(dwProcessId),
         m_startupSem(SEM_FAILED),
         m_continueSem(SEM_FAILED)
     {
@@ -1430,19 +1439,29 @@ public:
         if (m_startupSem != SEM_FAILED)
         {
             char startupSemName[NAME_MAX - 4];
-            sprintf_s(startupSemName, sizeof(startupSemName), RuntimeStartupSemaphoreName, m_processId);
+            sprintf_s(startupSemName,
+                      sizeof(startupSemName),
+                      RuntimeStartupSemaphoreName,
+                      m_processId,
+                      m_processIdDisambiguationKey);
 
             sem_close(m_startupSem);
             sem_unlink(startupSemName);
         }
+
         if (m_continueSem != SEM_FAILED)
         {
             char continueSemName[NAME_MAX - 4];
-            sprintf_s(continueSemName, sizeof(continueSemName), RuntimeContinueSemaphoreName, m_processId);
+            sprintf_s(continueSemName,
+                      sizeof(continueSemName),
+                      RuntimeContinueSemaphoreName,
+                      m_processId,
+                      m_processIdDisambiguationKey);
 
             sem_close(m_continueSem);
             sem_unlink(continueSemName);
         }
+
         if (m_threadHandle != NULL)
         {
             CloseHandle(m_threadHandle);
@@ -1451,7 +1470,7 @@ public:
 
     LONG AddRef()
     {
-        LONG ref = InterlockedIncrement(&m_ref);    
+        LONG ref = InterlockedIncrement(&m_ref);
         return ref;
     }
 
@@ -1472,8 +1491,23 @@ public:
         char continueSemName[NAME_MAX - 4];
         PAL_ERROR pe = NO_ERROR;
 
-        sprintf_s(startupSemName, sizeof(startupSemName), RuntimeStartupSemaphoreName, m_processId);
-        sprintf_s(continueSemName, sizeof(continueSemName), RuntimeContinueSemaphoreName, m_processId);
+        // See semaphore name format for details about this value. We store it so that
+        // it can be used by the cleanup code that removes the semaphore with sem_unlink.
+        INDEBUG(BOOL disambiguationKeyRet = )
+        GetProcessIdDisambiguationKey(m_processId, &m_processIdDisambiguationKey);
+        _ASSERTE(disambiguationKeyRet == TRUE || m_processIdDisambiguationKey == 0);
+
+        sprintf_s(startupSemName,
+                  sizeof(startupSemName),
+                  RuntimeStartupSemaphoreName,
+                  m_processId,
+                  m_processIdDisambiguationKey);
+
+        sprintf_s(continueSemName,
+                  sizeof(continueSemName),
+                  RuntimeContinueSemaphoreName,
+                  m_processId,
+                  m_processIdDisambiguationKey);
 
         TRACE("PAL_RuntimeStartupHelper.Register startup '%s' continue '%s'\n", startupSemName, continueSemName);
 
@@ -1751,8 +1785,11 @@ PAL_NotifyRuntimeStarted()
     sem_t *continueSem = SEM_FAILED;
     BOOL result = TRUE;
 
-    sprintf_s(szStartupSemName, sizeof(szStartupSemName), RuntimeStartupSemaphoreName, gPID);
-    sprintf_s(szContinueSemName, sizeof(szContinueSemName), RuntimeContinueSemaphoreName, gPID);
+    UINT64 processIdDisambiguationKey = 0;
+    GetProcessIdDisambiguationKey(gPID, &processIdDisambiguationKey);
+
+    sprintf_s(szStartupSemName, sizeof(szStartupSemName), RuntimeStartupSemaphoreName, gPID, processIdDisambiguationKey);
+    sprintf_s(szContinueSemName, sizeof(szContinueSemName), RuntimeContinueSemaphoreName, gPID, processIdDisambiguationKey);
 
     TRACE("PAL_NotifyRuntimeStarted opening startup '%s' continue '%s'\n", szStartupSemName, szContinueSemName);
 
@@ -1805,23 +1842,23 @@ exit:
 
 /*++
  Function:
-  GetUniqueTimeValueForProcess
-  
+  GetProcessIdDisambiguationKey
+
   Get a numeric value that can be used to disambiguate between processes with the same PID,
   provided that one of them is still running. The numeric value can mean different things
   on different platforms, so it should not be used for any other purpose. Under the hood,
   it is implemented based on the creation time of the process.
 --*/
 BOOL
-GetUniqueTimeValueForProcess(DWORD processId, UINT64 *uniqueTimeValue)
+GetProcessIdDisambiguationKey(DWORD processId, UINT64 *disambiguationKey)
 {
-    if (uniqueTimeValue == nullptr)
+    if (disambiguationKey == nullptr)
     {
-        _ASSERTE(!"uniqueTimeValue argument cannot be null!");
+        _ASSERTE(!"disambiguationKey argument cannot be null!");
         return FALSE;
     }
 
-    *uniqueTimeValue = 0;
+    *disambiguationKey = 0;
 
 #if defined(__APPLE__)
 
@@ -1837,7 +1874,7 @@ GetUniqueTimeValueForProcess(DWORD processId, UINT64 *uniqueTimeValue)
         timeval procStartTime = info.kp_proc.p_starttime;
         long secondsSinceEpoch = procStartTime.tv_sec;
 
-        *uniqueTimeValue = secondsSinceEpoch;
+        *disambiguationKey = secondsSinceEpoch;
         return TRUE;
     }
     else
@@ -1889,12 +1926,12 @@ GetUniqueTimeValueForProcess(DWORD processId, UINT64 *uniqueTimeValue)
     free(line);
     fclose(statFile);
 
-    *uniqueTimeValue = starttime;
+    *disambiguationKey = starttime;
     return TRUE;
 
 #else
     // If this is not OS X and we don't have /proc, we just return FALSE.
-    //////_ASSERTE(!"Not implemented on this platform."); // should this be enabled?
+    WARN(!"GetProcessIdDisambiguationKey was called but is not implemented on this platform!");
     return FALSE;
 #endif
 }


### PR DESCRIPTION
This change fixes an issue that occurs in situations where the pipes used by the debugging code aren't cleaned up (for example, if the process was killed forcefully). When this happens, the next time a process with the same PID starts, managed debuggers will fail to attach to it because there is garbage left over from the previous process. This scenario sounds implausible, but it is very common when running on Docker since the main process always gets the same PID (1) and the /tmp directory isn't cleared when a container is killed and restarted.

To get around this, we needed to add something to the pipe name that could: 
- (a) be used to distinguish between processes with the same PID
- (b) be derived by the process itself and also by any other process that wants to debug it.

This change adds a function to PAL that can be called to get a unique numeric value that can be used for this purpose. The value is based on the start time of the process, so it satisfies (a), but it means something different on different platforms. On OS X, it is expressed in seconds since the Unix epoch, and on platforms with the proc filesystem, it's expressed in jiffies since boot. Because the only purpose of this function is to distinguish between processes with the same PID, these differences are not problematic. Further, any type of time conversion to unify them risks compromising (b) due to off-by-one or rounding errors that could be introduced.

Please do not merge this yet, as I haven't completed testing it.

We'll need to do the same for semaphores. If this PR is ready to merge before I get to it, I'll open a new one for that change. Otherwise, I'll update this one.

@mikem8361 