### PR TITLE
Fix impossible condition

### DIFF
--- a/src/debug/ee/amd64/amd64walker.cpp
+++ b/src/debug/ee/amd64/amd64walker.cpp
@@ -744,7 +744,7 @@ LLegacyPrefix:
             }
 
             // RET
-            if ((lowNibble == 0x2) && (lowNibble == 0x3))
+            if ((lowNibble == 0x2) || (lowNibble == 0x3))
             {
                 break;
             }


### PR DESCRIPTION
This was found with Cppcheck. The original code would never have that `break` executed. Control would fall down to the if-else-if chain and then hit the `break` at end of chain. Nothing serious, just a piece of effectively dead code.