### PR TITLE
Fix for not using ilasm from the build binary

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -232,6 +232,12 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tls\test-tls\test-tls.cmd" >
              <Issue>2441</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\directed\ldloca_s_r4\ldloca_s_r4.cmd" >
+             <Issue>3517</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\directed\ldloca_s_r8\ldloca_s_r8.cmd" >
+             <Issue>3517</Issue>
+        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\v1-m10\b07847\b07847\b07847.cmd" >
              <Issue>2441</Issue>
         </ExcludeList>

--- a/tests/src/IL.targets
+++ b/tests/src/IL.targets
@@ -22,7 +22,7 @@
       <_IlasmSwitches Condition="'$(Optimize)' == 'True'">$(_IlasmSwitches) -OPTIMIZE</_IlasmSwitches>
     </PropertyGroup>
 
-    <Exec Command="$(__BinDir)\ilasm $(_OutputTypeArgument) /OUTPUT=@(IntermediateAssembly) $(_IlasmSwitches) @(Compile)">
+    <Exec Command="ilasm $(_OutputTypeArgument) /OUTPUT=@(IntermediateAssembly) $(_IlasmSwitches) @(Compile)">
       <Output TaskParameter="ExitCode" PropertyName="_ILAsmExitCode" />
     </Exec>
     <Error Text="ILAsm failed" Condition="'$(_ILAsmExitCode)' != '0'" />


### PR DESCRIPTION
Using ilasm from the build is a desire to test ilasm tool -- in fact we've
now had ildasm-ilasm round-trip tests, so this is not critical either.
But when building cross-target like ARM64,
running such native ilasm in the different host (x64) is not an option.
Given the current test architect where tests are all populated in Windows,
I just fall back to use one from VS tool same as other tools like CSC.
Ideally, we should download such host tools based on host target especially
when we start populating tests on non-Window platforms.