### PR TITLE
Fix license header for test files

### DIFF
--- a/tests/src/CoreMangLib/components/fileversioninfo/assembly1.cs
+++ b/tests/src/CoreMangLib/components/fileversioninfo/assembly1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Reflection;
 
 // Comments

--- a/tests/src/CoreMangLib/components/stopwatch/co9600ctor.cs
+++ b/tests/src/CoreMangLib/components/stopwatch/co9600ctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Diagnostics;

--- a/tests/src/CoreMangLib/components/stopwatch/co9604get_isrunning.cs
+++ b/tests/src/CoreMangLib/components/stopwatch/co9604get_isrunning.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Diagnostics;

--- a/tests/src/CoreMangLib/cti/system/action/actionctor.cs
+++ b/tests/src/CoreMangLib/cti/system/action/actionctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/action/actioninvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/action/actioninvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/activator/activatorcreateinstance2.cs
+++ b/tests/src/CoreMangLib/cti/system/activator/activatorcreateinstance2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/argumentexception/argumentexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/argumentexception/argumentexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/argumentnullexception/argumentnullexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/argumentnullexception/argumentnullexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/argumentoutofrangeexception/argumentoutofrangeexceptionctor.cs
+++ b/tests/src/CoreMangLib/cti/system/argumentoutofrangeexception/argumentoutofrangeexceptionctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/argumentoutofrangeexception/argumentoutofrangeexceptionmessage.cs
+++ b/tests/src/CoreMangLib/cti/system/argumentoutofrangeexception/argumentoutofrangeexceptionmessage.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/arithmeticexception/arithmeticexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/arithmeticexception/arithmeticexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraybinarysearch1b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraybinarysearch1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraybinarysearch2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraybinarysearch2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraybinarysearch3b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraybinarysearch3b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraybinarysearch4b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraybinarysearch4b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraybinarysearch5b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraybinarysearch5b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraycopy1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycopy1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/array/arraycopy2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycopy2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/array/arraycopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/array/arraycreateinstance1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycreateinstance1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/array/arraycreateinstance1b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycreateinstance1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraycreateinstance2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycreateinstance2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraycreateinstance2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraycreateinstance2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/array/arraygetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/array/arraygetlength.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetlength.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Array.GetLength(System.Int32)

--- a/tests/src/CoreMangLib/cti/system/array/arraygetlowerbound.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetlowerbound.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Array.GetLowerBound(System.Int32)

--- a/tests/src/CoreMangLib/cti/system/array/arraygetupperbound.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetupperbound.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Array.GetUpperBound(System.Int32)

--- a/tests/src/CoreMangLib/cti/system/array/arraygetvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraygetvalue1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetvalue1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraygetvalue2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetvalue2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraygetvalue2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraygetvalue2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayicollectionget_count.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayicollectionget_count.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistadd.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistclear.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistcontains.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistcontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistget_item.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistget_item.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistindexof.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistindexof.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistinsert.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistinsert.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistremove.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistremoveat.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistremoveat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayilistset_item.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayilistset_item.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof1b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof3.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof3b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof3b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof4.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arrayindexof4b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayindexof4b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayinitialize.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayinitialize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof1b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof3.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof3b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof3b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraylastindexof4.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylastindexof4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraylength.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraylength.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayrank.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayrank.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayreserse1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayreserse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arrayreserse2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayreserse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arrayreverse1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayreverse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arrayreverse2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arrayreverse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysetvalue1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysetvalue1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraysetvalue1b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysetvalue1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysetvalue2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysetvalue2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraysetvalue2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysetvalue2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort1.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort10.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/array/arraysort11.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraysort13.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/array/arraysort14.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/array/arraysort1b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraysort2.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort2b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort3.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort3b.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort3b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort4.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort5.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/array/arraysort6.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/array/arraysort9.cs
+++ b/tests/src/CoreMangLib/cti/system/array/arraysort9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/attribute/ddb125472_gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/attribute/ddb125472_gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/attribute/gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/attribute/gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/attributeusageattribute/attributeusageattributeallowmultiple.cs
+++ b/tests/src/CoreMangLib/cti/system/attributeusageattribute/attributeusageattributeallowmultiple.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/attributeusageattribute/attributeusageattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/attributeusageattribute/attributeusageattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionmessage.cs
+++ b/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptionmessage.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptiontostring.cs
+++ b/tests/src/CoreMangLib/cti/system/badimageformatexception/badimageformatexceptiontostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/boolean/booleancompareto_boolean.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleancompareto_boolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanCompareTo_Boolean

--- a/tests/src/CoreMangLib/cti/system/boolean/booleanequals_boolean.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleanequals_boolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanEquals_Boolean

--- a/tests/src/CoreMangLib/cti/system/boolean/booleanequals_object.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleanequals_object.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanEquals_Object

--- a/tests/src/CoreMangLib/cti/system/boolean/booleanfalsestring.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleanfalsestring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanFalseString

--- a/tests/src/CoreMangLib/cti/system/boolean/booleangethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleangethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanGetHashCode

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertableToBoolean

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToByte

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToChar

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToDateTime

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToInt16

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToInt32

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToInt64

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToSByte

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 class MyTestClass

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToUInt16

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToUInt32

--- a/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleaniconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanIConvertibleToInt64

--- a/tests/src/CoreMangLib/cti/system/boolean/booleanparse.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleanparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/boolean/booleantostring.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleantostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/boolean/booleantruestring.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleantruestring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class BooleanTrueString

--- a/tests/src/CoreMangLib/cti/system/boolean/booleantryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/boolean/booleantryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 // This test was ported over to CoreCLR from Co7521TryParse.cs

--- a/tests/src/CoreMangLib/cti/system/byte/byteequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/byte/byteequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/byte/bytegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/bytegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteiconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/bytemaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/bytemaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/byte/byteminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/byte/byteparse1.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteparse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/byte/byteparse3.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/byteparse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/bytetostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/bytetostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/bytetostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/bytetostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/bytetostring4.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/bytetostring4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/byte/bytetryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/byte/bytetryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Security;

--- a/tests/src/CoreMangLib/cti/system/char/charcompateto1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charcompateto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chargethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chargethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization; //for number format info
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/char/chariscontrol1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariscontrol1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariscontrol2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariscontrol2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisdigit1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisdigit1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisdigit2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisdigit2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisletter1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisletter1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisletter2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisletter2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisletterordigit1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisletterordigit1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization; //for UnicodeCategory enumeration
 

--- a/tests/src/CoreMangLib/cti/system/char/charisletterordigit2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisletterordigit2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charislower1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charislower1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charislower2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charislower2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisnumber1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisnumber1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisnumber2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisnumber2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charispunctuation2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charispunctuation2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisseparator1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisseparator1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisseparator2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisseparator2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charissurrogate1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charissurrogate1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charissurrogate2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charissurrogate2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charissurrogatepair1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charissurrogatepair1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charissurrogatepair2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charissurrogatepair2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charissymbol1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charissymbol1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisupper1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisupper1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charisupper2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charisupper2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariswhitespace1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariswhitespace1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chariswhitespace2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chariswhitespace2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charmaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charmaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/charminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/char/charminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chartostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chartostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chartostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chartostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/char/chartryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/char/chartryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 // Ported to CoreCLR from Desktop test Co7522TryParse.cs

--- a/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorienumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorienumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorienumgetcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorienumgetcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorreset.cs
+++ b/tests/src/CoreMangLib/cti/system/charenumerator/charenumeratorreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/clscompliantattribute/clscompliantattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/clscompliantattribute/clscompliantattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/clscompliantattribute/clscompliantattributeiscompliant.cs
+++ b/tests/src/CoreMangLib/cti/system/clscompliantattribute/clscompliantattributeiscompliant.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/dictionaryentryctor.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/dictionaryentryctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/dictionaryentrykey.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/dictionaryentrykey.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/dictionaryentryvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/dictionaryentry/dictionaryentryvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparercompare1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparercompare1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparercompare2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparercompare2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparerctor.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparerctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparerdefault.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/comparer/comparerdefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycomparer.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycomparer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycontainskey.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycontainskey.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycontainsvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycontainsvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarycount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor4.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor5.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor6.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryctor6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarygetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarygetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectioncontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectioncontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectioncopyto2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectioncopyto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionisreadonly2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionisreadonly2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionissynchronized.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionissynchronized.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionissynchronized2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionissynchronized2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionsyncroot.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionsyncroot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionsyncroot2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryicollectionsyncroot2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarycontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarycontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarygetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarygetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisfixedsize.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisfixedsize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisfixedsize2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisfixedsize2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisreadonly2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryisreadonly2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryitem.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryitem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryitem2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryitem2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys4.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionarykeys4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalue2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalue2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalue3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalue3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalue4.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalue4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalues.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryidictionaryvalues.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryienumerablegetenumerator2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryienumerablegetenumerator2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionaryremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarytrygetvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionary/dictionarytrygetvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratordispose.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratordispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratoridictionaryenumeratorget_entry.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratoridictionaryenumeratorget_entry.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratoridictionaryenumeratorget_key.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratoridictionaryenumeratorget_key.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratoridictionaryenumeratorget_value.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratoridictionaryenumeratorget_value.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratorienumeratorget_current.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratorienumeratorget_current.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratorienumeratorreset.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratorienumeratorreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryenumerator/dictionaryenumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectioncount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectioncount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectionctor.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectionctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectiongetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/keycollectiongetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectioncontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectioncontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericicollectionremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsgenericienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsicollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsicollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsicollectionissynchronized.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsicollectionissynchronized.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsicollectionsyncroot.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsicollectionsyncroot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionarykeycollection/systemcollectionsienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectioncount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectioncount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectionctor.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectionctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectiongetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/dictionaryvaluecollectiongetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/systemcollectionsicollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/systemcollectionsicollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/systemcollectionsicollectionissynchronized.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/systemcollectionsicollectionissynchronized.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/systemcollectionsicollectionsyncroot.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/systemcollectionsicollectionsyncroot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectioncontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectioncontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericicollectionremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectiongenericienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectionienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictionaryvaluecollection/valuecollectionienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionarykeycollectionenumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionarykeycollectionenumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionarykeycollectionenumeratordispose.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionarykeycollectionenumeratordispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionarykeycollectionenumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionarykeycollectionenumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionaryvaluecollectionenumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionaryvaluecollectionenumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionaryvaluecollectionenumeratordispose.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionaryvaluecollectionenumeratordispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionaryvaluecollectionenumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/dictionaryvaluecollectionenumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/keycollectionenumeratorienumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/keycollectionenumeratorienumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/keycollectionenumeratorienumeratorreset.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/keycollectionenumeratorienumeratorreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/valuecollectionenumeratorienumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/valuecollectionenumeratorienumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/valuecollectionenumeratorienumeratorreset.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictkeycollenum/valuecollectionenumeratorienumeratorreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/dictionaryvaluecollectionenumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/dictionaryvaluecollectionenumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/dictionaryvaluecollectionenumeratordispose.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/dictionaryvaluecollectionenumeratordispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/dictionaryvaluecollectionenumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/dictionaryvaluecollectionenumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/valuecollectionenumeratorienumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/valuecollectionenumeratorienumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/valuecollectionenumeratorienumeratorreset.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/dictvalcollenum/valuecollectionenumeratorienumeratorreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/equalitycomparerequals.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/equalitycomparerequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/equalitycomparergethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/equalitycomparergethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/equlitycomparerdefault.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/equalitycomparer/equlitycomparerdefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectioncontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectioncontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectioncount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectioncount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/icollection/icollectionremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionarycontainskey.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionarycontainskey.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionaryitem.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionaryitem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionarykeys.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionarykeys.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionarytrygetvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionarytrygetvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionaryvalues.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/idictionary/idictionaryvalues.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/ienumerable/ienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/ienumerable/ienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/ienumerator/ienumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/ienumerator/ienumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/iequalitycomparer/iequalitycomparerequals.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/iequalitycomparer/iequalitycomparerequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/iequalitycomparer/iequalitycomparergethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/iequalitycomparer/iequalitycomparergethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/binarysearch1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/binarysearch1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/binarysearch2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/binarysearch2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/binarysearch3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/binarysearch3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/copyto1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/copyto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/copyto2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/copyto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/copyto3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/copyto3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listaddrange.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listaddrange.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listcontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listcontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listforeach.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listforeach.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listgetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listgetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listgetrange.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listgetrange.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listicollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listicollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listindexof1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listindexof1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listindexof2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listindexof2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listindexof3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listindexof3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listinsertrange.cs.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listinsertrange.cs.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listlastindexof1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listlastindexof1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listlastindexof2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listlastindexof2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listlastindexof3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listlastindexof3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listremoveat.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listremoveat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listremoverange.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listremoverange.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listreverse.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listreverse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/list/listreverse2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/list/listreverse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queueclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queueclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuecontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuecontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuecopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuecopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuecount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuecount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuector1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuector1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuector2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuector2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuector3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuector3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuedequeue.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuedequeue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queueenqueue.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queueenqueue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuepeek.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuepeek.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuetoarray.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queue/queuetoarray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/enumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/enumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/enumeratordispose.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/enumeratordispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/enumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/queueenumerator/enumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackcontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackcontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackcopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackcopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackcount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackcount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackgetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackgetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackpeek.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackpeek.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackpop.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackpop.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; // for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackpush.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stackpush.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stack/stacktoarray.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stack/stacktoarray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/stackenumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/stackenumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/stackenumeratordispose.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/stackenumeratordispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/stackenumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/generic/stackenumerator/stackenumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text; //for StringBuilder
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/icollection/icollectioncopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/icollection/icollectioncopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/icollection/icollectioncount.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/icollection/icollectioncount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/icollection/icollectionissynchronized.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/icollection/icollectionissynchronized.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/icollection/icollectionsyncroot.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/icollection/icollectionsyncroot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/icomparer/icomparercompare.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/icomparer/icomparercompare.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryadd.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections; 
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryclear.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryclear.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionarycontains.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionarycontains.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections; 
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionarygetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionarygetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections; 
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryisfixedsize.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryisfixedsize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections; 
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections; 
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryremove.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/idictionary/idictionaryremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections; 
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/ienumerator/ienumeratorcurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/ienumerator/ienumeratorcurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/ienumerator/ienumeratormovenext.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/ienumerator/ienumeratormovenext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/ienumerator/ienumeratorreset.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/ienumerator/ienumeratorreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/collections/ilist/ilistisfixedsize.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/ilist/ilistisfixedsize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/collections/ilist/ilistitem.cs
+++ b/tests/src/CoreMangLib/cti/system/collections/ilist/ilistitem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/comparison/comparisonbegininvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/comparison/comparisonbegininvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/comparison/comparisonendinvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/comparison/comparisonendinvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/comparison/comparisoninvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/comparison/comparisoninvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/console/consoleseterror.cs
+++ b/tests/src/CoreMangLib/cti/system/console/consoleseterror.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/console/consolesetout.cs
+++ b/tests/src/CoreMangLib/cti/system/console/consolesetout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/convert/convertchangetype2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/convertchangetype2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/convertfrombase64chararray.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/convertfrombase64chararray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/convertfrombase64string.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/convertfrombase64string.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/convert/converttobase64chararray.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobase64chararray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttobase64string1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobase64string1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttobase64string2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobase64string2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoboolean8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoboolean8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte3.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttobyte8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttobyte8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar12.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar13.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar14.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar15.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttochar9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttochar9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal12.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal13.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal14.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal15.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal18.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodecimal9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodecimal9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble12.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble13.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble14.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble15.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttodouble9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttodouble9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_18.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_3.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint16_9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint16_9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_18.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_3.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint32_9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint32_9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ConvertToInt64_1

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_18.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_3.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttoint64_9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttoint64_9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte3.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosbyte9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosbyte9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/convert/converttosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttosingle13.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosingle13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosingle14.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosingle14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttosingle15.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosingle15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosingle16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosingle16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttosingle17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttosingle17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring10.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring11.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring12.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring13.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring14.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring15.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring17.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring18.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring19.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring19.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring20.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring20.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring21.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring21.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring22.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring22.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring23.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring23.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring24.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring24.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring25.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring25.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring28.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring28.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring29.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring29.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring30.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring30.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring31.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring31.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring32.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring33.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring33.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring4.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Runtime.CompilerServices;

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring5.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring6.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring7.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring8.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttostring9.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttostring9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint161.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint161.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Boolean)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1610.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1610.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(UInt32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1611.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1611.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(UInt64)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1612.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1612.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(SByte)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1613.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1613.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(object)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1614.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1614.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(object,IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1615.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1615.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Single)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1616.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1616.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(String)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1617.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1617.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(string,int32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint1618.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint1618.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint162.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint162.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Byte)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint163.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint163.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Char)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint164.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint164.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt164(Decimal)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint165.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint165.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Double)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint166.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint166.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Int16)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint167.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint167.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Int32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint168.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint168.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(Int64)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint169.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint169.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt16(UInt16)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint321.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint321.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Boolean)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3210.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3210.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(UInt16)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3211.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3211.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(UInt32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3212.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3212.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(UInt64)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3213.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3213.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Sbyte)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3215.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3215.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Object)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3216.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3216.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Object,IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3217.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3217.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(String)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3218.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3218.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint3219.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint3219.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(String,Int32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint322.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint322.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Byte)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint323.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint323.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Char)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint324.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint324.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Decimal)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint325.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint325.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Double)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint326.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint326.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(DateTime)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint327.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint327.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Int16)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint328.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint328.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Int32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint329.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint329.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt32(Int64)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint641.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint641.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Boolean)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6410.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6410.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Int32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6411.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6411.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Int64)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6412.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6412.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(SByte)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6413.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6413.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Single)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6414.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6414.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Object)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6415.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6415.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Object,IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6416.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6416.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(String)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6417.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6417.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint6418.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint6418.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(String,Int32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint642.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint642.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Byte)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint643.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint643.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Char)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint644.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint644.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(UInt16)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint645.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint645.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(UInt32)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint646.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint646.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(UInt64)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint647.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint647.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Decimal)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint648.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint648.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Double)

