### PR TITLE
PAL tests on NetBSD: Clean-up

### DIFF
--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -20,7 +20,7 @@ extern "C" int DllTest2();
 
 int main(int argc, char *argv[])
 {
-#ifndef __FreeBSD__
+#if !defined(__FreeBSD__) && !defined(__NetBSD__)
     if (0 != InitializeDllTest1())
     {
         return 1;

--- a/src/pal/tests/palsuite/threading/GetCurrentThread/test2/test2.c
+++ b/src/pal/tests/palsuite/threading/GetCurrentThread/test2/test2.c
@@ -94,7 +94,7 @@ INT __cdecl main( INT argc, CHAR **argv )
     /* Defining thread priority for SCHED_OTHER is implementation defined.
        Some platforms like NetBSD cannot reassign it as they are dynamic.
     */
-    printf("paltest_getcurrentthread_test1 has been disabled on this platform\n");
+    printf("paltest_getcurrentthread_test2 has been disabled on this platform\n");
 #else
     /* Create multiple threads. */
     hThread = CreateThread(    NULL,         /* no security attributes    */


### PR DESCRIPTION
1. Fix a typo
2. Temporarily disable `paltest_pal_sxs_test1` on NetBSD (it's already disabled on FreeBSD)

With these changes (and chery-picked pending patches for NetBSD) all PAL tests pass on this platform.