### PR TITLE
Validate PowerShell prerequisite. Update documentation. -- Issue #3355

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -32,6 +32,10 @@ any recent (2.4+) version of Python should work, including Python 3.
 - Install [Python](https://www.python.org/downloads/) for Windows.
 - Add it to the PATH environment variable.
 
+PowerShell
+----------
+PowerShell is used in the build system. Ensure that it is accessible via the PATH environment variable. Typically this is %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.
+
 Git Setup
 ---------
 

--- a/build.cmd
+++ b/build.cmd
@@ -212,6 +212,10 @@ if defined __MscorlibOnly goto CheckVS
 
 echo %__MsgPrefix%Checking prerequisites
 
+:: Validate that PowerShell is accessibile.
+for %%X in (powershell.exe) do (set __PSDir=%%~$PATH:X)
+if not defined __PSDir goto NoPS
+
 :: Eval the output from probe-win1.ps1
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& ""%__SourceDir%\pal\tools\probe-win.ps1"""') do %%a
 
@@ -648,6 +652,12 @@ echo     build all x86
 echo        -- builds all build types for x86
 echo     build all x64 x86 Checked Release
 echo        -- builds x64 and x86 architectures, Checked and Release build types for each
+exit /b 1
+
+:NoPS
+echo PowerShell is a prerequisite to build this repository, but it is not accessible.
+echo Ensure that it is defined in the PATH environment variable.
+echo Typically it should be %%SYSTEMROOT%%\System32\WindowsPowerShell\v1.0\.
 exit /b 1
 
 :NoVS


### PR DESCRIPTION
- Add validation that PowerShell is accessible to the build script.
- Document that PowerShell is a prerequisite for building.

Fixes issue #3355.
