### PR TITLE
Inline Refactoring: set up policy for bad inlinees

### DIFF
--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -13,56 +13,56 @@ endif (CLR_CMAKE_PLATFORM_ARCH_AMD64)
 
 set( JIT_SOURCES
   alloc.cpp
+  assertionprop.cpp
   bitset.cpp
   block.cpp
+  codegencommon.cpp
   compiler.cpp
+  copyprop.cpp
   disasm.cpp
   earlyprop.cpp
-  eeinterface.cpp
   ee_il_dll.cpp
-  jiteh.cpp
+  eeinterface.cpp
+  emit.cpp
   error.cpp
   flowgraph.cpp
-  gcinfo.cpp
   gcdecode.cpp
   gcencode.cpp
+  gcinfo.cpp
   gentree.cpp
   gschecks.cpp
   hashbv.cpp
   importer.cpp
+  inline.cpp
+  inlinepolicy.cpp
   instr.cpp
   jitconfig.cpp
+  jiteh.cpp
   jittelemetry.cpp
   lclvars.cpp
   liveness.cpp
+  loopcloning.cpp
+  lower.cpp
+  lsra.cpp
   morph.cpp
-  optimizer.cpp
   optcse.cpp
+  optimizer.cpp
+  rangecheck.cpp
   rationalize.cpp
   regalloc.cpp
-  regset.cpp
   register_arg_convention.cpp
-  emit.cpp
+  regset.cpp
   scopeinfo.cpp
   sharedfloat.cpp
   sm.cpp
   smdata.cpp
   smweights.cpp
+  ssabuilder.cpp
+  ssarenamestate.cpp
   typeinfo.cpp
   unwind.cpp
   utils.cpp
-  ssabuilder.cpp
-  ssarenamestate.cpp
   valuenum.cpp
-  copyprop.cpp
-  codegencommon.cpp
-  assertionprop.cpp
-  rangecheck.cpp
-  jittelemetry.cpp
-  loopcloning.cpp
-  lower.cpp
-  lsra.cpp
-  inline.cpp
 )
 
 if(CLR_CMAKE_PLATFORM_ARCH_AMD64)

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4870,9 +4870,7 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
                     // This decision better not be context-dependent.
                     assert(trialResult.isNever());
 
-                    // Mark it in the EE.
-                    info.compCompHnd->setMethodAttribs(methodHnd, CORINFO_FLG_BAD_INLINEE);
-
+                    // Don't bother with the second stage of the evaluation for this method.
                     hasBeenMarkedAsBadInlinee = true;
                 }
                 else
@@ -4921,9 +4919,6 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
                 // Bingo! It is a bad inlinee according to impCanInlineNative.
                 // This decision better not be context-dependent.
                 assert(trialResult.isNever());
