### PR TITLE
Bugfix: incorrect variable to initialize Linux distribution name.

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -64,7 +64,7 @@ esac
 
 # Initialize Linux Distribution name and .NET CLI package name.
 
-initDistroName $OS
+initDistroName $OSName
 if [ "$__DistroName" == "centos" ]; then
     __DOTNET_PKG=dotnet-centos-x64
 fi


### PR DESCRIPTION
The initDistroName() function handles the exact release name
(e.g. ubuntu, centos, rhel, and debian) using the $OS variable
to initialize name of Linux distribution.
However, the variable is redundant.
Let's modify the variable with existing $OSName varialbe.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: Prajwal A N <an.prajwal@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>