### PR TITLE
Change avtest priority to 0

### DIFF
--- a/tests/src/Regressions/coreclr/0014/avtest.csproj
+++ b/tests/src/Regressions/coreclr/0014/avtest.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildAndRun</CLRTestKind>
-    <CLRTestPriority>1</CLRTestPriority>
+    <CLRTestPriority>0</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This change modifies the priority of the coreclr regression test avtest
to 0 so that it is run in the lab as part of the CI. This fulfills the #1703.