### PR TITLE
Revert "Fix PR trigger for ubuntu/osx corefx testing"

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -290,8 +290,7 @@ def static addTriggers(def job, def isPR, def architecture, def os, def configur
                 case 'Ubuntu':
                 case 'OSX':
                     // Triggers on the non-flow jobs aren't necessary here
-					// Corefx testing uses a single non-flow job like Windows coreclr testing.
-                    if (!isFlowJob && !isCorefxTesting(scenario)) {
+                    if (!isFlowJob) {
                         break
                     }
                     switch (scenario) {
@@ -799,11 +798,6 @@ combinedScenarios.each { scenario ->
                         case 'CentOS7.1':
                         case 'RHEL7.2':
                         case 'OpenSUSE13.2':
-						
-							// Ubuntu and OSX coreclr testing uses a different build flow.
-							if (os in Constants.crossList && !enableCorefxTesting) {
-								break;
-							}
                             switch (architecture) {
                                 case 'x64':
                                 case 'x86':


### PR DESCRIPTION
Reverts dotnet/coreclr#3253

Skips the build steps for all Linux builds.

/cc @chcosta @sejongoh 