### PR TITLE
Avoid string allocations in some Concat overloads

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3237,20 +3237,19 @@ namespace System {
                 (str2 == null ? 0 : str2.Length));
             Contract.EndContractBlock();
 
-            if (str0==null && str1==null && str2==null) {
-                return String.Empty;
+            if (IsNullOrEmpty(str0))
+            {
+                return Concat(str1, str2);
             }
 
-            if (str0==null) {
-                str0 = String.Empty;
+            if (IsNullOrEmpty(str1))
+            {
+                return Concat(str0, str2);
             }
 
-            if (str1==null) {
-                str1 = String.Empty;
-            }
-
-            if (str2 == null) {
-                str2 = String.Empty;
+            if (IsNullOrEmpty(str2))
+            {
+                return Concat(str0, str1);
             }
 
             int totalLength = str0.Length + str1.Length + str2.Length;
@@ -3273,24 +3272,24 @@ namespace System {
                 (str3 == null ? 0 : str3.Length));
             Contract.EndContractBlock();
 
-            if (str0==null && str1==null && str2==null && str3==null) {
-                return String.Empty;
+            if (IsNullOrEmpty(str0))
+            {
+                return Concat(str1, str2, str3);
             }
 
-            if (str0==null) {
-                str0 = String.Empty;
+            if (IsNullOrEmpty(str1))
+            {
+                return Concat(str0, str2, str3);
             }
 
-            if (str1==null) {
-                str1 = String.Empty;
+            if (IsNullOrEmpty(str2))
+            {
+                return Concat(str0, str1, str3);
             }
 
-            if (str2 == null) {
-                str2 = String.Empty;
-            }
-            
-            if (str3 == null) {
-                str3 = String.Empty;
+            if (IsNullOrEmpty(str3))
+            {
+                return Concat(str0, str1, str2);
             }
 
             int totalLength = str0.Length + str1.Length + str2.Length + str3.Length;


### PR DESCRIPTION
Previously, if you called something like `string.Concat("", null, "123")` it would try to allocate a new string and return the result. This is wasteful, since if all of the other parameters are null/empty then you can just return the remaining parameter.

This PR avoids such allocations by delegating down to other overloads of `Concat` which perform such checks, which lets us reap perf benefits without resorting to spaghetti code. It also avoids checking for the (very unlikely) case of all 3/4 parameters being null.

Related CoreRT pull request: dotnet/corert#903