### PR TITLE
Fix the osx exception port forwarding limitations.

### DIFF
--- a/src/pal/src/arch/i386/dispatchexceptionwrapper.S
+++ b/src/pal/src/arch/i386/dispatchexceptionwrapper.S
@@ -16,16 +16,10 @@
 .intel_syntax noprefix
 #include "unixasmmacros.inc"
 
-#if defined(__x86_64__)
-#define PAL_DISPATCHEXCEPTION __Z21PAL_DispatchExceptionmmmmmmP8_CONTEXTP17_EXCEPTION_RECORDP11MachMessage
-#else //!defined(_AMD64_)
-#define PAL_DISPATCHEXCEPTION __Z21PAL_DispatchExceptionP8_CONTEXTP17_EXCEPTION_RECORDP11MachMessage
-#endif // defined(_AMD64_)
-
-// Offset of the return address from the PAL_DISPATCHEXCEPTION in the PAL_DispatchExceptionWrapper
+// Offset of the return address from the PAL_DispatchException in the PAL_DispatchExceptionWrapper
 .globl C_FUNC(PAL_DispatchExceptionReturnOffset)
 C_FUNC(PAL_DispatchExceptionReturnOffset):
-    .int LOCAL_LABEL(PAL_DispatchExceptionReturn)-C_FUNC(PAL_DispatchExceptionWrapper)
+    .int LOCAL_LABEL(PAL_DispatchExceptionReturn) - C_FUNC(PAL_DispatchExceptionWrapper)
 
 //
 // PAL_DispatchExceptionWrapper will never be called; it only serves
@@ -33,14 +27,14 @@ C_FUNC(PAL_DispatchExceptionReturnOffset):
 // unwinding behavior is equivalent to any standard function having
 // an ebp frame. It is analogous to the following source file.
 // 
-// void PAL_DispatchException(CONTEXT *pContext, EXCEPTION_RECORD *pExceptionRecord, MachMessage *pMessage);
+// extern "C" void PAL_DispatchException(CONTEXT *pContext, EXCEPTION_RECORD *pExceptionRecord, MachExceptionInfo *pMachExceptionInfo);
 // 
 // extern "C" void PAL_DispatchExceptionWrapper()
 // {
 //     CONTEXT Context;
 //     EXCEPTION_RECORD ExceptionRecord;
-//     MachMessage Message;
-//     PAL_DispatchException(&Context, &ExceptionRecord, &Message);
+//     MachExceptionInfo MachExceptionInfo;
+//     PAL_DispatchException(&Context, &ExceptionRecord, &MachExceptionInfo);
 // }
 //
 
@@ -49,10 +43,9 @@ NESTED_ENTRY PAL_DispatchExceptionWrapper, _TEXT, NoHandler
     mov     rbp, rsp
     set_cfa_register rbp, (2*8)
     int3
-    call    PAL_DISPATCHEXCEPTION
+    call    C_FUNC(PAL_DispatchException)
 LOCAL_LABEL(PAL_DispatchExceptionReturn):
     int3
     pop_nonvol_reg rbp
     ret
 NESTED_END PAL_DispatchExceptionWrapper, _TEXT
-

--- a/src/pal/src/exception/machexception.h
+++ b/src/pal/src/exception/machexception.h
@@ -4,16 +4,12 @@
 
 /*++
 
-
-
 Module Name:
 
-    exception/machexception.h
+    machexception.h
 
 Abstract:
     Private mach exception handling utilities for SEH
-
-
 
 --*/
 
@@ -31,18 +27,17 @@ extern "C"
 
 #define HIJACK_ON_SIGNAL 1
 
-// Process and thread Initialization/Cleanup routines
+// List of exception types we will be watching for
+// NOTE: if you change any of these, you need to adapt s_nMachExceptionPortsMax in thread.hpp
+#define PAL_EXC_ILLEGAL_MASK   (EXC_MASK_BAD_INSTRUCTION | EXC_MASK_EMULATION)
+#define PAL_EXC_DEBUGGING_MASK (EXC_MASK_BREAKPOINT | EXC_MASK_SOFTWARE)
+#define PAL_EXC_MANAGED_MASK   (EXC_MASK_BAD_ACCESS | EXC_MASK_ARITHMETIC)
+#define PAL_EXC_ALL_MASK       (PAL_EXC_ILLEGAL_MASK | PAL_EXC_DEBUGGING_MASK | PAL_EXC_MANAGED_MASK)
+
+// Process and thread initialization/cleanup/context routines
 BOOL SEHInitializeMachExceptions(void);
 void SEHCleanupExceptionPort (void);
 void MachExceptionInitializeDebug(void);
