### PR TITLE
Support long paths in CoreCLR runtime on Windows

### DIFF
--- a/src/binder/assemblybinder.cpp
+++ b/src/binder/assemblybinder.cpp
@@ -173,9 +173,18 @@ namespace BINDER_SPACE
                                                           dwCCFullAssemblyPath,
                                                           pwzFullAssemblyPath,
                                                           NULL);
+                if (dwCCFullAssemblyPath > MAX_LONGPATH)
+                {
+                    fullAssemblyPath.CloseBuffer();
+                    pwzFullAssemblyPath = fullAssemblyPath.OpenUnicodeBuffer(dwCCFullAssemblyPath - 1);
+                    dwCCFullAssemblyPath = WszGetFullPathName(assemblyPath.GetUnicode(),
+                                                              dwCCFullAssemblyPath,
+                                                              pwzFullAssemblyPath,
+                                                              NULL);
+                }
                 fullAssemblyPath.CloseBuffer(dwCCFullAssemblyPath);
 
-                if ((dwCCFullAssemblyPath == 0) || (dwCCFullAssemblyPath > (MAX_LONGPATH + 1)))
+                if (dwCCFullAssemblyPath == 0)
                 {
                     hr = HRESULT_FROM_GetLastError();
                 }

--- a/src/binder/cdebuglog.cpp
+++ b/src/binder/cdebuglog.cpp
@@ -58,12 +58,6 @@ namespace BINDER_SPACE
             PathString szPathString;
             DWORD   dw = 0;
 
-            // _ASSERTE (pszPath ) ;
-            if (wcslen(pszName) >= MAX_LONGPATH)
-            {
-                IF_FAIL_GO(HRESULT_FROM_WIN32(ERROR_BUFFER_OVERFLOW));
-            }
-        
             size_t pszNameLen = wcslen(pszName);
             WCHAR * szPath = szPathString.OpenUnicodeBuffer(static_cast<COUNT_T>(pszNameLen));
             size_t cbSzPath = (sizeof(WCHAR)) * (pszNameLen + 1); // SString allocates extra byte for null

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -23,7 +23,12 @@ else()
     )
 
     target_link_libraries(CoreRun
-        msvcrt.lib
+        utilcodestaticnohost
+        advapi32.lib
+        oleaut32.lib
+        uuid.lib
+        user32.lib
+        msvcrt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib
     )
 
     # Can't compile on linux yet so only add for windows

--- a/src/coreclr/hosts/corerun/coreRun.nativeproj
+++ b/src/coreclr/hosts/corerun/coreRun.nativeproj
@@ -19,9 +19,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <LinkPreCrtLibs Include="$(ClrLibPath)\utilcodestaticnohost.lib" />
+    <ProjectReference Include="$(ClrSrcDirectory)utilcode\staticnohost\staticnohost.nativeproj" />
+  </ItemGroup>
+  <ItemGroup>
     <TargetLib Include="$(CoreSystemCrt)" />
     <TargetLib Condition="'$(BuildForWindows7)'=='true'" Include="$(SdkLibPath)\mincore_fw.lib" />
     <TargetLib Condition="'$(BuildForWindows7)'!='true'" Include="$(SdkLibPath)\mincore.lib" />
+    <TargetLib Include="$(SdkLibPath)\oleaut32.lib" />
+    <TargetLib Include="$(SdkLibPath)\uuid.lib" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/inc/clr/fs/dir.h
+++ b/src/inc/clr/fs/dir.h
@@ -75,16 +75,12 @@ namespace clr
 
                 if (cchDirPath == 0)
                 {
-                    IfFailRet(StringCchLength(wzDirPath, _MAX_PATH, &cchDirPath));
-                }
-
-                if (cchDirPath >= _MAX_PATH)
-                {
-                    return E_INVALIDARG;
+                    cchDirPath = wcslen(wzDirPath);
                 }
 
                 // Try to create the path. If it fails, assume that's because the parent folder does
                 // not exist. Try to create the parent then re-attempt.
+                WCHAR chOrig = wzDirPath[cchDirPath];
                 hr = Create(wzDirPath);
                 if (hr == HRESULT_FROM_WIN32(ERROR_PATH_NOT_FOUND))
                 {
@@ -118,11 +114,11 @@ namespace clr
                 }
 
                 // Make a writable copy of wzDirPath
