### PR TITLE
Reenable an assert.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2676,12 +2676,8 @@ CodeGen::genStoreRegisterReturnInLclVar(GenTreePtr treeNode)
 
         assert(structDesc.passedInRegisters);
 
-        // TODO-Amd64-Unix: Have Lubo Review this change
-        // Test case JIT.opt.ETW.TailCallCases.TailCallCases has eightByteCount == 1
-        // This occurs with a TYP_STRUCT that is 3 bytes in size
-        // commenting out this assert results in correct codegen
-        //
-        // assert(structDesc.eightByteCount == CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
+        // The type of LclVars of TYP_STRUCT with one eightbyte is normalized.
+        assert(structDesc.eightByteCount == CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_PASS_IN_REGISTERS);
 
         GenTreePtr op1 = treeNode->gtOp.gtOp1;
         genConsumeRegs(op1);


### PR DESCRIPTION
Back in December an assert was commented out in the code (when a big PR
was done).
The issue was that in one case of a tail call test there was a LcLVar with
type of TYP_STRUCT with a single eightbyte.
This should not have happened since in such cses the type of the LclVar is
normalized to the type of the first structs' eightbyte.
Enabling the assert has no effect on the test in question - it passes.
I suspect the issue was resolved sometime back (in January) when we
discovered there were some bad merges in the big PR wiping . As I recall, at least
one was related to a taken out tail call fix.

Fixes issue 3360.