### PR TITLE
Add CORINFO_TOKENKIND_NewObj

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -1584,6 +1584,11 @@ enum CorInfoTokenKind
 
     // token comes from CEE_CONSTRAINED
     CORINFO_TOKENKIND_Constrained = 0x100 | CORINFO_TOKENKIND_Class,
+
+#if COR_JIT_EE_VERSION > 460
+    // token comes from CEE_NEWOBJ
+    CORINFO_TOKENKIND_NewObj    = 0x200 | CORINFO_TOKENKIND_Method,
+#endif
 };
 
 struct CORINFO_RESOLVED_TOKEN

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -11232,7 +11232,11 @@ DO_LDFTN:
             /* NEWOBJ does not respond to CONSTRAINED */
             prefixFlags &= ~PREFIX_CONSTRAINED;
 
+#if COR_JIT_EE_VERSION > 460
+            _impResolveToken(CORINFO_TOKENKIND_NewObj);
+#else
             _impResolveToken(CORINFO_TOKENKIND_Method);
+#endif
 
             eeGetCallInfo(&resolvedToken, 0 /* constraint typeRef*/,
                           addVerifyFlag(combine(CORINFO_CALLINFO_SECURITYCHECKS,


### PR DESCRIPTION
CoreRT implementation of the JIT-EE interface needs to know whether the token is coming from newobj instruction