### PR TITLE
Arm-Linux Fixes (libunwind usage issues)

### DIFF
--- a/src/pal/src/config.h.in
+++ b/src/pal/src/config.h.in
@@ -53,6 +53,8 @@
 #cmakedefine01 HAS_SYSV_SEMAPHORES
 #cmakedefine01 HAS_PTHREAD_MUTEXES
 #cmakedefine01 HAVE_TTRACE
+#cmakedefine HAVE_UNW_GET_SAVE_LOC
+#cmakedefine HAVE_UNW_GET_ACCESSORS
 
 #cmakedefine01 HAVE_STAT_TIMESPEC
 #cmakedefine01 HAVE_STAT_NSEC

--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -73,8 +73,28 @@ check_function_exists(directio HAVE_DIRECTIO)
 check_function_exists(semget HAS_SYSV_SEMAPHORES)
 check_function_exists(pthread_mutex_init HAS_PTHREAD_MUTEXES)
 check_function_exists(ttrace HAVE_TTRACE)
-check_function_exists(unw_get_save_loc HAVE_UNW_GET_SAVE_LOC)
-check_function_exists(unw_get_accessors HAVE_UNW_GET_ACCESSORS)
+set(CMAKE_REQUIRED_LIBRARIES unwind unwind-generic)
+check_cxx_source_compiles("
+#include <libunwind.h>
+
+int main(int argc, char **argv) {
+  unw_cursor_t cursor;
+  unw_save_loc_t saveLoc;
+  int reg = UNW_REG_IP;
+  unw_get_save_loc(&cursor, reg, &saveLoc);
+
+  return 0;
+}" HAVE_UNW_GET_SAVE_LOC)
+check_cxx_source_compiles("
+#include <libunwind.h>
+
+int main(int argc, char **argv) {
+  unw_addr_space_t as;
+  unw_get_accessors(as);
+
+  return 0;
+}" HAVE_UNW_GET_ACCESSORS)
+set(CMAKE_REQUIRED_LIBRARIES)
 
 check_struct_has_member ("struct stat" st_atimespec "sys/types.h;sys/stat.h" HAVE_STAT_TIMESPEC)
 check_struct_has_member ("struct stat" st_atimensec "sys/types.h;sys/stat.h" HAVE_STAT_NSEC)

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -97,17 +97,29 @@ static void WinContextToUnwindCursor(CONTEXT *winContext, unw_cursor_t *cursor)
     unw_set_reg(cursor, UNW_X86_64_R14, winContext->R14);
     unw_set_reg(cursor, UNW_X86_64_R15, winContext->R15);
 #elif defined(_ARM_)
-    unw_set_reg(cursor, UNW_ARM_R13, winContext->Sp);
-    unw_set_reg(cursor, UNW_ARM_R14, winContext->Lr);
-    unw_set_reg(cursor, UNW_ARM_R15, winContext->Pc);
-    unw_set_reg(cursor, UNW_ARM_R4, winContext->R4);
-    unw_set_reg(cursor, UNW_ARM_R5, winContext->R5);
-    unw_set_reg(cursor, UNW_ARM_R6, winContext->R6);
-    unw_set_reg(cursor, UNW_ARM_R7, winContext->R7);
-    unw_set_reg(cursor, UNW_ARM_R8, winContext->R8);
-    unw_set_reg(cursor, UNW_ARM_R9, winContext->R9);
-    unw_set_reg(cursor, UNW_ARM_R10, winContext->R10);
-    unw_set_reg(cursor, UNW_ARM_R11, winContext->R11);
+    // Assuming that unw_set_reg() on cursor will point the cursor to the
+    // supposed stack frame is dangerous for libunwind-arm in Linux.
+    // It is because libunwind's unw_cursor_t has other data structure
+    // initialized by unw_init_local(), which are not updated by
+    // unw_set_reg().
+    unw_context_t context;
+    context.regs[0] = 0;
+    context.regs[1] = 0;
+    context.regs[2] = 0;
+    context.regs[3] = 0;
+    context.regs[4] = winContext->R4;
+    context.regs[5] = winContext->R5;
+    context.regs[6] = winContext->R6;
+    context.regs[7] = winContext->R7;
+    context.regs[8] = winContext->R8;
+    context.regs[9] = winContext->R9;
+    context.regs[10] = winContext->R10;
+    context.regs[11] = winContext->R11;
+    context.regs[12] = 0;
+    context.regs[13] = winContext->Sp;
+    context.regs[14] = winContext->Lr;
+    context.regs[15] = winContext->Pc;
+    unw_init_local(cursor, &context);
 #endif
 }
 #endif
@@ -124,9 +136,9 @@ static void UnwindContextToWinContext(unw_cursor_t *cursor, CONTEXT *winContext)
     unw_get_reg(cursor, UNW_X86_64_R14, (unw_word_t *) &winContext->R14);
     unw_get_reg(cursor, UNW_X86_64_R15, (unw_word_t *) &winContext->R15);
 #elif defined(_ARM_)
-    unw_get_reg(cursor, UNW_ARM_R13, (unw_word_t *) &winContext->Sp);
+    unw_get_reg(cursor, UNW_REG_SP, (unw_word_t *) &winContext->Sp);
+    unw_get_reg(cursor, UNW_REG_IP, (unw_word_t *) &winContext->Pc);
     unw_get_reg(cursor, UNW_ARM_R14, (unw_word_t *) &winContext->Lr);
-    unw_get_reg(cursor, UNW_ARM_R15, (unw_word_t *) &winContext->Pc);
     unw_get_reg(cursor, UNW_ARM_R4, (unw_word_t *) &winContext->R4);
     unw_get_reg(cursor, UNW_ARM_R5, (unw_word_t *) &winContext->R5);
     unw_get_reg(cursor, UNW_ARM_R6, (unw_word_t *) &winContext->R6);


### PR DESCRIPTION
This set fixes #3312 and #3372.

Unfortunately, betraying the expected, fixing #3312 does not fix #3309 simultaneously.
**[EDIT, 2016/3/2]** This fixes #3309 as well. This has exposed another bug #3462, which is related with many runtime execution paths expanded from the cases of #3309.

The code has been tested with Linux/ARM (armv7l, gnueabi, quad-core cortex a9, Linux 3.10)
with debug build. Because of the possibilities that other OS with ARM might been working properly, I have limited the effects to Linux only although I speculate that the same issue has (3372) just not exposed with other Unix-based OS only because the tested platforms support UNWIND_CONTEXT_IS_UCONTEXT_T.

Note that there are other issues exposed after solving the two issues, which did not allow me to complete the given test cases in the issue pages. I'll post such issues and move on to them.
