### PR TITLE
Stop masking SIGTSTP and SIGCONT

### DIFF
--- a/src/pal/src/thread/threadsusp.cpp
+++ b/src/pal/src/thread/threadsusp.cpp
@@ -792,7 +792,8 @@ CThreadSuspensionInfo::InitializeSignalSets()
     // Note that SIGPROF is used by the BSD thread scheduler and masking it caused a 
     // significant reduction in performance. Note that SIGCHLD is used by Linux
     // for parent->child process notifications, and masking it caused parents
-    // not to recognize their children had died.
+    // not to recognize their children had died. Masking SIGTSTP and SIGCONT causes
+    // problems for job management.
     sigaddset(&smDefaultmask, SIGHUP);
     sigaddset(&smDefaultmask, SIGABRT);
 #ifdef SIGEMT
@@ -801,8 +802,6 @@ CThreadSuspensionInfo::InitializeSignalSets()
     sigaddset(&smDefaultmask, SIGSYS);
     sigaddset(&smDefaultmask, SIGALRM);
     sigaddset(&smDefaultmask, SIGURG);
-    sigaddset(&smDefaultmask, SIGTSTP);
-    sigaddset(&smDefaultmask, SIGCONT);
     sigaddset(&smDefaultmask, SIGTTIN);
     sigaddset(&smDefaultmask, SIGTTOU);
     sigaddset(&smDefaultmask, SIGIO);


### PR DESCRIPTION
These are needed for job management, e.g. with SIGTSTP masked, ctrl-z doesn't work to suspend a process, and with SIGCONT masked, when a process is resumed after suspension it doesn't get notified.

@janvorli, I know with #3305 you're planning to investigate the whole list here, but in the meantime these are needed for some changes being done in System.Console.

cc: @jkotas, @janvorli 