### PR TITLE
Reenable tests after #2728 workaround in place

### DIFF
--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -11,9 +11,6 @@ JIT/Directed/UnrollLoop/loop6_cs_d/loop6_cs_d.sh
 JIT/Directed/UnrollLoop/loop6_cs_do/loop6_cs_do.sh
 JIT/Directed/UnrollLoop/loop6_cs_r/loop6_cs_r.sh
 JIT/Directed/UnrollLoop/loop6_cs_ro/loop6_cs_ro.sh
-JIT/Directed/coverage/oldtests/Desktop/callipinvoke_il_d/callipinvoke_il_d.sh
-JIT/Directed/coverage/oldtests/Desktop/callipinvoke_il_r/callipinvoke_il_r.sh
-JIT/Directed/coverage/oldtests/callipinvoke/callipinvoke.sh
 JIT/Directed/lifetime/lifetime2/lifetime2.sh
 JIT/Methodical/refany/_dbgstress1/_dbgstress1.sh
 JIT/Methodical/refany/_dbgstress3/_dbgstress3.sh
@@ -30,9 +27,6 @@ JIT/Methodical/varargs/callconv/gc_ctor_il_r/gc_ctor_il_r.sh
 JIT/Methodical/varargs/callconv/val_ctor_il_d/val_ctor_il_d.sh
 JIT/Methodical/varargs/callconv/val_ctor_il_r/val_ctor_il_r.sh
 JIT/Methodical/varargs/misc/Dev10_615402/Dev10_615402.sh
-JIT/Performance/CodeQuality/Serialization/Serialize/Serialize.sh
-JIT/Performance/CodeQuality/Serialization/Deserialize/Deserialize.sh
-JIT/Performance/CodeQuality/Roslyn/CscBench/CscBench.sh
 JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b26323/b26323/b26323.sh
 JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b16423/b16423/b16423.sh
 JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b28901/b28901/b28901.sh

--- a/tests/testsUnsupportedOutsideWindows.txt
+++ b/tests/testsUnsupportedOutsideWindows.txt
@@ -118,9 +118,6 @@ JIT/Methodical/explicit/coverage/seq_short_1_d/seq_short_1_d.sh
 JIT/Methodical/explicit/coverage/seq_short_1_r/seq_short_1_r.sh
 JIT/Methodical/explicit/coverage/seq_val_1_d/seq_val_1_d.sh
 JIT/Methodical/explicit/coverage/seq_val_1_r/seq_val_1_r.sh
-JIT/Performance/CodeQuality/Roslyn/CscBench/CscBench.sh
-JIT/Performance/CodeQuality/Serialization/Deserialize/Deserialize.sh
-JIT/Performance/CodeQuality/Serialization/Serialize/Serialize.sh
 JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32374/b32374/b32374.sh
 JIT/Regression/CLR-x86-JIT/V1.2-M01/b07493/b07493/b07493.sh
 JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b427411/Desktop/b427411/b427411.sh


### PR DESCRIPTION
Reenable CscBench and serialization tests that were failing due to #2728
now that a workaround should be in place.

Also remove callipinvoke tests that were tagged as both "failing" and
"unsupported" on non-Windows platforms.  Leave them in the more specific
"unsupported" file.