-
-// List of exception types we will be watching for
-// NOTE: if you change any of these, you need to adapt s_nMachExceptionPortsMax in thread.hpp
-#define PAL_EXC_ILLEGAL_MASK   (EXC_MASK_BAD_INSTRUCTION|EXC_MASK_EMULATION)
-#define PAL_EXC_DEBUGGING_MASK (EXC_MASK_BREAKPOINT|EXC_MASK_SOFTWARE)
-#define PAL_EXC_MANAGED_MASK   (EXC_MASK_BAD_ACCESS|EXC_MASK_ARITHMETIC)
-#define PAL_EXC_ALL_MASK       (PAL_EXC_ILLEGAL_MASK|PAL_EXC_DEBUGGING_MASK|PAL_EXC_MANAGED_MASK)
-
 PAL_NORETURN void MachSetThreadContext(CONTEXT *lpContext);
 
 #ifdef __cplusplus

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest1.cpp
@@ -30,10 +30,10 @@ int DllTest1()
 
     PAL_TRY(VOID*, unused, NULL)
     {
-        volatile int* p = (volatile int *)0x11; /* invalid pointer */
+        volatile int* p = (volatile int *)0x11; // Invalid pointer
 
-        bTry = TRUE;    /* indicate we hit the PAL_TRY block */
-        *p = 13;        /* causes an access violation exception */
+        bTry = TRUE;                            // Indicate we hit the PAL_TRY block
+        *p = 1;                                 // Causes an access violation exception
 
         Fail("ERROR: code was executed after the access violation.\n");
     }
@@ -44,7 +44,13 @@ int DllTest1()
             Fail("ERROR: PAL_EXCEPT was hit without PAL_TRY being hit.\n");
         }
 
-        bExcept = TRUE; /* indicate we hit the PAL_EXCEPT block */
+        // Validate that the faulting address is correct; the contents of "p" (0x11).
+        if (ex.ExceptionRecord.ExceptionInformation[1] != 0x11)
+        {
+            Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x11\n");
+        }
+
+        bExcept = TRUE;                         // Indicate we hit the PAL_EXCEPT block 
     }
     PAL_ENDTRY;
 
@@ -58,13 +64,12 @@ int DllTest1()
         Trace("ERROR: the code in the PAL_EXCEPT block was not executed.\n");
     }
 
-    /* did we hit all the code blocks? */
+    // Did we hit all the code blocks? 
     if(!bTry || !bExcept)
     {
         Fail("DllTest1 FAILED\n");
     }
 
     Trace("DLLTest1 PASSED\n");
-
     return PASS;
 }

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/dlltest2.cpp
@@ -30,10 +30,10 @@ int DllTest2()
 
     PAL_TRY(VOID*, unused, NULL)
     {
-        volatile int* p = (volatile int *)0x22; /* invalid pointer */
+        volatile int* p = (volatile int *)0x22; // Invalid pointer
 
-        bTry = TRUE;    /* indicate we hit the PAL_TRY block */
-        *p = 13;        /* causes an access violation exception */
+        bTry = TRUE;                            // Indicate we hit the PAL_TRY block
+        *p = 2;                                 // Causes an access violation exception
 
         Fail("ERROR: code was executed after the access violation.\n");
     }
@@ -44,7 +44,13 @@ int DllTest2()
             Fail("ERROR: PAL_EXCEPT was hit without PAL_TRY being hit.\n");
         }
 
-        bExcept = TRUE; /* indicate we hit the PAL_EXCEPT block */
+        // Validate that the faulting address is correct; the contents of "p" (0x22).
+        if (ex.ExceptionRecord.ExceptionInformation[1] != 0x22)
+        {
+            Fail("ERROR: PAL_EXCEPT ExceptionInformation[1] != 0x22\n");
+        }
+
+        bExcept = TRUE;                         // Indicate we hit the PAL_EXCEPT block
     }
     PAL_ENDTRY;
 
@@ -58,13 +64,12 @@ int DllTest2()
         Trace("ERROR: the code in the PAL_EXCEPT block was not executed.\n");
     }
 
