### PR TITLE
Fix to second CoreFX SIMD test failure mentioned in issue #2886.

### DIFF
--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -601,9 +601,18 @@ void Lowering::LowerNode(GenTreePtr* ppTree, Compiler::fgWalkData* data)
         if ((*ppTree)->TypeGet() == TYP_SIMD12)
         {
 #ifdef _TARGET_64BIT_
-            // On 64-bit architectures, size of Vector3 local on stack will be
-            // rounded to TARGET_POINTER_SIZE and hence will be 16 bytes. Therefore,
-            // Vector3 locals on stack could be read/written as if they were TYP_SIMD16
+            // Assumption 1:
+            // RyuJit backend depends on the assumption that on 64-Bit targets Vector3 size is rounded off
+            // to TARGET_POINTER_SIZE and hence Vector3 locals on stack can be treated as TYP_SIMD16 for
+            // reading and writing purposes. 
+            //
+            // Assumption 2:
+            // RyuJit backend is making another implicit assumption that Vector3 type args when passed in
+            // registers or on stack, the upper most 4-bytes will be zero.  
+            //
+            // TODO-64bit: assumptions 1 and 2 hold within RyuJIT generated code. It is not clear whether
+            // these assumptions hold when a Vector3 type arg is passed by native code. Example: PInvoke
+            // returning Vector3 type value or RPInvoke passing Vector3 type args.
             (*ppTree)->gtType = TYP_SIMD16;
 #else
             NYI("Lowering of TYP_SIMD12 locals");


### PR DESCRIPTION
Root Cause:
The following managed method is executed by the test

  Vector3 Vecor3.Normalize(Vector3)

Vector3 on Unix gets passed in two registers by caller of Normalize()
method.  Within prolog of Normalize(), RyuJIt homes Vector3 arg by
writing only 12 bytes of arg regs xmm0/xmm1. As a result the upper
4-bytes could end up garbage.  Further down test performs dot product
and the codegen of which makes the assumption that Vector3 types
when loaded in regs will have upper 4-bytes zero'ed out.  Since
that assumption is violated, incorrect results gets computed and
hence CoreFx test failure not fiding expected result.

Fix:  While homing Vector3 arg treat it as TYP_SIMD16 and home
16-bytes of arg regs xmm0/xmm1.

Also added a TODO comment on the assumptions RyuJIT is making on
Vector3 type.  Opened #3347 to track it.

Fixes #2886