-                
-                // Mark it in the EE.
-                info.compCompHnd->setMethodAttribs(methodHnd, CORINFO_FLG_BAD_INLINEE);
             }
             else 
             {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -16965,11 +16965,6 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
         ++Compiler::jitCheckCanInlineFailureCount;    // This is actually the number of methods that starts the inline attempt.
 #endif         
 
-        if (inlineResult.isNever())
-        {
-            info.compCompHnd->setMethodAttribs(fncHandle, CORINFO_FLG_BAD_INLINEE);
-        }
-
         return;
     }
 

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -1,0 +1,186 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "jitpch.h"
+#ifdef _MSC_VER
+#pragma hdrstop
+#endif
+
+#include "inlinepolicy.h"
+
+//------------------------------------------------------------------------
+// getPolicy: Factory method for getting an InlinePolicy
+//
+// Arguments:
+//    compiler - the compiler instance that will evaluate inlines
+//
+// Return Value:
+//    InlinePolicy to use in evaluating the inlines
+//
+// Notes:
+//    Determines which of the various policies should apply,
+//    and creates (or reuses) a policy instance to use.
+
+InlinePolicy* InlinePolicy::getPolicy(Compiler* compiler)
+{
+    // For now, always create a Legacy policy.
+    InlinePolicy* policy = new (compiler, CMK_Inlining) LegacyPolicy();
+
+    return policy;
+}
+
+//------------------------------------------------------------------------
+// noteCandidate: handle passing a set of inlining checks successfully
+//
+// Arguments:
+//    obs      - the current obsevation
+
+void LegacyPolicy::noteCandidate(InlineObservation obs)
+{
+    assert(!inlDecisionIsDecided(inlDecision));
+
+    // Check the impact, it should be INFORMATION
+    InlineImpact impact = inlGetImpact(obs);
+    assert(impact == InlineImpact::INFORMATION);
+
+    // Update the status
+    setCommon(InlineDecision::CANDIDATE, obs);
+}
+
+//------------------------------------------------------------------------
+// noteSuccess: handle finishing all the inlining checks successfully
+
+void LegacyPolicy::noteSuccess()
+{
+    assert(inlDecisionIsCandidate(inlDecision));
+    inlDecision = InlineDecision::SUCCESS;
+}
+
+//------------------------------------------------------------------------
+// note: handle an observation with non-fatal impact
+//
+// Arguments:
+//    obs      - the current obsevation
+
+void LegacyPolicy::note(InlineObservation obs)
+{
+    // Check the impact
+    InlineImpact impact = inlGetImpact(obs);
+
+    // As a safeguard, all fatal impact must be
+    // reported via noteFatal.
+    assert(impact != InlineImpact::FATAL);
+    noteInternal(obs, impact);
+}
+
+//------------------------------------------------------------------------
+// noteFatal: handle an observation with fatal impact
+//
+// Arguments:
+//    obs      - the current obsevation
+
+void LegacyPolicy::noteFatal(InlineObservation obs)
+{
+    // Check the impact
+    InlineImpact impact = inlGetImpact(obs);
+
+    // As a safeguard, all fatal impact must be
+    // reported via noteFatal.
+    assert(impact == InlineImpact::FATAL);
+    noteInternal(obs, impact);
+    assert(inlDecisionIsFailure(inlDecision));
+}
+
+//------------------------------------------------------------------------
+// noteInt: handle an observed integer value
+//
+// Arguments:
+//    obs      - the current obsevation
+//    value    - the value being observed
+
+void LegacyPolicy::noteInt(InlineObservation obs, int value)
+{
+    (void) value;
+    note(obs);
+}
+
+//------------------------------------------------------------------------
+// noteDouble: handle an observed double value
+//
+// Arguments:
+//    obs      - the current obsevation
+//    value    - the value being observed
+
+void LegacyPolicy::noteDouble(InlineObservation obs, double value)
+{
+    (void) value;
+    note(obs);
+}
+
+//------------------------------------------------------------------------
+// setNever: helper for handling an observation
+//
+// Arguments:
+//    obs      - the current obsevation
+//    impact   - impact of the current observation
+
+void LegacyPolicy::noteInternal(InlineObservation obs, InlineImpact impact)
+{
+    // Ignore INFORMATION for now, since policy
+    // is still embedded at the observation sites.
+    if (impact == InlineImpact::INFORMATION)
+    {
+        return;
+    }
+
+    InlineTarget target = inlGetTarget(obs);
+
+    if (target == InlineTarget::CALLEE)
+    {
+        this->setNever(obs);
+    }
+    else
+    {
+        this->setFailure(obs);
+    }
+}
+
+//------------------------------------------------------------------------
+// setNever: helper for setting a failling decision
+//
+// Arguments:
+//    obs      - the current obsevation
+
+void LegacyPolicy::setFailure(InlineObservation obs)
+{
+    assert(!inlDecisionIsSuccess(inlDecision));
+    setCommon(InlineDecision::FAILURE, obs);
+}
+
+//------------------------------------------------------------------------
+// setNever: helper for setting a never decision
+//
+// Arguments:
+//    obs      - the current obsevation
+
+void LegacyPolicy::setNever(InlineObservation obs)
+{
+    assert(!inlDecisionIsSuccess(inlDecision));
+    setCommon(InlineDecision::NEVER, obs);
+}
+
+//------------------------------------------------------------------------
+// setCommon: helper for updating decision and observation
+//
+// Arguments:
+//    decision - the updated decision
+//    obs      - the current obsevation
+
+void LegacyPolicy::setCommon(InlineDecision decision, InlineObservation obs)
+{
+    assert(inlIsValidObservation(obs));
+    assert(decision != InlineDecision::UNDECIDED);
+    inlDecision = decision;
+    inlObservation = obs;
+}

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -1,0 +1,110 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+// Inlining Policies
+//
+// This file contains class definitions for various inlining
+// policies used by the jit.
+//
+// -- CLASSES --
+//
+// LegacyPolicy        - policy to provide legacy inline behavior
+
+#ifndef _INLINE_POLICY_H_
+#define _INLINE_POLICY_H_
+
+#include "jit.h"
+#include "inline.h"
+
+// LegacyPolicy implements the inlining policy used by the jit in its
+// initial release.
+
+class LegacyPolicy : public InlinePolicy
+{
+public:
+
+    LegacyPolicy()
+        : InlinePolicy()
+    {
+        // empty
+    }
+
+    // Policy observations
+    void noteCandidate(InlineObservation obs) override;
+    void noteSuccess() override;
+    void note(InlineObservation obs) override;
+    void noteFatal(InlineObservation obs) override;
+    void noteInt(InlineObservation obs, int value) override;
+    void noteDouble(InlineObservation obs, double value) override;
+
+    // Policy decisions
+    bool propagateNeverToRuntime() const override { return true; }
+
+#ifdef DEBUG
+    const char* getName() const override { return "LegacyPolicy"; }
+#endif
+
+private:
+
+    // Helper methods
+    void noteInternal(InlineObservation obs, InlineImpact impact);
+    void setFailure(InlineObservation obs);
+    void setNever(InlineObservation obs);
+    void setCommon(InlineDecision decision, InlineObservation obs);
+};
+
+//
+// Enums are used throughout to provide various descriptions.
+//
+// Classes are used as follows. There are 5 sitations where inline
+// candidacy is evaluated.  In each case an InlineResult is allocated
+// on the stack to collect information about the inline candidate.
+//
+// 1. Importer Candidate Screen (impMarkInlineCandidate)
+//
+// Creates: InlineCandidateInfo
+//
+// During importing, the IL being imported is scanned to identify
+// inline candidates. This happens both when the root method is being
+// imported as well as when prospective inlines are being imported.
+// Candidates are marked in the IL and given an InlineCandidateInfo.
+//
+// 2. Inlining Optimization Pass -- candidates (fgInline)
+//
+// Creates / Uses: InlineContext
+// Creates: InlineInfo, InlArgInfo, InlLocalVarInfo
+//
+// During the inlining optimation pass, each candidate is further
+// analyzed. Viable candidates will eventually inspire creation of an
+// InlineInfo and a set of InlArgInfos (for call arguments) and 
+// InlLocalVarInfos (for callee locals).
+//
+// The analysis will also examine InlineContexts from relevant prior
+// inlines. If the inline is successful, a new InlineContext will be
+// created to remember this inline. In DEBUG builds, failing inlines
+// also create InlineContexts.
+//
+// 3. Inlining Optimization Pass -- non-candidates (fgNoteNotInlineCandidate)
+//
+// Creates / Uses: InlineContext
+//
+// In DEBUG, the jit also searches for non-candidate calls to try
+// and get a complete picture of the set of failed inlines.
+//
+// 4 & 5. Prejit suitability screens (compCompileHelper)
+//
+// When prejitting, each method is scanned to see if it is a viable
+// inline candidate. The scanning happens in two stages.
+//
+// A note on InlinePolicy
+//
+// In the current code base, the inlining policy is distributed across
+// the various parts of the code that drive the inlining process
+// forward. Subsequent refactoring will extract some or all of this
+// policy into a separate InlinePolicy object, to make it feasible to
+// create and experiment with alternative policies, while preserving
+// the existing policy as a baseline and fallback.
+
+
+#endif // _INLINE_POLICY_H_

