### PR TITLE
Inline refactoring: convert hints into observations

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3098,7 +3098,6 @@ private:
 
     void                impCanInlineNative(int              callsiteNativeEstimate, 
                                            int              calleeNativeSizeEstimate,
-                                           InlineHints      inlineHints,
                                            InlineInfo*      pInlineInfo,
                                            InlineResult*    inlineResult);
 
@@ -8555,7 +8554,6 @@ public:
 #define NATIVE_SIZE_INVALID  (-10000)                
 
     int                     compNativeSizeEstimate;     // The estimated native size of this method.
-    InlineHints             compInlineeHints;           // Inlining hints from the inline candidate.
 
 #ifdef DEBUG   
     CodeSeqSM               fgCodeSeqSm;                // The code sequence state machine used in the inliner.

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -15522,7 +15522,6 @@ int   Compiler::impEstimateCallsiteNativeSize(CORINFO_METHOD_INFO *  methInfo)
 
 void             Compiler::impCanInlineNative(int           callsiteNativeEstimate,
                                               int           calleeNativeSizeEstimate,
-                                              InlineHints   inlineHints,
                                               InlineInfo*   pInlineInfo,     // NULL for static inlining hint for ngen.
                                               InlineResult* inlineResult)
 {
@@ -15546,116 +15545,36 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
     }
 #endif 
 
-
-    //Compute all the static information first.
-    double multiplier = 0.0;
-
-    // Increase the multiplier for instance constructors.
+    // Note if this method is an instance constructor
     if ((info.compFlags & CORINFO_FLG_CONSTRUCTOR) != 0 &&
         (info.compFlags & CORINFO_FLG_STATIC)      == 0)
     {
-        multiplier += 1.5;
-
-#ifdef  DEBUG
-        if (verbose)
-        {
-            printf("\nmultiplier in instance constructors increased to %g.", (double)multiplier);
-        }
-#endif        
-        
+        inlineResult->note(InlineObservation::CALLEE_IS_INSTANCE_CTOR);
     }
 