--- a/tests/src/CoreMangLib/cti/system/convert/converttouint649.cs
+++ b/tests/src/CoreMangLib/cti/system/convert/converttouint649.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Convert.ToUInt64(Int16)

--- a/tests/src/CoreMangLib/cti/system/datetime/cfdatetimetools.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/cfdatetimetools.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using TestLibrary;
 using System.Runtime.InteropServices;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimecompare.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimecompare.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimecompareto1.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimecompareto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimector1.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimector1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimector3.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimector3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimector4.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimector4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimector6.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimector6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimector7.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimector7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimedate.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimedate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimehour.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimehour.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimekind.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimekind.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimemaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimemaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimemillisecond.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimemillisecond.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeminute.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeminute.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimenow.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimenow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeparse1.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeparse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeparse2.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeparse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class DateTimeParse2

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeparse3.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeparse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization ;
 

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeparseexact1.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeparseexact1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeparseexact2.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeparseexact2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeparseexact3.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeparseexact3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimesecond.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimesecond.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimesubtract1.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimesubtract1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimesubtract2.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimesubtract2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeticks.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeticks.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetimeofday.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetimeofday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetoday.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetoday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetofiletime.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetofiletime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetofiletimeutc.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetofiletimeutc.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetolocaltime.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetolocaltime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimetostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimetostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/datetime/datetimeutcnow.cs
+++ b/tests/src/CoreMangLib/cti/system/datetime/datetimeutcnow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Threading;

--- a/tests/src/CoreMangLib/cti/system/datetimekind/datetimekindlocal.cs
+++ b/tests/src/CoreMangLib/cti/system/datetimekind/datetimekindlocal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/datetimekind/datetimekindunspecified.cs
+++ b/tests/src/CoreMangLib/cti/system/datetimekind/datetimekindunspecified.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/datetimekind/datetimekindutc.cs
+++ b/tests/src/CoreMangLib/cti/system/datetimekind/datetimekindutc.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekfriday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekfriday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekmonday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekmonday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweeksaturday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweeksaturday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweeksunday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweeksunday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekthursday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekthursday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweektuesday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweektuesday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekwednesday.cs
+++ b/tests/src/CoreMangLib/cti/system/dayofweek/dayofweekwednesday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimafloor.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimafloor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaladd.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaladd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalcompare.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalcompare.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor4.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor5.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor6.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor7.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalctor8.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalctor8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaldivide.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaldivide.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalequals3.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalequals3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalmaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalmaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalminusone.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalminusone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalnegate.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalnegate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Negate(System.Decimal)

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalone.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalparse.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalparse2.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalparse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalparse3.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalparse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalparse4.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalparse4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltobyte1.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltobyte1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltostring4.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltostring4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltruncate.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltruncate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Truncate(System.Decimal)

--- a/tests/src/CoreMangLib/cti/system/decimal/decimaltryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimaltryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/decimal/decimalzero.cs
+++ b/tests/src/CoreMangLib/cti/system/decimal/decimalzero.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/delegate/delegatecombine1.cs
+++ b/tests/src/CoreMangLib/cti/system/delegate/delegatecombine1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/delegate/delegatecombineimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/delegate/delegatecombineimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/delegate/testforotherassembly.cs
+++ b/tests/src/CoreMangLib/cti/system/delegate/testforotherassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/diagnostics/conditionalattribute/conditionalattributeconditionstring.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/conditionalattribute/conditionalattributeconditionstring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/diagnostics/conditionalattribute/conditionalattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/conditionalattribute/conditionalattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesdefault.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesdefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesdisableoptimizations.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesdisableoptimizations.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesenableeditandcontinue.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesenableeditandcontinue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesignoresymbolstoresequencepoints.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesignoresymbolstoresequencepoints.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesnone.cs
+++ b/tests/src/CoreMangLib/cti/system/diagnostics/debuggingmodes/debuggingmodesnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/CoreMangLib/cti/system/dividebyzeroexception/dividebyzeroexceptionctor.cs
+++ b/tests/src/CoreMangLib/cti/system/dividebyzeroexception/dividebyzeroexceptionctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dividebyzeroexception/dividebyzeroexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/dividebyzeroexception/dividebyzeroexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dividebyzeroexception/dividebyzeroexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/dividebyzeroexception/dividebyzeroexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dllnotfoundexception/dllnotfoundexception1.cs
+++ b/tests/src/CoreMangLib/cti/system/dllnotfoundexception/dllnotfoundexception1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dllnotfoundexception/dllnotfoundexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/dllnotfoundexception/dllnotfoundexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/dllnotfoundexception/dllnotfoundexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/dllnotfoundexception/dllnotfoundexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/double/doublecompareto1.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doublecompareto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/double/doubleepsilon.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleepsilon.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/double/doubleequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doublegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doublegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class DoubleIConvertibleToBoolean

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleiconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleisinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleisinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleisnan.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleisnan.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleisnegativeinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleisnegativeinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubleispositiveinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleispositiveinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doublemaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doublemaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/double/doubleminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // v-jinfw
 // Does not build
 

--- a/tests/src/CoreMangLib/cti/system/double/doublenan.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doublenan.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/double/doublenegativeinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doublenegativeinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/double/doubleparse3.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubleparse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/double/doublepositiveinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doublepositiveinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/double/doubletostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubletostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/double/doubletostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubletostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/double/doubletostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubletostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/double/doubletostring4.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubletostring4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/double/doubletryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/double/doubletryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumiconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumisdefined.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumisdefined.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/enum/enumtoobjectb.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumtoobjectb.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/enum/enumtostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/enum/enumtostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/environment/environmentnewline.cs
+++ b/tests/src/CoreMangLib/cti/system/environment/environmentnewline.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/eventargs/eventargsctor.cs
+++ b/tests/src/CoreMangLib/cti/system/eventargs/eventargsctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/eventhandler/eventhandlerinvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/eventhandler/eventhandlerinvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerbegininvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerbegininvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerctor.cs
+++ b/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerendinvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerendinvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerinvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/eventhandler_generic/eventhandlerinvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/exception/exceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/exception/exceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/exception/exceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/exception/exceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/exception/exceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/exception/exceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestException : Exception

--- a/tests/src/CoreMangLib/cti/system/exception/exceptiongetbaseexception.cs
+++ b/tests/src/CoreMangLib/cti/system/exception/exceptiongetbaseexception.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestException : Exception

--- a/tests/src/CoreMangLib/cti/system/flagsattribute/flagsattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/flagsattribute/flagsattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/formatexception/formatexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/formatexception/formatexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/formatexception/formatexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/formatexception/formatexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/formatexception/formatexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/formatexception/formatexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/gc/gccollect.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gccollect.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/gc/gcgettotalmemory.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gcgettotalmemory.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/gc/gckeepalive.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gckeepalive.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/CoreMangLib/cti/system/gc/gcmaxgeneration.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gcmaxgeneration.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/gc/gcreregisterforfinalize.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gcreregisterforfinalize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/gc/gcsuppressfinalize.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gcsuppressfinalize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/gc/gcwaitforpendingfinalizers.cs
+++ b/tests/src/CoreMangLib/cti/system/gc/gcwaitforpendingfinalizers.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 using System.Runtime.CompilerServices;

--- a/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/calendarweekrulefirstday.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/calendarweekrulefirstday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/calendarweekrulefirstfourdayweek.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/calendarweekrulefirstfourdayweek.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/calendarweekrulefirstfullweek.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/calendarweekrule/calendarweekrulefirstfullweek.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetnumericvalue1.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetnumericvalue1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetnumericvalue2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetnumericvalue2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetunicodecategory1.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetunicodecategory1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetunicodecategory2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/charunicodeinfo/charunicodeinfogetunicodecategory2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareinfo/compareinfocompare2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareinfo/compareinfocompare2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/globalization/compareinfo/compareinfoindexof2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareinfo/compareinfoindexof2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorecase.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorecase.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorekanatype.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorekanatype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorenonspace.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorenonspace.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignoresymbols.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignoresymbols.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorewidth.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsignorewidth.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsnone.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsordinal.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsordinal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsordinaligorecase.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsordinaligorecase.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsstringsort.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/compareoptions/compareoptionsstringsort.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfoclone.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfoclone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfocurrentinfo.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfocurrentinfo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetabbreviatedmonthname.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetabbreviatedmonthname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetformat.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetformat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetinstance.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetinstance.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetmonthname.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfogetmonthname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfoinvariantinfo.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfoinvariantinfo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfoisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfoisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinforeadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinforeadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinforfc1123pattern.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinforfc1123pattern.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfosortabledatetimepattern.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfosortabledatetimepattern.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfouniversalsortabledatetimepattern.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimeformatinfo/datetimeformatinfouniversalsortabledatetimepattern.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestyleallowinnerwhite.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestyleallowinnerwhite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesadjusttouniversal.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesadjusttouniversal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesallowleadingwhite.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesallowleadingwhite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesallowtrailingwhite.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesallowtrailingwhite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesallowwhitespaces.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesallowwhitespaces.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesassumelocal.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesassumelocal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesassumeuniversal.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesassumeuniversal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesnocurrentdatedefault.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesnocurrentdatedefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesnone.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesroundtripkind.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/datetimestyles/datetimestylesroundtripkind.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfoclone.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfoclone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfoctor.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfoctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfocurrencydecimalseparator.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfocurrencydecimalseparator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfocurrencygroupseparator.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfocurrencygroupseparator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfogetformat.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfogetformat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfogetinstance.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinfogetinstance.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinforeadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberformatinfo/numberformatinforeadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowcurrencysymbol.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowcurrencysymbol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowdecimalpoint.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowdecimalpoint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowexponent.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowexponent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowhexspecifier.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowhexspecifier.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowleadingsign.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowleadingsign.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowleadingwhite.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowleadingwhite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowparentheses.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowparentheses.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowthousands.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowthousands.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowtrailingsign.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowtrailingsign.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowtrailingwhite.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesallowtrailingwhite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesany.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesany.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylescurrency.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylescurrency.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesfloat.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesfloat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstyleshexnumber.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstyleshexnumber.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesinteger.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesinteger.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesnone.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesnumber.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/numberstyles/numberstylesnumber.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfocurrentregion.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfocurrentregion.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoequals.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfogethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfogethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoismetric.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoismetric.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoisocurrencysymbol.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoisocurrencysymbol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoname.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfoname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfotostring.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfotostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfotwoletterisoregionname.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/regioninfo/regioninfotwoletterisoregionname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoequals.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogetnexttextelement2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogetnexttextelement2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogettextelementenumerator1.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogettextelementenumerator1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogettextelementenumerator2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfogettextelementenumerator2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfolengthintextelements.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfolengthintextelements.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoparsecombiningcharacters.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfoparsecombiningcharacters.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfostring.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/stringinfo/stringinfostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfoculturename.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfoculturename.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfoequals.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfoequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfogethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfogethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfoisreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfoisreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfotostring.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfotostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfotoupper1.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfotoupper1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfotoupper2.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/textinfo/textinfotoupper2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryclosepunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryclosepunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryconnectorpunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryconnectorpunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorycontrol.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorycontrol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorydashpunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorydashpunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorydecimaldigitnumber.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorydecimaldigitnumber.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryenclosingmark.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryenclosingmark.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryfinalquotepunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryfinalquotepunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryformat.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryformat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryinitialquotepunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryinitialquotepunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryletternumber.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryletternumber.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorylineseparator.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorylineseparator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorylowercaseletter.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorylowercaseletter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorymathsymbol.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorymathsymbol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorymodifierletter.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorymodifierletter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorymodifiersymbol.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorymodifiersymbol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorynonspacingmark.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorynonspacingmark.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryopenpunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryopenpunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryotherletter.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryotherletter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryothernotassigned.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryothernotassigned.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryothernumber.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryothernumber.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryotherpunctuation.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryotherpunctuation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryothersymbol.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryothersymbol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryparagraphseparator.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryparagraphseparator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryprivateuse.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryprivateuse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryspaceseparator.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryspaceseparator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryspacingcombiningmark.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryspacingcombiningmark.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorysurrogate.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorysurrogate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorytitlecaseletter.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategorytitlecaseletter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryuppercaseletter.cs
+++ b/tests/src/CoreMangLib/cti/system/globalization/unicodecategory/unicodecategoryuppercaseletter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidcompareto1_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidcompareto1_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidcompareto2.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidcompareto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/guid/guidctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/guid/guidctor1_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidctor1_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidctor2_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidctor2_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/guid/guidctor3_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidctor3_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidempty.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidempty.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/guid/guidequals1_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidequals1_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/guid/guidequals2_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidequals2_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidequals3.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidequals3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/guid/guidgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidgethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidnewguid.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidnewguid.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidtobytearray.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidtobytearray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/guid/guidtostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/guid/guidtostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/icomparable/icomparablecompareto.cs
+++ b/tests/src/CoreMangLib/cti/system/icomparable/icomparablecompareto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/icomparable_generic/icomparable_genericcompareto.cs
+++ b/tests/src/CoreMangLib/cti/system/icomparable_generic/icomparable_genericcompareto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IConvertibleToBoolean

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IConvertibleToByte

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IConvertibleToChar

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IConvertibleToDateTime

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IConvertibleToDecimal

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/iconvertible/iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/idisposable/idisposabledispose.cs
+++ b/tests/src/CoreMangLib/cti/system/idisposable/idisposabledispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/iformatable/iformatabletostring.cs
+++ b/tests/src/CoreMangLib/cti/system/iformatable/iformatabletostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/indexoutofrangeexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/indexoutofrangeexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.IndexOutOfRangeException.ctor() [v-minch]

--- a/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/indexoutofrangeexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/indexoutofrangeexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/indexoutofrangeexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/indexoutofrangeexception/indexoutofrangeexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.IndexOutOfRangeException.ctor(string,Exception) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/int/int32compareto1.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32compareto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32CompareTo1

--- a/tests/src/CoreMangLib/cti/system/int/int32equals1.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32equals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.Equals(System.Int32)

--- a/tests/src/CoreMangLib/cti/system/int/int32equals2.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32equals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.Equals(System.Object)

