### PR TITLE
Fix build on NetBSD: Include <stdarg.h> for va_arg(3)

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/inc/lldbservices.h
+++ b/src/ToolBox/SOS/lldbplugin/inc/lldbservices.h
@@ -11,6 +11,8 @@
 #ifndef __LLDBSERVICES_H__
 #define __LLDBSERVICES_H__
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
```
STDARG(3)                  Library Functions Manual                  STDARG(3)

NAME
     stdarg, va_arg, va_copy, va_end, va_start - variable argument lists

SYNOPSIS
     #include <stdarg.h>

     void
     va_start(va_list ap, last);

     type
     va_arg(va_list ap, type);

     void
     va_copy(va_list dest, va_list src);

     void
     va_end(va_list ap);

NetBSD 7.99                      June 14, 2015                     NetBSD 7.99
```