-    /* did we hit all the code blocks? */
+    // Did we hit all the code blocks?
     if(!bTry || !bExcept)
     {
         Fail("DllTest2 FAILED\n");
     }
 
     Trace("DLLTest2 PASSED\n");
-
     return PASS;
 }

--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -13,27 +13,112 @@
 **
 **===================================================================*/
 
+#include <stdio.h>
+#include <signal.h>
+#include <errno.h>
+#include <sys/ucontext.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+enum
+{
+    PASS = 0,
+    FAIL = 1
+};
+
 extern "C" int InitializeDllTest1();
 extern "C" int InitializeDllTest2();
 extern "C" int DllTest1();
 extern "C" int DllTest2();
 
-int main(int argc, char *argv[])
+#if !defined(__FreeBSD__) && !defined(__NetBSD__)
+
+bool bSignal = false;
+bool bCatch = false;
+bool bHandler = false;
+
+void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
+{
+    printf("pal_sxs test1: signal handler called\n");
+    bHandler = true;                                // Mark that the signal handler was executed
+
+    if (!bSignal)
+    {
+        printf("ERROR: executed signal handler NOT from try/catch\n");
+        _exit(FAIL);
+    }
+
+    // Validate that the faulting address is correct; the contents of "p" (0x22).
+    if (siginfo->si_addr != (void *)0x33)
+    {
+        printf("ERROR: signal handler faulting address != 0x33\n");
+        _exit(FAIL);
+    }
+
+    // Unmask signal so we can receive it again
+    sigset_t signal_set;
+    sigemptyset(&signal_set);
+    sigaddset(&signal_set, SIGSEGV);
+    if (-1 == sigprocmask(SIG_UNBLOCK, &signal_set, NULL))
+    {
+        printf("ERROR: sigprocmask failed; error is %d\n", errno);
+        _exit(FAIL);
+    } 
+
+    printf("Signal chaining PASSED\n");
+    _exit(PASS);
+}
+
+#endif
+
+int __cdecl main(int argc, char *argv[])
 {
 #if !defined(__FreeBSD__) && !defined(__NetBSD__)
+    struct sigaction newAction;
+    struct sigaction oldAction;
+    newAction.sa_flags = SA_SIGINFO | SA_RESTART;
+    newAction.sa_handler = NULL;
+    newAction.sa_sigaction = sigsegv_handler;
+    sigemptyset(&newAction.sa_mask);
+
+    if (-1 == sigaction(SIGSEGV, &newAction, &oldAction))
+    {
+        printf("ERROR: sigaction failed; error is %d\n", errno);
+        return FAIL;
+    }
+
+    printf("PAL_SXS test1 SIGSEGV handler %p\n", oldAction.sa_sigaction);
+
     if (0 != InitializeDllTest1())
     {
-        return 1;
+        return FAIL;
     }
 
     if (0 != InitializeDllTest2())
     {
-        return 1;
+        return FAIL;
     }
 
+    // Test catching exceptions in other PAL instances
     DllTest2();
     DllTest1();
     DllTest2();
+
+    if (bHandler)
+    {
+        printf("ERROR: signal handler called by PAL sxs tests\n");
+        return FAIL;
+    }
+
+    printf("Starting PAL_SXS test1 signal chaining\n");
+
+    bSignal = true;
+
+    volatile int* p = (volatile int *)0x33; // Invalid pointer
+    *p = 3;                                 // Causes an access violation exception
+
+    printf("ERROR: code was executed after the access violation.\n");
+    return FAIL;
 #endif
-    return 0;
+    return PASS;
 }


### PR DESCRIPTION
Cleanup CThreadMachExceptionHandlerNode/CThreadMachExceptionHandlers.

Send forward exception, save thread info, restore thread back to faulting context and restart faulting instruction and forward.

Add MachExceptionInfo struct used to pass all the exception state around. Bump the IP back one when restarting breakpoint exceptions.

Match lldb exception port options.  Found and fix bug with MACH_EXCEPTION_CODES behavior. Needed pack(4) around the exception message structs.

Cleaned up the _ASSERT, CHECK_MACH, FATAL_ERROR macros.

Dump the task level exception ports.

Add more checks to PAL SXS tests. Validate that the fault addr (ExceptionRecord.ExceptionInformation[1]) is correct.  Check that a third party signal handler will be properly chained to.