### PR TITLE
Add the "sosdocsunix.txt" sos help file to the nuget packages.

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -20,6 +20,7 @@
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsos.so"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsosplugin.so"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)System.Globalization.Native.so" />
 
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -18,6 +18,7 @@
     <ArchitectureSpecificNativeFile Include="$(BinDir)libmscordbi.dylib"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsos.dylib"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)System.Globalization.Native.dylib"/>
 
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -20,6 +20,7 @@
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsos.so"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsosplugin.so"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)System.Globalization.Native.so" />
 
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -20,6 +20,7 @@
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsos.so"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)libsosplugin.so"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)sosdocsunix.txt"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)System.Globalization.Native.so"/>
 
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>


### PR DESCRIPTION
This allows the sos help command to work when installed from our packages.