### PR TITLE
add helix run support to coreclr repo

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -176,7 +176,8 @@ echo %__MsgPrefix%Commencing CoreCLR Repo build
 set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__IntermediatesDir=%__RootBinDir%\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__PackagesBinDir=%__BinDir%\.nuget"
-set "__TestBinDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%"
+set "__TestRootDir=%__RootBinDir%\tests"
+set "__TestBinDir=%__TestRootDir%\%__BuildOS%.%__BuildArch%.%__BuildType%"
 set "__TestIntermediatesDir=%__RootBinDir%\tests\obj\%__BuildOS%.%__BuildArch%.%__BuildType%"
 
 :: Use this variable to locate dynamically generated files; the actual location though will be different.

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -87,7 +87,8 @@ if %__verbosity%==detailed (
 echo %__MsgPrefix%Commencing CoreCLR repo test build
 
 set "__BinDir=%__RootBinDir%\Product\%__BuildOS%.%__BuildArch%.%__BuildType%"
-set "__TestBinDir=%__RootBinDir%\tests\%__BuildOS%.%__BuildArch%.%__BuildType%\"
+set "__TestRootDir=%__RootBinDir%\tests"
+set "__TestBinDir=%__TestRootDir%\%__BuildOS%.%__BuildArch%.%__BuildType%"
 :: We have different managed and native intermediate dirs because the managed bits will include
 :: the configuration information deeper in the intermediates path.
 :: These variables are used by the msbuild project files.

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -47,6 +47,17 @@
     <NugetRestoreCommand>$(NugetRestoreCommand) -Verbosity detailed</NugetRestoreCommand>
     <NugetRestoreCommand Condition="'$(OsEnvironment)'=='Unix'">mono $(NuGetRestoreCommand)</NugetRestoreCommand>
   </PropertyGroup>
+
+   <!-- list of nuget package sources passed to dnu --> 
+   <ItemGroup> 
+     <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. --> 
+     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-core/" /> 
+     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-corefxtestdata/" /> 
+     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/dotnet-buildtools/" /> 
+     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/nugetbuild/" /> 
+     <DnuSourceList Include="https:%2F%2Fwww.nuget.org/api/v2/" /> 
+   </ItemGroup> 
+
   
   <!-- list of directories to perform batch restore -->
   <ItemGroup>
@@ -67,7 +78,7 @@
     
     <DnuRestoreCommand>"$(DotnetToolCommand)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
-    <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('\\'))"</DnuRestoreCommand>
+    <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
     <DnuRestoreCommand Condition="'$(LockDependencies)' == 'true'">$(DnuRestoreCommand) --lock</DnuRestoreCommand>
     
   </PropertyGroup>

