### PR TITLE
Define ALT_JIT for protojit.dll

### DIFF
--- a/src/jit/protojit/CMakeLists.txt
+++ b/src/jit/protojit/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(protojit)
 
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
+add_definitions(-DALT_JIT)
 
 add_library_clr(protojit
    SHARED


### PR DESCRIPTION
This enables the use of the COMPlus variables for controlling which
files use the altjit, as well as for dumps, etc.