### PR TITLE
Fix for pMustExpand early fail.

### DIFF
--- a/src/.nuget/Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/Microsoft.DotNet.RyuJit.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Microsoft.DotNet.RyuJit</id>
-    <version>1.0.5-prerelease-00001</version>
+    <version>1.0.6-prerelease-00001</version>
     <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/.nuget/runtime.json
+++ b/src/.nuget/runtime.json
@@ -2,17 +2,17 @@
   "runtimes": {
     "win7-x64": {
       "Microsoft.DotNet.RyuJit": {
-        "toolchain.win7-x64.Microsoft.DotNet.RyuJit": "1.0.5-prerelease-00001"
+        "toolchain.win7-x64.Microsoft.DotNet.RyuJit": "1.0.6-prerelease-00001"
       }
     },
     "ubuntu.14.04-x64": {
       "Microsoft.DotNet.RyuJit": {
-        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit": "1.0.5-prerelease-00001"
+        "toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit": "1.0.6-prerelease-00001"
       }
     },
     "osx.10.10-x64": {
       "Microsoft.DotNet.RyuJit": {
-        "toolchain.osx.10.10-x64.Microsoft.DotNet.RyuJit": "1.0.5-prerelease-00001"
+        "toolchain.osx.10.10-x64.Microsoft.DotNet.RyuJit": "1.0.6-prerelease-00001"
       }
     }
   }

--- a/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/toolchain.osx.10.10-x64.Microsoft.DotNet.RyuJit.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.osx.10.10-x64.Microsoft.DotNet.RyuJit</id>
-    <version>1.0.5-prerelease-00001</version>
+    <version>1.0.6-prerelease-00001</version>
     <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.ubuntu.14.04-x64.Microsoft.DotNet.RyuJit</id>
-    <version>1.0.5-prerelease-00001</version>
+    <version>1.0.6-prerelease-00001</version>
     <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec
+++ b/src/.nuget/toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>toolchain.win7-x64.Microsoft.DotNet.RyuJit</id>
-    <version>1.0.5-prerelease-00001</version>
+    <version>1.0.6-prerelease-00001</version>
     <title>Microsoft DotNet Standalone Managed to Native Code-Generator</title>
     <authors>Microsoft</authors>
     <owners>Microsoft</owners>

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2968,13 +2968,6 @@ GenTreePtr      Compiler::impIntrinsic(CORINFO_CLASS_HANDLE     clsHnd,
         {
             switch (sig->numArgs)
             {
-                case 0:
-                    // It seems that all the math intrinsics listed take a single argument, so this
-                    // case will never currently be taken.  
-                    assert(false);
-                    op1 = nullptr;
-                    break;
-
                 case 1:
                     op1 = impPopStack().val;
 
@@ -3208,8 +3201,11 @@ InterlockedBinOpCommon:
         {
             NO_WAY("JIT must expand the intrinsic!");
         }
-        else if (IsIntrinsicImplementedByUserCall(intrinsicID))
+        else if ((retNode->gtFlags & GTF_CALL) != 0)
         {
+            // If we must expand the intrinsic,
+            // retNode (the tree that corresponds to the intrinsic expansion) must be non-null,
+            // and the returned tree must not contain a call.
             NO_WAY("JIT must not implement the intrinsic by a user call!");
         }
     }


### PR DESCRIPTION
When EE tells Jit to enforce intrinsic expansion, we also checked whether
the intrinsic will be turned into a user call by IsIntrinsicImplementedByUserCall.
In fact, this API is primarily for math intrinsic and thus somewhat ambiguous since
even for any arbitrary non-math intrinsic ID, it returns true.
There are some side-effects, so I didn't refactor this API in this change.
Instead, the fix for pMustExpand is to check whether gtFlags has GTF_CALL.