### PR TITLE
Remove mask of SIGCHLD

### DIFF
--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -790,7 +790,9 @@ CThreadSuspensionInfo::InitializeSignalSets()
     // The default signal mask masks all common signals except those that represent 
     // synchronous exceptions in the PAL or are used by the system (e.g. SIGPROF on BSD).
     // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a 
-    // significant reduction in performance.
+    // significant reduction in performance. Note that SIGCHLD is used by Linux
+    // for parent->child process notifications, and masking it caused parents
+    // not to recognize their children had died.
     sigaddset(&smDefaultmask, SIGHUP);
     sigaddset(&smDefaultmask, SIGABRT);
 #ifdef SIGEMT
@@ -801,7 +803,6 @@ CThreadSuspensionInfo::InitializeSignalSets()
     sigaddset(&smDefaultmask, SIGURG);
     sigaddset(&smDefaultmask, SIGTSTP);
     sigaddset(&smDefaultmask, SIGCONT);
-    sigaddset(&smDefaultmask, SIGCHLD);
     sigaddset(&smDefaultmask, SIGTTIN);
     sigaddset(&smDefaultmask, SIGTTOU);
     sigaddset(&smDefaultmask, SIGIO);


### PR DESCRIPTION
When a .NET Core program invoked a process that invoked its own child, the masking of SIGCHLD prevented the process from recognizing its child had exited, which some processes require. This caused the .NET Core app to hang in certain internal scenarios.

This PR removes the mask entirely.

/cc @jkotas @stephentoub 