### PR TITLE
Inliner refactoring: allow repeated bad observations

### DIFF
--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -230,7 +230,7 @@ bool inlDecisionIsFailure(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsFailure: check if this decision describes a sucessful inline
+// inlDecisionIsSuccess: check if this decision describes a sucessful inline
 //
 // Arguments:
 //    d - the decision in question
@@ -255,7 +255,7 @@ bool inlDecisionIsSuccess(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsFailure: check if this decision describes a never inline
+// inlDecisionIsNever: check if this decision describes a never inline
 //
 // Arguments:
 //    d - the decision in question
@@ -280,7 +280,7 @@ bool inlDecisionIsNever(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsFailure: check if this decision describes a viable candidate
+// inlDecisionIsCandidate: check if this decision describes a viable candidate
 //
 // Arguments:
 //    d - the decision in question
@@ -294,7 +294,7 @@ bool inlDecisionIsCandidate(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsFailure: check if this decision has been made
+// inlDecisionIsDecided: check if this decision has been made
 //
 // Arguments:
 //    d - the decision in question

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -249,7 +249,7 @@ private:
 
     // No copying or assignment supported
     InlinePolicy(const InlinePolicy&) = delete;
-    // InlinePolicy operator=(const InlinePolicy&) = delete;
+    InlinePolicy& operator=(const InlinePolicy&) = delete;
 
 protected:
 
@@ -413,7 +413,7 @@ private:
 
     // No copying or assignment allowed.
     InlineResult(const InlineResult&) = delete;
-    InlineResult operator=(const InlineResult&) = delete;
+    InlineResult& operator=(const InlineResult&) = delete;
 
     // Report/log/dump decision as appropriate
     void report();

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -19,6 +19,17 @@
 
 // LegacyPolicy implements the inlining policy used by the jit in its
 // initial release.
+//
+// Generally speaking, the legacy policy expects the inlining attempt
+// to fail fast when a fatal or equivalent observation is made. So
+// once an observation causes failure, no more observations are
+// expected. However for the prejit scan case (where the jit is not
+// actually inlining, but is assessing a method's general
+// inlinability) the legacy policy allows multiple failing
+// observations provided they have the same impact. Only the first
+// observation that puts the policy into a failing state is
+// remembered. Transitions from failing states to candidate or success
+// states are not allowed.
 
 class LegacyPolicy : public InlinePolicy
 {
@@ -54,7 +65,13 @@ private:
     void noteInternal(InlineObservation obs, InlineImpact impact);
     void setFailure(InlineObservation obs);
     void setNever(InlineObservation obs);
-    void setCommon(InlineDecision decision, InlineObservation obs);
+
+    // True if this policy is being used to scan a method during
+    // prejitting.
+    bool isPrejitScan() const 
+    { 
+        return !inlCompiler->compIsForInlining(); 
+    }
 
     // Constants
     const unsigned MAX_BASIC_BLOCKS = 5;
@@ -63,58 +80,5 @@ private:
     Compiler* inlCompiler;
     bool      inlIsForceInline;
 };
-
-//
-// Enums are used throughout to provide various descriptions.
-//
-// Classes are used as follows. There are 5 sitations where inline
-// candidacy is evaluated.  In each case an InlineResult is allocated
-// on the stack to collect information about the inline candidate.
-//
-// 1. Importer Candidate Screen (impMarkInlineCandidate)
-//
-// Creates: InlineCandidateInfo
-//
-// During importing, the IL being imported is scanned to identify
-// inline candidates. This happens both when the root method is being
-// imported as well as when prospective inlines are being imported.
-// Candidates are marked in the IL and given an InlineCandidateInfo.
-//
-// 2. Inlining Optimization Pass -- candidates (fgInline)
-//
-// Creates / Uses: InlineContext
-// Creates: InlineInfo, InlArgInfo, InlLocalVarInfo
-//
-// During the inlining optimation pass, each candidate is further
-// analyzed. Viable candidates will eventually inspire creation of an
-// InlineInfo and a set of InlArgInfos (for call arguments) and 
-// InlLocalVarInfos (for callee locals).
-//
-// The analysis will also examine InlineContexts from relevant prior
-// inlines. If the inline is successful, a new InlineContext will be
-// created to remember this inline. In DEBUG builds, failing inlines
-// also create InlineContexts.
-//
-// 3. Inlining Optimization Pass -- non-candidates (fgNoteNotInlineCandidate)
-//
-// Creates / Uses: InlineContext
-//
-// In DEBUG, the jit also searches for non-candidate calls to try
-// and get a complete picture of the set of failed inlines.
-//
-// 4 & 5. Prejit suitability screens (compCompileHelper)
-//
-// When prejitting, each method is scanned to see if it is a viable
-// inline candidate. The scanning happens in two stages.
-//
-// A note on InlinePolicy
-//
-// In the current code base, the inlining policy is distributed across
-// the various parts of the code that drive the inlining process
-// forward. Subsequent refactoring will extract some or all of this
-// policy into a separate InlinePolicy object, to make it feasible to
-// create and experiment with alternative policies, while preserving
-// the existing policy as a baseline and fallback.
-
 
 #endif // _INLINE_POLICY_H_


### PR DESCRIPTION
The LegacyPolicy now allows repeated observations leading to never
or failing inlines, provided the policy is used as part of the prejit
scan and the observations all have the same impact (that is, all nevers
or all failures). Only the first bad observation is remembered and it
is used as the reason for badness.

This addresses another of the items in issue #3371.

Also, clean up a few things:

Fix a few copy and paste errors in comment headers.

Fix broken "disallow copy-assignment" pattern for InlineResult
and uncomment and fix same for InlinePolicy.

Remove an accidentally duplicated comment block (original is still
there in inline.h).