-                WCHAR wzBuffer[_MAX_PATH];
-                WCHAR * pPathEnd;
-                IfFailRet(StringCchCopyEx(wzBuffer, countof(wzBuffer), wzDirPath,
-                                          &pPathEnd, nullptr, STRSAFE_NULL_ON_FAILURE));
-                IfFailRet(CreateRecursively(wzBuffer, pPathEnd - wzBuffer));
+                size_t cchDirPath = wcslen(wzDirPath);
+                CQuickWSTR wzBuffer;
+                IfFailRet(wzBuffer.ReSizeNoThrow(cchDirPath + 1));
+                wcscpy_s(wzBuffer.Ptr(), wzBuffer.Size(), wzDirPath);
+                IfFailRet(CreateRecursively(wzBuffer.Ptr(), cchDirPath));
 
                 return hr;
             }

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -1162,10 +1162,18 @@ void    SplitPathInterior(
     __out_opt LPCWSTR *pwszFileName, __out_opt size_t *pcchFileName,
     __out_opt LPCWSTR *pwszExt,      __out_opt size_t *pcchExt);
 
+#ifndef FEATURE_CORECLR
 void    MakePath(__out_ecount (MAX_LONGPATH) register WCHAR *path, 
                  __in LPCWSTR drive, 
                  __in LPCWSTR dir, 
                  __in LPCWSTR fname, 
+                 __in LPCWSTR ext);
+#endif
+
+void    MakePath(__out CQuickWSTR &path,
+                 __in LPCWSTR drive,
+                 __in LPCWSTR dir,
+                 __in LPCWSTR fname,
                  __in LPCWSTR ext);
 
 WCHAR * FullPath(__out_ecount (maxlen) WCHAR *UserBuf, const WCHAR *path, size_t maxlen);

--- a/src/inc/zapper.h
+++ b/src/inc/zapper.h
@@ -102,7 +102,7 @@ class Zapper
     CORINFO_ASSEMBLY_HANDLE m_hAssembly;
     IMDInternalImport      *m_pAssemblyImport;
 
-    WCHAR                   m_outputPath[MAX_LONGPATH]; // Temp folder for creating the output file
+    SString                 m_outputPath; // Temp folder for creating the output file
 
     IMetaDataAssemblyEmit  *m_pAssemblyEmit;
     IMetaDataAssemblyEmit  *CreateAssemblyEmitter();

