### PR TITLE
Refactor the pooled ArenaAllocator.

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5622,16 +5622,12 @@ START:
     {
         IEEMemoryManager* pMemoryManager = compHnd->getMemoryManager();
 
-        // Try to reuse the pre-inited allocator ?
+        // Try to reuse the pre-inited allocator
         pAlloc = ArenaAllocator::getPooledAllocator(pMemoryManager);
 
-        if (!pAlloc)
+        if (pAlloc == nullptr)
         {
-            bool res = alloc.initialize(pMemoryManager, false);
-            if  (!res) 
-            {
-                return CORJIT_OUTOFMEM;
-            }
+            alloc = ArenaAllocator(pMemoryManager);
             pAlloc = &alloc;
         }
     }
@@ -5737,16 +5733,9 @@ START:
             }
 
             if (pParamOuter->inlineInfo == NULL)
-            {                      
-                // Now free up whichever allocator we were using
-                if (pParamOuter->pAlloc != pParamOuter->alloc)
-                {
-                    ArenaAllocator::returnPooledAllocator(pParamOuter->pAlloc);
-                }
-                else
-                {
-                    pParamOuter->alloc->destroy();
-                }
+            {
+                // Free up the allocator we were using
+                pParamOuter->pAlloc->destroy();
             }
         }
         endErrorTrap()


### PR DESCRIPTION
The mark/release functionality on `ArenaAllocator` was only being used by the pooled
allocator, and caused some complications in API and implementation. Instead of
providing this functionality on all allocators, refactor this functionality out of
`ArenaAllocator` and into a new subclass, `PooledAllocator`, that provides the
singleton pooled allocator.

A number of additional usability/reliability changes have been enabled as part of this
change:
- `ArenaAllocator::initialize` has been replaced with move assignment
- Asserts have been added on all relevant instance methods to ensure that
  `ArenaAllocator` values are initialized before use
- `ArenaAllocator::returnPooledAllocator` has been replaced by making
  `ArenaAllocator::destroy` virtual and having `PooledAllocator::destroy` return the
  singleton
- The teardown of the pooled allocator is now thread-safe w.r.t. the shutdown of the
  arena allocator subsystem