### PR TITLE
Helix test: remove hack to copy currently built runtime.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,6 +265,7 @@ Temporary Items
 TestWrappers_x64_debug
 TestWrappers_x64_checked
 TestWrappers_x64_release
+tests/src/common/test_runtime/project.json
 
 Vagrantfile
 .vagrant

--- a/tests/helix.targets
+++ b/tests/helix.targets
@@ -3,25 +3,30 @@
 
   <PropertyGroup>
       <PackageTestRuntimeFolder>$(PackagesDir)test.Microsoft.NETCore.Runtime.CoreClr\1.1.1</PackageTestRuntimeFolder>
-      <BUILDTOOLS_OVERRIDE_RUNTIME>$(PackageTestRuntimeFolder)</BUILDTOOLS_OVERRIDE_RUNTIME>
   </PropertyGroup>
 
   <ItemGroup>
-    <CoreRootFiles Include="$(CORE_ROOT)\*.*" />
+    <!-- TODO This should come from some package -->
+    <CoreRootFiles Include="$(CORE_ROOT)\crossgen.exe" /> 
+    <CoreRootFiles Include="$(CORE_ROOT)\ildasm.exe" /> 
+    <CoreRootFiles Include="$(CORE_ROOT)\ilasm.exe" /> 
+
+    <!-- TODO these files should get copied to core_root but does not as they are xunit files. Using temporary workaround for now -->
     <CoreRootFiles Include="$(PackagesDir)Microsoft.DotNet.xunit.performance\1.0.0-alpha-build0027\lib\dotnet\xunit.performance.core.dll" />
     <CoreRootFiles Include="$(PackagesDir)xunit.extensibility.core\2.1.0\lib\dotnet\xunit.core.dll" />
   </ItemGroup>
 
+  <!-- replace *.lock.json to be that of actual tests than XunitWrapper -->
   <Target Name="ReplaceProjectLockJson"
           BeforeTargets="CopyTestToTestDirectory">
     <PropertyGroup>
       <ProjectLockJson></ProjectLockJson>
+      <TestRuntimeProjectLockJson></TestRuntimeProjectLockJson>
     </PropertyGroup>
     <ItemGroup>
       <TestNugetProjectLockFile Include="$(SourceDir)$(Category)\**\project.lock.json"/>
     </ItemGroup>
   </Target>
-
 
   <Target Name="CopyProductInPackagesFolder"
           BeforeTargets="CopyTestToTestDirectory">
@@ -38,17 +43,24 @@
  
   </Target>
 
+
   <Target Name="AddFilesToAssemblyList" 
           BeforeTargets="CreateAssemblyListTxt">
 
     <ItemGroup>
 
-      <RuntimeFiles Include="$(PackageTestRuntimeFolder)\*" />
+      <ToReplace Include="$(PackageTestRuntimeFolder)\*" />
+
       <XunitConsoleExe Include="$(PackagesDir)xunit.runner.console\**\xunit.console.exe" />
 
-      <_TestCopyLocalByFileNameWithoutDuplicates Include="@(RuntimeFiles)">
+      <ToRemove Include="@(_TestCopyLocalByFileNameWithoutDuplicates)" Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.Filename)' == 'xunit.performance.core'"/>
+      <ToRemove Include="@(_TestCopyLocalByFileNameWithoutDuplicates)" Condition="'%(_TestCopyLocalByFileNameWithoutDuplicates.Filename)' == 'xunit.core'"/>
+
+      <_TestCopyLocalByFileNameWithoutDuplicates Remove="@(ToRemove)" />
+
+      <_TestCopyLocalByFileNameWithoutDuplicates Include="@(ToReplace)">
         <NugetPackageId>test.Microsoft.NETCore.Runtime.CoreClr</NugetPackageId>
-        <SourcePath>%(RuntimeFiles.Identity)</SourcePath>
+        <SourcePath>%(ToReplace.Identity)</SourcePath>
       </_TestCopyLocalByFileNameWithoutDuplicates>
 
       <_TestCopyLocalByFileNameWithoutDuplicates Include="@(XunitConsoleExe)">
