### PR TITLE
Don't return pointer to already deleted object

### DIFF
--- a/src/debug/di/process.cpp
+++ b/src/debug/di/process.cpp
@@ -7361,6 +7361,7 @@ CordbUnmanagedThread *CordbProcess::HandleUnmanagedCreateThread(DWORD dwThreadId
         if (!SUCCEEDED(hr))
         {
             delete ut;
+            ut = NULL;
 
             LOG((LF_CORDB, LL_INFO10000, "Failed adding unmanaged thread to process!\n"));
             CORDBSetUnrecoverableError(this, hr, 0);


### PR DESCRIPTION
This was found with Cppcheck. The original code would `delete` the object and then return the pointer to an already deleted object. The latter causes undefined behavior by itself - even when the pointer if not dereferenced.