### PR TITLE
Fix bug in optOptimizeBools for equality of 0/1.

### DIFF
--- a/src/jit/optimizer.cpp
+++ b/src/jit/optimizer.cpp
@@ -7837,7 +7837,9 @@ GenTree *           Compiler::optIsBoolCond(GenTree *   condBranch,
     if  (opr2->gtOper != GT_CNS_INT)
         return  NULL;
 
-    if  (((unsigned) opr2->gtIntCon.gtIconVal) > 1)
+    ssize_t ival2 = opr2->gtIntCon.gtIconVal;
+
+    if (ival2 != 0 && ival2 != 1)
         return NULL;
 
     /* Is the value a boolean?
@@ -7850,7 +7852,9 @@ GenTree *           Compiler::optIsBoolCond(GenTree *   condBranch,
     }
     else if (opr1->gtOper == GT_CNS_INT)
     {
-        if (((unsigned) opr1->gtIntCon.gtIconVal) <= 1)
+        ssize_t ival1 = opr1->gtIntCon.gtIconVal;
+
+        if (ival1 == 0 || ival1 == 1)
             isBool = true;
     }
     else if (opr1->gtOper == GT_LCL_VAR)
@@ -7865,7 +7869,7 @@ GenTree *           Compiler::optIsBoolCond(GenTree *   condBranch,
     }
 
     /* Was our comparison against the constant 1 (i.e. true) */
-    if  (opr2->gtIntCon.gtIconVal == 1)
+    if  (ival2 == 1)
     {
         // If this is a boolean expression tree we can reverse the relop 
         // and change the true to false.

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_168744/DevDiv_168744.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_168744/DevDiv_168744.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+internal class Program
+{
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool Test(ulong i)
+    {
+        bool res;
+
+        // When folding boolean conditionals (optOptimizeBools) RyuJIT failed to
+        // correctly identify when the result of the compare is against 0/1 value.
+        if (((i & 0x8000000000000000) == 0x8000000000000000)
+            && ((i & 0x0100000000000000) == 0x0100000000000000))
+        {
+            res = true;
+        }
+        else
+        {
+            res = false;
+        }
+
+        return res;
+    }
+
+    private static int Main()
+    {
+        bool res = Program.Test(0x8100000000000000);
+
+        if (res == true)
+        {
+            Console.WriteLine("Pass");
+            return 100;
+        }
+
+        Console.WriteLine("Fail");
+        return 101;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_168744/DevDiv_168744.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_168744/DevDiv_168744.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_168744/app.config
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_168744/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
The method optIsBoolCond had a clever way to test for a constant
of value 0/1 by casting the resulting gtIconVal to (unsigned) and
comparing for <= 1. Unfortunately, for 64-bit targets gtIconVal as
ssize_t holds 64-bits and the cast to (unsigned) results in truncating
significant bits and results in the optimization falsely recognizing
legal patterns of bit-tests comparing against 0/1. Because 32-bit
targets represent 64-bit long constants as GT_CNS_LNG they do not
suffer from this problem as the code already had exclusions for them.

I've chosen to rewrite the code to use explicit comparisons that make
the intent of the code more obvious and readable. I've added a unit test
to ensure the bug has been fixed in regression testing.

@BruceForstall 
@dotnet/jit-contrib 