@@ -56,16 +68,6 @@
         <SourcePath>%(XunitConsoleExe.Identity)</SourcePath>
       </_TestCopyLocalByFileNameWithoutDuplicates>
     </ItemGroup>
-
-    <RemoveDuplicatesWithLastOneWinsPolicy Inputs="@(_TestCopyLocalByFileNameWithoutDuplicates)">
-      <Output TaskParameter="Filtered" ItemName="FilteredList" />
-    </RemoveDuplicatesWithLastOneWinsPolicy>
-
-    <ItemGroup>
-       <_TestCopyLocalByFileNameWithoutDuplicates Remove="*" />
-       <_TestCopyLocalByFileNameWithoutDuplicates Include="@(FilteredList)" />
-    </ItemGroup>
-
   </Target>
 
 </Project>

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -315,7 +315,55 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
              Targets="CopyDependecyToCoreRoot"/>
   </Target>
 
+  <!-- All the test projects need to add dependency to currently built runtime as they require that to run. 
+       In addition the version number of built runtime can change so all project.json needs to be dynamically generated. 
+       In order to avoid regenerating project.json for all the tests projects...I added a common project for all the tests.
+       This project is at tests\src\common\test_runtime\test_runtime.csproj. This project is adding common dependencies to
+       all the tests like dependency on Microsoft.netcore.runtime.coreclr ..etc. Project.json for this project is dynamically 
+       generated via task CreateTestRuntimeJsonFile. -->
+  <Target Name="CreateTestRuntimeJsonFile">
+    <ItemGroup>
+      <CoreclrPackage Include="$(CORE_ROOT)\.nuget\**\Microsoft.NETCore.Runtime.CoreCLR.*.nupkg"/>
+    </ItemGroup>
+    <PropertyGroup>
+      <CoreclrPackageFileName>%(CoreclrPackage.Filename)</CoreclrPackageFileName>
+      <!-- Get package version number from nuget package filename at core_root -->
+      <CoreclrPackageVersion>$([System.String]::Copy('$(CoreclrPackageFileName)').Replace('Microsoft.NETCore.Runtime.CoreCLR.',''))</CoreclrPackageVersion>
+      <TestRuntimeJsonContents>
+        <![CDATA[
+{
+  "dependencies": {
+    "Microsoft.NETCore.Runtime.CoreCLR": "$(CoreclrPackageVersion)",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23816",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}        
+
+        ]]>
+      </TestRuntimeJsonContents>
+    </PropertyGroup>
+
+    <!-- Write the file -->
+    <WriteLinesToFile
+      File="src\Common\test_runtime\project.json"
+      Lines="$(TestRuntimeJsonContents)"
+      Overwrite="true" />
+
+  </Target>
+
   <Target Name="Build">
+
+    <!-- generate project.json for runtime dependency -->
+    <MSBuild Projects="$(MSBuildProjectFile)"
+             Targets="CreateTestRuntimeJsonFile"
+             Condition=" '$(NoBuild)'!='true' " />
+
+    <!-- generate project.lock.json file corresponding to above json file -->
+    <MSBuild Projects="src\Common\test_runtime\test_runtime.csproj"
+             Condition=" '$(NoBuild)'!='true' " />
+
     <!-- Default for building -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CreateAllWrappers"

--- a/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/tests/src/Common/test_runtime/test_runtime.csproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+    <GenerateRunScript>false</GenerateRunScript>
+    <CLRTestKind>BuildOnly</CLRTestKind>
+  </PropertyGroup>
+  <ItemGroup>
+     <DnuSourceList Include="$(CORE_ROOT)\.nuget\pkg" /> 
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/tests/src/dirs.proj
+++ b/tests/src/dirs.proj
@@ -17,6 +17,7 @@
       <DisabledProjects Include="TestWrappers*\*\*.csproj" />
       <DisabledProjects Include="*\**\cs_template.csproj" />
       <DisabledProjects Include="Common\Coreclr.TestWrapper\Coreclr.TestWrapper.csproj" />
+      <DisabledProjects Include="Common\test_runtime\test_runtime.csproj" />
     </ItemGroup>
     
     <ItemGroup>


### PR DESCRIPTION
remove hack to copy currently built runtime.
Instead add dependency to currently built runtime package