### PR TITLE
Add export to define environment variables

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -123,7 +123,7 @@ def static genStressModeScriptStep(def os, def stressModeName, def stressModeVar
             // Write out what we are writing to the script file
             stepScript += "echo Setting ${k}=${v}\n"
             // Write out the set itself to the script file`
-            stepScript += "${k}=${v}\n"
+            stepScript += "export ${k}=${v}\n"
         }
     }
     return stepScript


### PR DESCRIPTION
@mmitche Could you review the changes? I am not sure if environment variables can be properly set w/o export since a variable w/o export is not visible to child processes. I ran an individual test script under bin/tests/... with defining COMPlus_JitDump w/o export, and it didn't work. I added 'export' to make sure this works; however, if you don't think that it is needed, please let me know.