### PR TITLE
Fix race condition in Pri 2 tests, and revert those tests to Pri 1

### DIFF
--- a/tests/src/Loader/classloader/nesting/coreclr/VSW491577.csproj
+++ b/tests/src/Loader/classloader/nesting/coreclr/VSW491577.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/Loader/classloader/nesting/coreclr/VSW491577_1.csproj
+++ b/tests/src/Loader/classloader/nesting/coreclr/VSW491577_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>VSW491577.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/Loader/classloader/nesting/coreclr/VSW491577_2.csproj
+++ b/tests/src/Loader/classloader/nesting/coreclr/VSW491577_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>VSW491577.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddInt.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddInt_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddInt_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:0 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddInt_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddInt_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:2147483647 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddLong.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddLong_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddLong_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:-922337203685477 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/CheckAddLong_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/CheckAddLong_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CheckAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/start:922337203685477 /add:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:214748</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_4.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddInt_4.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:-214748</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:-922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/add/InterlockedAddLong_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>InterlockedAddLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVal:100</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:-1</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:12345</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_4.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeLong_4.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>/loops:100 /addVar:-922337203685477</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeTClass.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>"hello world"</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/compareexchange/CompareExchangeTClass_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>CompareExchangeTClass.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>null</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_1.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_2.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>null "This is a string"</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_3.csproj
+++ b/tests/src/baseservices/threading/interlocked/exchange/ExchangeTString_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ExchangeTString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>empty "This is a long string that I am trying to test to be sure that the Exchange can handle this long of a string.  If it can't then that's bad and we will have to fix it."</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartBool.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>true</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartBool_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartBool.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>false</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartByte_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartCast.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartCast.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartCast_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartCast.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>k</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>1234</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_4.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartChar_4.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartChar.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDecimal.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDecimal.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDecimal_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDecimal.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDelegate.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDelegate.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDelegate_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDelegate.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDouble.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDouble.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartDouble_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartDouble.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartFloat.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartFloat.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartFloat_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartFloat.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartGenerics.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartGenerics.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartGenerics_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartGenerics.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartInt_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartLong_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartLong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartObject.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>MyObject</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartObject_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartObject.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>""</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartOperations.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartOperations.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartOperations_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartOperations.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartSByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartSByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartSByte_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartSByte.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartShort_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>" "</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>""</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>null</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_4.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartString_4.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartString.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>MyStringHere</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUInt_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUInt.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartULong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartULong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartULong_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartULong.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort.csproj
@@ -16,7 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
     <CLRTestKind>BuildOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_1.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_1.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>min</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_2.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_2.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>0</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_3.csproj
+++ b/tests/src/baseservices/threading/paramthreadstart/ThreadStartUShort_3.csproj
@@ -6,7 +6,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
@@ -15,7 +14,7 @@
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLRTestKind>RunOnly</CLRTestKind>
-    <CLRTestPriority>2</CLRTestPriority>
+    <CLRTestPriority>1</CLRTestPriority>
     <CLRTestProjectToRun>ThreadStartUShort.csproj</CLRTestProjectToRun>
     <CLRTestExecutionArguments>max</CLRTestExecutionArguments>
   </PropertyGroup>

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -55,7 +55,6 @@
   <PropertyGroup>
     <CLRTestKind Condition="'$(CLRTestKind)' == ' '">BuildAndRun</CLRTestKind>
     <CLRTestPriority Condition="'$(CLRTestPriority)' == ''">0</CLRTestPriority>
-    <_CLRTestInServiceOfHigherPriority Condition="'$(_CLRTestInServiceOfHigherPriority)' == ''">false</_CLRTestInServiceOfHigherPriority>
   </PropertyGroup>
 
 </Project>

--- a/tests/src/dir.targets
+++ b/tests/src/dir.targets
@@ -62,17 +62,16 @@
   <Target Name="CoreCompile" />
   
   <!-- If we are a run-only, that depends on another project, this is the "Build" we use. I.e. build all dependency projects, absolutely.
-  OR, in rare conditions (i.e. non-existant ones so far) a run-only script might be something we depend on, and so we may be asked to
-  build a run only for a higher priority testcase.
   -->
-  <Target Name="Build" Condition="('$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)') Or ('$(_CLRTestInServiceOfHigherPriority)')">
-    <MSBuild Projects="@(ProjectReference)" Properties="_CLRTestInServiceOfHigherPriority=true"/>
+
+  <Target Name="Build" Condition="('$(CLRTestKind)'=='RunOnly') And ('$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)')">
+    <MSBuild Projects="@(ProjectReference)" />
     <MakeDir Condition="'$(CLRTestKind)' == 'RunOnly'" ContinueOnError="false" Directories="$(OutputPath)" />
   </Target>
   
   <!-- We will use an imported build here in the instance that we have source that we need to build, and we are the correct priority...OR if we are being asked to build for
   a test with a higher priority. -->
-  <Import Project="$(ToolsDir)Build.Common.targets" Condition="(Exists('$(ToolsDir)Build.Common.targets') And $(_CLRTestCompilesSource) And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)') Or ('$(_CLRTestInServiceOfHigherPriority)')" />
+  <Import Project="$(ToolsDir)Build.Common.targets" Condition="('$(CLRTestKind)'!='RunOnly') And (Exists('$(ToolsDir)Build.Common.targets') And $(_CLRTestCompilesSource) And '$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)')" />
 
 
   <Import Project="..\override.targets" Condition="Exists('..\override.targets')"/>
@@ -97,7 +96,7 @@
   <Import Project="CLRTest.Execute.targets" />
   <Target Name="CreateExecuteScript" 
           AfterTargets="Build"
-          Condition="'$(GenerateRunScript)' != 'false' And (('$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)') Or '$(_CLRTestInServiceOfHigherPriority)')"
+          Condition="'$(GenerateRunScript)' != 'false' And ('$(CLRTestPriority)' &lt;= '$(CLRTestPriorityToBuild)')"
           DependsOnTargets="GenerateExecutionScriptsInternal" />
 
   <PropertyGroup>
@@ -160,4 +159,3 @@
   </Target>
 
 </Project>
-

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -1,3 +1,4 @@
+baseservices/threading/paramthreadstart/ThreadStartString_1/ThreadStartString_1.sh
 CoreMangLib/cti/system/multicastdelegate/MulticastDelegateCtor/MulticastDelegateCtor.sh
 CoreMangLib/cti/system/runtime/interopservices/marshal/MarshalGetLastWin32Error_PSC/MarshalGetLastWin32Error_PSC.sh
 Interop/ICastable/Castable/Castable.sh


### PR DESCRIPTION
This should fix the race condition that was causing a build break with run-only/build-only .csproj dependencies.