### PR TITLE
Use default calling convention small type widening rules for R2R

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7741,9 +7741,8 @@ public :
         inline bool         IsJit64Compat()
         {
 #if defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
-            // JIT64 interop not required for ReadyToRun since it can simply fall-back
-            return !IsReadyToRun();
-#else // defined(_TARGET_AMD64_) && !defined(FEATURE_CORECLR)
+            return true;
+#else
             return false;
 #endif
         }

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -5616,7 +5616,9 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
     // the time being that the callee might be compiled by the other JIT and thus the return
     // value will need to be widened by us (or not widened at all...)
 
-    bool            checkForSmallType = opts.IsJit64Compat();
+    // ReadyToRun code sticks with default calling convention that does not widen small return types.
+
+    bool            checkForSmallType = opts.IsJit64Compat() || opts.IsReadyToRun();
     bool            bIntrinsicImported = false;
 
     CORINFO_SIG_INFO calliSig;


### PR DESCRIPTION
Sticking to default calling convention is key for interoperability that is the primary goal of R2R.