### PR TITLE
Fix .gitignore so src/tools is not ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ syntax: glob
 [Bb]inaries/
 
 # Build tools related files
-[Tt]ools/
+/[Tt]ools/
 
 ### VisualStudio ###
 


### PR DESCRIPTION
Commit 3079b40 modified .gitignore to ignore top-level Tools directory.
However the change was too broad and caused src/tools to be ignored as well.
This commit fixes it.