### PR TITLE
Export CorJitHost interface

### DIFF
--- a/src/inc/CMakeLists.txt
+++ b/src/inc/CMakeLists.txt
@@ -77,6 +77,7 @@ install (FILES cfi.h
                corhdr.h
                corinfo.h
                corjit.h
+               corjithost.h
                opcode.def
                openum.h
                gcinfoencoder.h


### PR DESCRIPTION
Export the CorJitHost interface to the build directory, so that
alternate JITs can use it.

This change is necessary to fix LLILC build break.