### PR TITLE
Generate WinX86 Nuget package

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -424,15 +424,7 @@ if defined __MscorlibOnly (
     exit /b 0
 )
 
-REM Consider doing crossgen build of mscorlib.
-
-if /i "%__BuildArch%" == "x86" (
-    if not defined __DoCrossgen (
-        echo %__MsgPrefix%Skipping Crossgen
-        goto SkipCrossGenBuild
-    )
-)
-
+REM Consider doing crossgen build of mscorlib unless we are skipping it intentionally
 if /i "%__BuildArch%" == "arm64" (
     if not defined __DoCrossgen (
         echo %__MsgPrefix%Skipping Crossgen

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.builds
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  
+
   <PropertyGroup>
     <!-- This property must be set to the same value as $(PackageOutputPath) for the nuspecs and nupkgs to be binplaced to the intended location. -->
     <OutputPath>$(PackageOutputPath)</OutputPath>
@@ -14,6 +14,10 @@
     <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Windows_NT</OSGroup>
       <Platform>amd64</Platform>
+    </Project>
+    <Project Condition="'$(TargetsWindows)' == 'true'" Include="win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>x86</Platform>
     </Project>
     <Project Condition="'$(TargetsLinux)' == 'true' and '$(DistroName)' == 'rhel'" Include="rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <OSGroup>Linux</OSGroup>

--- a/src/build.proj
+++ b/src/build.proj
@@ -17,8 +17,8 @@
     <NugetPackageBuildTargets>BuildNuGetPackages</NugetPackageBuildTargets>
   </PropertyGroup>
 
-  <!-- Generate RyuJIT nuget package -->
-  <Target Name="BuildNuGetPackages" AfterTargets="MovePDB" Condition="'$(BuildNugetPackage)' != 'false'">
+  <!-- Generate RyuJIT nuget package - currently only supported for x64 -->
+  <Target Name="BuildNuGetPackages" AfterTargets="MovePDB" Condition="'$(BuildNugetPackage)' != 'false' and '$(BuildArch)' == 'x64'">
     <MakeDir Directories="$(PackagesBinDir)" Condition="!Exists('$(PackagesBinDir)')" />
     <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(PackagesBinDir)" />
     <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" />


### PR DESCRIPTION
This change enables generating Microsoft.NETCore.Runtime.CoreCLR nuget package for x86 and also enables generating mscorlib.ni.dll as part of the build.

I have also fixed a version bump I missed.

@weshaggard PTAL.