### PR TITLE
Fix ecma-spec link

### DIFF
--- a/Documentation/botr/intro-to-clr.md
+++ b/Documentation/botr/intro-to-clr.md
@@ -256,6 +256,6 @@ Phew!  The runtime does a lot! It has taken many pages just to describe _some_ o
 - [CoreCLR Repo Documentation](README.md)
 
 [clr]: http://msdn.microsoft.com/library/8bs2ecf4.aspx
-[ecma-spec]: dotnet-standards.md 
+[ecma-spec]: ../project-docs/dotnet-standards.md
 [cil-spec]: http://download.microsoft.com/download/7/3/3/733AD403-90B2-4064-A81E-01035A7FE13C/MS%20Partition%20III.pdf
 [fx-design-guidelines]: http://msdn.microsoft.com/en-us/library/ms229042.aspx


### PR DESCRIPTION
I was just reading through the Book of the Runtime tonight and found a broken link so I figured I'd just correct it. The other links in the document seemed fine.