--- a/tests/helix.targets
+++ b/tests/helix.targets
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+      <PackageTestRuntimeFolder>$(PackagesDir)test.Microsoft.NETCore.Runtime.CoreClr\1.1.1</PackageTestRuntimeFolder>
+      <BUILDTOOLS_OVERRIDE_RUNTIME>$(PackageTestRuntimeFolder)</BUILDTOOLS_OVERRIDE_RUNTIME>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CoreRootFiles Include="$(CORE_ROOT)\*.*" />
+  </ItemGroup>
+
+  <Target Name="ReplaceProjectLockJson"
+          BeforeTargets="CopyTestToTestDirectory">
+    <PropertyGroup>
+      <ProjectLockJson></ProjectLockJson>
+    </PropertyGroup>
+    <ItemGroup>
+      <TestNugetProjectLockFile Include="$(SourceDir)$(Category)\**\project.lock.json"/>
+    </ItemGroup>
+  </Target>
+
+
+  <Target Name="CopyProductInPackagesFolder"
+          BeforeTargets="CopyTestToTestDirectory">
+
+    <Copy
+      SourceFiles="@(CoreRootFiles)"
+      DestinationFolder="$(PackageTestRuntimeFolder)"
+      SkipUnchangedFiles="false"
+      OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+      Retries="$(CopyRetryCount)"
+      RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)"
+      UseHardlinksIfPossible="$(CreateHardLinksForCopyFilesToOutputDirectoryIfPossible)">
+    </Copy>
+ 
+  </Target>
+
+  <Target Name="AddFilesToAssemblyList" 
+          BeforeTargets="CreateAssemblyListTxt">
+
+    <ItemGroup>
+
+      <RuntimeFiles Include="$(PackageTestRuntimeFolder)\*" />
+      <XunitConsoleExe Include="$(PackagesDir)xunit.runner.console\**\xunit.console.exe" />
+
+      <_TestCopyLocalByFileNameWithoutDuplicates Include="@(RuntimeFiles)">
+        <NugetPackageId>test.Microsoft.NETCore.Runtime.CoreClr</NugetPackageId>
+        <SourcePath>%(RuntimeFiles.Identity)</SourcePath>
+      </_TestCopyLocalByFileNameWithoutDuplicates>
+
+      <_TestCopyLocalByFileNameWithoutDuplicates Include="@(XunitConsoleExe)">
+        <NugetPackageId>xunit.runner.console</NugetPackageId>
+        <SourcePath>%(XunitConsoleExe.Identity)</SourcePath>
+      </_TestCopyLocalByFileNameWithoutDuplicates>
+    </ItemGroup>
+
+    <RemoveDuplicatesWithLastOneWinsPolicy Inputs="@(_TestCopyLocalByFileNameWithoutDuplicates)">
+      <Output TaskParameter="Filtered" ItemName="FilteredList" />
+    </RemoveDuplicatesWithLastOneWinsPolicy>
+
+    <ItemGroup>
+       <_TestCopyLocalByFileNameWithoutDuplicates Remove="*" />
+       <_TestCopyLocalByFileNameWithoutDuplicates Include="@(FilteredList)" />
+    </ItemGroup>
+
+  </Target>
+
+</Project>

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="src\dir.props" />
+  <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets') AND '$(NoBuild)' != 'true'" /> 
 
   <PropertyGroup>
     <XunitTestBinBase Condition="'$(XunitTestBinBase)'==''" >$(BaseOutputPathWithConfig)</XunitTestBinBase>
@@ -86,6 +87,7 @@ $(_XunitEpilog)
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <CLRTestKind>BuildOnly</CLRTestKind>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '%24(Configuration)|%24(Platform)' == 'Debug|AnyCPU' ">
@@ -113,8 +115,9 @@ $(_XunitEpilog)
     <Reference Include="mscorlib" />
   </ItemGroup>
   <Import Project="%24([MSBuild]::GetDirectoryNameOfFileAbove(%24(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <Import Project="%24([MSBuild]::GetDirectoryNameOfFileAbove(%24(MSBuildThisFileDirectory), helix.targets))\helix.targets" />
   <PropertyGroup>
-     <OutDir>$(XunitWrapperOutputIntermediatedDirBase)\XunitRunner\</OutDir>
+     <OutDir>$(XunitTestBinBase)\$(Category)\</OutDir>
   </PropertyGroup>
 </Project>
         ]]>
@@ -179,6 +182,7 @@ using Xunit%3B
 using System%3B
 using System.Collections.Generic%3B
 using System.Diagnostics%3B
+using System.Reflection%3B
 using CoreclrTestLib%3B
 
 namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").Replace("-","_"))
@@ -192,16 +196,16 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
 
             static _Global()
             {
-                reportBase = System.IO.Path.GetFullPath(System.Environment.GetEnvironmentVariable(%22XunitTestReportDirBase%22))%3B
-                testBinaryBase = System.IO.Path.GetFullPath(System.Environment.GetEnvironmentVariable(%22XunitTestBinBase%22))%3B
+                reportBase = System.Environment.GetEnvironmentVariable(%22XunitTestReportDirBase%22)%3B
+                testBinaryBase = System.IO.Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath)%3B
                 coreRoot = System.IO.Path.GetFullPath(System.Environment.GetEnvironmentVariable(%22CORE_ROOT%22))%3B
 
                 if (String.IsNullOrEmpty(reportBase)) {
-                    throw new ArgumentException("Environment variable XunitTestReportDirBase is not set")%3B
+                    reportBase = System.IO.Path.Combine(testBinaryBase, "Reports")%3B
                 }
