### PR TITLE
Move devdiv374539 out of test priority 0.

### DIFF
--- a/tests/src/JIT/Regression/clr-x64-JIT/v4.0/devdiv374539/DevDiv_374539.csproj
+++ b/tests/src/JIT/Regression/clr-x64-JIT/v4.0/devdiv374539/DevDiv_374539.csproj
@@ -15,6 +15,9 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+
+    <!-- This test takes a long time to run; exclude it by default -->
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This test takes a very long time to execute (~60% of the total time
spent in JIT tests on my machine) and does not seem to be providing
an enormous amount of value. This change moves the test into priority
1, which excludes it from the build by default. If you already have
a test build, you will need to do a clean build in order to avoid
running this test.