### PR TITLE
InlineRefactoring: capturing bits of legacy policy

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4962,13 +4962,16 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
         compGenTreeID = 0;
 #endif
 
-        if (compIsForInlining() &&
-            (fgBBcount > 5) &&
-            !forceInline)
+        if (compIsForInlining())
         {
-            compInlineResult->note(InlineObservation::CALLEE_TOO_MANY_BASIC_BLOCKS);
+            if (forceInline)
+            {
+                compInlineResult->noteCandidate(InlineObservation::CALLEE_IS_FORCE_INLINE);
+            }
 
-            if (compInlineResult->isFailure()) 
+            compInlineResult->noteInt(InlineObservation::CALLEE_NUMBER_OF_BASIC_BLOCKS, fgBBcount);
+
+            if (compInlineResult->isFailure())
             {
                 goto _Next;
             }

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2509,6 +2509,9 @@ public :
 
     InlineInfo         * impInlineInfo;      
 
+    // Get the maximum IL size allowed for an inline
+    unsigned             getImpInlineSize() const { return impInlineSize; }
+
     // The Compiler* that is the root of the inlining tree of which "this" is a member.
     Compiler*            impInlineRoot();
 
@@ -2583,8 +2586,10 @@ protected :
     //-------------------- Stack manipulation ---------------------------------
 
     unsigned            impStkSize;   // Size of the full stack
-    StackEntry          impSmallStack[16];  // Use this array is possible
 
+#define SMALL_STACK_SIZE 16           // number of elements in impSmallStack
+
+    StackEntry          impSmallStack[SMALL_STACK_SIZE];  // Use this array if possible
 
     struct SavedStack                   // used to save/restore stack contents.
     {
@@ -3076,10 +3081,6 @@ private:
 
     static unsigned jitIciStmtIsTheLastInBB;
     static unsigned jitInlineeContainsOnlyOneBB;
-
-    #define             INLINER_FAILED                  "\nINLINER FAILED: "
-    #define             INLINER_WARNING                 "\nINLINER WARNING: "
-    #define             INLINER_INFO                    "\nINLINER INFO: "
 
 #endif // defined(DEBUG) || MEASURE_INLINING
 

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4423,8 +4423,11 @@ DECODE_OPCODE:
 
             if (compIsForInlining())
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_SWITCH);
-                return;
+                compInlineResult->note(InlineObservation::CALLEE_HAS_SWITCH);
+                if (compInlineResult->isFailure()) 
+                {
+                    return;
+                }
             }
 
             // Make sure we don't go past the end reading the number of cases
@@ -21919,7 +21922,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
 
             JITLOG_THIS(pParam->pThis,
                         (LL_INFO100000,
-                         INLINER_INFO "inlineInfo.tokenLookupContextHandle for %s set to 0x%p:\n",
+                         "INLINER: inlineInfo.tokenLookupContextHandle for %s set to 0x%p:\n",
                          pParam->pThis->eeGetMethodFullName(pParam->fncHandle),
                          pParam->pThis->dspPtr(pParam->inlineInfo->tokenLookupContextHandle)));
 

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -41,7 +41,6 @@ INLINE_OBSERVATION(HAS_NATIVE_VARARGS,        bool,   "native varargs",         
 INLINE_OBSERVATION(HAS_NO_BODY,               bool,   "has no body",                   FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_NULL_FOR_LDELEM,       bool,   "has null pointer for ldelem",   FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_PINNED_LOCALS,         bool,   "has pinned locals",             FATAL,       CALLEE)
-INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_ARRAY_METHOD,           bool,   "is array method",               FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_GENERIC_VIRTUAL,        bool,   "generic virtual",               FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_JIT_NOINLINE,           bool,   "noinline per JitNoinline",      FATAL,       CALLEE)
@@ -66,6 +65,7 @@ INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",     
 
 // ------ Callee Performance ------- 
 
+INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    PERFORMANCE, CALLEE)
 INLINE_OBSERVATION(LDFLD_STATIC_VALUECLASS,   bool,   "ldsfld of value class",         PERFORMANCE, CALLEE)
 INLINE_OBSERVATION(TOO_MANY_BASIC_BLOCKS,     bool,   "too many basic blocks",         PERFORMANCE, CALLEE)
 INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",             PERFORMANCE, CALLEE)
@@ -75,10 +75,11 @@ INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",      
 INLINE_OBSERVATION(BELOW_ALWAYS_INLINE_SIZE,  bool,   "below ALWAYS_INLINE size",      INFORMATION, CALLEE)
 INLINE_OBSERVATION(CAN_INLINE_IL,             bool,   "IL passes basic checks",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(CHECK_CAN_INLINE_IL,       bool,   "IL passes detailed checks",     INFORMATION, CALLEE)
-INLINE_OBSERVATION(HAS_FORCE_INLINE,          bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",           INFORMATION, CALLEE)
+INLINE_OBSERVATION(NUMBER_OF_BASIC_BLOCKS,    int,    "number of basic blocks",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_IL_BYTES,        int,    "number of bytes of IL",         INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_LOCALS,          int,    "number of locals",              INFORMATION, CALLEE)
 

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -24,8 +24,11 @@ class LegacyPolicy : public InlinePolicy
 {
 public:
 
-    LegacyPolicy()
+    // Construct a LegacyPolicy
+    LegacyPolicy(Compiler* compiler)
         : InlinePolicy()
+        , inlCompiler(compiler)
+        , inlIsForceInline(false)
     {
         // empty
     }
@@ -52,6 +55,13 @@ private:
     void setFailure(InlineObservation obs);
     void setNever(InlineObservation obs);
     void setCommon(InlineDecision decision, InlineObservation obs);
+
+    // Constants
+    const unsigned MAX_BASIC_BLOCKS = 5;
+
+    // Data members
+    Compiler* inlCompiler;
+    bool      inlIsForceInline;
 };
 
 //


### PR DESCRIPTION
Rework the logic for force inline, basic block count, il size,
and maxstack so that the policy decides when these values
should inhibit inlining.