### PR TITLE
Resolve time.h header file path for Linux specific CLOCK_MONOTONIC_COARSE

### DIFF
--- a/src/pal/src/configure.cmake
+++ b/src/pal/src/configure.cmake
@@ -360,6 +360,9 @@ check_cxx_source_runs("
 #include <stdlib.h>
 #include <time.h>
 #include <sys/time.h>
+#ifdef __linux__
+#include <linux/sys/time.h>
+#endif
 
 int main()
 {


### PR DESCRIPTION
The Linux-specific CLOCK_MONOTONIC_COARSE is created since Linux 2.6.32
to get the faster time-stamps even though it's not fine-grained time-stamps.
It is declared in /usr/include/linux/time.h (not in /usr/include/time.h)
in Linux operating system.

* http://lxr.free-electrons.com/source/include/uapi/linux/time.h?v=3.10

This patch corrects the include path of the Linux specific time header file
in order to build native coreclr on Ubuntu 14.04.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: Prajwal A N <an.prajwal@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>