### PR TITLE
ARM64: Fix for pow test

### DIFF
--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -2657,7 +2657,7 @@ WorkingDir=JIT\Directed\intrinsic\pow\pow1
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_PASS
 [_il_relbinop.exe_4069]
 RelativePath=JIT\Methodical\int64\misc\_il_relbinop\_il_relbinop.exe
 WorkingDir=JIT\Methodical\int64\misc\_il_relbinop

--- a/tests/src/JIT/Directed/intrinsic/pow/pow1.cs
+++ b/tests/src/JIT/Directed/intrinsic/pow/pow1.cs
@@ -14,16 +14,18 @@ internal class pow1
         double x, y, z;
         bool pass = true;
 
-        //Check if the test is being executed on ARM
-        bool isProcessorArm = false;
+        //Check if the test is being executed on ARMARCH
+        bool isProcessorArmArch = false;
 
         string processorArchEnvVar = null;
 
         processorArchEnvVar = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE");
 
-        if ((processorArchEnvVar != null) && processorArchEnvVar.Equals("ARM", StringComparison.CurrentCultureIgnoreCase))
+        if ((processorArchEnvVar != null)
+            && (processorArchEnvVar.Equals("ARM", StringComparison.CurrentCultureIgnoreCase)
+                || processorArchEnvVar.Equals("ARM64", StringComparison.CurrentCultureIgnoreCase)))
         {
-            isProcessorArm = true;
+            isProcessorArmArch = true;
         }
 
         x = 0;
@@ -44,10 +46,10 @@ internal class pow1
             pass = false;
         }
 
-        if (isProcessorArm)
+        if (isProcessorArmArch)
         {
-            //Skip this Test due to the way how Double.Epsilon is defined on ARM
-            Console.WriteLine("Skipping Pow(Double.Epsilon,1) test on ARM");
+            //Skip this Test due to the way how Double.Epsilon is defined on ARMARCH
+            Console.WriteLine("Skipping Pow(Double.Epsilon,1) test on ARMARCH");
         }
         else
         {


### PR DESCRIPTION
This skips Pow(Double.Epsilon,1) test for ARM64 same as ARM.