### PR TITLE
Delete FEATURE_REF_ZERO_OFFSET_ALLOWED

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -16091,11 +16091,7 @@ bool Compiler::fgFitsInOrNotLoc(GenTreePtr tree, unsigned width)
 
 void Compiler::fgAddFieldSeqForZeroOffset(GenTreePtr op1, FieldSeqNode* fieldSeq)
 {
-#ifdef FEATURE_REF_ZERO_OFFSET_ALLOWED
     assert(op1->TypeGet() == TYP_BYREF || op1->TypeGet() == TYP_I_IMPL || op1->TypeGet() == TYP_REF);
-#else
-    assert(op1->TypeGet() == TYP_BYREF || op1->TypeGet() == TYP_I_IMPL);
-#endif
 
     switch (op1->OperGet())
     {

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -2,7 +2,6 @@ project(ryujit)
 add_definitions(-DFEATURE_NO_HOST)
 add_definitions(-DSELF_NO_HOST)
 add_definitions(-DFEATURE_READYTORUN_COMPILER)
-add_definitions(-DFEATURE_REF_ZERO_OFFSET_ALLOWED)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
 add_library_clr(ryujit


### PR DESCRIPTION
This ifdef was originally introduced when it was not clear how many RyuJIT build flavors are there going to be. I believe that we are firmly on a plan now to favor one that can handle everything and configure the desired behavior dynamically if necessary.

In theory, this feature could be configured dynamically, but it does not seem to be worth the complexity since it is just weakening one assertion.