--- a/src/md/compiler/regmeta_emit.cpp
+++ b/src/md/compiler/regmeta_emit.cpp
@@ -67,17 +67,11 @@ STDMETHODIMP RegMeta::SetModuleProps(   // S_OK or error.
     IfFailGo(m_pStgdb->m_MiniMd.GetModuleRecord(1, &pModule));
     if (szName != NULL)
     {
-        WCHAR       rcFile[_MAX_PATH]={0};
-        WCHAR       rcExt[_MAX_PATH]={0};
-        WCHAR       rcNewFileName[_MAX_PATH]={0};
+        LPCWSTR szFile = NULL;
+        size_t  cchFile;
 
-        // If the total name is less than _MAX_PATH, the components are, too.
-        if (wcslen(szName) >= _MAX_PATH)
-            IfFailGo(E_INVALIDARG);
-
-        SplitPath(szName, NULL, 0, NULL, 0, rcFile, COUNTOF(rcFile), rcExt, COUNTOF(rcExt));
-        MakePath(rcNewFileName, NULL, NULL, rcFile, rcExt);
-        IfFailGo(m_pStgdb->m_MiniMd.PutStringW(TBL_Module, ModuleRec::COL_Name, pModule, rcNewFileName));
+        SplitPathInterior(szName, NULL, 0, NULL, 0, &szFile, &cchFile, NULL, 0);
+        IfFailGo(m_pStgdb->m_MiniMd.PutStringW(TBL_Module, ModuleRec::COL_Name, pModule, szFile));
     }
 
     IfFailGo(UpdateENCLog(TokenFromRid(1, mdtModule)));

--- a/src/md/enc/liteweightstgdbrw.cpp
+++ b/src/md/enc/liteweightstgdbrw.cpp
@@ -1251,6 +1251,9 @@ BOOL
 CLiteWeightStgdbRW::IsValidFileNameLength(
     const WCHAR * wszFileName)
 {
+#ifdef FEATURE_CORECLR
+    return TRUE;
+#else
     static const WCHAR const_wszLongPathPrefix[] = W("\\\\?\\");
 
     if (wszFileName == NULL)
@@ -1271,4 +1274,5 @@ CLiteWeightStgdbRW::IsValidFileNameLength(
         return TRUE;
     }
     return FALSE;
+#endif
 } // CLiteWeightStgdbRW::IsValidFileNameLength

--- a/src/tools/crossgen/crossgen.cpp
+++ b/src/tools/crossgen/crossgen.cpp
@@ -464,7 +464,7 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
     LPCWSTR pwzAppNiPaths = nullptr;
     LPCWSTR pwzPlatformAssembliesPaths = nullptr;
     LPCWSTR pwzPlatformWinmdPaths = nullptr;
-    WCHAR wzDirectoryToStorePDB[MAX_LONGPATH] = W("\0");
+    StackSString wzDirectoryToStorePDB;
     bool fCreatePDB = false;
     bool fGeneratePDBLinesInfo = false;
     LPWSTR pwzSearchPathForManagedPDB = NULL;
@@ -696,28 +696,14 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
             dwFlags = dwFlags & ~(NGENWORKER_FLAGS_FULLTRUSTDOMAIN | NGENWORKER_FLAGS_READYTORUN);
 
             // Parse: <directory to store PDB>
-            if (wcscpy_s(
-                wzDirectoryToStorePDB, 
-                _countof(wzDirectoryToStorePDB), 
-                argv[0]) != 0)
-            {
-                Output(W("Unable to parse output directory to store PDB"));
-                exit(FAILURE_RESULT);
-            }
+            wzDirectoryToStorePDB.Set(argv[0]);
             argv++;
             argc--;
 
             // Ensure output dir ends in a backslash, or else diasymreader has issues
-            if (wzDirectoryToStorePDB[wcslen(wzDirectoryToStorePDB)-1] != DIRECTORY_SEPARATOR_CHAR_W)
+            if (wzDirectoryToStorePDB[wzDirectoryToStorePDB.GetCount()-1] != DIRECTORY_SEPARATOR_CHAR_W)
             {
-                if (wcscat_s(
-                        wzDirectoryToStorePDB, 
-                        _countof(wzDirectoryToStorePDB), 
-                        DIRECTORY_SEPARATOR_STR_W) != 0)
-                {
-                    Output(W("Unable to parse output directory to store PDB"));
-                    exit(FAILURE_RESULT);
-                }
+                wzDirectoryToStorePDB.Append(DIRECTORY_SEPARATOR_STR_W);
             }
 
             if (argc == 0)
@@ -773,28 +759,14 @@ int _cdecl wmain(int argc, __in_ecount(argc) WCHAR **argv)
             dwFlags = dwFlags & ~NGENWORKER_FLAGS_READYTORUN;
 
             // Parse: <directory to store PDB>
-            if (wcscpy_s(
-                wzDirectoryToStorePDB,
-                _countof(wzDirectoryToStorePDB),
-                argv[0]) != 0)
-            {
-                Output(W("Unable to parse output directory to store perfmap"));
-                exit(FAILURE_RESULT);
-            }
+            wzDirectoryToStorePDB.Set(argv[0]);
             argv++;
             argc--;
 
             // Ensure output dir ends in a backslash
             if (wzDirectoryToStorePDB[wcslen(wzDirectoryToStorePDB)-1] != DIRECTORY_SEPARATOR_CHAR_W)
             {
-                if (wcscat_s(
-                        wzDirectoryToStorePDB,
-                        _countof(wzDirectoryToStorePDB),
-                        DIRECTORY_SEPARATOR_STR_W) != 0)
-                {
-                    Output(W("Unable to parse output directory to store perfmap"));
-                    exit(FAILURE_RESULT);
-                }
+                wzDirectoryToStorePDB.Append(DIRECTORY_SEPARATOR_STR_W);
             }
 
             if (argc == 0)

--- a/src/utilcode/makepath.cpp
+++ b/src/utilcode/makepath.cpp
@@ -15,6 +15,7 @@
 #include "utilcode.h"
 #include "ex.h"
 
+#ifndef FEATURE_CORECLR
 /***
 *void _makepath() - build path name from components
 *
@@ -164,6 +165,146 @@ void MakePath (
                 /* better add the 0-terminator */
                 *path = _T('\0');
         }