-    // Bump up the multiplier for methods in promotable struct 
+    // Note if this method's class is a promotable struct
     if ((info.compClassAttr & CORINFO_FLG_VALUECLASS) != 0)        
     {        
         lvaStructPromotionInfo structPromotionInfo;
         lvaCanPromoteStructType(info.compClassHnd, &structPromotionInfo, false);
         if (structPromotionInfo.canPromote)
-        {        
-            multiplier += 3;                               
-
-#ifdef  DEBUG
-            if (verbose)
-            {
-                printf("\nmultiplier in methods of promotable struct increased to %g.", multiplier);
-            }
-#endif        
+        {
+            inlineResult->note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
         }
     }               
 
-    //Check the rest of the static hints
-    if (inlineHints & InlLooksLikeWrapperMethod)
-    {
-        multiplier += 1.0;
-#ifdef  DEBUG
-        if (verbose)
-            printf("\nInline candidate looks like a wrapper method.  Multipler increased to %g.", multiplier);
-#endif 
-    }
-    if (inlineHints & InlArgFeedsConstantTest)
-    {
-        multiplier += 1.0;
-#ifdef  DEBUG
-        if (verbose)
-            printf("\nInline candidate has an arg that feeds a constant test.  Multipler increased to %g.", multiplier);
-#endif 
-    }
-    //Consider making this the same as "always inline"
-    if (inlineHints & InlMethodMostlyLdSt)
-    {
-        multiplier += 3.0;
-#ifdef  DEBUG
-        if (verbose)
-            printf("\nInline candidate is mostly loads and stores.  Multipler increased to %g.", multiplier);
-#endif 
-    }
-#if 0
-    if (inlineHints & InlMethodContainsCondThrow)
-    {
-        multiplier += 1.5;
-#ifdef  DEBUG
-        if (verbose)
-            printf("\nInline candidate contains a conditional throw.  Multipler increased to %g.", multiplier);
-#endif 
-    }
-#endif
-   
 #ifdef FEATURE_SIMD
+
+    // Note if this method is has SIMD args or return value
     if (pInlineInfo != nullptr && pInlineInfo->hasSIMDTypeArgLocalOrReturn)
     {
-        // The default value of the SIMD multiplier is set in clrconfigvalues.h.
-        // The current default value (3) addresses the inlining issues raised by the BepuPhysics benchmark
-        // (which required at least a value of 3), and appears to have a mild positive impact on ConsoleMandel
-        // (which only seemed to require a value of 1 to get the benefit).  For most of the benchmarks, the
-        // effect of different values was within the standard deviation.  This may be a place where future tuning
-        // (with additional benchmarks) would be valuable.
-
-        static ConfigDWORD fJitInlineSIMDMultiplier;
-        int simdMultiplier = fJitInlineSIMDMultiplier.val(CLRConfig::INTERNAL_JitInlineSIMDMultiplier);
-
-        multiplier += simdMultiplier;
-        JITDUMP("\nInline candidate has SIMD type args, locals or return value.  Multipler increased to %g.", multiplier);
+        inlineResult->note(InlineObservation::CALLEE_HAS_SIMD);
     }
+
 #endif // FEATURE_SIMD
 
-    if (inlineHints & InlArgFeedsRngChk)
-    {
-        multiplier += 0.5;
-#ifdef  DEBUG
-        if (verbose)
-            printf("\nInline candidate has arg that feeds range check.  Multipler increased to %g.", multiplier);
-#endif 
-    }
-
-    //Handle the dynamic flags.
-    if (inlineHints & InlIncomingConstFeedsCond)
-    {
-        multiplier += 3;
-#ifdef  DEBUG
-        if (verbose)
-            printf("\nInline candidate has const arg that conditional.  Multipler increased to %g.", multiplier);
-#endif 
-    }
+    // Determine base multiplier given the various observations made so far.
+    double multiplier = inlineResult->determineMultiplier();
 
     //Because it is an if ... else if, keep them in sorted order by multiplier.  This ensures that we always
     //get the maximum multipler.  Also, pInlineInfo is null for static hints.  Make sure that the first case

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -660,7 +660,7 @@ void InlineResult::report()
             if (VERBOSE)
             {
                 const char* obsString = inlGetObservationString(obs);
-                JITDUMP("INLINER: Marking %s as NOINLINE because of %s", callee, obsString);
+                JITDUMP("\nINLINER: Marking %s as NOINLINE because of %s\n", callee, obsString);
             }
 
 #endif  // DEBUG

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -65,18 +65,25 @@ INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",     
 
 // ------ Callee Performance ------- 
 
-INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    PERFORMANCE, CALLEE)
 INLINE_OBSERVATION(LDFLD_STATIC_VALUECLASS,   bool,   "ldsfld of value class",         PERFORMANCE, CALLEE)
 INLINE_OBSERVATION(TOO_MANY_BASIC_BLOCKS,     bool,   "too many basic blocks",         PERFORMANCE, CALLEE)
 INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",             PERFORMANCE, CALLEE)
 
 // ------ Callee Information ------- 
 
