### PR TITLE
DbgShim!RegisterForRuntimeStartup: Avoid extra call to callback

### DIFF
--- a/src/dlls/dbgshim/dbgshim.cpp
+++ b/src/dlls/dbgshim/dbgshim.cpp
@@ -436,7 +436,7 @@ public:
             }
         }
 
-        if (FAILED(hr))
+        if (FAILED(hr) && !m_canceled)
         {
             m_callback(NULL, m_parameter, hr);
         }

--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -1668,7 +1668,7 @@ public:
             }
         }
 
-        if (pe != NO_ERROR)
+        if (pe != NO_ERROR && !m_canceled)
         {
             SetLastError(pe);
             m_callback(NULL, NULL, m_parameter);


### PR DESCRIPTION
If the target process exits, and the debugger notifies dbgshim by
calling Unregister then dbgshim was calling back into the callback
to let it know that it couldn't enumerate modules.

With this fix, dbgshim no longer invokes the call back on errors
at the end if unregister has already been called.