+}
+#endif // !FEATURE_CORECLR
+
+/***
+*void Makepath() - build path name from components
+*
+*Purpose:
+*       create a path name from its individual components
+*
+*Entry:
+*       CQuickWSTR &szPath - Buffer for constructed path
+*       WCHAR *drive - pointer to drive component, may or may not contain
+*                     trailing ':'
+*       WCHAR *dir   - pointer to subdirectory component, may or may not include
+*                     leading and/or trailing '/' or '\' characters
+*       WCHAR *fname - pointer to file base name component
+*       WCHAR *ext   - pointer to extension component, may or may not contain
+*                     a leading '.'.
+*
+*Exit:
+*       path - pointer to constructed path name
+*
+*Exceptions:
+*
+*******************************************************************************/
+
+void MakePath (
+        __out CQuickWSTR &szPath,
+        __in LPCWSTR drive,
+        __in LPCWSTR dir,
+        __in LPCWSTR fname,
+        __in LPCWSTR ext
+        )
+{
+        CONTRACTL
+        {
+            NOTHROW;
+            GC_NOTRIGGER;
+        }
+        CONTRACTL_END
+
+        SIZE_T maxCount = 4      // Possible separators between components, plus null terminator
+            + (drive != nullptr ? 2 : 0)
+            + (dir != nullptr ? wcslen(dir) : 0)
+            + (fname != nullptr ? wcslen(fname) : 0)
+            + (ext != nullptr ? wcslen(ext) : 0);
+        LPWSTR path = szPath.AllocNoThrow(maxCount);
+
+        const WCHAR *p;
+        DWORD count = 0;
+
+        /* we assume that the arguments are in the following form (although we
+         * do not diagnose invalid arguments or illegal filenames (such as
+         * names longer than 8.3 or with illegal characters in them)
+         *
+         *  drive:
+         *      A           ; or
+         *      A:
+         *  dir:
+         *      \top\next\last\     ; or
+         *      /top/next/last/     ; or
+         *      either of the above forms with either/both the leading
+         *      and trailing / or \ removed.  Mixed use of '/' and '\' is
+         *      also tolerated
+         *  fname:
+         *      any valid file name
+         *  ext:
+         *      any valid extension (none if empty or null )
+         */
+
+        /* copy drive */
+
+        if (drive && *drive) {
+                *path++ = *drive;
+                *path++ = _T(':');
+                count += 2;
+        }
+
+        /* copy dir */
+
+        if ((p = dir)) {
+                while (*p) {
+                        *path++ = *p++;
+                        count++;
+
+                        _ASSERTE(count < maxCount);
+                }
+
+#ifdef _MBCS
+                if (*(p=_mbsdec(dir,p)) != _T('/') && *p != _T('\\')) {
+#else  /* _MBCS */
+                // suppress warning for the following line; this is safe but would require significant code
+                // delta for prefast to understand.
+#ifdef _PREFAST_
+                #pragma warning( suppress: 26001 ) 
+#endif
+                if (*(p-1) != _T('/') && *(p-1) != _T('\\')) {
+#endif  /* _MBCS */
+                        *path++ = _T('\\');
+                        count++;
+
+                        _ASSERTE(count < maxCount);
+                }
+        }
+
+        /* copy fname */
+
+        if ((p = fname)) {
+                while (*p) {
+                        *path++ = *p++;
+                        count++;
+
+                        _ASSERTE(count < maxCount);
+                }
+        }
+
+        /* copy ext, including 0-terminator - check to see if a '.' needs
+         * to be inserted.
+         */
+
+        if ((p = ext)) {
+                if (*p && *p != _T('.')) {
+                        *path++ = _T('.');
+                        count++;
+
+                        _ASSERTE(count < maxCount);
+                }
+
+                while ((*path++ = *p++)) {
+                    count++;
+
+                    _ASSERTE(count < maxCount);
+                }
+        }
+        else {
+                /* better add the 0-terminator */
+                *path = _T('\0');
+        }
+
+        szPath.Shrink(count + 1);
 }
 
 #if !defined(FEATURE_CORECLR)

--- a/src/utilcode/safewrap.cpp
+++ b/src/utilcode/safewrap.cpp
@@ -175,9 +175,13 @@ ClrDirectoryEnumerator::ClrDirectoryEnumerator(LPCWSTR pBaseDirectory, LPCWSTR p
     }
     CONTRACTL_END;
 
-    StackSString strMask;
-    SString s(SString::Literal, W("\\"));
-    strMask.Set(pBaseDirectory, s, pMask);
+    StackSString strMask(pBaseDirectory);
+    SString s(SString::Literal, DIRECTORY_SEPARATOR_STR_W);
+    if (!strMask.EndsWith(s))
+    {
+        strMask.Append(s);
+    }
+    strMask.Append(pMask);
     dirHandle = WszFindFirstFile(strMask, &data);
 
     if (dirHandle == INVALID_HANDLE_VALUE)

--- a/src/utilcode/splitpath.cpp
+++ b/src/utilcode/splitpath.cpp
@@ -124,7 +124,7 @@ void    SplitPathInterior(
 
     /* extract drive letter and :, if any */
 
-    if ((wcslen(wszPath) >= (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
+    if ((wcslen(wszPath) > (_MAX_DRIVE - 2)) && (*(wszPath + _MAX_DRIVE - 2) == _T(':'))) {
         if (pwszDrive && pcchDrive) {
             *pwszDrive = wszPath;
             *pcchDrive = _MAX_DRIVE - 1;
@@ -243,38 +243,25 @@ void    SplitPath(__in SString const &path,
                   __inout_opt SString *fname,
                   __inout_opt SString *ext)
 {
-    LPWSTR wzDrive = NULL;
-    if (drive != NULL)
-        wzDrive = drive->OpenUnicodeBuffer(_MAX_DRIVE);
+    LPCWSTR wzDrive, wzDir, wzFname, wzExt;
+    size_t cchDrive, cchDir, cchFname, cchExt;
 
-    LPWSTR wzDir = NULL;
-    if (dir != NULL)
-        wzDir = dir->OpenUnicodeBuffer(_MAX_DIR);
-
-    LPWSTR wzFname = NULL;
-    if (fname != NULL)
-        wzFname = fname->OpenUnicodeBuffer(_MAX_FNAME);
-
-    LPWSTR wzExt = NULL;
-    if (ext != NULL)
-        wzExt = ext->OpenUnicodeBuffer(_MAX_EXT);
-
-    SplitPath(path,
-            wzDrive, _MAX_DRIVE,
-            wzDir, _MAX_DIR,
-            wzFname, _MAX_FNAME,
-            wzExt, _MAX_EXT);
+    SplitPathInterior(path,
+            &wzDrive, &cchDrive,
+            &wzDir, &cchDir,
+            &wzFname, &cchFname,
+            &wzExt, &cchExt);
 
     if (drive != NULL)
-        drive->CloseBuffer(static_cast<COUNT_T>(wcslen(wzDrive)));
+        drive->Set(wzDrive, (COUNT_T)cchDrive);
 
     if (dir != NULL)
-        dir->CloseBuffer(static_cast<COUNT_T>(wcslen(wzDir)));
+        dir->Set(wzDir, (COUNT_T)cchDir);
 
     if (fname != NULL)
-        fname->CloseBuffer(static_cast<COUNT_T>(wcslen(wzFname)));
+        fname->Set(wzFname, (COUNT_T)cchFname);
 
     if (ext != NULL)
-        ext->CloseBuffer(static_cast<COUNT_T>(wcslen(wzExt)));
+        ext->Set(wzExt, (COUNT_T)cchExt);
 }
 

--- a/src/vm/stdinterfaces.cpp
+++ b/src/vm/stdinterfaces.cpp
@@ -776,8 +776,21 @@ HRESULT GetITypeLibForAssembly(Assembly *pAssembly, ITypeLib **ppTLB, int bAutoC
 
     // Add a ".tlb" extension and try again.
     IfFailGo(rName.ReSizeNoThrow((int)(wcslen(szModule) + 5)));
-    SplitPath(szModule, rcDrive, _MAX_DRIVE, rcDir, _MAX_DIR, rcFname, _MAX_FNAME, 0, 0);
-    MakePath(rName.Ptr(), rcDrive, rcDir, rcFname, W(".tlb"));
+    // Check if szModule already has an extension.
+    LPCWSTR ext;
+    size_t extSize;
+    SplitPathInterior(szModule, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, &ext, &extSize);
+    if (ext != nullptr)
+    {
+        // szModule already has an extension. Make a copy without the extension.
+        wcsncpy_s(rName.Ptr(), rName.Size(), szModule, ext - szModule);
+    }
+    else
+    {
+        // szModule does not have an extension. Copy the whole string.
+        wcscpy_s(rName.Ptr(), rName.Size(), szModule);
+    }
+    wcscat_s(rName.Ptr(), rName.Size(), W(".tlb"));
     
     hr = LoadTypeLibExWithFlags(rName.Ptr(), flags, &pITLB);
     if(hr == S_OK)

--- a/src/vm/tlbexport.cpp
+++ b/src/vm/tlbexport.cpp
@@ -276,10 +276,13 @@ void ExportTypeLibFromLoadedAssembly(
 
     TypeLibExporter exporter;           // Exporter object.
     LPCWSTR     szModule=0;             // Module filename.
-    WCHAR       rcDrive[_MAX_DRIVE] = {0};
-    WCHAR       rcDir[_MAX_DIR] = {0};
-    WCHAR       rcFile[_MAX_FNAME] = {0};
-    WCHAR       rcTlb[_MAX_PATH+5] = {0};     // Buffer for the tlb filename.
+    StackSString ssDrive;
+    StackSString ssDir;
+    StackSString ssFile;
+    size_t      cchDrive;
+    size_t      cchDir;
+    size_t      cchFile;
+    CQuickWSTR  rcTlb;     // Buffer for the tlb filename.
     int         bDynamic=0;             // If true, dynamic module.
     Module      *pModule;               // The Assembly's SecurityModule.
     
@@ -310,9 +313,9 @@ void ExportTypeLibFromLoadedAssembly(
             szTlb = W("");
         else
         {
-            SplitPath(szModule, rcDrive, _MAX_DRIVE, rcDir, _MAX_DIR, rcFile, _MAX_FNAME, 0, 0);
-            MakePath(rcTlb, rcDrive, rcDir, rcFile, szTypeLibExt);
-            szTlb = rcTlb;
+            SplitPath(szModule, &ssDrive, &ssDir, &ssFile, nullptr);
+            MakePath(rcTlb, ssDrive.GetUnicode(), ssDir.GetUnicode(), ssFile.GetUnicode(), szTypeLibExt);
+            szTlb = rcTlb.Ptr();
         }
     }
 

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -546,6 +546,7 @@ Zapper::Zapper(NGenOptions *pOptions, bool fromDllHost)
         zo->m_compilerFlags |= CORJIT_FLG_PROF_ENTERLEAVE;
     }
 
+#ifdef FEATURE_FUSION
     if (pOptions->lpszRepositoryDir != NULL && pOptions->lpszRepositoryDir[0] != '\0')
     {
         size_t buflen = wcslen(pOptions->lpszRepositoryDir) + 1;
@@ -589,6 +590,7 @@ Zapper::Zapper(NGenOptions *pOptions, bool fromDllHost)
         if (zo->m_repositoryFlags == RepositoryDefault)
             zo->m_repositoryFlags = MoveFromRepository;
     }
+#endif //FEATURE_FUSION
 
     if (pOptions->fInstrument)
         zo->m_compilerFlags |= CORJIT_FLG_BBINSTR;
@@ -3238,7 +3240,7 @@ void Zapper::GetOutputFolder()
     // active use because process ID is unique), increment N, and try again.  Give up if N gets too large.
     for (DWORD n = 0; ; n++)
     {
-        swprintf_s(m_outputPath, W("%s\\%x-%x"), (LPCWSTR)tempPath, GetCurrentProcessId(), n);
+        m_outputPath.Printf(W("%s\\%x-%x"), (LPCWSTR)tempPath, GetCurrentProcessId(), n);
         if (WszCreateDirectory(m_outputPath, NULL))
             break;
 
@@ -3576,11 +3578,11 @@ void Zapper::CompileAssembly(CORCOMPILE_NGEN_SIGNATURE * pNativeImageSig)
         const WCHAR * pathend = wcsrchr( assemblyPath, DIRECTORY_SEPARATOR_CHAR_W );
         if( pathend )
         {
-            wcsncpy_s(m_outputPath, _countof(m_outputPath), assemblyPath, pathend - assemblyPath);
+            m_outputPath.Set(assemblyPath, COUNT_T(pathend - assemblyPath));
         }
         else
         {
-            wcscpy_s(m_outputPath, _countof(m_outputPath), W(".") DIRECTORY_SEPARATOR_STR_W);
+            m_outputPath.Set(W(".") DIRECTORY_SEPARATOR_STR_W);
         }
     }
 #endif // FEATURE_FUSION


### PR DESCRIPTION
The CoreCLR runtime is updated to support long file paths on Windows.
Pending updates to mscorlib.dll, the following scenarios are supported:
* Run managed apps from a long path.
* Load CoreCLR runtime and framework from a long path.
* Load user assemblies from a long path.
* Run CrossGen from a long path, with its input/output from a long path.
* Generate debug log file at a long path.

The following scenarios are not yet supported, and will be fixed in
future commits:
* Mscorlib.dll and framework assemblies are not yet long path compatible.
  Note that until mscorlib.dll is fixed, most of the runtime changes can't
  actually be used.
* Support on non-Windows platforms.
* Support for debugging and error reporting.
* Tools such as ilasm or ildasm.