+INLINE_OBSERVATION(ARG_FEEDS_CONSTANT_TEST,   bool,   "argument feeds constant test",  INFORMATION, CALLEE)
+INLINE_OBSERVATION(ARG_FEEDS_RANGE_CHECK,     bool,   "argument feeds range check",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(BELOW_ALWAYS_INLINE_SIZE,  bool,   "below ALWAYS_INLINE size",      INFORMATION, CALLEE)
 INLINE_OBSERVATION(CAN_INLINE_IL,             bool,   "IL passes basic checks",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(CHECK_CAN_INLINE_IL,       bool,   "IL passes detailed checks",     INFORMATION, CALLEE)
+INLINE_OBSERVATION(CLASS_PROMOTABLE,          bool,   "promotable value class",        INFORMATION, CALLEE)
+INLINE_OBSERVATION(HAS_SIMD,                  bool,   "has SIMD arg, local, or ret",   INFORMATION, CALLEE)
+INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_INSTANCE_CTOR,          bool,   "instance constructor",          INFORMATION, CALLEE)
+INLINE_OBSERVATION(LOOKS_LIKE_WRAPPER,        bool,   "thin wrapper around a call",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_MOSTLY_LOAD_STORE,      bool,   "method is mostly load/store",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",           INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_BASIC_BLOCKS,    int,    "number of basic blocks",        INFORMATION, CALLEE)
@@ -136,7 +143,8 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 
 INLINE_OBSERVATION(ARGS_OK,                   bool,   "arguments suitable",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(BENEFIT_MULTIPLIER,        double, "benefit multiplier",            INFORMATION, CALLSITE)
-INLINE_OBSERVATION(DEPTH,                     int,    "depth"             ,            INFORMATION, CALLSITE)
+INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds test",  INFORMATION, CALLSITE)
+INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
 INLINE_OBSERVATION(LOCALS_OK,                 bool,   "locals suitable",               INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE_OK,   bool,   "native size estimate ok",       INFORMATION, CALLSITE)

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -13,7 +13,6 @@
 // InlineTarget        - target of a particular observation
 // InlineImpact        - impact of a particular observation
 // InlineObservation   - facts observed when considering an inline
-// InlineHints         - alternative form of observations
 //
 // -- CLASSES --
 //
@@ -228,7 +227,10 @@ public:
     virtual void noteInt(InlineObservation obs, int value) = 0;
     virtual void noteDouble(InlineObservation obs, double value) = 0;
 
-    // Policy decisions
+    // Policy determinations
+    virtual double determineMultiplier() = 0;
+
+    // Policy policies
     virtual bool propagateNeverToRuntime() const = 0;
 
 #ifdef DEBUG
@@ -361,6 +363,12 @@ public:
         inlPolicy->noteDouble(obs, value);
     }
 
+    // Determine the benfit multiplier for this inline.
+    double determineMultiplier()
+    {
+        return inlPolicy->determineMultiplier();
+    }
+
     // Ensure details of this inlining process are appropriately
     // reported when the result goes out of scope.
     ~InlineResult()
@@ -469,29 +477,6 @@ struct InlLclVarInfo
     var_types       lclTypeInfo;
     typeInfo        lclVerTypeInfo;
     bool            lclHasLdlocaOp; // Is there LDLOCA(s) operation on this argument?
-};
-
-// InlineHints are a legacy form of observations.
-
-enum InlineHints
-{
-    //Static inline hints are here.
-    InlLooksLikeWrapperMethod = 0x0001,     // The inline candidate looks like it's a simple wrapper method.
-
-    InlArgFeedsConstantTest   = 0x0002,     // One or more of the incoming arguments feeds into a test
-                                            //against a constant.  This is a good candidate for assertion
-                                            //prop.
-
-    InlMethodMostlyLdSt       = 0x0004,     //This method is mostly loads and stores.
-
-    InlMethodContainsCondThrow= 0x0008,     //Method contains a conditional throw, so it does not bloat the
-                                            //code as much.
-    InlArgFeedsRngChk         = 0x0010,     //Incoming arg feeds an array bounds check.  A good assertion
-                                            //prop candidate.
-
-    //Dynamic inline hints are here.  Only put hints that add to the multiplier in here.
-    InlIncomingConstFeedsCond = 0x0100,     //Incoming argument is constant and feeds a conditional.
-    InlAllDynamicHints        = InlIncomingConstFeedsCond
 };
 
 // InlineInfo provides detailed information about a particular inline candidate.

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -44,18 +44,6 @@ void LegacyPolicy::noteCandidate(InlineObservation obs)
     InlineImpact impact = inlGetImpact(obs);
     assert(impact == InlineImpact::INFORMATION);
 
-    switch (obs)
-    {
-    case InlineObservation::CALLEE_IS_FORCE_INLINE:
-        {
-            inlIsForceInline = true;
-            break;
-        }
-
-    default:
-        break;
-    }
-
     switch (inlDecision)
     {
     case InlineDecision::UNDECIDED:
@@ -69,6 +57,9 @@ void LegacyPolicy::noteCandidate(InlineObservation obs)
         assert(!"Unexpected inlDecision");
         unreached();
     }
+
+    // Now fall through to the general handling.
+    note(obs);
 }
 
 //------------------------------------------------------------------------
@@ -95,7 +86,55 @@ void LegacyPolicy::note(InlineObservation obs)
     // reported via noteFatal.
     assert(impact != InlineImpact::FATAL);
 
