### PR TITLE
Short-circuit for empty strings in string.Insert and Remove

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -2851,12 +2851,17 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.Ensures(Contract.Result<String>().Length == this.Length + value.Length);
             Contract.EndContractBlock();
+            
             int oldLength = Length;
             int insertLength = value.Length;
+            
+            if (oldLength == 0)
+                return value;
+            if (insertLength == 0)
+                return this;
+            
             // In case this computation overflows, newLength will be negative and FastAllocateString throws OutOfMemoryException
             int newLength = oldLength + insertLength;
-            if (newLength == 0)
-                return String.Empty;
             String result = FastAllocateString(newLength);
             unsafe
             {
@@ -2937,9 +2942,13 @@ namespace System {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.Ensures(Contract.Result<String>().Length == this.Length - count);
             Contract.EndContractBlock();
+            
+            if (count == 0)
+                return this;
             int newLength = Length - count;
             if (newLength == 0)
                 return String.Empty;
+            
             String result = FastAllocateString(newLength);
             unsafe
             {


### PR DESCRIPTION
Essentially what the title says; if `Insert` is called with `string.Empty` (or on it), don't allocate a new string.

*Note:* I removed a comment about a 'computation overflow' happening if the length of the strings were too high, so you may want to take a look into that. (I highly doubt a string could be realistically allocated with a size of > 1 GB, but then again I'm not too familiar with CLR internals.)

cc @jkotas

**edit:** Also, shouldn't we be checking if it's **less than** 0 to account for an overflow? This is what we seem to be doing in [CoreRT](https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/src/System/String.cs#L2692-L2693).