### PR TITLE
Replace reference to msvcr110.dll with msvcrt.dll in test b286991

### DIFF
--- a/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b286991/b286991.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-RTM/b286991/b286991.il
@@ -26,7 +26,7 @@
    ret
 }
 
-.method public static pinvokeimpl("msvcr110.dll" cdecl)
+.method public static pinvokeimpl("msvcrt.dll" cdecl)
     int32 isupper(int32) cil managed preservesig
 {
    .custom instance void [mscorlib]System.Security.SuppressUnmanagedCodeSecurityAttribute::ctor() = (01 00 00 00)


### PR DESCRIPTION
Removes unsupported dependency and makes the test consistent with its peers.

Fixes #3322