-    noteInternal(obs, impact);
+    // Handle most information here
+    bool isInformation = (impact == InlineImpact::INFORMATION);
+    bool propagate = !isInformation;
+
+    if (isInformation)
+    {
+        switch (obs)
+        {
+        case InlineObservation::CALLEE_IS_FORCE_INLINE:
+            inlIsForceInline = true;
+            break;
+        case InlineObservation::CALLEE_IS_INSTANCE_CTOR:
+            inlIsInstanceCtor = true;
+            break;
+        case InlineObservation::CALLEE_CLASS_PROMOTABLE:
+            inlIsFromPromotableValueClass = true;
+            break;
+        case InlineObservation::CALLEE_HAS_SIMD:
+            inlHasSimd = true;
+            break;
+        case InlineObservation::CALLEE_LOOKS_LIKE_WRAPPER:
+            inlLooksLikeWrapperMethod = true;
+            break;
+        case InlineObservation::CALLEE_ARG_FEEDS_CONSTANT_TEST:
+            inlArgFeedsConstantTest = true;
+            break;
+        case InlineObservation::CALLEE_ARG_FEEDS_RANGE_CHECK:
+            inlArgFeedsRangeCheck = true;
+            break;
+        case InlineObservation::CALLEE_IS_MOSTLY_LOAD_STORE:
+            inlMethodIsMostlyLoadStore = true;
+            break;
+        case InlineObservation::CALLEE_HAS_SWITCH:
+            // Pass this one on, it should cause inlining to fail.
+            propagate = true;
+            break;
+        case InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST:
+            inlConstantFeedsConstantTest = true;
+            break;
+        default:
+            // Ignore the remainder for now
+            break;
+        }
+    }
+
+    if (propagate)
+    {
+        noteInternal(obs);
+    }
 }
 
 //------------------------------------------------------------------------
@@ -106,13 +145,10 @@ void LegacyPolicy::note(InlineObservation obs)
 
 void LegacyPolicy::noteFatal(InlineObservation obs)
 {
-    // Check the impact
-    InlineImpact impact = inlGetImpact(obs);
-
     // As a safeguard, all fatal impact must be
     // reported via noteFatal.
-    assert(impact == InlineImpact::FATAL);
-    noteInternal(obs, impact);
+    assert(inlGetImpact(obs) == InlineImpact::FATAL);
+    noteInternal(obs);
     assert(inlDecisionIsFailure(inlDecision));
 }
 
@@ -192,17 +228,11 @@ void LegacyPolicy::noteDouble(InlineObservation obs, double value)
 //
 // Arguments:
 //    obs      - the current obsevation
-//    impact   - impact of the current observation
 
-void LegacyPolicy::noteInternal(InlineObservation obs, InlineImpact impact)
+void LegacyPolicy::noteInternal(InlineObservation obs)
 {
-    // Ignore INFORMATION for now, since policy
-    // is still embedded at the observation sites.
-    if (impact == InlineImpact::INFORMATION)
-    {
-        return;
-    }
-
+    // Note any INFORMATION that reaches here will now cause failure.
+    // Non-fatal INFORMATION observations must be handled higher up.
     InlineTarget target = inlGetTarget(obs);
 
     if (target == InlineTarget::CALLEE)
@@ -271,4 +301,76 @@ void LegacyPolicy::setNever(InlineObservation obs)
         assert(!"Unexpected inlDecision");
         unreached();
     }
