### PR TITLE
fix warning C4334

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -8193,7 +8193,7 @@ int index_of_set_bit (size_t power2)
     while (low <= high)
     {
         mid = ((low + high)/2);
-        size_t temp = 1 << mid;
+        size_t temp = (size_t)1 << mid;
         if (power2 & temp)
         {
             return mid;


### PR DESCRIPTION
Fixes below build error. << operator type casts the results to left operand. In this case 1 is 32-bit and is implicitly converted to 64-bit and assigned to size_t. Fix is to type cast left operand to result type.

c:\github\coreclr\src\gc\gc.cpp(8196): warning C4334: '<<': result of 32-bit sh
ift implicitly converted to 64 bits (was 64-bit shift intended?) [C:\github\cor
eclr\bin\obj\Windows_NT.x64.Debug\src\gc\sample\gcsample.vcxproj]
c:\github\coreclr\src\gc\gc.cpp(8196): error C2220: warning treated as error -
no 'object' file generated [C:\github\coreclr\bin\obj\Windows_NT.x64.Debug\src\
gc\sample\gcsample.vcxproj]