### PR TITLE
Fix PerfMap::GetNativeImageSignature to work for ready to run images

### DIFF
--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -231,16 +231,15 @@ void PerfMap::GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned 
 {
     CONTRACTL{
         PRECONDITION(pFile != NULL);
-        PRECONDITION(pFile->HasNativeImage());
         PRECONDITION(pwszSig != NULL);
         PRECONDITION(nSigSize >= 39);
     } CONTRACTL_END;
 
-    PEImageHolder pNativeImage(pFile->GetNativeImageWithRef());
-    CORCOMPILE_VERSION_INFO * pVersionInfo = pNativeImage->GetLoadedLayout()->GetNativeVersionInfo();
-    _ASSERTE(pVersionInfo);
-    CORCOMPILE_NGEN_SIGNATURE * pSignature = &pVersionInfo->signature;
-    if(!StringFromGUID2(*pSignature, pwszSig, nSigSize))
+    // We use the MVID as the signature, since ready to run images
+    // don't have a native image signature.
+    GUID mvid;
+    pFile->GetMVID(&mvid);
+    if(!StringFromGUID2(mvid, pwszSig, nSigSize))
     {
         pwszSig[0] = '\0';
     }


### PR DESCRIPTION
PerfMap::GetNativeImageSignature previously used a field that is not present in ready to run images, which causes ./crossgen /CreatePerfmap to crash.  Modify PerfMap::GetNativeImageSignature to use the MVID which is present in all native images.