### PR TITLE
Reduce length of debugger semaphore names.

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1396,8 +1396,10 @@ static bool IsCoreClrModule(const char* pModulePath)
 // between processes with the same PID (which ran at different times). This is to avoid
 // cases where a prior process with the same PID exited abnormally without having a chance
 // to clean up its semaphore. 
-static const char* RuntimeStartupSemaphoreName = "/RuntimeStartupEvent%08x-%llu";
-static const char* RuntimeContinueSemaphoreName = "/RuntimeContinueEvent%08x-%llu";
+// Note to anyone modifying these names in the future: Semaphore names on OS X are limited
+// to SEM_NAME_LEN characters, including null. SEM_NAME_LEN is 31 (at least on OS X 10.11).
+static const char* RuntimeStartupSemaphoreName = "/clrst%08x%016llx";
+static const char* RuntimeContinueSemaphoreName = "/clrco%08x%016llx";
 
 class PAL_RuntimeStartupHelper
 {


### PR DESCRIPTION
On OS X, `SEM_NAME_LEN` is 31, so `sem_open` will fail to create semaphores with names longer than 31 characters (including the null). This change simply reduces the length of the static portions of the strings we use for the names so that we don't hit this limit.

@mikem8361 