### PR TITLE
Mark compTypeCtxtArg as lvOnFrame

### DIFF
--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -991,6 +991,14 @@ void                Compiler::lvaInitGenericsCtxt(InitVarDscInfo *  varDscInfo)
             }
 #endif
         }
+#ifndef LEGACY_BACKEND
+        else
+        {
+            // For the RyuJIT backend, we need to mark these as being on the stack,
+            // as this is not done elsewhere in the case that canEnreg returns false.
+            varDsc->lvOnFrame = true;
+        }
+#endif // !LEGACY_BACKEND
 
         compArgSize += TARGET_POINTER_SIZE;
 


### PR DESCRIPTION
The type context argument must be initialized to lvOnFrame if it is
not a register argument (as on x86, since it is passed after user
arguments).
