### PR TITLE
Fix the explicit frames unwinding on Unix

### DIFF
--- a/src/vm/frames.cpp
+++ b/src/vm/frames.cpp
@@ -481,21 +481,27 @@ VOID Frame::Pop(Thread *pThread)
     m_Next = NULL;
 }
 
-#ifdef FEATURE_PAL     
-Frame::~Frame()        
+#if defined(FEATURE_PAL) && !defined(DACCESS_COMPILE) && !defined(CROSSGEN_COMPILE)
+void Frame::PopIfChained()
 {      
+    CONTRACTL
+    {
+        NOTHROW;
+        GC_NOTRIGGER;
+        MODE_COOPERATIVE;
+        SO_TOLERANT;
+    }
+    CONTRACTL_END;
+
     if (m_Next != NULL)
     {
+        GCX_COOP();
         // When the frame is destroyed, make sure it is no longer in the
         // frame chain managed by the Thread.
-        Thread* pThread = GetThread();
-        if (pThread != NULL && pThread->GetFrame() == this)
-        {
-            Pop(pThread);
-        }
+        Pop();
     }
 }      
-#endif // FEATURE_PAL
+#endif // FEATURE_PAL && !DACCESS_COMPILE && !CROSSGEN_COMPILE
 
 //-----------------------------------------------------------------------
 #endif // #ifndef DACCESS_COMPILE


### PR DESCRIPTION
This change fixes a problem when exception unwinds native frames of code that contains
explicit frames. There were two issues. First, the destructor of the explicit frame
base class Frame that was responsible for popping the frames was missing switch to
GC cooperative mode and so it could pop frames that GC was currently walking.
And second, after adding the switch to cooperative mode, it turned out that if a
thread gets blocked in the Frame destructor due to GC and the stack walker tries to
get stack cookie from FrameWithCookie wrapper of a class derived from the Frame,
it fails since the vtable pointer was already reset to the vtable of the base Frame
class and it detects that as an invalid case.

The fix was to add destructors to all final classes derived from Frame and perform
the frame popping from there.