### PR TITLE
ARM64: Fix for casting long to ulong

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -5990,7 +5990,9 @@ void CodeGen::genIntToIntCast(GenTreePtr treeNode)
             emit->emitIns_R_I(INS_cmp, cmpSize, sourceReg, 0);
             emitJumpKind jmpLT = genJumpKindForOper(GT_LT, CK_SIGNED);
             genJumpToThrowHlpBlk(jmpLT, SCK_OVERFLOW);
-            if (dstType == TYP_ULONG)
+            noway_assert(genTypeSize(srcType) == 4 || genTypeSize(srcType) == 8);
+            // This is only interesting case to ensure zero-upper bits.
+            if ((srcType == TYP_INT) && (dstType == TYP_ULONG))
             {
                 // cast to TYP_ULONG:
                 // We use a mov with size=EA_4BYTE

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -12891,7 +12891,7 @@ WorkingDir=JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_i8_u8
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_PASS
 [b89409.exe_5447]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b89409\b89409\b89409.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b89409\b89409


### PR DESCRIPTION
When converting long (i8) to ulong (u8) with overflow check,
JIT inadvertently inserts 4 byte mov which clears the upper bits.
This explicit conversion is only needed when converting from i4 to u8.

Before
```
IN0002: 000024      cmp     x0, #0
IN0003: 000028      bge     G_M62889_IG03
IN0004: 00002C      bl      CORINFO_HELP_OVERFLOW
IN0005: 000030      mov     w0, w0   --> Incorrect conversion clearing the
upper 32 bits of x0.
```

After
```
IN0005: 000028      cmp     x0, #0
IN0006: 00002C      bge     G_M62889_IG03
IN0007: 000030      bl      CORINFO_HELP_OVERFLOW
```