### PR TITLE
Disable not relevant tests for NetBSD: SCHED_OTHER may not be reassignable

### DIFF
--- a/src/pal/tests/palsuite/threading/DuplicateHandle/test8/test8.c
+++ b/src/pal/tests/palsuite/threading/DuplicateHandle/test8/test8.c
@@ -36,6 +36,13 @@ int __cdecl main(int argc, char* argv[])
     {
         return (FAIL);
     }
+
+#if !HAVE_SCHED_OTHER_ASSIGNABLE
+    /* Defining thread priority for SCHED_OTHER is implementation defined.
+       Some platforms like NetBSD cannot reassign it as they are dynamic.
+    */
+    printf("paltest_duplicatehandle_test8 has been disabled on this platform\n");
+#else
     
     /* Create a thread.*/
     hThread = CreateThread(NULL,            /* SD*/
@@ -143,6 +150,9 @@ int __cdecl main(int argc, char* argv[])
     /* Clean-up thread and Terminate the PAL.*/
     CloseHandle(hThread);
     CloseHandle(hDupThread);
+
+#endif
+
     PAL_Terminate();
     return PASS;
 }

--- a/src/pal/tests/palsuite/threading/DuplicateHandle/test8/test8.c
+++ b/src/pal/tests/palsuite/threading/DuplicateHandle/test8/test8.c
@@ -3,12 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 /*=====================================================================
-** 
+**
 ** Source:  test8.c (DuplicateHandle)
 **
 ** Purpose: Tests the PAL implementation of the DuplicateHandle function,
 **          with a handle from GetCurrentThread. The test will create a thread
-**          handle, get the current thread and its duplicate. Then get the 
+**          handle, get the current thread and its duplicate. Then get the
 **          priorities of the threads, set the priority of one and the change
 **          should be seen in the other.
 **
@@ -21,9 +21,9 @@ DWORD PALAPI CreateTestThread(LPVOID lpParam);
 
 int __cdecl main(int argc, char* argv[])
 {
-    HANDLE  hThread;  
-    HANDLE  hCurrentThread;  
-    HANDLE  hDupThread;  
+    HANDLE  hThread;
+    HANDLE  hCurrentThread;
+    HANDLE  hDupThread;
     DWORD   dwThreadId = 0;
     LPTHREAD_START_ROUTINE lpStartAddress =  &CreateTestThread;
 
@@ -43,7 +43,7 @@ int __cdecl main(int argc, char* argv[])
     */
     printf("paltest_duplicatehandle_test8 has been disabled on this platform\n");
 #else
-    
+
     /* Create a thread.*/
     hThread = CreateThread(NULL,            /* SD*/
                           (DWORD)0,         /* initial stack size*/

--- a/src/pal/tests/palsuite/threading/GetCurrentThread/test1/thread.c
+++ b/src/pal/tests/palsuite/threading/GetCurrentThread/test1/thread.c
@@ -30,7 +30,13 @@ int __cdecl main( int argc, char **argv )
     {
         return ( FAIL );
     }
-   
+
+#if !HAVE_SCHED_OTHER_ASSIGNABLE
+    /* Defining thread priority for SCHED_OTHER is implementation defined.
+       Some platforms like NetBSD cannot reassign it as they are dynamic.
+    */
+    printf("paltest_getcurrentthread_test1 has been disabled on this platform\n");
+#else   
     hThread = GetCurrentThread();
     
     nPriority = GetThreadPriority(hThread);
@@ -79,6 +85,7 @@ int __cdecl main( int argc, char **argv )
 		    "function failed.  Failing test.\n");
 	}
     }
+#endif
 
     PAL_Terminate();
     return ( PASS );    

--- a/src/pal/tests/palsuite/threading/GetCurrentThread/test1/thread.c
+++ b/src/pal/tests/palsuite/threading/GetCurrentThread/test1/thread.c
@@ -6,26 +6,26 @@
 **
 ** Source: GetCurrentThread/test1/thread.c
 **
-** Purpose: Test to ensure GetCurrentThread returns a handle to 
+** Purpose: Test to ensure GetCurrentThread returns a handle to
 ** the current thread.
 **
 ** Dependencies: GetThreadPriority
 **               SetThreadPriority
-**               Fail   
+**               Fail
 **               Trace
-** 
+**
 
 **
 **=========================================================*/
 
 #include <palsuite.h>
 
