### PR TITLE
Fix NetBSD build: Define PAL_STDCPP_COMPAT=1 for twowaypipe.cpp

### DIFF
--- a/src/debug/debug-pal/CMakeLists.txt
+++ b/src/debug/debug-pal/CMakeLists.txt
@@ -2,6 +2,7 @@
 include_directories(../inc)
 include_directories(../../pal/inc)
 
+add_definitions(-DPAL_STDCPP_COMPAT=1)
 
 if(WIN32)
     #use static crt


### PR DESCRIPTION
After recent changes in twowaypipe.cpp, this file started to use `<pal.h>`.
If we are mixing `<pal.h>` and system headers we need to define `PAL_STDCPP_COMPAT`
by a preprocessor.

Regression has been introduced with https://github.com/dotnet/coreclr/pull/3219
GIT commit ID 4fee7ae253a271cc70028202104e92128d1a5bd8