### PR TITLE
Fix GC holes for all platforms and a bug for System V OSs in the codegen

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4930,6 +4930,14 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
         }
         info.compRetNativeType = info.compRetType         = JITtype2varType(methodInfo->args.retType);
 
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+        // Set the strcutDesc for the return type if struct.
+        if (varTypeIsStruct(info.compRetType))
+        {
+            eeGetSystemVAmd64PassStructInRegisterDescriptor(info.compMethodInfo->args.retTypeClass, &(info.retStructDesc));
+        }
+#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
+
 #if INLINE_NDIRECT
         info.compCallUnmanaged   = 0;
         info.compLvFrameListRoot = BAD_VAR_NUM;

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7772,6 +7772,9 @@ public :
         #define         CPU_ARM            0x0300    // The generic ARM CPU
 
         unsigned        genCPU; // What CPU are we running on
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+        SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR retStructDesc; // The structDesc of the return type of the method.
+#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
     }
     info;
 

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structinregs.csproj
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structinregs.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <ProjectGuid>{649A239B-AB4B-4E20-BDCA-3BA736E8B790}</ProjectGuid>
     <OutputType>Exe</OutputType>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structrettest.cs
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structrettest.cs
@@ -103,6 +103,34 @@ namespace structinreg
             return tst5;
         }
 
+
+        [MethodImplAttribute(MethodImplOptions.NoInlining)]  
+        Test33 test7(Test33 t5)
+        {    
+            int fRes = t5.foo1.iFoo + t5.foo2.iFoo;    
+            Console.WriteLine("From Test7 members: {0} {1}", t5.foo1.iFoo, t5.foo2.iFoo);    
+            Console.WriteLine("From Test7: Res {0}", fRes);    
+            if (fRes != 43) {    
+                throw new Exception("Failed inside test6 test!");    
+            }
+
+            Test33 tst5 = default(Test33);
+
+            unsafe
+            {
+                int* array = stackalloc int[2];
+                array[0] = 28;
+                array[1] = 29;
+
+                tst5.foo1 = new Foo3();
+                tst5.foo2 = new Foo3();
+                tst5.foo1.iFoo = array[0];
+                tst5.foo2.iFoo = array[1];
+            }
+
+            return tst5;    
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         public static int Main1()
         {
@@ -147,6 +175,21 @@ namespace structinreg
             if ((t5Res.i1 + t5Res.i2 + t5Res.f1) != 42.0)
             {
                 throw new Exception("Failed test5 test!");
+            }
+
+
+
+            Test33 test7 = default(Test33);
+            test7.foo1 = new Foo3();
+            test7.foo2 = new Foo3();
+            test7.foo1.iFoo = 21;
+            test7.foo2.iFoo = 22;
+
+            Test33 t7Res = p.test7(test7);
+
+            Console.WriteLine("test7Result: {0}", t7Res.foo1.iFoo + t7Res.foo2.iFoo);
+            if ((t7Res.foo1.iFoo + t7Res.foo2.iFoo) != 57) {
+                throw new Exception("Failed test7 test!");
             }
 
             return 100;


### PR DESCRIPTION
for GS cookie comparison on amd64.

Fixes issue #3382.

There is a bug in the genEmitGSCookieCheck method for amd64 having to do
with potentially trashing a second rgister (RDX) for a 2 register returned
struct.

It also sets the byref state for RAX, if needed. And GCRef and BrRef for
RDX, if needed.