-
-                if (String.IsNullOrEmpty(testBinaryBase)) {
-                    throw new ArgumentException("Environment variable XunitTestBinBase is not set")%3B
+                else
+                {
+                    reportBase = System.IO.Path.GetFullPath(reportBase)%3B
                 }
 
                 if (String.IsNullOrEmpty(coreRoot)) {
@@ -256,7 +260,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
                   string testSubfolder = @"\$(Category)\$([System.String]::Copy('%(AllCMDs.RelativeDir)').Replace("$(_CMDDIR)\",''))"%3B
                   outputFile = System.IO.Path.GetFullPath(_Global.reportBase + testSubfolder + @"%(AllCMDs.FileName).output.txt")%3B
                   errorFile = System.IO.Path.GetFullPath(_Global.reportBase + testSubfolder + @"%(AllCMDs.FileName).error.txt")%3B
-                  testExecutable = System.IO.Path.GetFullPath(_Global.testBinaryBase + @"\$(Category)\$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",''))")%3B
+                  testExecutable = System.IO.Path.GetFullPath(_Global.testBinaryBase + @"$([System.String]::Copy('%(AllCMDs.FullPath)').Replace("$(_CMDDIR)",''))")%3B
 
                   if (!_Global.runningInWindows) {
                       testExecutable = testExecutable.Replace(".cmd", ".sh")%3B

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -35,16 +35,20 @@
 
 <!-- Setup the default output and intermediate paths -->
   <PropertyGroup>
-    <BaseOutputPathWithConfig>$(ProjectDir)\..\bin\tests\$(BuildOS).$(Platform).$(Configuration)\</BaseOutputPathWithConfig>
-    <BaseOutputPathWithConfig Condition="'$(__TestBinDir)' != ''">$(__TestBinDir)\</BaseOutputPathWithConfig>
+    <OSPlatformConfig>$(BuildOS).$(Platform).$(Configuration)</OSPlatformConfig>
+    <BaseOutputPath>$(ProjectDir)\..\bin\tests</BaseOutputPath>
+    <BaseOutputPath Condition="'$(__TestRootDir)' != ''">$(__TestRootDir)\</BaseOutputPath>
+    <BaseOutputPathWithConfig>$(BaseOutputPath)\$(OSPlatformConfig)\</BaseOutputPathWithConfig>
     <BinDir>$(BaseOutputPathWithConfig)</BinDir>
-    <BaseIntermediateOutputPath>$(ProjectDir)\..\bin\tests\obj\$(BuildOS).$(Platform).$(Configuration)\Managed</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath>$(ProjectDir)\..\bin\tests\obj\$(OSPlatformConfig)\Managed</BaseIntermediateOutputPath>
     <BaseIntermediateOutputPath Condition="'$(__ManagedTestIntermediatesDir)' != ''">$(__ManagedTestIntermediatesDir)\</BaseIntermediateOutputPath>
     <__NativeTestIntermediatesDir Condition="'$(__NativeTestIntermediatesDir)' == ''">$([System.IO.Path]::GetFullPath($(BaseOutputPathWithConfig)..\obj\$(BuildOS).$(Platform).$(Configuration)\Native\))</__NativeTestIntermediatesDir>
     <BuildProjectRelativeDir>$(MSBuildProjectName)\</BuildProjectRelativeDir>
     <BuildProjectRelativeDir Condition="'$(MSBuildProjectDirectory.Contains($(SourceDir)))'">$([System.String]::Copy('$(MSBuildProjectDirectory)').Replace($(SourceDir),''))\$(MSBuildProjectName)</BuildProjectRelativeDir>
     <IntermediateOutputPath>$(BaseIntermediateOutputPath)$(BuildProjectRelativeDir)</IntermediateOutputPath>
     <OutputPath>$(BaseOutputPathWithConfig)$(BuildProjectRelativeDir)\</OutputPath>
+    <TestWorkingDir Condition="'$(TestWorkingDir)'==''">$(BaseOutputPath)\testStagingDir\</TestWorkingDir>
+    <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)/</TestPath>
   </PropertyGroup>
 
   <!-- Default priority building values. -->

--- a/tests/tests.targets
+++ b/tests/tests.targets
@@ -8,26 +8,23 @@
   </ItemGroup>
 
   <PropertyGroup>
-      <TestAssemblyDir Condition="'$(TestAssemblyDir)' == ''">$(BaseOutputPathWithConfig)\tests\XunitRunner\</TestAssemblyDir>
+      <TestAssemblyDir Condition="'$(TestAssemblyDir)' == ''">$(BaseOutputPathWithConfig)\tests\</TestAssemblyDir>
       <__TestRunHtmlLog Condition="'$(__TestRunHtmlLog)' == ''">$(__LogsDir)\TestRun.html</__TestRunHtmlLog>
       <__TestRunXmlLog Condition="'$(__TestRunXmlLog)' == ''">$(__LogsDir)\TestRun.xml</__TestRunXmlLog>
   </PropertyGroup>
   <Target Name="FindTestDirectories">
     <ItemGroup>
-      <AllTestAssemblies Include="$(TestAssemblyDir)*.XUnitWrapper.dll" />
-      <TestAssemblies Include="@(AllTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity).XUnitWrapper.dll')" />
+      <AllTestAssemblies Include="$(BaseOutputPathWithConfig)\*\*.XUnitWrapper.dll" />
+      <TestAssemblies Include="@(AllTestAssemblies)" Exclude="@(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')" />
     </ItemGroup>
     
-    <Error  Text=" The wrappers must be compiled and placed at $(TestAssemblyDir) before they can be run, Do a clean Test Run"
+    <Error  Text=" The wrappers must be compiled and placed at $(TestAssemblyDir)\*\ before they can be run, Do a clean Test Run"
             Condition="'@(AllTestAssemblies)' == ''" />
     
     <Message Text= "AllTestAssemblies= @(AllTestAssemblies)"/>
     <Message Text= "TestAssemblies= @(TestAssemblies)"/>
-    <Message Text= "_SkipTestAssemblies= @(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity).XUnitWrapper.dll')"/>
+    <Message Text= "_SkipTestAssemblies= @(_SkipTestAssemblies -> '$(TestAssemblyDir)%(Identity)\%(Identity).XUnitWrapper.dll')"/>
   </Target>
-   <PropertyGroup>
-      <ThisTestWorkingDir>$(TestAssemblyDir)\</ThisTestWorkingDir>
-  </PropertyGroup>
 
   <UsingTask
     AssemblyFile="$(SourceDir)\packages\xunit.runner.msbuild\2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.runner.msbuild.dll"
@@ -35,8 +32,6 @@
 
    <Target Name="RunTests"
           DependsOnTargets="FindTestDirectories"
-          Inputs="@(TestAssemblies)"
-          Outputs="$(ThisTestWorkingDir)\*.*"
           Condition="'$(SkipTests)' != 'True'">
 
 
@@ -49,7 +44,6 @@
     </ItemGroup>
 
     <xunit Assemblies="@(TestAssemblies)"
-      WorkingFolder="$(ThisTestWorkingDir)"
       ParallelizeAssemblies="True"
       ParallelizeTestCollections="True"
       Html="$(__TestRunHtmlLog)"


### PR DESCRIPTION
1. binplaces <testCategory>.XunitRunner.dll in respective <testCategory> dir instead of XuniRunner Dir
2. changes to use publishtest & cloudtest targets from buildtools
3. specify nugget sources in dir.props instead of from config file
4. Adds helix.targets file to achieve the following needs:
- replace json to be those of actual coreclr tests instead of XunitRunner
- populate coreclr product in packages folder as current buildtools target do not have a way to specify recently built runtime in assemblylists.txt file
- add dependency to runtime copied in packages folder