--- a/src/jit/jit.settings.targets
+++ b/src/jit/jit.settings.targets
@@ -81,6 +81,7 @@
         <CppCompile Include="..\RangeCheck.cpp" />
         <CppCompile Include="..\LoopCloning.cpp" />
         <CppCompile Include="..\inline.cpp" />
+        <CppCompile Include="..\inlinepolicy.cpp" />
         <CppCompile Include="..\jitconfig.cpp" />
         <CppCompile Condition="'$(ClDefines.Contains(`LEGACY_BACKEND`))'=='True'" Include="..\CodeGenLegacy.cpp" />
         <CppCompile Condition="'$(ClDefines.Contains(`LEGACY_BACKEND`))'=='False'"  Include="..\Lower.cpp" />

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5729,14 +5729,6 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 
     if (result->isFailure()) 
     {
-       // Presumably this is one of the first times we've realized
-       // this inlinee can't be inlined, otherwise we would have
-       // filtered it out earlier.
-       if (result->isNever()) 
-       {
-          info.compCompHnd->setMethodAttribs(call->gtCall.gtCallMethHnd, CORINFO_FLG_BAD_INLINEE);
-       }
-
        // Undo some changes made in anticipation of inlining...
 
        // Zero out the used locals


### PR DESCRIPTION
Move inline policies to their own header and cpp file.

Add a method to the policy class to indicate if the policy wants newly
discovered `Never` inline cases to change the callee method attributes
to Noinline. This is an existing optimization that saves time when the
jit sees calls to this callee elsewhere as a possible inline candidates.

For example, in the trace below, at for the call at offset 31, the jit
determines that `ToInt32` is too large to be inlined and so marks it as
noinline. Then when it sees another call to `ToInt31` at offset 44 it
immediately fails the inline attempt.

```
Inlines into RegistryTimeZoneInformation:.ctor(ref):this
  ...
  [IL=0031 TR=000040] [FAILED: too many il bytes] System.BitConverter:ToInt32(ref,int):int
  [IL=0044 TR=000049] [FAILED: noinline per IL/cached result] System.BitConverter:ToInt32(ref,int):int
  [IL=0057 TR=000058] [FAILED: noinline per IL/cached result] System.BitConverter:ToInt32(ref,int):int
```

Diagnostic and experimental policies may choose to disable this
optimization to make it easier to locally reason about failed inlines.

There were 5 calls to `setMethodAttribs` passing `CORINFO_FLG_BAD_INLINEE`.
This change consolidates 4 of them into the inlining code. The remaining
call is for a method with verification errors. I've left it as is.