--- a/tests/src/CoreMangLib/cti/system/int/int32gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32GetHashCode

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //system.Int32.System.IConvertibleToBoolean

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.System.IConvertibleToByte

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToChar

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToDateTime

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToDecimal

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.IConvertibleToDouble(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.ConvertibleToInt16(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToInt32

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToInt64

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToSByte

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32IConvertibleToSingle

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.System.IConvertible.ToType(System.Type,System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.System.IConvertible.ToUInt16(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.System.IConvertible.ToUInt32(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int/int32iconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32iconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int32.System.IConvertible.ToUInt64(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int/int32maxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32maxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int32MaxValue

--- a/tests/src/CoreMangLib/cti/system/int/int32minvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32minvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 class Int32MinValue

--- a/tests/src/CoreMangLib/cti/system/int/int32parse1.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32parse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //system.Int32.Parse(system.string)

--- a/tests/src/CoreMangLib/cti/system/int/int32parse2.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32parse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int/int32parse3.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32parse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int/int32parse4.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32parse4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int/int32tostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32tostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/int/int32tryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/int/int32tryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int16/int16equals1.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16equals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16equals2.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16equals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int16GetHashCode

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //system.Int16.System.IConvertibleToBoolean

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int16.System.IConvertibleToByte

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int16.IConvertibleToDouble(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int16.System.IConvertible.ToUInt16(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int16.System.IConvertible.ToUInt32(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16iconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 //System.Int16.System.IConvertible.ToUInt64(System.IFormatProvider)

--- a/tests/src/CoreMangLib/cti/system/int16/int16maxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16maxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int16MaxValue

--- a/tests/src/CoreMangLib/cti/system/int16/int16minvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16minvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Int16MinValue

--- a/tests/src/CoreMangLib/cti/system/int16/int16parse1.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16parse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int16/int16parse2.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16parse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int16/int16parse3.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16parse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int16/int16tryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/int16/int16tryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/int64/int64compareto1.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64compareto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Int64.CompareTo(Int64)

--- a/tests/src/CoreMangLib/cti/system/int64/int64equals1.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64equals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Int64.Equals(int64)

--- a/tests/src/CoreMangLib/cti/system/int64/int64equals2.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64equals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Int64.Equals(Object)

--- a/tests/src/CoreMangLib/cti/system/int64/int64gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Int64.GetHashCode()

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64iconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64maxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64maxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Int64.MaxValue

--- a/tests/src/CoreMangLib/cti/system/int64/int64minvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64minvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Int64.MinValue

--- a/tests/src/CoreMangLib/cti/system/int64/int64parse1.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64parse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 /// <summary>
 /// Int64.Parse(string)

--- a/tests/src/CoreMangLib/cti/system/int64/int64parse2.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64parse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64parse3.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64parse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/int64/int64tostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64tostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/int64/int64tryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/int64/int64tryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrctor_int32.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrctor_int32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IntPtrCtor_Int32

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrctor_int64.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrctor_int64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IntPtrCtor_Int64

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrctor_void.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrctor_void.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrequals.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrgethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrtoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrtoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrtoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrtoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrtopointer.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrtopointer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrtostring.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrtostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrzero.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrzero.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class IntPtrZero

--- a/tests/src/CoreMangLib/cti/system/invalidcastexception/invalidcastexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidcastexception/invalidcastexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.InvalidCastException.ctor()

--- a/tests/src/CoreMangLib/cti/system/invalidcastexception/invalidcastexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidcastexception/invalidcastexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.InvalidCastException.ctor(String) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidcastexception/invalidcastexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidcastexception/invalidcastexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.InvalidCastException.ctor(String,Exception) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidoperationexception/invalidoperationexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidoperationexception/invalidoperationexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// InvalidOperationException.ctor() [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidoperationexception/invalidoperationexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidoperationexception/invalidoperationexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// InvalidOperationException.ctor(String) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidoperationexception/invalidoperationexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidoperationexception/invalidoperationexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// InvalidOperationException.ctor(String,Exception) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidprogramexception/invalidprogramexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidprogramexception/invalidprogramexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// InvalidProgramException.ctor() [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidprogramexception/invalidprogramexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidprogramexception/invalidprogramexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// InvalidProgramException.ctor(String) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/invalidprogramexception/invalidprogramexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/invalidprogramexception/invalidprogramexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// InvalidProgramException.ctor(String,Exception) [v-minch]

--- a/tests/src/CoreMangLib/cti/system/io/binarywriter/binarywriteroutstream.cs
+++ b/tests/src/CoreMangLib/cti/system/io/binarywriter/binarywriteroutstream.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/directorynotfoundexception/directorynotfoundexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/io/directorynotfoundexception/directorynotfoundexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/directorynotfoundexception/directorynotfoundexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/directorynotfoundexception/directorynotfoundexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/endofstreamexception/endofstreamexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/io/endofstreamexception/endofstreamexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/endofstreamexception/endofstreamexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/endofstreamexception/endofstreamexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccessenum.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccessenum.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccessread.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccessread.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccessreadwrite.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccessreadwrite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccesswrite.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileaccess/fileaccesswrite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesarchive.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesarchive.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributescompressed.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributescompressed.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesdeivce.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesdeivce.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesdirectory.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesdirectory.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesencrypted.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesencrypted.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesenum.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesenum.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributeshidden.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributeshidden.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesnormal.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesnormal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesnotcontentindexed.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesnotcontentindexed.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesoffline.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesoffline.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesreparsepoint.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributesreparsepoint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributessystem.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributessystem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributestemporary.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileattributes/fileattributestemporary.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodeappend.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodeappend.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodecreate.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodecreate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodecreatenew.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodecreatenew.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodeenum.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodeenum.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodeopen.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodeopen.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodeopenorcreate.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodeopenorcreate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filemode/filemodetruncate.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filemode/filemodetruncate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptionctor.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptionctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptiongetmessage.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptiongetmessage.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptiontostring.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filenotfoundexception/filenotfoundexceptiontostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/fileshare/fileshareenum.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileshare/fileshareenum.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/fileshare/filesharenone.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileshare/filesharenone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileshare/fileshareread.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileshare/fileshareread.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileshare/filesharereadwrite.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileshare/filesharereadwrite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/fileshare/filesharewrite.cs
+++ b/tests/src/CoreMangLib/cti/system/io/fileshare/filesharewrite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/filestream/filestreamdispose.cs
+++ b/tests/src/CoreMangLib/cti/system/io/filestream/filestreamdispose.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO; 

--- a/tests/src/CoreMangLib/cti/system/io/ioexception/ioexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/io/ioexception/ioexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/ioexception/ioexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/ioexception/ioexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor4.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor5.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor6.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor7.cs
+++ b/tests/src/CoreMangLib/cti/system/io/memorystream/memorystreamctor7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/pathtoolongexception/pathtoolongexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/io/pathtoolongexception/pathtoolongexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/pathtoolongexception/pathtoolongexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/pathtoolongexception/pathtoolongexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/seekorigin/seekoriginbegin.cs
+++ b/tests/src/CoreMangLib/cti/system/io/seekorigin/seekoriginbegin.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/io/seekorigin/seekorigincurrent.cs
+++ b/tests/src/CoreMangLib/cti/system/io/seekorigin/seekorigincurrent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/io/seekorigin/seekoriginend.cs
+++ b/tests/src/CoreMangLib/cti/system/io/seekorigin/seekoriginend.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/io/seekorigin/seekoriginenum.cs
+++ b/tests/src/CoreMangLib/cti/system/io/seekorigin/seekoriginenum.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/io/stream/streamdispose1.cs
+++ b/tests/src/CoreMangLib/cti/system/io/stream/streamdispose1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO; // For Stream

--- a/tests/src/CoreMangLib/cti/system/io/stream/streamdispose2.cs
+++ b/tests/src/CoreMangLib/cti/system/io/stream/streamdispose2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO; // For Stream

--- a/tests/src/CoreMangLib/cti/system/io/stream/streamnull.cs
+++ b/tests/src/CoreMangLib/cti/system/io/stream/streamnull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO; // For Stream
 using System.Security;

--- a/tests/src/CoreMangLib/cti/system/io/stream/streamreadtimeout.cs
+++ b/tests/src/CoreMangLib/cti/system/io/stream/streamreadtimeout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/io/stream/streamwritetimeout.cs
+++ b/tests/src/CoreMangLib/cti/system/io/stream/streamwritetimeout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/io/streamreader/streamreadernull.cs
+++ b/tests/src/CoreMangLib/cti/system/io/streamreader/streamreadernull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/stringwriter/stringwriterencoding.cs
+++ b/tests/src/CoreMangLib/cti/system/io/stringwriter/stringwriterencoding.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/io/textreader/textreadernull.cs
+++ b/tests/src/CoreMangLib/cti/system/io/textreader/textreadernull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/CoreMangLib/cti/system/io/textwriter/textwriternull.cs
+++ b/tests/src/CoreMangLib/cti/system/io/textwriter/textwriternull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.IO;

--- a/tests/src/CoreMangLib/cti/system/math/mathabs1.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathabs2.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathabs3.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathabs4.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathabs5.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathabs6.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathabs7.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathabs7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathacos.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathacos.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathatan.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathatan.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathatan2.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathatan2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathceiling.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathceiling.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathcos.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathcos.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathcosh.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathcosh.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathe.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathe.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathexp.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathexp.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathfloor.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathfloor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathieeeremainder.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathieeeremainder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathlog.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathlog.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathlog10.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathlog10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax1.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax10.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax11.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax2.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax3.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax4.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax5.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax6.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax7.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax8.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmax9.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmax9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin1.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin10.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin11.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin2.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin3.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin4.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin5.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin6.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin7.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin8.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathmin9.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathmin9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathpi.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathpi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathpow.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathpow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/math/mathround1.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathround1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/math/mathround2.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathround2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/math/mathround3.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathround3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class MathRound3

--- a/tests/src/CoreMangLib/cti/system/math/mathround4.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathround4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/math/mathsign1.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsign2.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsign3.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsign4.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsign5.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsign6.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsign7.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsign7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsin.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsin.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsinh.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsinh.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/math/mathsqrt.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathsqrt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Math.Sqrt(double)

--- a/tests/src/CoreMangLib/cti/system/math/mathtan.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathtan.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// System.Math.Tan(Double)

--- a/tests/src/CoreMangLib/cti/system/math/mathtanh.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathtanh.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// Math.Tanh(bouble)

--- a/tests/src/CoreMangLib/cti/system/math/mathtestlib.cs
+++ b/tests/src/CoreMangLib/cti/system/math/mathtestlib.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/delegatedefinitions.cs
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/delegatedefinitions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices; // for DllImportAttribute
 

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegatecombineimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegatecombineimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class MulticastDelegateCombineImpl

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegateequals.cs
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegateequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegategethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegategethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegategetinvocationlist.cs
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/multicastdelegategetinvocationlist.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/multicastdelegate/verificationagent.cs
+++ b/tests/src/CoreMangLib/cti/system/multicastdelegate/verificationagent.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablecompare.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablecompare.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablector.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullableequals.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullableequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullableequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullableequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablegetunderlyingtype.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablegetunderlyingtype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablegetvalueordefault1.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablegetvalueordefault1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablegetvalueordefault2.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablegetvalueordefault2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablehasvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablehasvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullabletostring.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullabletostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullable/nullablevalue.cs
+++ b/tests/src/CoreMangLib/cti/system/nullable/nullablevalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/nullreferenceexception/nullreferenceexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/nullreferenceexception/nullreferenceexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/object/objectctor.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ObjectCtor

--- a/tests/src/CoreMangLib/cti/system/object/objectequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ObjectEquals1

--- a/tests/src/CoreMangLib/cti/system/object/objectequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ObjectEquals2

--- a/tests/src/CoreMangLib/cti/system/object/objectfinalize.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectfinalize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/object/objectgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectgethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct Empty

--- a/tests/src/CoreMangLib/cti/system/object/objectmemberwiseclone.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectmemberwiseclone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct TestStruct

--- a/tests/src/CoreMangLib/cti/system/object/objectreferenceequals.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objectreferenceequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ObjectReferenceEquals

--- a/tests/src/CoreMangLib/cti/system/object/objecttostring.cs
+++ b/tests/src/CoreMangLib/cti/system/object/objecttostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ObjectToString

--- a/tests/src/CoreMangLib/cti/system/objectdisposedexception/objectdisposedexceptionmessage.cs
+++ b/tests/src/CoreMangLib/cti/system/objectdisposedexception/objectdisposedexceptionmessage.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/objectdisposedexception/objectdisposedexceptionobjectname.cs
+++ b/tests/src/CoreMangLib/cti/system/objectdisposedexception/objectdisposedexceptionobjectname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributector1.cs
+++ b/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributector1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributector2.cs
+++ b/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributector2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributector3.cs
+++ b/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributector3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ObsoleteAttributeCtor3

--- a/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributeiserror.cs
+++ b/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributeiserror.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributemessage.cs
+++ b/tests/src/CoreMangLib/cti/system/obsoleteattribute/obsoleteattributemessage.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/paramarrayattribute/paramarrayattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/paramarrayattribute/paramarrayattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/platformnotsupportedexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/platformnotsupportedexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/platformnotsupportedexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/platformnotsupportedexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/platformnotsupportedexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/platformnotsupportedexception/platformnotsupportedexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/predicate/predicatebegininvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/predicate/predicatebegininvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/predicate/predicateendinvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/predicate/predicateendinvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/predicate/predicateinvoke.cs
+++ b/tests/src/CoreMangLib/cti/system/predicate/predicateinvoke.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/random/randomctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomnext1.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomnext1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomnext2.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomnext2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomnext3.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomnext3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomnextbytes.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomnextbytes.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomnextdouble.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomnextdouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/random/randomsample.cs
+++ b/tests/src/CoreMangLib/cti/system/random/randomsample.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestRandom : Random

--- a/tests/src/CoreMangLib/cti/system/rankexception/rankexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/rankexception/rankexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/rankexception/rankexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/rankexception/rankexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/rankexception/rankexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/rankexception/rankexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/ambiguousmatchexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/ambiguousmatchexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/ambiguousmatchexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/ambiguousmatchexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/ambiguousmatchexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/ambiguousmatchexception/ambiguousmatchexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assembly/testassembly1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assembly/testassembly1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/reflection/assembly/testtarget.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assembly/testtarget.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyconfigurationattribute/assemblyconfigurationattributeconfiguration.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyconfigurationattribute/assemblyconfigurationattributeconfiguration.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyconfigurationattribute/assemblyconfigurationattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyconfigurationattribute/assemblyconfigurationattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydefaultaliasattribute/assemblydefaultaliasattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydefaultaliasattribute/assemblydefaultaliasattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydefaultaliasattribute/assemblydefaultaliasattributedefaultalias.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydefaultaliasattribute/assemblydefaultaliasattributedefaultalias.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydelaysignattribute/assemblydelaysignattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydelaysignattribute/assemblydelaysignattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydelaysignattribute/assemblydelaysignattributedelaysign.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydelaysignattribute/assemblydelaysignattributedelaysign.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydescriptionattribute/assemblydescriptionattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydescriptionattribute/assemblydescriptionattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblydescriptionattribute/assemblydescriptionattributedescription.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblydescriptionattribute/assemblydescriptionattributedescription.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblykeyfileattribute/assemblykeyfileattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblykeyfileattribute/assemblykeyfileattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblykeyfileattribute/assemblykeyfileattributekeyfile.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblykeyfileattribute/assemblykeyfileattributekeyfile.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblykeynameattribute/assemblykeynameattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblykeynameattribute/assemblykeynameattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblykeynameattribute/assemblykeynameattributekeyname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblykeynameattribute/assemblykeynameattributekeyname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamegetpublickey.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamegetpublickey.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamegetpublickeytoken.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamegetpublickeytoken.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamesetpublickey.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamesetpublickey.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamesetpublickeytoken.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynamesetpublickeytoken.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynameversion.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblyname/assemblynameversion.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsenablejitcompileoptimizer.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsenablejitcompileoptimizer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsenablejitcompiletracking.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsenablejitcompiletracking.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsnone.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagspublickey.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagspublickey.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsretargetable.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblynameflags/assemblynameflagsretargetable.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblytitleattribute/assemblytitleattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblytitleattribute/assemblytitleattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/assemblytitleattribute/assemblytitleattributetitle.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/assemblytitleattribute/assemblytitleattributetitle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsany.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsany.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsexplicitthis.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsexplicitthis.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionshasthis.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionshasthis.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsstandard.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsstandard.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsvarargs.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/callingconventions/callingconventionsvarargs.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/constructorinfo/constructorinfoconstructorname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/constructorinfo/constructorinfoconstructorname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/constructorinfo/constructorinfotypeconstructorname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/constructorinfo/constructorinfotypeconstructorname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/defaultmemberattribute/defaultmemberattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/defaultmemberattribute/defaultmemberattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/defaultmemberattribute/defaultmemberattributemembername.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/defaultmemberattribute/defaultmemberattributemembername.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolbranch.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolbranch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolcall.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolcall.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolcond_branch.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolcond_branch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolmeta.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolmeta.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolnext.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolnext.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolreturn.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolreturn.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolthrow.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/flowcontrol/flowcontrolthrow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeflowcontrol.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeflowcontrol.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodename.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodename.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeopcodetype.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeopcodetype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeoperandtype.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeoperandtype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesadd_ovf.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesadd_ovf.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesadd_ovf_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesadd_ovf_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesand.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesand.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesarglist.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesarglist.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbeq.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbeq.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbeq_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbeq_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge_un_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbge_un_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt_un_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbgt_un_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble_un_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesble_un_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt_un_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesblt_un_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbne_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbne_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbne_un_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbne_un_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbox.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbox.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbr.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbr.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbr_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbr_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbreak.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbreak.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrfalse.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrfalse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrfalse_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrfalse_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrtrue.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrtrue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrtrue_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesbrtrue_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescall.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescall.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescalli.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescalli.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescallvirt.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescallvirt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescastclass.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescastclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesceq.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesceq.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescgt.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescgt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescgt_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescgt_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesckfinite.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesckfinite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesclt.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesclt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesclt_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesclt_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconstrained.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconstrained.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i1_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i1_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i2_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i2_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i4_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i4_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i8_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i8_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_i_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u1_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u1_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u2_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u2_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u4_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u4_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u8_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u8_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_ovf_u_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_r4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_r4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_r8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_r8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_r_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_r_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesconv_u8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescpblk.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescpblk.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescpobj.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodescpobj.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesdiv.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesdiv.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesdiv_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesdiv_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesdup.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesdup.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesendfilter.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesendfilter.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesendfinally.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesendfinally.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesinitblk.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesinitblk.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesinitobj.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesinitobj.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesisinst.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesisinst.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesize.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesjmp.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesjmp.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_0.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarg_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarga.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarga.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarga_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldarga_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_0.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_5.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_6.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_7.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_m1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_m1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i4_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_r4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_r4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_r8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldc_r8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_r4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_r4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_r8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_r8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_ref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_ref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_u1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_u1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_u2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_u2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_u4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelem_u4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelema.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldelema.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldfld.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldfld.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldflda.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldflda.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldftn.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldftn.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_r4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_r4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_r8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_r8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_ref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_ref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_u1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_u1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_u2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_u2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_u4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldind_u4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldlen.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldlen.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_0.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloc_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloca.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloca.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloca_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldloca_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldnull.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldnull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldobj.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldobj.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldsfld.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldsfld.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldsflda.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldsflda.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldstr.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldstr.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldtoken.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldtoken.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldvirtftn.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesldvirtftn.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesleave.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesleave.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesleave_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesleave_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeslocalloc.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodeslocalloc.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmkrefany.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmkrefany.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmul.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmul.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmul_ovf.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmul_ovf.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmul_ovf_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesmul_ovf_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesneg.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesneg.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnewarr.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnewarr.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnewobj.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnewobj.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnop.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnop.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnot.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesnot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesor.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodespop.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodespop.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix5.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix6.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix7.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefix7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefixref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesprefixref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesreadonly.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesreadonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrefanytype.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrefanytype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrefanyval.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrefanyval.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrem_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrem_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesret.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesret.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrethrow.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesrethrow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesshl.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesshl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesshr.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesshr.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesshr_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesshr_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessizeof.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessizeof.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstarg.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstarg.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstarg_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstarg_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_r4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_r4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_r8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_r8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_ref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstelem_ref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstfld.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstfld.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_i8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_r4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_r4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_r8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_r8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_ref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstind_ref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_0.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_s.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstloc_s.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstobj.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstobj.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstsfld.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesstsfld.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessub.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessub.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessub_ovf.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessub_ovf.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessub_ovf_un.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodessub_ovf_un.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesswitch.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesswitch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestackbehaviourpop.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestackbehaviourpop.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestackbehaviourpush.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestackbehaviourpush.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestailcall.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestailcall.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestakessinglebyteargument.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodestakessinglebyteargument.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 using System.Reflection.Emit;

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesthrow.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesthrow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesunaligned.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesunaligned.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesunbox.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesunbox.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesunbox_any.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesunbox_any.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesvolatile.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesvolatile.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesxor.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodesxor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodetostring.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodetostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodevalue.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodes/opcodevalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypemacro.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypemacro.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypenternal.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypenternal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypeobjmodel.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypeobjmodel.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypeprefix.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypeprefix.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypeprimitive.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/opcodetype/opcodetypeprimitive.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinebrtarget.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinebrtarget.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinefield.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinefield.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinei.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinei.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinei8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinei8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinemethod.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinemethod.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinenone.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinenone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinliner.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinliner.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinesig.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinesig.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinestring.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinestring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlineswitch.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlineswitch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinetok.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinetok.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinetype.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinetype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinevar.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeinlinevar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinlinebrtarget.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinlinebrtarget.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinlinei.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinlinei.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinliner.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinliner.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinlinevar.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/operandtype/operandtypeshortinlinevar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsize16.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsize16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsize2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsize2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsize4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsize4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize128.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize128.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize32.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize64.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizesize8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizeunspecified.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/packingsize/packingsizeunspecified.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpop0.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpop0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpop1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpop1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpop1_pop1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpop1_pop1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_pop1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_pop1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popi.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popi8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popi8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popi_popi.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popi_popi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popr4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popr4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popr8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopi_popr8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_pop1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_pop1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_pop1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_pop1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popi.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popi8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popi8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popr4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popr4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popr8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popr8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpopref_popi_popref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpush0.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpush0.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpush1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpush1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpush1_push1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpush1_push1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushi.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushi8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushi8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushr4.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushr4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushr8.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushr8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourpushref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourvarpop.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourvarpop.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourvarpush.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/emit/stackbehaviour/stackbehaviourvarpush.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection.Emit;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/eventattributes/eventattributesnone.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/eventattributes/eventattributesnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/eventattributes/eventattributesrtspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/eventattributes/eventattributesrtspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/eventattributes/eventattributesspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/eventattributes/eventattributesspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesassembly.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfamandassem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfamandassem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfamily.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfamily.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfamorassem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfamorassem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class FieldAttributesFamORAssem

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfieldaccessmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesfieldaccessmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributeshasdefault.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributeshasdefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributeshasfieldrva.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributeshasfieldrva.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesinitonly.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesinitonly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesliteral.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesliteral.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesnotserialized.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesnotserialized.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributespinvokeimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributespinvokeimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesprivate.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesprivate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesprivatescope.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesprivatescope.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributespublic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributespublic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesrtspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesrtspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class FieldAttributesRTSpecialName

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesstatic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/fieldattributes/fieldattributesstatic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class FieldAttributesStatic

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesabstract.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesabstract.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfamandassem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfamandassem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfamily.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfamily.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfamorassem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfamorassem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfinal.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesfinal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributeshassecurity.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributeshassecurity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributeshidebysig.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributeshidebysig.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesmemberaccessmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesmemberaccessmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesnewslot.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesnewslot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributespinvokeimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributespinvokeimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesprivate.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesprivate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesprivatescope.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesprivatescope.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributespublic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributespublic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesrequiresecobject.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesrequiresecobject.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesreuseslot.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesreuseslot.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesrtspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesrtspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesstatic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesstatic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesunmanagedexport.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesunmanagedexport.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesvirtual.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesvirtual.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesvtablelayoutmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodattributes/methodattributesvtablelayoutmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributescodetypemask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributescodetypemask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesforwardref.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesforwardref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesil.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesil.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesinternalcall.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesinternalcall.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesmanaged.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesmanaged.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesmanagedmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesmanagedmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesnative.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesnative.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesnoinlining.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesnoinlining.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesoptil.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesoptil.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributespreservesig.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributespreservesig.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesruntime.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesruntime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributessynchronized.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributessynchronized.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesunmanaged.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/methodimplattributes/methodimplattributesunmanaged.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributeshasdefault.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributeshasdefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesin.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesin.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesnone.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesoptional.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesoptional.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesout.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesretval.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/parameterattributes/parameterattributesretval.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributeshasdefault.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributeshasdefault.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributesnone.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributesnone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributesrtspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributesrtspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributesspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/propertyattributes/propertyattributesspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/targetinvocationexception/targetinvocationexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetinvocationexception/targetinvocationexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/targetinvocationexception/targetinvocationexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetinvocationexception/targetinvocationexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/targetparametercountexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/targetparametercountexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/targetparametercountexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/targetparametercountexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/targetparametercountexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/targetparametercountexception/targetparametercountexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesabstract.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesabstract.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesansiclass.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesansiclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesautoclass.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesautoclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesautolayout.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesautolayout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesbeforefieldinit.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesbeforefieldinit.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesclass.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesclasssemanticsmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesclasssemanticsmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesexplicitlayout.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesexplicitlayout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributeshassecurity.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributeshassecurity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesimport.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesimport.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesinterface.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesinterface.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributeslayoutmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributeslayoutmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedassembly.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedfamandassem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedfamandassem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedfamily.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedfamily.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedfamorassem.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedfamorassem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedprivate.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedprivate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedpublic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesnestedpublic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributespublic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributespublic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesrtspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesrtspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributessealed.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributessealed.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributessequentiallayout.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributessequentiallayout.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesserializable.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesserializable.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesspecialname.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesspecialname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesstringformatmask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesstringformatmask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesunicodeclass.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesunicodeclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesvisibilitymask.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattributesvisibilitymask.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattribytesnotpublic.cs
+++ b/tests/src/CoreMangLib/cti/system/reflection/typeattributes/typeattribytesnotpublic.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/missingmanifestresourceexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/missingmanifestresourceexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/missingmanifestresourceexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/missingmanifestresourceexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/missingmanifestresourceexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/missingmanifestresourceexception/missingmanifestresourceexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/resources/neutralresourceslanguageattribute/neutralresourceslanguageattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/neutralresourceslanguageattribute/neutralresourceslanguageattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/resources/neutralresourceslanguageattribute/neutralresourceslanguageattributeculturename.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/neutralresourceslanguageattribute/neutralresourceslanguageattributeculturename.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/resources/resourcemanager/customculture.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/resourcemanager/customculture.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/resources/satellitecontractversionattribute/satellitecontractversionattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/satellitecontractversionattribute/satellitecontractversionattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/resources/satellitecontractversionattribute/satellitecontractversionattributeversion.cs
+++ b/tests/src/CoreMangLib/cti/system/resources/satellitecontractversionattribute/satellitecontractversionattributeversion.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/accessedthroughpropertyattribute/atpactor.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/accessedthroughpropertyattribute/atpactor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/accessedthroughpropertyattribute/atpapropertyname.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/accessedthroughpropertyattribute/atpapropertyname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilationrelaxations/compilationrelaxationsattributector1.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilationrelaxations/compilationrelaxationsattributector1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilergeneratedattribute/compilergeneratedattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/compilergeneratedattribute/compilergeneratedattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/customconstantattribute/customconstantattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/customconstantattribute/customconstantattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/indexernameattribute/indexernameattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/indexernameattribute/indexernameattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/internalsvisibletoattribute/internalsvisibletoattributeassemblyname.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/internalsvisibletoattribute/internalsvisibletoattributeassemblyname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/internalsvisibletoattribute/internalsvisibletoattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/internalsvisibletoattribute/internalsvisibletoattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/methodimploptions/methodimploptionsnoinlining.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/methodimploptions/methodimploptionsnoinlining.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/methodimploptions/methodimploptionspreservesig.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/methodimploptions/methodimploptionspreservesig.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimecompatibilityattribute/runtimecompatibilityattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimecompatibilityattribute/runtimecompatibilityattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimecompatibilityattribute/runtimecompatibilityattributewrapnonexceptionthrows.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimecompatibilityattribute/runtimecompatibilityattributewrapnonexceptionthrows.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Runtime.CompilerServices;

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/platformassembly.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/platformassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Platform types for RunClassConstructor tests
 
 using System;

--- a/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/userassembly.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/compilerservices/runtimehelpers/userassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // User/transparent types for RunClassConstructor tests
 
 using System;

--- a/tests/src/CoreMangLib/cti/system/runtime/decimalconstantattribute/decimalconstantattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/decimalconstantattribute/decimalconstantattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/decimalconstantattribute/decimalconstantattributevalue.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/decimalconstantattribute/decimalconstantattributevalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/fixedbufferattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/fixedbufferattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/fixedbufferattributeelementtype.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/fixedbufferattributeelementtype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/fixedbufferattributelength.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/fixedbufferattribute/fixedbufferattributelength.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/callingconvention/callingconventionwinapi.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/callingconvention/callingconventionwinapi.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/charset/charsetunicode.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/charset/charsetunicode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/dllimportattribute/dllimporttest.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/dllimportattribute/dllimporttest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/fieldoffsetattribute/fieldoffsetattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/fieldoffsetattribute/fieldoffsetattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/fieldoffsetattribute/fieldoffsetattributevalue.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/fieldoffsetattribute/fieldoffsetattributevalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandleaddrofpinnedobject.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandleaddrofpinnedobject.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandlealloc1.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandlealloc1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandlefree.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandlefree.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandletarget.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandle/gchandletarget.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypenormal.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypenormal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypepinned.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypepinned.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypeweak.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypeweak.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypeweaktrackresurrection.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/gchandletype/gchandletypeweaktrackresurrection.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/inattribute/inattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/inattribute/inattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/layoutkind/layoutkindauto.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/layoutkind/layoutkindauto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/layoutkind/layoutkindsequential.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/layoutkind/layoutkindsequential.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/marshalsizeof1.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/marshalsizeof1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/marshalsizeof2.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/marshalsizeof2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/oleaut32.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshal/oleaut32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributearraysubtype.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributearraysubtype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributector1.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributector1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributector2.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributector2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributemarshalcookie.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributemarshalcookie.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributemarshaltype.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributemarshaltype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributemarshaltyperef.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributemarshaltyperef.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributesizeconst.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributesizeconst.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributesizeparamindex.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributesizeparamindex.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributevalue.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/marshalasattribute/marshalasattributevalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/outattribute/outattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/outattribute/outattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/preservesigattribute/preservesigattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/preservesigattribute/preservesigattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlector_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlector_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices;

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledangerousaddref.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledangerousaddref.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledangerousgethandle.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledangerousgethandle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledangerousrelease.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledangerousrelease.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledispose1.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledispose1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHanlde

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledispose2.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandledispose2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlehandle.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlehandle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandleisclosed.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandleisclosed.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandleisinvalid.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandleisinvalid.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlesethandle.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlesethandle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlesethandleasinvalid.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/safehandle/safehandlesethandleasinvalid.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using System.Runtime.InteropServices; // For SafeHandle

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributecharset.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributecharset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributector.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributepack.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributepack.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributesize.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributesize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributevalue.cs
+++ b/tests/src/CoreMangLib/cti/system/runtime/interopservices/structlayoutattribute/structlayoutattributevalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtimefieldhandle/runtimefieldhandleequals.cs
+++ b/tests/src/CoreMangLib/cti/system/runtimefieldhandle/runtimefieldhandleequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtimefieldhandle/runtimefieldhandlegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/runtimefieldhandle/runtimefieldhandlegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/runtimemethodhandle/runtimemethodhandleequals.cs
+++ b/tests/src/CoreMangLib/cti/system/runtimemethodhandle/runtimemethodhandleequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/runtimemethodhandle/runtimemethodhanldegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/runtimemethodhandle/runtimemethodhanldegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/runtimetypehandle/runtimetypehandleequals.cs
+++ b/tests/src/CoreMangLib/cti/system/runtimetypehandle/runtimetypehandleequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestEmptyClass

--- a/tests/src/CoreMangLib/cti/system/runtimetypehandle/runtimetypehandlegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/runtimetypehandle/runtimetypehandlegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestEmptyClass

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbytecompareto2.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbytecompareto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.CompareTo(SByte)

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.Equals(object)

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.Equals(SByte)

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbytegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbytegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.GetHashCode()

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteiconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbytemaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbytemaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.MaxValue

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.MinValue

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteparse1.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteparse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// SByte.Parse(string)

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteparse2.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteparse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbyteparse3.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbyteparse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/sbyte/sbytetryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/sbyte/sbytetryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptiontostring.cs
+++ b/tests/src/CoreMangLib/cti/system/security/securityexception/securityexceptiontostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/CoreMangLib/cti/system/single/singlegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singlegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// GetHashCode

--- a/tests/src/CoreMangLib/cti/system/single/singleisinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singleisinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// IsInfinity(System.Single)

--- a/tests/src/CoreMangLib/cti/system/single/singleisnan.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singleisnan.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// IsNaN(System.Single)

--- a/tests/src/CoreMangLib/cti/system/single/singleisnegativeinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singleisnegativeinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// IsNegativeInfinity(System.Single)

--- a/tests/src/CoreMangLib/cti/system/single/singleispositiveinfinity.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singleispositiveinfinity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// IsPositiveInfinity(System.Single)

--- a/tests/src/CoreMangLib/cti/system/single/singletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/single/singletryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/single/singletryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringchars.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringchars.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringcompare1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringcompare1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/string/stringcompare15.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringcompare15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/string/stringcompare2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringcompare2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/string/stringcompare9.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringcompare9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringcompareordinal1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringcompareordinal1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat3.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat4.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat5.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat6.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat7.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringconcat8.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringconcat8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringcopyto.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringcopyto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringctor5.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringctor5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringctorchar.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringctorchar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringempty.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringempty.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 namespace StringTest

--- a/tests/src/CoreMangLib/cti/system/string/stringequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringequals3.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringequals3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringequals6.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringequals6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringformat1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringformat1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringformat2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringformat2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringgetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringgetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringgethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringiconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringiconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringienumerablegetenumerator.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringienumerablegetenumerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/string/stringindexof10.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringindexof10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringinsert.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringinsert.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// String.Insert(Int32, String)  

--- a/tests/src/CoreMangLib/cti/system/string/stringisnullorempty.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringisnullorempty.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringjoin1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringjoin1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// String.Join(String, String[])  

--- a/tests/src/CoreMangLib/cti/system/string/stringjoin2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringjoin2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 /// String.Join(String, String[], Int32, Int32)

--- a/tests/src/CoreMangLib/cti/system/string/stringlength.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringlength.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringpadleft.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringpadleft.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringpadleft1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringpadleft1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringpadleft2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringpadleft2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringpadright.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringpadright.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/string/stringpadright1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringpadright1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringpadright2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringpadright2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringremove1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringremove1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringremove2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringremove2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringreplace1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringreplace1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringreplace2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringreplace2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringsubstring1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringsubstring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringsubstring2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringsubstring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/string/stringtochararray.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtochararray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringtostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringtrim1.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtrim1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringtrim1b.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtrim1b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringtrim2.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtrim2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringtrim3.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtrim3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/string/stringtrim4.cs
+++ b/tests/src/CoreMangLib/cti/system/string/stringtrim4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/stringcompare/stringcomparerctor.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcompare/stringcomparerctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 

--- a/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparercompare2.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparercompare2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 

--- a/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparerequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparerequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 

--- a/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparerequals3.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparerequals3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 

--- a/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparergettype.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparer/stringcomparergettype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 /// <summary>
 

--- a/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisoncurrentculture.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisoncurrentculture.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisoncurrentcultureignorecase.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisoncurrentcultureignorecase.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisonordinal.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisonordinal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisonordinalignorecase.cs
+++ b/tests/src/CoreMangLib/cti/system/stringcomparison/stringcomparisonordinalignorecase.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/szarrayhelper/szarrayhelpersetitem.cs
+++ b/tests/src/CoreMangLib/cti/system/szarrayhelper/szarrayhelpersetitem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/text/decoder/decoderctor.cs
+++ b/tests/src/CoreMangLib/cti/system/text/decoder/decoderctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/decoder/decoderreset.cs
+++ b/tests/src/CoreMangLib/cti/system/text/decoder/decoderreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoder/encoderctor.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoder/encoderctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingbigendianunicode.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingbigendianunicode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingclone.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingclone.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingconvert1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingconvert1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingconvert2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingconvert2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingequals.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytecount3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes4.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes5.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetbytes5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetcharcount1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetcharcount1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetcharcount2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetcharcount2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetchars2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetchars2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetchars3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetchars3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetdecoder.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetdecoder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetencoder.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetencoder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetencoding2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetencoding2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetpreamble.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodinggetpreamble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingunicode.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingunicode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingutf8.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingutf8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/encoding/encodingwebname.cs
+++ b/tests/src/CoreMangLib/cti/system/text/encoding/encodingwebname.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend10.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend11.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend12.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend13.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend14.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend15.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend16.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend17.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend18.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend19.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend19.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend4.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend5.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend6.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend7.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend8.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend9.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderappend9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildercapacity.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildercapacity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildercapacity_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildercapacity_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderchars.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderchars.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor4.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor5.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor6.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderctor6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderinsert.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderinsert.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderinsert3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderinsert3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderinsert4.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderinsert4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderlength.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderlength.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderlength_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderlength_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderremove.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderremove.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace4.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuilderreplace4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildertostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildertostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildertostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/stringbuilder/stringbuildertostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodingctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodingctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodingequals.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodingequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetbytecount1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetbytecount1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetbytecount2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetbytecount2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetbytes2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetbytes2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetcharcount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetcharcount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetchars.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetchars.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetdecoder.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetdecoder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetencoder.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetencoder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetmaxbytecount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetmaxbytecount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetmaxcharcount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetmaxcharcount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetpreamble.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetpreamble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetstring.cs
+++ b/tests/src/CoreMangLib/cti/system/text/unicodeencoding/unicodeencodinggetstring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingctor.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingequals.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodingequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytecount1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytecount1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytecount2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytecount2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytes1.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytes1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytes2.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetbytes2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetcharcount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetcharcount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetchars.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetchars.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetdecoder.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetdecoder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetencoder.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetencoder.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetmaxbytecount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetmaxbytecount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetmaxcharcount.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetmaxcharcount.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetpreamble.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetpreamble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetstring.cs
+++ b/tests/src/CoreMangLib/cti/system/text/utf8encoding/utf8encodinggetstring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/cti/system/threading/autoresetevent/autoreseteventctor.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/autoresetevent/autoreseteventctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/autoresetevent/autoreseteventreset.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/autoresetevent/autoreseteventreset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/autoresetevent/autoreseteventset.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/autoresetevent/autoreseteventset.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedadd1.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedadd1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedadd2.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedadd2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange1.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange5.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange6.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange7.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedcompareexchange7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockeddecrement1.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockeddecrement1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockeddecrement2.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockeddecrement2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange1.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange5.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange6.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange7.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedexchange7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedincrement1.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedincrement1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedincrement2.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/interlocked/interlockedincrement2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/manualresetevent/manualreseteventctor.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/manualresetevent/manualreseteventctor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/timeout/timeoutinfinite.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/timeout/timeoutinfinite.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/waithandle/waithandlector.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/waithandle/waithandlector.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/waithandle/waithandledispose1.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/waithandle/waithandledispose1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/threading/waithandle/waithandledispose3.cs
+++ b/tests/src/CoreMangLib/cti/system/threading/waithandle/waithandledispose3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/CoreMangLib/cti/system/timeoutexception/timeoutexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/timeoutexception/timeoutexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timeoutexception/timeoutexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/timeoutexception/timeoutexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timeoutexception/timeoutexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/timeoutexception/timeoutexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestException : Exception

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanadd.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanadd.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespancompare1.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespancompare1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespancompareto2.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespancompareto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanctor4.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanctor4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanduration.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanduration.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TimeSpanEquals2

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanequals3.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanequals3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanfromticks.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanfromticks.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespangethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespangethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanmaxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanmaxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanminvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanminvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespannegate.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespannegate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespansupport.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespansupport.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanticks.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanticks.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanticksperday.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanticksperday.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanticksperhour.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanticksperhour.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanticksperminute.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanticksperminute.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantickspersecond.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantickspersecond.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantostring_str.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantostring_str.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantotaldays.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantotaldays.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantotalhours.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantotalhours.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantotalmilliseconds.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantotalmilliseconds.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantotalminutes.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantotalminutes.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespantotalseconds.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespantotalseconds.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/timespan/timespanzero.cs
+++ b/tests/src/CoreMangLib/cti/system/timespan/timespanzero.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/type/typeequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typeequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/type/typeequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typeequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TypeEquals2

--- a/tests/src/CoreMangLib/cti/system/type/typegetarrayrank.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typegetarrayrank.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TypeGetArrayRank

--- a/tests/src/CoreMangLib/cti/system/type/typegetgenerictypedefinition.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typegetgenerictypedefinition.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/type/typegethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typegethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/type/typegettype1.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typegettype1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/type/typegettype2.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typegettype2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/cti/system/type/typegettypefromhandle.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typegettypefromhandle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/type/typehaselementtypeimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typehaselementtypeimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/type/typeisbyrefimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typeisbyrefimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Reflection;

--- a/tests/src/CoreMangLib/cti/system/type/typeispointerimpl.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typeispointerimpl.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct TestGenericType2

--- a/tests/src/CoreMangLib/cti/system/type/typemakearraytype1.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typemakearraytype1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/type/typemakearraytype2.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typemakearraytype2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/type/typemakebyreftype.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typemakebyreftype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/type/typemakepointertype.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typemakepointertype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/type/typetostring.cs
+++ b/tests/src/CoreMangLib/cti/system/type/typetostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using TestHelper;

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodebyte.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodebyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodechar.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodechar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodedatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodedatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodedecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodedecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodedouble.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodedouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeempty.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeempty.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeint16.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeint32.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeint64.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeobject.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeobject.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodesbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodesbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodesingle.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodesingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodestring.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodestring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeuint16.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeuint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeuint32.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeuint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TypeCodeUInt32

--- a/tests/src/CoreMangLib/cti/system/typecode/typecodeuint64.cs
+++ b/tests/src/CoreMangLib/cti/system/typecode/typecodeuint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionctor1.cs
+++ b/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionctor1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionctor2.cs
+++ b/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionctor2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionctor3.cs
+++ b/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionctor3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionmessage.cs
+++ b/tests/src/CoreMangLib/cti/system/typeloadexception/typeloadexceptionmessage.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 ///<summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16compareto1.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16compareto1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16equals1.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16equals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16equals2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16equals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16iconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16parse1.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16parse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16parse2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16parse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16parse3.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16parse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16tostring3.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16tostring3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization; //for NumberFormatInfo
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16tostring4.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16tostring4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization; //for NumberFormatInfo
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/uint16/uint16tryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/uint16/uint16tryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32compareto2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32compareto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32equals1.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32equals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32equals2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32equals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32iconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32maxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32maxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32minvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32minvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32parse1.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32parse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // v-minch
 
 using System;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32parse2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32parse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32parse3.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32parse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32tostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32tostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Collections.Generic;

--- a/tests/src/CoreMangLib/cti/system/uint32/uint32tryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/uint32/uint32tryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64gethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoboolean.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoboolean.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletobyte.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletobyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletochar.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletochar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletodatetime.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletodatetime.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletodecimal.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletodecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletodouble.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletodouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoint16.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletoint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletosbyte.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletosbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletosingle.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletosingle.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletotype.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletotype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletouint16.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletouint16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64iconvertibletouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64maxvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64maxvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64minvalue.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64minvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64parse1.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64parse1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64parse2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64parse2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64parse3.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64parse3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64tostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64tostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/uint64/uint64tryparse.cs
+++ b/tests/src/CoreMangLib/cti/system/uint64/uint64tryparse.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrctor_uint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrctor_uint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrctor_uint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrctor_uint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrctor_voidptr.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrctor_voidptr.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrequals.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrequals.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrgethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrsize.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrsize.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrtopointer.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrtopointer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrtostring.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrtostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrtouint32.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrtouint32.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrtouint64.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrtouint64.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrzero.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrzero.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/version/versionbuild.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versionbuild.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/version/versioncompareto2.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versioncompareto2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/version/versionctor4.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versionctor4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/version/versionequals1.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versionequals1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/version/versionequals2.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versionequals2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/version/versiongethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versiongethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/version/versionmajor.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versionmajor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/version/versionrevision.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versionrevision.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/version/versiontostring1.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versiontostring1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 

--- a/tests/src/CoreMangLib/cti/system/version/versiontostring2.cs
+++ b/tests/src/CoreMangLib/cti/system/version/versiontostring2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/CoreMangLib/cti/system/weakreference/helper.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/helper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class myClass

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferencector1.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferencector1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferencector2.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferencector2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferencector2b.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferencector2b.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisalive.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisalive.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 using TestLibrary;

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisaliveb.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferenceisaliveb.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferencetargetb.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferencetargetb.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 

--- a/tests/src/CoreMangLib/cti/system/weakreference/weakreferencetrackresurrection_cti.cs
+++ b/tests/src/CoreMangLib/cti/system/weakreference/weakreferencetrackresurrection_cti.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Security;
 using System;
 

--- a/tests/src/CoreMangLib/reflection/assembly/testassembly.cs
+++ b/tests/src/CoreMangLib/reflection/assembly/testassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass1

--- a/tests/src/CoreMangLib/system/buffer/asurt_99893.cs
+++ b/tests/src/CoreMangLib/system/buffer/asurt_99893.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // ASURT 99893 - These Buffer members were correctly checking that the array was a
 // primitive type, but the check for primitive type did not include the assembly,
 // and thus one could define a new System.Int32 (as below) and use that instead.

--- a/tests/src/CoreMangLib/system/collections/generic/hashset/regression_dev10_609271.cs
+++ b/tests/src/CoreMangLib/system/collections/generic/hashset/regression_dev10_609271.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/CoreMangLib/system/collections/generic/hashset/regression_dev10_624201.cs
+++ b/tests/src/CoreMangLib/system/collections/generic/hashset/regression_dev10_624201.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using System.Collections;

--- a/tests/src/CoreMangLib/system/datetime/co7510parseexact_formatarray.cs
+++ b/tests/src/CoreMangLib/system/datetime/co7510parseexact_formatarray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/system/delegate/generics/common.cs
+++ b/tests/src/CoreMangLib/system/delegate/generics/common.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //@TODO - API level testing for generics, particulary with multicast invocation lists and co/contra variant generics
 //@TODO - Vary the return type
 

--- a/tests/src/CoreMangLib/system/delegate/generics/negativegenerics.cs
+++ b/tests/src/CoreMangLib/system/delegate/generics/negativegenerics.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //Covers various negative binding cases for delegates and generics...
 using System;
 

--- a/tests/src/CoreMangLib/system/delegate/generics/ng_standard.cs
+++ b/tests/src/CoreMangLib/system/delegate/generics/ng_standard.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 class Test{

--- a/tests/src/CoreMangLib/system/delegate/generics/nullabletypes.cs
+++ b/tests/src/CoreMangLib/system/delegate/generics/nullabletypes.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 #pragma warning disable 414
 
 using System;

--- a/tests/src/CoreMangLib/system/delegate/miscellaneous/co6031gethashcode.cs
+++ b/tests/src/CoreMangLib/system/delegate/miscellaneous/co6031gethashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 delegate int Int32_VoidDelegate();

--- a/tests/src/CoreMangLib/system/delegate/regressions/devdivbugs/113347/ddb113347.cs
+++ b/tests/src/CoreMangLib/system/delegate/regressions/devdivbugs/113347/ddb113347.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 using System.Security;

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/public/testclass.cs
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/public/testclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/public/testclassframeworkinternal.cs
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/public/testclassframeworkinternal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/tests/bindingtarget.cs
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/tests/bindingtarget.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Reflection;

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/tests/critconstructorclass.cs
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/tests/critconstructorclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/tests/testclass.cs
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/tests/testclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/system/delegate/threatmodel/tests/testclassframeworkinternal.cs
+++ b/tests/src/CoreMangLib/system/delegate/threatmodel/tests/testclassframeworkinternal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/CoreMangLib/system/exception/data_helper.cs
+++ b/tests/src/CoreMangLib/system/exception/data_helper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class NonSerializableClass

--- a/tests/src/CoreMangLib/system/guid/guid_parsing.cs
+++ b/tests/src/CoreMangLib/system/guid/guid_parsing.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/CoreMangLib/system/lazyt/lazyttf.cs
+++ b/tests/src/CoreMangLib/system/lazyt/lazyttf.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 class Test

--- a/tests/src/CoreMangLib/system/reflection/assembly/server1.cs
+++ b/tests/src/CoreMangLib/system/reflection/assembly/server1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/system/reflection/assembly/server2.cs
+++ b/tests/src/CoreMangLib/system/reflection/assembly/server2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/system/reflection/assembly/server3.cs
+++ b/tests/src/CoreMangLib/system/reflection/assembly/server3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/system/reflection/assembly/server4.cs
+++ b/tests/src/CoreMangLib/system/reflection/assembly/server4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/CoreMangLib/system/resources/resourcemanager/customculture.cs
+++ b/tests/src/CoreMangLib/system/resources/resourcemanager/customculture.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/CoreMangLib/system/text/encoding/shift_jis.cs
+++ b/tests/src/CoreMangLib/system/text/encoding/shift_jis.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 using TestLibrary;

--- a/tests/src/CoreMangLib/system/version/version_parsing.cs
+++ b/tests/src/CoreMangLib/system/version/version_parsing.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/Exceptions/Finalization/Finalizer.cs
+++ b/tests/src/Exceptions/Finalization/Finalizer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /*

--- a/tests/src/GC/Scenarios/Boxing/doubLink.cs
+++ b/tests/src/GC/Scenarios/Boxing/doubLink.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace GCVariant
 {

--- a/tests/src/GC/Scenarios/FinalNStruct/strmap.cs
+++ b/tests/src/GC/Scenarios/FinalNStruct/strmap.cs
@@ -1,9 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System.Runtime.InteropServices;
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace NStruct
 {

--- a/tests/src/GC/Scenarios/FinalizeTimeout/FinalizeTimeout.cs
+++ b/tests/src/GC/Scenarios/FinalizeTimeout/FinalizeTimeout.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 
 using System;
 using System.Threading;

--- a/tests/src/GC/Stress/Tests/DirectedGraph.cs
+++ b/tests/src/GC/Stress/Tests/DirectedGraph.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 /************************************************************************************************************
 This test does the following:

--- a/tests/src/GC/Stress/Tests/GCQueue.cs
+++ b/tests/src/GC/Stress/Tests/GCQueue.cs
@@ -1,9 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
 using System.Collections;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/GC/Stress/Tests/GCVariant.cs
+++ b/tests/src/GC/Stress/Tests/GCVariant.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/GC/Stress/Tests/LeakGenThrd.cs
+++ b/tests/src/GC/Stress/Tests/LeakGenThrd.cs
@@ -1,10 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System.Threading;
 using System;
 using System.IO;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/GC/Stress/Tests/MulDimJagAry.cs
+++ b/tests/src/GC/Stress/Tests/MulDimJagAry.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/GC/Stress/Tests/SingLinkStay.cs
+++ b/tests/src/GC/Stress/Tests/SingLinkStay.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/GC/Stress/Tests/ThdTreeGrowingObj.cs
+++ b/tests/src/GC/Stress/Tests/ThdTreeGrowingObj.cs
@@ -1,10 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System.Threading;
 using System;
 using System.IO;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/GC/Stress/Tests/doubLinkStay.cs
+++ b/tests/src/GC/Stress/Tests/doubLinkStay.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.cs
+++ b/tests/src/Interop/ArrayMarshalling/BoolArray/MarshalBoolArrayTest.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 //
 
 //

--- a/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.cs
+++ b/tests/src/Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/Interop/ICastable/Castable.cs
+++ b/tests/src/Interop/ICastable/Castable.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/tests/src/Interop/NativeCallable/NativeCallableTest.cs
+++ b/tests/src/Interop/NativeCallable/NativeCallableTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/tests/src/Interop/PrimitiveMarshalling/Bool/BoolTest.cs
+++ b/tests/src/Interop/PrimitiveMarshalling/Bool/BoolTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Runtime.InteropServices;
 using System;
 using System.Reflection;

--- a/tests/src/Interop/PrimitiveMarshalling/Bool/NativeMethodDef.cs
+++ b/tests/src/Interop/PrimitiveMarshalling/Bool/NativeMethodDef.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 ﻿using System;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/tests/src/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.cs
+++ b/tests/src/Interop/PrimitiveMarshalling/UIntPtr/PInvokeUIntPtrTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System.Runtime.InteropServices;
 using System;
 using System.Reflection;

--- a/tests/src/Interop/common/Assertion.cs
+++ b/tests/src/Interop/common/Assertion.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 // Note: Exception messages call ToString instead of Name to avoid MissingMetadataException when just outputting basic info
 
 using System;

--- a/tests/src/JIT/Directed/nullabletypes/Desktop/boxunboxvaluetype.cs
+++ b/tests/src/JIT/Directed/nullabletypes/Desktop/boxunboxvaluetype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;

--- a/tests/src/JIT/Directed/nullabletypes/constructor.cs
+++ b/tests/src/JIT/Directed/nullabletypes/constructor.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //<Title>Nullable types have a default single-parameter constructor</Title>
 //<Description>
 // A nullable type can be created with a single argument constructor

--- a/tests/src/JIT/Directed/nullabletypes/hashcode.cs
+++ b/tests/src/JIT/Directed/nullabletypes/hashcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //<Title>Nullable types lift the GetHashCode() method from the underlying struct</Title>
 //<Description>
 //  A nullable type with a value returns the GetHashCode() from the underlying struct

--- a/tests/src/JIT/Directed/nullabletypes/hasvalue.cs
+++ b/tests/src/JIT/Directed/nullabletypes/hasvalue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //<Title>Nullable types have the HasValue property</Title>
 //<Description>
 // If the nullable type has a null value, HasValue is false

--- a/tests/src/JIT/Directed/nullabletypes/invocation.cs
+++ b/tests/src/JIT/Directed/nullabletypes/invocation.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //<Title>Nullable types lift the GetHashCode() method from the underlying struct</Title>
 //<Description>
 //  A nullable type with a value returns the GetHashCode() from the underlying struct

--- a/tests/src/JIT/Directed/nullabletypes/tostring.cs
+++ b/tests/src/JIT/Directed/nullabletypes/tostring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //<Title>Nullable types lift the ToString() method from the underlying struct</Title>
 //<Description>
 //  A nullable type with a value returns the ToString() from the underlying struct

--- a/tests/src/JIT/Directed/perffix/primitivevt/mixed1.cs
+++ b/tests/src/JIT/Directed/perffix/primitivevt/mixed1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 unsafe class testout1
 {

--- a/tests/src/JIT/Methodical/Boxing/callconv/instance.cs
+++ b/tests/src/JIT/Methodical/Boxing/callconv/instance.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace BoxTest
 {

--- a/tests/src/JIT/Methodical/Boxing/functional/fibo.cs
+++ b/tests/src/JIT/Methodical/Boxing/functional/fibo.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace BoxTest
 {

--- a/tests/src/JIT/Methodical/Boxing/functional/sin.cs
+++ b/tests/src/JIT/Methodical/Boxing/functional/sin.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace SinCalc
 {

--- a/tests/src/JIT/Methodical/Boxing/morph/sin.cs
+++ b/tests/src/JIT/Methodical/Boxing/morph/sin.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace SinCalc
 {

--- a/tests/src/JIT/Methodical/Boxing/seh/try.cs
+++ b/tests/src/JIT/Methodical/Boxing/seh/try.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace SinCalc
 {

--- a/tests/src/JIT/Methodical/cctor/xassem/xprecise1.cs
+++ b/tests/src/JIT/Methodical/cctor/xassem/xprecise1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // static method
 using System;
 namespace Precise {

--- a/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/GCOverReporting.cs
+++ b/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/GCOverReporting.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
 
 /*
  * If using a value type/struct that contains only a single reference type field, under certain situations the x64 JIT reports the stack location as a live GC pointer before zero-initializing it.

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structpasstest.cs
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structpasstest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 namespace structinreg

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structpasstest1.cs
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structpasstest1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structpinvoketests.cs
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structpinvoketests.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;  
 using System.Runtime.InteropServices;  
 

--- a/tests/src/JIT/Methodical/structs/systemvbringup/structrettest.cs
+++ b/tests/src/JIT/Methodical/structs/systemvbringup/structrettest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/JIT/Methodical/xxobj/sizeof/sizeof32.cs
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/sizeof32.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace JitTest
 {

--- a/tests/src/JIT/Methodical/xxobj/sizeof/sizeof64.cs
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/sizeof64.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 // sizeof converted to I8 and used with arithmetic operations
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/binarytrees/binarytrees.csharp.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/ 
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fasta/fasta.csharp-2.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fasta/fasta.csharp-2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fastaredux/fastaredux.csharp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/fastaredux/fastaredux.csharp.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/nbody/nbody.csharp-3.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/nbody/nbody.csharp-3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
 

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
  * http://benchmarksgame.alioth.debian.org/
  *

--- a/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/spectralnorm/spectralnorm.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchmarksGame/spectralnorm/spectralnorm.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* The Computer Language Benchmarks Game
    http://benchmarksgame.alioth.debian.org/
  

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ByteMark.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/Huffman.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/Huffman.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/StringSort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/StringSort.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/assign_jagged.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/assign_jagged.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/assign_rect.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/assign_rect.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/bitops.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/bitops.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/emfloat.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/emfloat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/emfloatclass.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/emfloatclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/fourier.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/fourier.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/idea.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/idea.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/ludecomp.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/ludecomp.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/neural-dat.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/neural-dat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/neural.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/neural.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/neuraljagged.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/neuraljagged.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/Bytemark/numericsort.cs
+++ b/tests/src/JIT/Performance/CodeQuality/Bytemark/numericsort.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
 ** Copyright (c) Microsoft. All rights reserved.
 ** Licensed under the MIT license. 

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/CommandLine.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/CommandLine.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/Constants.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/Constants.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/FFT.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/FFT.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/LU.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/LU.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/MonteCarlo.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/MonteCarlo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/Random.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/Random.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/SOR.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/SOR.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/SparseCompRow.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/SparseCompRow.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/Stopwatch.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/Stopwatch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/SciMark/kernel.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/kernel.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /// <license>
 /// This is a port of the SciMark2a Java Benchmark to C# by
 /// Chris Re (cmr28@cornell.edu) and Werner Vogels (vogels@cs.cornell.edu)

--- a/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
  * Copyright (c) 2003-2005  Tom Wu
  * All Rights Reserved.

--- a/tests/src/JIT/Performance/CodeQuality/V8/DeltaBlue/DeltaBlue.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/DeltaBlue/DeltaBlue.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*
   This is a Java implemention of the DeltaBlue algorithm described in:
     "The DeltaBlue Algorithm: An Incremental Constraint Hierarchy Solver"

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b29456/b29456.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b29456/b29456.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace Tests
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13944/b13944.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b13944/b13944.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace DefaultNamespace
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14228/b14228.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14228/b14228.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace DefaultNamespace
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14323/b14323.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14323/b14323.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace DefaultNamespace
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14475/b14475.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14475/b14475.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace DefaultNamespace
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14779/b14779.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b14779/b14779.cs
@@ -1,9 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
 using System.Globalization;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace DefaultNamespace
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16102/b16102.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09/b16102/b16102.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace N
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b41990/b41990.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b41990/b41990.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace Test
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51875/b51875.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b51875/b51875.cs
@@ -1,9 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
 using System.Collections;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace Test
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53547/b53547.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b53547/b53547.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace Test
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71093/b71093.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b71093/b71093.cs
@@ -1,8 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace Test
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b80764/b80764.cs
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M12-Beta2/b80764/b80764.cs
@@ -1,9 +1,11 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;
 using System.Runtime.InteropServices;
-// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 
 namespace JitTest
 {

--- a/tests/src/JIT/Regression/Dev11/External/dev11_132534/Core.cs
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_132534/Core.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 namespace Test

--- a/tests/src/JIT/Regression/JitBlue/GitHub_1296/GitHub_1296.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_1296/GitHub_1296.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 // Simple struct containing two integers (size 8).

--- a/tests/src/JIT/Regression/JitBlue/GitHub_1323/GitHub_1323.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_1323/GitHub_1323.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Copyright (c) Andrey Akinshin. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 //

--- a/tests/src/JIT/SIMD/AbsGeneric.cs
+++ b/tests/src/JIT/SIMD/AbsGeneric.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/AbsSqrt.cs
+++ b/tests/src/JIT/SIMD/AbsSqrt.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/AddingSequence.cs
+++ b/tests/src/JIT/SIMD/AddingSequence.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector2;

--- a/tests/src/JIT/SIMD/BitwiseOperations.cs
+++ b/tests/src/JIT/SIMD/BitwiseOperations.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector2;

--- a/tests/src/JIT/SIMD/BoxUnbox.cs
+++ b/tests/src/JIT/SIMD/BoxUnbox.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/BugWithAVX.cs
+++ b/tests/src/JIT/SIMD/BugWithAVX.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Numerics;
 

--- a/tests/src/JIT/SIMD/CircleInConvex.cs
+++ b/tests/src/JIT/SIMD/CircleInConvex.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Test generates Points, builds ConvexHull and then find the biggest Circle inside it.
 
 using System;

--- a/tests/src/JIT/SIMD/CreateGeneric.cs
+++ b/tests/src/JIT/SIMD/CreateGeneric.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/CtorFromArray.cs
+++ b/tests/src/JIT/SIMD/CtorFromArray.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector<int>;

--- a/tests/src/JIT/SIMD/Ctors.cs
+++ b/tests/src/JIT/SIMD/Ctors.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/DivSignedUnsignedTest.cs
+++ b/tests/src/JIT/SIMD/DivSignedUnsignedTest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/Dup.cs
+++ b/tests/src/JIT/SIMD/Dup.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector4;

--- a/tests/src/JIT/SIMD/Haar-likeFeaturesGeneric.cs
+++ b/tests/src/JIT/SIMD/Haar-likeFeaturesGeneric.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector<double>;

--- a/tests/src/JIT/SIMD/Ldfld.cs
+++ b/tests/src/JIT/SIMD/Ldfld.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector4;

--- a/tests/src/JIT/SIMD/LdfldGeneric.cs
+++ b/tests/src/JIT/SIMD/LdfldGeneric.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector<int>;

--- a/tests/src/JIT/SIMD/Ldind.cs
+++ b/tests/src/JIT/SIMD/Ldind.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;

--- a/tests/src/JIT/SIMD/MinMax.cs
+++ b/tests/src/JIT/SIMD/MinMax.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector4;

--- a/tests/src/JIT/SIMD/Mul.cs
+++ b/tests/src/JIT/SIMD/Mul.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector2;

--- a/tests/src/JIT/SIMD/SqrtGeneric.cs
+++ b/tests/src/JIT/SIMD/SqrtGeneric.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Numerics;

--- a/tests/src/JIT/SIMD/StoreElement.cs
+++ b/tests/src/JIT/SIMD/StoreElement.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector<int>;

--- a/tests/src/JIT/SIMD/Sums.cs
+++ b/tests/src/JIT/SIMD/Sums.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector4;

--- a/tests/src/JIT/SIMD/Vector3.cs
+++ b/tests/src/JIT/SIMD/Vector3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector3;

--- a/tests/src/JIT/SIMD/Vector4.cs
+++ b/tests/src/JIT/SIMD/Vector4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using Point = System.Numerics.Vector4;

--- a/tests/src/Loader/binding/assemblies/assemblybugs/102140/test.cs
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/102140/test.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/Loader/binding/assemblies/assemblybugs/177066w/repro177066.cs
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/177066w/repro177066.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/Loader/binding/assemblies/assemblybugs/203962w/client.cs
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/203962w/client.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/properties.cs
+++ b/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/properties.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 using System.IO;

--- a/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/server1.cs
+++ b/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/server1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/server2.cs
+++ b/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/server2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/server3.cs
+++ b/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/server3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/Loader/binding/assemblies/generics/arilistienum/methods/exceptions.cs
+++ b/tests/src/Loader/binding/assemblies/generics/arilistienum/methods/exceptions.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //array<T> IList properties
 
 using System;

--- a/tests/src/Loader/binding/assemblies/generics/arilistienum/methods/methods.cs
+++ b/tests/src/Loader/binding/assemblies/generics/arilistienum/methods/methods.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //array<T> IList properties
 
 using System;

--- a/tests/src/Loader/classloader/explicitlayout/misc/derivedexplicitclass.cs
+++ b/tests/src/Loader/classloader/explicitlayout/misc/derivedexplicitclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case1.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // struct
 //   int
 //   struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case11.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // here, the overlapping int only partial overlaps with an objref in the nested struct.
 // 
 // struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case12.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // super simple case. forget wrapper structs, just overlap an int and an objref!
 using System;
 using System.Runtime.InteropServices;

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case14.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // struct
 //   enum
 //   struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case15.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // struct
 //   int
 //   struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case2.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Same as case1, but exercises a different error path by going ahead and trying to use
 // the invalid type.  That code path should never be reached, however, because the bug fix
 // is "fail-fast".

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case3.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // struct
 //   int
 //   struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case4.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // like case1, except that the union type is a class rather than a struct.
 //
 // class

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case5.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // like case1, except that the order of the overlapping fields is
 // struct/int, instead of int/struct.
 // struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case6.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case6.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // like case4, except that the order of overlapping fields is reversed.
 // it is struct/int instead of int/struct.
 //

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case7.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case7.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // like case1 except that we have multiple instances of structs
 // overlapping with the int.
 // struct

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case8.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case8.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // like case4, except that there are multiple structs overlapping with the int.
 //
 // class

--- a/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case9.cs
+++ b/tests/src/Loader/classloader/explicitlayout/objrefandnonobjrefoverlap/case9.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // like case1, except that the overlapping doesn't occur in the first 
 // "slot" of the union.
 // struct

--- a/tests/src/Loader/classloader/generics/regressions/vsw237932/repro237932.cs
+++ b/tests/src/Loader/classloader/generics/regressions/vsw237932/repro237932.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // This is regression test for VSWhidbey 237932
 // The issue here was that the ThreadStatic field was previously shared for all C1<objref> types
 // and so when we created C1<System.OverflowException> and C1<System.InvalidCastException> the ThreadStatic

--- a/tests/src/Loader/classloader/generics/regressions/vsw514968/vsw514968.cs
+++ b/tests/src/Loader/classloader/generics/regressions/vsw514968/vsw514968.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class C { }

--- a/tests/src/Loader/classloader/generics/regressions/vsw524571/staticsproblem5.cs
+++ b/tests/src/Loader/classloader/generics/regressions/vsw524571/staticsproblem5.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 // the subtype here that contains a Canonical type is Node<NodeStruct<NodeSys<a[]>>>
 

--- a/tests/src/Loader/classloader/methodoverriding/regressions/549411/exploit.cs
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/549411/exploit.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // this is regression test for VSWhidbey 549411
 // The exception was not correctly caught, and so cleanup did not happen in the right way.
 // we make sure exception is caught exactly once

--- a/tests/src/Loader/classloader/methodoverriding/regressions/577403/vsw577403.cs
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/577403/vsw577403.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* 
 
 This is regression test for VSW 577403 

--- a/tests/src/Loader/classloader/methodoverriding/regressions/593884/vsw593884.cs
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/593884/vsw593884.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* 
 
 This is regression test for VSW 593884

--- a/tests/src/Loader/classloader/nesting/coreclr/vsw491577.cs
+++ b/tests/src/Loader/classloader/nesting/coreclr/vsw491577.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // this is regression test for VSW 491577
 // we have nested types (up to depth 73).
 // Loading the 73rd type resulted in AV

--- a/tests/src/Loader/classloader/regressions/101904/test.cs
+++ b/tests/src/Loader/classloader/regressions/101904/test.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // This test should be run with verification on: e.g. caspol -m -cg 1.1 Everything
 // In this test, we have MyType implementing IFoo<T> twice, first indirectly through MyBaseType
 // as IFoo<string>, and second directly as IFoo<int>.

--- a/tests/src/Loader/classloader/regressions/123413/ilib.cs
+++ b/tests/src/Loader/classloader/regressions/123413/ilib.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public interface Int<A,B>

--- a/tests/src/Loader/classloader/regressions/123413/lib.cs
+++ b/tests/src/Loader/classloader/regressions/123413/lib.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Base<A,B>

--- a/tests/src/Loader/classloader/regressions/123413/testint.cs
+++ b/tests/src/Loader/classloader/regressions/123413/testint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 // This test is basically a clone of a regression test

--- a/tests/src/Loader/classloader/regressions/144257/vsw144257.cs
+++ b/tests/src/Loader/classloader/regressions/144257/vsw144257.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // this is regression test for VSW1 144257
 // Loading type C resulted in TypeLoadException
 

--- a/tests/src/Loader/classloader/regressions/245191/nullenum1000.cs
+++ b/tests/src/Loader/classloader/regressions/245191/nullenum1000.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 using System.Collections;

--- a/tests/src/Loader/classloader/regressions/359519/test359519.cs
+++ b/tests/src/Loader/classloader/regressions/359519/test359519.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // this is a regression test for VSWhidbey 359519
 // a struct Root, has a static field that appears earlier in the metadata than a valuetype instance field.
 

--- a/tests/src/Loader/classloader/regressions/405223/vsw405223.cs
+++ b/tests/src/Loader/classloader/regressions/405223/vsw405223.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Regression test for VSW 405223
 // We shouldn't be able to cast from short[] to char[]  or from char[] to short[]
 // since that is the behavior in Everett and we should be consistent in Whidbey.

--- a/tests/src/Loader/classloader/regressions/434481/b434481_genericrecurinit.cs
+++ b/tests/src/Loader/classloader/regressions/434481/b434481_genericrecurinit.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 internal class Program

--- a/tests/src/Loader/classloader/regressions/dev10_851479/dev10_851479.cs
+++ b/tests/src/Loader/classloader/regressions/dev10_851479/dev10_851479.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /// <summary>

--- a/tests/src/Loader/classloader/regressions/dev10_889822/dev10_889822.cs
+++ b/tests/src/Loader/classloader/regressions/dev10_889822/dev10_889822.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/Loader/classloader/regressions/vsw111021/main.cs
+++ b/tests/src/Loader/classloader/regressions/vsw111021/main.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 public class CMain{
     public static int Count = 0;

--- a/tests/src/Loader/classloader/regressions/vsw307137/vsw307137.cs
+++ b/tests/src/Loader/classloader/regressions/vsw307137/vsw307137.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // this is regression test for VSW 307137
 
 /*

--- a/tests/src/Loader/lowlevel/regress/105736/exception.cs
+++ b/tests/src/Loader/lowlevel/regress/105736/exception.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System;
 

--- a/tests/src/Loader/multimodule/dontusenetmodule.cs
+++ b/tests/src/Loader/multimodule/dontusenetmodule.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class B

--- a/tests/src/Loader/versioning/coverage/assemblyattrs.cs
+++ b/tests/src/Loader/versioning/coverage/assemblyattrs.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/Regressions/coreclr/0014/avtest.cs
+++ b/tests/src/Regressions/coreclr/0014/avtest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 class ReflectObj

--- a/tests/src/Regressions/coreclr/0028/thread08-simplified.cs
+++ b/tests/src/Regressions/coreclr/0028/thread08-simplified.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/Regressions/coreclr/0041/body_double.cs
+++ b/tests/src/Regressions/coreclr/0041/body_double.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/Regressions/coreclr/0041/expl_double_1.cs
+++ b/tests/src/Regressions/coreclr/0041/expl_double_1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/Regressions/coreclr/0044/nullable.cs
+++ b/tests/src/Regressions/coreclr/0044/nullable.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Nullable

--- a/tests/src/Regressions/coreclr/0046/istype.cs
+++ b/tests/src/Regressions/coreclr/0046/istype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct MyStruct {}

--- a/tests/src/Regressions/coreclr/0069/date.cs
+++ b/tests/src/Regressions/coreclr/0069/date.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class DateRepro

--- a/tests/src/Regressions/coreclr/0075/largearraytest.cs
+++ b/tests/src/Regressions/coreclr/0075/largearraytest.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* NAME:		LargeArrayTest
  * SDET:		clyon
  * DATE:		2004-03-02

--- a/tests/src/Regressions/coreclr/0077/interlock.cs
+++ b/tests/src/Regressions/coreclr/0077/interlock.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class A

--- a/tests/src/Regressions/coreclr/0080/delete_next_card_table.cs
+++ b/tests/src/Regressions/coreclr/0080/delete_next_card_table.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /* TEST:        delete_next_card_table
  * SDET:        clyon
  * DESCRIPTION: gains 14 blocks in gc.cpp

--- a/tests/src/Regressions/coreclr/0099/abovestacklimit.cs
+++ b/tests/src/Regressions/coreclr/0099/abovestacklimit.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 class Test{

--- a/tests/src/Regressions/coreclr/0138/pow3.cs
+++ b/tests/src/Regressions/coreclr/0138/pow3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //different data types, Int16, Int32, Int64, etc
 using System;
 

--- a/tests/src/Regressions/coreclr/0149/sampleassembly.cs
+++ b/tests/src/Regressions/coreclr/0149/sampleassembly.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestClass

--- a/tests/src/Regressions/coreclr/0198/compex.cs
+++ b/tests/src/Regressions/coreclr/0198/compex.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/Regressions/coreclr/0202/threadculture.cs
+++ b/tests/src/Regressions/coreclr/0202/threadculture.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.Threading;

--- a/tests/src/Regressions/coreclr/0211/genrecur.cs
+++ b/tests/src/Regressions/coreclr/0211/genrecur.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 // Some generally-useful stuff

--- a/tests/src/Regressions/coreclr/0275/marshal.cs
+++ b/tests/src/Regressions/coreclr/0275/marshal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 using System.Security;

--- a/tests/src/Regressions/coreclr/0308/tolower.cs
+++ b/tests/src/Regressions/coreclr/0308/tolower.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class ToLowerRepro

--- a/tests/src/Regressions/coreclr/0341/platformcode.cs
+++ b/tests/src/Regressions/coreclr/0341/platformcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/Regressions/coreclr/0341/usercode.cs
+++ b/tests/src/Regressions/coreclr/0341/usercode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Security;

--- a/tests/src/Regressions/coreclr/0342/unsafe.cs
+++ b/tests/src/Regressions/coreclr/0342/unsafe.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 

--- a/tests/src/Regressions/coreclr/0416/hello.cs
+++ b/tests/src/Regressions/coreclr/0416/hello.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Hello

--- a/tests/src/Regressions/coreclr/0433/assem.cs
+++ b/tests/src/Regressions/coreclr/0433/assem.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 

--- a/tests/src/Regressions/coreclr/0433/test.cs
+++ b/tests/src/Regressions/coreclr/0433/test.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // regression test for CoreCLR #433
 using System;
 

--- a/tests/src/Regressions/coreclr/0487/test.cs
+++ b/tests/src/Regressions/coreclr/0487/test.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // This is a regression test for VSWhidbey 139763
 // Static Constructor introduces bad side effects for generic type instantiated 
 // to reference type in async static event case.

--- a/tests/src/Regressions/coreclr/0570/test570.cs
+++ b/tests/src/Regressions/coreclr/0570/test570.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/Regressions/coreclr/0576/test0576.cs
+++ b/tests/src/Regressions/coreclr/0576/test0576.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/Regressions/coreclr/0582/csgen.1.cs
+++ b/tests/src/Regressions/coreclr/0582/csgen.1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;

--- a/tests/src/Regressions/coreclr/0583/test583.cs
+++ b/tests/src/Regressions/coreclr/0583/test583.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 using System.IO;

--- a/tests/src/Regressions/coreclr/0584/test584.cs
+++ b/tests/src/Regressions/coreclr/0584/test584.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 public class test

--- a/tests/src/Regressions/coreclr/0694/criticalcode.cs
+++ b/tests/src/Regressions/coreclr/0694/criticalcode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using System.Reflection;

--- a/tests/src/Regressions/coreclr/0792/test0792.cs
+++ b/tests/src/Regressions/coreclr/0792/test0792.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/Regressions/coreclr/0828/test0828.cs
+++ b/tests/src/Regressions/coreclr/0828/test0828.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Test

--- a/tests/src/Regressions/coreclr/0829/test0829.cs
+++ b/tests/src/Regressions/coreclr/0829/test0829.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Test

--- a/tests/src/Regressions/coreclr/0857/override.cs
+++ b/tests/src/Regressions/coreclr/0857/override.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Test

--- a/tests/src/Regressions/coreclr/0939/test0939.cs
+++ b/tests/src/Regressions/coreclr/0939/test0939.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class Test

--- a/tests/src/Regressions/coreclr/0968/test968.cs
+++ b/tests/src/Regressions/coreclr/0968/test968.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Resources;
 using System.IO;

--- a/tests/src/Regressions/coreclr/1307/test1307.cs
+++ b/tests/src/Regressions/coreclr/1307/test1307.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 

--- a/tests/src/Regressions/coreclr/1333/testclass.cs
+++ b/tests/src/Regressions/coreclr/1333/testclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Security;

--- a/tests/src/Regressions/coreclr/1333/testinterface.cs
+++ b/tests/src/Regressions/coreclr/1333/testinterface.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Security;

--- a/tests/src/Regressions/coreclr/1337/test1337.cs
+++ b/tests/src/Regressions/coreclr/1337/test1337.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/Regressions/coreclr/1380/forwarder1.cs
+++ b/tests/src/Regressions/coreclr/1380/forwarder1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 public class Foo
 {
 }

--- a/tests/src/Regressions/coreclr/1386/co1727ctor_oo.cs
+++ b/tests/src/Regressions/coreclr/1386/co1727ctor_oo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Globalization;

--- a/tests/src/Regressions/coreclr/1402/test1402.cs
+++ b/tests/src/Regressions/coreclr/1402/test1402.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/Regressions/coreclr/1514/interlockexchange.cs
+++ b/tests/src/Regressions/coreclr/1514/interlockexchange.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/Regressions/coreclr/1534/test1534.cs
+++ b/tests/src/Regressions/coreclr/1534/test1534.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/Regressions/coreclr/1535/test1535.cs
+++ b/tests/src/Regressions/coreclr/1535/test1535.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 

--- a/tests/src/Regressions/coreclr/1549/test1549.cs
+++ b/tests/src/Regressions/coreclr/1549/test1549.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Text;
 

--- a/tests/src/Regressions/coreclr/72162/test72162.cs
+++ b/tests/src/Regressions/coreclr/72162/test72162.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 public class Test72162

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/dev10_535767.cs
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/dev10_535767.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //
 // Basic test for dependent handles.
 //

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/helper.cs
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/helper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/test448035.cs
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/test448035.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/testapis.cs
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/testapis.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;

--- a/tests/src/baseservices/compilerservices/dynamicobjectproperties/testoverrides.cs
+++ b/tests/src/baseservices/compilerservices/dynamicobjectproperties/testoverrides.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 

--- a/tests/src/baseservices/exceptions/generics/genericexceptions01.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions02.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions03.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions04.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions04.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions05.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions06.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions07.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions07.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/genericexceptions08.cs
+++ b/tests/src/baseservices/exceptions/generics/genericexceptions08.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Globalization;
 using System.IO;

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch01.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch02.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch03.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch04.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch04.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch05.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch06.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch07.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch07.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch08.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch08.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch09.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch09.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/nested-try-catch10.cs
+++ b/tests/src/baseservices/exceptions/generics/nested-try-catch10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-finally-struct01.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-finally-struct01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-finally-struct02.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-finally-struct02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-finally-struct03.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-finally-struct03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-finally01.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-finally01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-finally02.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-finally02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-finally03.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-finally03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct01.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct02.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct03.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct04.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct04.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct05.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct06.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct07.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct07.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct08.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct08.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch-struct09.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch-struct09.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch01.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch02.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch03.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch04.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch04.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch05.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch06.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch07.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch07.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch08.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch08.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-catch09.cs
+++ b/tests/src/baseservices/exceptions/generics/try-catch09.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-finally-struct01.cs
+++ b/tests/src/baseservices/exceptions/generics/try-finally-struct01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-finally-struct02.cs
+++ b/tests/src/baseservices/exceptions/generics/try-finally-struct02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-finally-struct03.cs
+++ b/tests/src/baseservices/exceptions/generics/try-finally-struct03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-finally01.cs
+++ b/tests/src/baseservices/exceptions/generics/try-finally01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-finally02.cs
+++ b/tests/src/baseservices/exceptions/generics/try-finally02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/try-finally03.cs
+++ b/tests/src/baseservices/exceptions/generics/try-finally03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public struct ValX0 {}

--- a/tests/src/baseservices/exceptions/generics/typeparameter001.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter001.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter002.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter002.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter003.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter003.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter004.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter004.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter005.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter005.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter006.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter006.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter007.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter007.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter008.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter008.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter009.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter009.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter010.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter010.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter011.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter011.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter012.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter012.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter013.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter013.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter014.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter014.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter015.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter015.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter016.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter016.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter017.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter017.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/generics/typeparameter018.cs
+++ b/tests/src/baseservices/exceptions/generics/typeparameter018.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // <Area> Generics - Expressions - specific catch clauses </Area>
 // <Title> 
 // catch type parameters bound by Exception or a subclass of it in the form catch(T)

--- a/tests/src/baseservices/exceptions/regressions/v4.0/640474/other2.cs
+++ b/tests/src/baseservices/exceptions/regressions/v4.0/640474/other2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 #pragma warning disable 0169

--- a/tests/src/baseservices/exceptions/regressions/v4.0/706099/managedcom.cs
+++ b/tests/src/baseservices/exceptions/regressions/v4.0/706099/managedcom.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 

--- a/tests/src/baseservices/exceptions/regressions/whidbeybeta2/349379/349379.cs
+++ b/tests/src/baseservices/exceptions/regressions/whidbeybeta2/349379/349379.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 namespace TestCS

--- a/tests/src/baseservices/exceptions/regressions/whidbeybeta2/366085/366085.cs
+++ b/tests/src/baseservices/exceptions/regressions/whidbeybeta2/366085/366085.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/106011/106011.cs
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/106011/106011.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 
 using System;

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/293674/securedispatcher.cs
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/293674/securedispatcher.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 namespace Avalon.Secure

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/302680/302680.cs
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/302680/302680.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class xa {

--- a/tests/src/baseservices/exceptions/regressions/whidbeym3.3/302680/data.cs
+++ b/tests/src/baseservices/exceptions/regressions/whidbeym3.3/302680/data.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class x {

--- a/tests/src/baseservices/exceptions/sharedexceptions/emptystacktrace/oomexception01.cs
+++ b/tests/src/baseservices/exceptions/sharedexceptions/emptystacktrace/oomexception01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Diagnostics;
 

--- a/tests/src/baseservices/exceptions/simple/finally.cs
+++ b/tests/src/baseservices/exceptions/simple/finally.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/exceptions/unittests/baseclass.cs
+++ b/tests/src/baseservices/exceptions/unittests/baseclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/baseservices/exceptions/unittests/innerfinally.cs
+++ b/tests/src/baseservices/exceptions/unittests/innerfinally.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/baseservices/exceptions/unittests/rethrowandfinally.cs
+++ b/tests/src/baseservices/exceptions/unittests/rethrowandfinally.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/baseservices/exceptions/unittests/returnfromcatch.cs
+++ b/tests/src/baseservices/exceptions/unittests/returnfromcatch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class TestSet

--- a/tests/src/baseservices/exceptions/unittests/throwincatch.cs
+++ b/tests/src/baseservices/exceptions/unittests/throwincatch.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/baseservices/exceptions/unittests/throwinfinally.cs
+++ b/tests/src/baseservices/exceptions/unittests/throwinfinally.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/baseservices/exceptions/unittests/trace.cs
+++ b/tests/src/baseservices/exceptions/unittests/trace.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 using TestLibrary;

--- a/tests/src/baseservices/exceptions/unittests/trycatchinfinally.cs
+++ b/tests/src/baseservices/exceptions/unittests/trycatchinfinally.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.IO;
 

--- a/tests/src/baseservices/finalization/finalizer.cs
+++ b/tests/src/baseservices/finalization/finalizer.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 /*

--- a/tests/src/baseservices/ilasm_ildasm/regression/dd130885/xlib.cs
+++ b/tests/src/baseservices/ilasm_ildasm/regression/dd130885/xlib.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 public struct myDateTime : IEquatable<myDateTime>
 {

--- a/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey267905/267905.cs
+++ b/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey267905/267905.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey305155/305155.cs
+++ b/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey305155/305155.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 [AttributeUsage(AttributeTargets.Method)]

--- a/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey395914/395914.cs
+++ b/tests/src/baseservices/ilasm_ildasm/regression/vswhidbey395914/395914.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class C {

--- a/tests/src/baseservices/regression/v1/threads/functional/thread/tculturedll.cs
+++ b/tests/src/baseservices/regression/v1/threads/functional/thread/tculturedll.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 namespace TCulture

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/fibonacci.cs
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/fibonacci.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*	==========================================================	*\
 	Fibonacci
 	Fibonacci.Compute		WaitDelegate

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/foo.cs
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/foo.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /*	==========================================================	*\
 	Class:    Foo
 	Copyright (c) Microsoft, 1999

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_threadpoolnullchecks/cs_threadpoolnullchecks.cs
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_threadpoolnullchecks/cs_threadpoolnullchecks.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Threading;

--- a/tests/src/baseservices/regression/v1/threads/hostedscenario/apunload/mgdhelper.cs
+++ b/tests/src/baseservices/regression/v1/threads/hostedscenario/apunload/mgdhelper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/tests/src/baseservices/regression/v1/threads/hostedscenario/apunloadtwo/sample.cs
+++ b/tests/src/baseservices/regression/v1/threads/hostedscenario/apunloadtwo/sample.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/tests/src/baseservices/threading/currentculture/culturechangesecurity.cs
+++ b/tests/src/baseservices/threading/currentculture/culturechangesecurity.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 using System.Globalization;

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread01.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread02.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread03.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread04.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread04.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread05.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread06.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread07.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread07.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread08.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread08.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread09.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread09.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread10.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread11.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread12.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread13.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread14.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread15.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread16.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread17.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread18.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread19.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread19.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread20.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread20.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread21.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread21.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread22.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread22.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread23.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread23.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread24.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread24.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread25.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread25.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread26.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread26.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread27.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread27.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread28.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread28.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread29.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread29.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/syncdelegate/thread30.cs
+++ b/tests/src/baseservices/threading/generics/syncdelegate/thread30.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread01.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread02.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread03.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread04.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread04.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread05.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread06.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread07.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread07.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread08.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread08.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread09.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread09.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread10.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread10.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread11.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread11.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread12.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread12.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread13.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread13.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread14.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread14.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread15.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread15.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread16.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread16.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread17.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread17.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread18.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread18.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread19.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread19.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread20.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread20.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread21.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread21.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread22.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread22.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread23.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread23.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread24.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread24.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread25.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread25.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread26.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread26.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread27.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread27.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread28.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread28.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread29.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread29.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/generics/threadstart/thread30.cs
+++ b/tests/src/baseservices/threading/generics/threadstart/thread30.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/add/checkaddint.cs
+++ b/tests/src/baseservices/threading/interlocked/add/checkaddint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/add/checkaddlong.cs
+++ b/tests/src/baseservices/threading/interlocked/add/checkaddlong.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/add/interlockedaddint.cs
+++ b/tests/src/baseservices/threading/interlocked/add/interlockedaddint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/add/interlockedaddlong.cs
+++ b/tests/src/baseservices/threading/interlocked/add/interlockedaddlong.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/add/interlockedaddlongwithsubtract.cs
+++ b/tests/src/baseservices/threading/interlocked/add/interlockedaddlongwithsubtract.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 //Regression for DevDiv Bugs 48020

--- a/tests/src/baseservices/threading/interlocked/compareexchange/compareexchangelong.cs
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/compareexchangelong.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/compareexchange/compareexchangetclass.cs
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/compareexchangetclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/compareexchange/compareexchangetstring.cs
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/compareexchangetstring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/exchange/exchangeint.cs
+++ b/tests/src/baseservices/threading/interlocked/exchange/exchangeint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/exchange/exchangelong.cs
+++ b/tests/src/baseservices/threading/interlocked/exchange/exchangelong.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/exchange/exchangetclass.cs
+++ b/tests/src/baseservices/threading/interlocked/exchange/exchangetclass.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/interlocked/exchange/exchangetstring.cs
+++ b/tests/src/baseservices/threading/interlocked/exchange/exchangetstring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 using System.Collections;

--- a/tests/src/baseservices/threading/monitor/enter/enternull.cs
+++ b/tests/src/baseservices/threading/monitor/enter/enternull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/exit/exitnull.cs
+++ b/tests/src/baseservices/threading/monitor/exit/exitnull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/pulse/pulsenull.cs
+++ b/tests/src/baseservices/threading/monitor/pulse/pulsenull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/pulseall/pulseallnull.cs
+++ b/tests/src/baseservices/threading/monitor/pulseall/pulseallnull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/unownedlock/enterexitexit.cs
+++ b/tests/src/baseservices/threading/monitor/unownedlock/enterexitexit.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/unownedlock/noenterobject.cs
+++ b/tests/src/baseservices/threading/monitor/unownedlock/noenterobject.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/unownedlock/noenterobjectnew.cs
+++ b/tests/src/baseservices/threading/monitor/unownedlock/noenterobjectnew.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/monitor/unownedlock/noentervaltype.cs
+++ b/tests/src/baseservices/threading/monitor/unownedlock/noentervaltype.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartbool.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartbool.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartbyte.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartcast.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartcast.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartchar.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartchar.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartdecimal.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartdecimal.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartdelegate.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartdelegate.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartdouble.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartdouble.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartfloat.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartfloat.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartgenerics.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartgenerics.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartint.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartlong.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartlong.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartneg1.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartneg1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartneg3.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartneg3.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartneg4.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartneg4.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartnull.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartnull.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartnull2.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartnull2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartobject.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartobject.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartoperations.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartoperations.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartsbyte.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartsbyte.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartshort.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartshort.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartstring.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartstring.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartuint.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartuint.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartulong.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartulong.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/paramthreadstart/threadstartushort.cs
+++ b/tests/src/baseservices/threading/paramthreadstart/threadstartushort.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/readerwriterlockslim/singlereleasewriteddbug71632.cs
+++ b/tests/src/baseservices/threading/readerwriterlockslim/singlereleasewriteddbug71632.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/readerwriterlockslim/tryenterfailureddbugs124485.cs
+++ b/tests/src/baseservices/threading/readerwriterlockslim/tryenterfailureddbugs124485.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/readerwriterlockslim/upgrader.cs
+++ b/tests/src/baseservices/threading/readerwriterlockslim/upgrader.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/regressions/17360/avhelper.cs
+++ b/tests/src/baseservices/threading/regressions/17360/avhelper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.InteropServices;
 using System.Reflection;

--- a/tests/src/baseservices/threading/regressions/576463/576463.cs
+++ b/tests/src/baseservices/threading/regressions/576463/576463.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/regressions/6906/repro.cs
+++ b/tests/src/baseservices/threading/regressions/6906/repro.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Threading;
 

--- a/tests/src/baseservices/threading/stress/sudoku/isudokuboard.cs
+++ b/tests/src/baseservices/threading/stress/sudoku/isudokuboard.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Author: JeffSchw
 // Date:   2/21/2006
 

--- a/tests/src/baseservices/threading/stress/sudoku/isudokugenerator.cs
+++ b/tests/src/baseservices/threading/stress/sudoku/isudokugenerator.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Author: JeffSchw
 // Date:   2/21/2006
 //

--- a/tests/src/baseservices/threading/stress/sudoku/isudokusolver.cs
+++ b/tests/src/baseservices/threading/stress/sudoku/isudokusolver.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Author: SneshaA
 // Date:   3/03/2006
 

--- a/tests/src/baseservices/threading/stress/sudoku/stack.cs
+++ b/tests/src/baseservices/threading/stress/sudoku/stack.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 /***************************
  * Stack.cs
  * Author: Alina Popa

--- a/tests/src/baseservices/threading/threadstatic/threadstatic01.cs
+++ b/tests/src/baseservices/threading/threadstatic/threadstatic01.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //Test is checking the ReserveSlot function
 //   If someone screws up the function we will end up
 //   setting values in the wrong slots and the totals will be wrong

--- a/tests/src/baseservices/threading/threadstatic/threadstatic02.cs
+++ b/tests/src/baseservices/threading/threadstatic/threadstatic02.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //ThreadStatics are only initialized on the first thread to call the constructor
 //   All other threads will generate a NullRefException when accessing the ref types
 

--- a/tests/src/baseservices/threading/threadstatic/threadstatic03.cs
+++ b/tests/src/baseservices/threading/threadstatic/threadstatic03.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //ThreadStatics are only initialized on the first thread to call the constructor
 //   All other threads get the value 0 set for value types
 

--- a/tests/src/baseservices/threading/threadstatic/threadstatic04helper.cs
+++ b/tests/src/baseservices/threading/threadstatic/threadstatic04helper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 public class LIA

--- a/tests/src/baseservices/threading/threadstatic/threadstatic05.cs
+++ b/tests/src/baseservices/threading/threadstatic/threadstatic05.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //ThreadStatics are only initialized on the first thread to call the constructor
 //   All other threads will generate a NullRefException when accessing the ref types
 

--- a/tests/src/baseservices/threading/threadstatic/threadstatic06.cs
+++ b/tests/src/baseservices/threading/threadstatic/threadstatic06.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 //ThreadStatics are only initialized on the first thread to call the constructor
 //   All other threads get the value 0 set for value types
 

--- a/tests/src/baseservices/visibility/target.cs
+++ b/tests/src/baseservices/visibility/target.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Security;

--- a/tests/src/hosting/coreclr/activation/sxshost/delegates.cs
+++ b/tests/src/hosting/coreclr/activation/sxshost/delegates.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 using System.Runtime.InteropServices;

--- a/tests/src/hosting/coreclr/activation/sxshost/usercases.cs
+++ b/tests/src/hosting/coreclr/activation/sxshost/usercases.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/tests/src/hosting/coreclr/activation/sxshost/usercode.cs
+++ b/tests/src/hosting/coreclr/activation/sxshost/usercode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/hosting/samples/hosting/usercode/usercode.cs
+++ b/tests/src/hosting/samples/hosting/usercode/usercode.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Reflection;
 

--- a/tests/src/hosting/samples/resolveevent/usercodedependency/usercodedependency.cs
+++ b/tests/src/hosting/samples/resolveevent/usercodedependency/usercodedependency.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections.Generic;
 using System.Text;

--- a/tests/src/hosting/stress/testset1/csgen.1.cs
+++ b/tests/src/hosting/stress/testset1/csgen.1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;

--- a/tests/src/hosting/stress/testset1/csgen.2.cs
+++ b/tests/src/hosting/stress/testset1/csgen.2.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Collections;
 using System.Runtime.InteropServices;

--- a/tests/src/hosting/stress/testset1/simple1.cs
+++ b/tests/src/hosting/stress/testset1/simple1.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 
 // Do a simple 5 dimensional Jagged array.

--- a/tests/src/reflection/regression/dev10bugs/dev10_629953.cs
+++ b/tests/src/reflection/regression/dev10bugs/dev10_629953.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 // Regression case for:
 //      CoreCLR => Dev10 #629953 - SL4: User Breaking Change: Enum.IsDefined no longer throws an ArgumentException in invalid cases
 //      Desktop => Dev10 #766944 - Breaking change follow up: Enum.IsDefined no longer throws an ArgumentException in invalid cases (This bug should be fixed, if 629953 is fixed for Silverlight)

--- a/tests/src/reflection/regression/dev10bugs/dev10_630880.cs
+++ b/tests/src/reflection/regression/dev10bugs/dev10_630880.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Runtime.CompilerServices;
 using System.Security;

--- a/tests/src/reflection/regression/reflectionrepromasterforsl/helper.cs
+++ b/tests/src/reflection/regression/reflectionrepromasterforsl/helper.cs
@@ -1,3 +1,6 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 using System;
 using System.Security;
 


### PR DESCRIPTION
A number of tests did not have a license header, had the incorrect (old) license header, or had the license header in the wrong place (i.e. not the top of the file). This PR fixes these files to ensure that the correct license header is at the top of the file.

These changes were performed by this script: https://gist.github.com/swgillespie/c4187a147de3e1d814c1 , which works on Python 3.5+.