### PR TITLE
Add linker magic to non-Windows standalone RyuJIT build

### DIFF
--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -4,6 +4,11 @@ add_definitions(-DSELF_NO_HOST)
 add_definitions(-DFEATURE_READYTORUN_COMPILER)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
+if(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_NETBSD)
+    # This is required to force using our own PAL, not one that we are loaded with.
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
+endif(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_NETBSD)
+
 add_library_clr(ryujit
    SHARED
    ${SHARED_LIB_SOURCES}


### PR DESCRIPTION
This makes PAL work better when dynamically loading the standalone JIT.
