### PR TITLE
Correctly cleaning up the ToolRuntime folder once a new version is required

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -29,6 +29,8 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :EOF
 )
 
+if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"
+
 :: Download Nuget.exe
 if NOT exist "%PACKAGES_DIR%NuGet.exe" (
   if NOT exist "%PACKAGES_DIR%" mkdir "%PACKAGES_DIR%"


### PR DESCRIPTION
Corefx has the same issue than buildtools: dotnet/buildtools#474
This line fixes that here as well.

CC: @rahku 