### PR TITLE
Bug 2388 Do not transform user-implemented math intrinsics that are tail calls.

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2686,6 +2686,7 @@ protected :
                                              CORINFO_SIG_INFO *     sig,
                                              int                    memberRef,
                                              bool                   readonlyCall,
+                                             bool                   tailCall,
                                              CorInfoIntrinsics *    pIntrinsicID);
     GenTreePtr          impArrayAccessIntrinsic(CORINFO_CLASS_HANDLE    clsHnd,
                                                 CORINFO_SIG_INFO *      sig,


### PR DESCRIPTION
Intrinsics that are not implemented directly by target instructions will be rematerialized as users calls in rationalizer. For prefixed tail calls, don't do this optimization, because
       1. Languages like F# requires a mandatory tail call optimization. A tail call converted to an intrinsic and then converted back to a call will miss out the tail call optimization.
       2. Tail call optimization may be more beneficial.

No asm diffs were seen.