### PR TITLE
InlineRefactoring: capture remaining failing cases in inline tree

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -4533,8 +4533,12 @@ private:
                                                               GenTreePtr tmpAssignmentInsertionPoint, GenTreePtr paramAssignmentInsertionPoint);
     static int          fgEstimateCallStackSize(GenTreeCall* call);
     GenTreePtr          fgMorphCall         (GenTreeCall*   call);
-    bool                fgMorphCallInline   (GenTreePtr     call);
+    void                fgMorphCallInline      (GenTreeCall* call, InlineResult* result);
     void                fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result);
+#if DEBUG
+    void                fgNoteNonInlineCandidate(GenTreePtr     tree, GenTreeCall* call);
+    static fgWalkPreFn  fgFindNonInlineCandidate;
+#endif
     GenTreePtr          fgOptimizeDelegateConstructor(GenTreePtr call, CORINFO_CONTEXT_HANDLE * ExactContextHnd);
     GenTreePtr          fgMorphLeaf         (GenTreePtr     tree);
     void                fgAssignSetVarDef   (GenTreePtr     tree);

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1104,6 +1104,13 @@ GenTreeCall*        Compiler::gtNewHelperCallNode(unsigned        helper,
                                         type,
                                         args);
     result->gtFlags |= flags;
+
+#if DEBUG
+    // Helper calls are never candidates.
+
+    result->gtInlineObservation = InlineObservation::CALLSITE_IS_CALL_TO_HELPER;
+#endif
+
     return result;
 }
 

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -27,7 +27,7 @@
 //
 // Enums are used throughout to provide various descriptions.
 //
-// Classes are used as follows. There are 4 sitations where inline
+// Classes are used as follows. There are 5 sitations where inline
 // candidacy is evaluated.  In each case an InlineResult is allocated
 // on the stack to collect information about the inline candidate.
 //
@@ -40,7 +40,7 @@
 // imported as well as when prospective inlines are being imported.
 // Candidates are marked in the IL and given an InlineCandidateInfo.
 //
-// 2. Inlining Optimization Pass (fgInline/fgMorphCallInline)
+// 2. Inlining Optimization Pass -- candidates (fgInline)
 //
 // Creates / Uses: InlineContext
 // Creates: InlineInfo, InlArgInfo, InlLocalVarInfo
@@ -55,7 +55,14 @@
 // created to remember this inline. In DEBUG builds, failing inlines
 // also create InlineContexts.
 //
-// 3 & 4. Prejit suitability screens (compCompileHelper)
+// 3. Inlining Optimization Pass -- non-candidates (fgNoteNotInlineCandidate)
+//
+// Creates / Uses: InlineContext
+//
+// In DEBUG, the jit also searches for non-candidate calls to try
+// and get a complete picture of the set of failed inlines.
+//
+// 4 & 5. Prejit suitability screens (compCompileHelper)
 //
 // When prejitting, each method is scanned to see if it is a viable
 // inline candidate. The scanning happens in two stages.


### PR DESCRIPTION
The main ininling loop in `fgInline` currently only looks at calls
that are inline candidates and at top-level in their statements.
This is sensible since any call that is an inline candidate has been
hoisted to top-level during importing.

However, to find all the failed inline cases, the jit also needs to
look through the full tree to find calls that were not identified as
candidates.

For instance, in the Secant test, the jit decides to inline `TestBase`
into `Main`. While importing the code for `TestBase` for inlining, the
jit sees that the call to `Bench` is marked with
`[MethodImpl(MethodImplOptions.NoInlining)]` and so the call is not
considered to be an inline candidate. And because `Bench` returns a
value, the call expression is in a subtree under an assign expression.
Thus the failure to inline `Bench` is overlooked by the current code.

```
;; current code
Inlines into Secant:Main():int
  [IL=0000 TR=000001] [below ALWAYS_INLINE size] Secant:TestBase():bool
```

With this change, under DEBUG, the main inline control loop in `fgInline`
now also scans the tree for non-candidates, and adds their failures
to the InlineContext tree in appropriate locations.

`fgMorphInline` and `fgMorphInlineHelper` are now simpified since they
can assume any call they see must be a candidate.

The jit now also only notes failures for `CT_USER_FUNC` calls, since
otherwise the trees would be full of failed calls to helpers and the
like.

With this change, the jit can now report that `Bench` is a failed inline
into `Main`.

```
;; new code
Inlines into Secant:Main():int
  [IL=0000 TR=000001] [below ALWAYS_INLINE size] Secant:TestBase():bool
    [IL=0000 TR=000021] [FAILED: noinline per IL/cached result] Secant:Bench():bool
```