### PR TITLE
Fix stack walker on Unix

### DIFF
--- a/src/vm/exceptionhandling.h
+++ b/src/vm/exceptionhandling.h
@@ -565,7 +565,7 @@ public:
         return m_EnclosingClauseInfoOfCollapsedTracker.GetEnclosingClauseCallerSP();
     }
 
-#ifndef FEATURE_PAL          
+#ifndef FEATURE_PAL
 private:
     EHWatsonBucketTracker m_WatsonBucketTracker;
 public:

--- a/src/vm/exstate.cpp
+++ b/src/vm/exstate.cpp
@@ -538,6 +538,8 @@ BOOL DebuggerExState::SetDebuggerInterceptInfo(IJitManager *pJitManager,
 }
 #endif // DEBUGGING_SUPPORTED
 
+#endif // DACCESS_COMPILE
+
 EHClauseInfo* ThreadExceptionState::GetCurrentEHClauseInfo()
 {
 #ifdef WIN64EXCEPTIONS
@@ -564,8 +566,6 @@ EHClauseInfo* ThreadExceptionState::GetCurrentEHClauseInfo()
     return &(m_currentExInfo.m_EHClauseInfo);
 #endif // WIN64EXCEPTIONS
 }
-
-#endif // DACCESS_COMPILE
 
 void ThreadExceptionState::SetThreadExceptionFlag(ThreadExceptionFlag flag)
 {


### PR DESCRIPTION
This change fixes the stack walker on Unix to properly account for the cases
when funclet frames were reclaimed due to native frames unwinding and so
they are not on the stack anymore. The stack walker needs to know that to
properly skip reporting GC references for the parent frame of the funclet.
While there was already code attempting to do that, it was incorrectly
skipping some exception trackers and not skipping the current tracker
in case the catch handler was not called yet.
This problem was discovered while running stress tests with GCStress 3.