-int __cdecl main( int argc, char **argv ) 
+int __cdecl main( int argc, char **argv )
 {
 
-    HANDLE hThread; 
+    HANDLE hThread;
     int nPriority;
- 
+
     if(0 != (PAL_Initialize(argc, argv)))
     {
         return ( FAIL );
@@ -36,19 +36,19 @@ int __cdecl main( int argc, char **argv )
        Some platforms like NetBSD cannot reassign it as they are dynamic.
     */
     printf("paltest_getcurrentthread_test1 has been disabled on this platform\n");
-#else   
+#else
     hThread = GetCurrentThread();
-    
+
     nPriority = GetThreadPriority(hThread);
 
     if ( THREAD_PRIORITY_NORMAL != nPriority )
     {
-	if ( THREAD_PRIORITY_ERROR_RETURN == nPriority ) 
+	if ( THREAD_PRIORITY_ERROR_RETURN == nPriority )
 	{
 	    Fail ("GetThreadPriority function call failed for %s\n"
 		    "GetLastError returned %d\n", argv[0], GetLastError());
 	}
-	else 
+	else
 	{
 	    Fail ("GetThreadPriority function call failed for %s\n"
 		    "The priority returned was %d\n", argv[0], nPriority);
@@ -58,7 +58,7 @@ int __cdecl main( int argc, char **argv )
     {
 	nPriority = 0;
 	
-	if (0 == SetThreadPriority(hThread, THREAD_PRIORITY_HIGHEST)) 
+	if (0 == SetThreadPriority(hThread, THREAD_PRIORITY_HIGHEST))
 	{
 	    Fail ("Unable to set thread priority.  Either handle doesn't"
 		    " point to current thread \nor SetThreadPriority "
@@ -67,18 +67,18 @@ int __cdecl main( int argc, char **argv )
 	
 	nPriority = GetThreadPriority(hThread);
 	
-	if ( THREAD_PRIORITY_ERROR_RETURN == nPriority ) 
+	if ( THREAD_PRIORITY_ERROR_RETURN == nPriority )
 	{
 	    Fail ("GetThreadPriority function call failed for %s\n"
 		    "GetLastError returned %d\n", argv[0], GetLastError());
 	}
-	else if ( THREAD_PRIORITY_HIGHEST == nPriority ) 
+	else if ( THREAD_PRIORITY_HIGHEST == nPriority )
 	{
 	    Trace ("GetCurrentThread returns handle to the current "
 		    "thread.\n");
 	    exit ( PASS );
-	} 
-	else 
+	}
+	else
 	{
 	    Fail ("Unable to set thread priority.  Either handle doesn't"
 		    " point to current thread \nor SetThreadPriority "
@@ -88,6 +88,6 @@ int __cdecl main( int argc, char **argv )
 #endif
 
     PAL_Terminate();
-    return ( PASS );    
-    
+    return ( PASS );
+
 }

--- a/src/pal/tests/palsuite/threading/GetCurrentThread/test2/test2.c
+++ b/src/pal/tests/palsuite/threading/GetCurrentThread/test2/test2.c
@@ -90,7 +90,12 @@ INT __cdecl main( INT argc, CHAR **argv )
         return( FAIL );
     }
 
-
+#if !HAVE_SCHED_OTHER_ASSIGNABLE
+    /* Defining thread priority for SCHED_OTHER is implementation defined.
+       Some platforms like NetBSD cannot reassign it as they are dynamic.
+    */
+    printf("paltest_getcurrentthread_test1 has been disabled on this platform\n");
+#else
     /* Create multiple threads. */
     hThread = CreateThread(    NULL,         /* no security attributes    */
                                0,            /* use default stack size    */
@@ -132,10 +137,8 @@ INT __cdecl main( INT argc, CHAR **argv )
         Fail( "FAIL:Unexpected thread priority %d returned, expected %d\n",
                 g_priority, THREAD_PRIORITY_TIME_CRITICAL );
     }
-    
-    
+#endif    
 
     PAL_Terminate();
     return PASS;
 }
-

--- a/src/pal/tests/palsuite/threading/GetCurrentThread/test2/test2.c
+++ b/src/pal/tests/palsuite/threading/GetCurrentThread/test2/test2.c
@@ -25,7 +25,7 @@
 ** retrieve a handle to itself, and calls GetThreadPriority()
 ** to verify that its priority matches what it was set to on
 ** the main execution thread.
-** 
+**
 
 **
 **===========================================================================*/
@@ -47,7 +47,7 @@ DWORD PALAPI ThreadFunc( LPVOID param )
 {
     int      priority;
     HANDLE   hThread;
-    
+
     /* call GetCurrentThread() to get a pseudo-handle to */
     /* the current thread                                */
     hThread = GetCurrentThread();
@@ -55,8 +55,8 @@ DWORD PALAPI ThreadFunc( LPVOID param )
     {
         Fail( "GetCurrentThread() call failed\n" );
     }
-    
-    
+
+
     /* get the current thread priority */
     priority = GetThreadPriority( hThread );
     if( priority == THREAD_PRIORITY_ERROR_RETURN )
@@ -66,7 +66,7 @@ DWORD PALAPI ThreadFunc( LPVOID param )
     }
 
     /* store this globally because we don't have GetExitCodeThread() */
-    g_priority = priority;    
+    g_priority = priority;
     return (DWORD)priority;
 }
 
@@ -118,7 +118,7 @@ INT __cdecl main( INT argc, CHAR **argv )
         Fail( "ERROR:%lu:SetThreadPriority() call failed\n", GetLastError() );
     }
 
-    /* let the child thread run now */    
+    /* let the child thread run now */
     ResumeThread( hThread );
 
 
@@ -137,7 +137,7 @@ INT __cdecl main( INT argc, CHAR **argv )
         Fail( "FAIL:Unexpected thread priority %d returned, expected %d\n",
                 g_priority, THREAD_PRIORITY_TIME_CRITICAL );
     }
-#endif    
+#endif
 
     PAL_Terminate();
     return PASS;


### PR DESCRIPTION
This addresses the following issues:
    
- `threading/GetCurrentThread/test1/paltest_getcurrentthread_test1. Exit code: 1`
- `threading/GetCurrentThread/test2/paltest_getcurrentthread_test2. Exit code: 1`
- `threading/GetProcessTimes/test2/paltest_getprocesstimes_test2. Exit code: 1`