### PR TITLE
Remove dead definitions in alloc.h.

### DIFF
--- a/src/jit/alloc.h
+++ b/src/jit/alloc.h
@@ -151,14 +151,6 @@ public:
     size_t          nraTotalSizeAlloc();
     size_t          nraTotalSizeUsed ();
 
-    /* The following used to visit all of the allocated pages */
-
-    void    *       nraPageWalkerStart();
-    void    *       nraPageWalkerNext (void *page);
-
-    void    *       nraPageGetData(void *page);
-    size_t          nraPageGetSize(void *page);
-
     IEEMemoryManager * nraGetMemoryManager()
     {
         return nraMemoryManager;


### PR DESCRIPTION
Just what it says on the tin.