+}
+
+//------------------------------------------------------------------------
+// determineMultiplier: determine benefit multiplier for this inline
+//
+// Notes: uses the accumulated set of observations to compute a
+// profitability boost for the inline candidate.
+
+double LegacyPolicy::determineMultiplier()
+{
+    double multiplier = 0;
+
+    // Bump up the multiplier for instance constructors
+
+    if (inlIsInstanceCtor)
+    {
+        multiplier += 1.5;
+        JITDUMP("\nmultiplier in instance constructors increased to %g.", multiplier);
+    }
+
+    // Bump up the multiplier for methods in promotable struct
+
+    if (inlIsFromPromotableValueClass)
+    {
+        multiplier += 3;
+        JITDUMP("\nmultiplier in methods of promotable struct increased to %g.", multiplier);
+    }
+
+#ifdef FEATURE_SIMD
+
+    if (inlHasSimd)
+    {
+        static ConfigDWORD fJitInlineSIMDMultiplier;
+        int simdMultiplier = fJitInlineSIMDMultiplier.val(CLRConfig::INTERNAL_JitInlineSIMDMultiplier);
+
+        multiplier += simdMultiplier;
+        JITDUMP("\nInline candidate has SIMD type args, locals or return value.  Multiplier increased to %g.", multiplier);
+    }
+
+#endif // FEATURE_SIMD
+
+    if (inlLooksLikeWrapperMethod)
+    {
+        multiplier += 1.0;
+        JITDUMP("\nInline candidate looks like a wrapper method.  Multiplier increased to %g.", multiplier);
+    }
+
+    if (inlArgFeedsConstantTest)
+    {
+        multiplier += 1.0;
+        JITDUMP("\nInline candidate has an arg that feeds a constant test.  Multiplier increased to %g.", multiplier);
+    }
+
+    if (inlMethodIsMostlyLoadStore)
+    {
+        multiplier += 3.0;
+        JITDUMP("\nInline candidate is mostly loads and stores.  Multiplier increased to %g.", multiplier);
+    }
+
+    if (inlArgFeedsRangeCheck)
+    {
+        multiplier += 0.5;
+        JITDUMP("\nInline candidate has arg that feeds range check.  Multiplier increased to %g.", multiplier);
+    }
+
+    if (inlConstantFeedsConstantTest)
+    {
+        multiplier += 3.0;
+        JITDUMP("\nInline candidate has const arg that feeds a conditional.  Multiplier increased to %g.", multiplier);
+    }
+
+    return multiplier;
 }

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -40,6 +40,14 @@ public:
         : InlinePolicy()
         , inlCompiler(compiler)
         , inlIsForceInline(false)
+        , inlIsInstanceCtor(false)
+        , inlIsFromPromotableValueClass(false)
+        , inlHasSimd(false)
+        , inlLooksLikeWrapperMethod(false)
+        , inlArgFeedsConstantTest(false)
+        , inlMethodIsMostlyLoadStore(false)
+        , inlArgFeedsRangeCheck(false)
+        , inlConstantFeedsConstantTest(false)
     {
         // empty
     }
@@ -52,7 +60,10 @@ public:
     void noteInt(InlineObservation obs, int value) override;
     void noteDouble(InlineObservation obs, double value) override;
 
-    // Policy decisions
+    // Policy determinations
+    double determineMultiplier() override;
+
+    // Policy policies
     bool propagateNeverToRuntime() const override { return true; }
 
 #ifdef DEBUG
@@ -62,7 +73,7 @@ public:
 private:
 
     // Helper methods
-    void noteInternal(InlineObservation obs, InlineImpact impact);
+    void noteInternal(InlineObservation obs);
     void setFailure(InlineObservation obs);
     void setNever(InlineObservation obs);
 
@@ -78,7 +89,15 @@ private:
 
     // Data members
     Compiler* inlCompiler;
-    bool      inlIsForceInline;
+    bool      inlIsForceInline :1;
+    bool      inlIsInstanceCtor :1;
+    bool      inlIsFromPromotableValueClass :1;
+    bool      inlHasSimd :1;
+    bool      inlLooksLikeWrapperMethod :1;
+    bool      inlArgFeedsConstantTest :1;
+    bool      inlMethodIsMostlyLoadStore :1;
+    bool      inlArgFeedsRangeCheck :1;
+    bool      inlConstantFeedsConstantTest :1;
 };
 
 #endif // _INLINE_POLICY_H_


### PR DESCRIPTION
This change updates the inlining code to use observations in place of
the InlineHints and hint-like things (eg "HasSimd"). A number of new
observations were added in support of this.

The `compInlineeHints` member of the compiler object was removed as
the same information is now tracked by the inline policy. The policy
also now contains most of the weights and combining logic used to
compute the profitabiliy boost for the candidate.

There is one subtle and tricky aspect to the change. For the most part
the hints were ignored during the prejit-root analysis, but the mostly
load-store hint was propagated and influenced the inlines done when
crossgenning mscorlib. See #3482 for more on this particular quirk.

I've preserved this behavior by "passing" the prejit inline result
into `fgFindJumpTargets`. In actuality the result is passed by
temporarily setting the `compInlineResult` compiler member variable.
Then, in `fgFindJumpTargets`, the load-store observation is the only
one not guarded by `compIsForInlining`. In a subsequent change I'll redo
the guards at other observation sites and put the policy aspects of these
observations into the policy object.

This addresses another piece of the work outlined in #3371.