### PR TITLE
Fixes to build CentOS CoreCLR Nuget Package

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00157
+1.0.25-prerelease-00171

--- a/build.sh
+++ b/build.sh
@@ -199,14 +199,15 @@ isMSBuildOnNETCoreSupported()
     if [ "$__BuildArch" == "x64" ]; then
         if [ "$__BuildOS" == "Linux" ]; then
             if [ "$__DistroName" == "ubuntu" ]; then
-                __OSVersion=$(lsb_release -sr)
-                if [ "$__OSVersion" == "14.04" ]; then
-                    __isMSBuildOnNETCoreSupported=1
-                fi 
+                __isMSBuildOnNETCoreSupported=1
+            elif [ "$__DistroName" == "rhel" ]; then
+                __isMSBuildOnNETCoreSupported=1
+            elif [ "$__DistroName" == "debian" ]; then
+                __isMSBuildOnNETCoreSupported=1
             fi
         elif [ "$__BuildOS" == "OSX" ]; then
             __isMSBuildOnNETCoreSupported=1
-        fi 
+        fi
     fi
 }
 

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
+
   <PropertyGroup>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <SkipPackageFileCheck>true</SkipPackageFileCheck>
     <SkipValidatePackage>true</SkipValidatePackage>
     <PackagePlatforms>x64;x86;arm</PackagePlatforms>
     <OutputPath>$(PackagesOutputPath)</OutputPath>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="win\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>


### PR DESCRIPTION
@ellismg PTAL - this includes the updated BuildTools version fix and also updates the check to look for specific version numbers of the OS/Distros we are supporting.

@weshaggard PTAL - I missed updating the package version in the root pkgproj, which this change fixes.