### PR TITLE
Fix CRT linkages for uCRT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -617,8 +617,18 @@ endif (CLR_CMAKE_PLATFORM_UNIX)
 # Libraries
 
 if (WIN32)
+
+    # Define the CRT lib references that link into Desktop imports
     set(STATIC_MT_CRT_LIB  "libcmt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
+    set(STATIC_MT_VCRT_LIB  "libvcruntime$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
     set(STATIC_MT_CPP_LIB  "libcpmt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
+
+    # ARM64_TODO: Enable this for Windows Arm64
+    if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+      # Define the uCRT lib reference
+      set(STATIC_MT_UCRT_LIB  "libucrt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
+    endif()
+
 endif(WIN32)
 
 # Definition directives

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -83,6 +83,14 @@ if(WIN32)
     psapi.lib
     ntdll.lib
   )
+
+  # ARM64_TODO: Enable this for Windows Arm64
+  if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+      list(APPEND SOS_LIBRARY 
+        ${STATIC_MT_VCRT_LIB}
+      )
+  endif()
+    
 else(WIN32)
   add_definitions(-DFEATURE_ENABLE_HARDWARE_EXCEPTIONS)
   add_definitions(-DPAL_STDCPP_COMPAT=1)

--- a/src/dlls/dbgshim/CMakeLists.txt
+++ b/src/dlls/dbgshim/CMakeLists.txt
@@ -52,6 +52,14 @@ if(WIN32)
         version.lib
         psapi.lib
     )
+
+    # ARM64_TODO: Enable this for Windows Arm64
+    if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+        list(APPEND DBGSHIM_LIBRARIES 
+            ${STATIC_MT_VCRT_LIB}
+        )
+    endif()
+  
 else()
     list(APPEND DBGSHIM_LIBRARIES
         coreclrpal

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -87,6 +87,14 @@ if(WIN32)
         user32.lib
         ${STATIC_MT_CRT_LIB}
     )
+
+    # ARM64_TODO: Enable this for Windows Arm64
+    if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+        list(APPEND COREDAC_LIBRARIES 
+          ${STATIC_MT_VCRT_LIB}
+        )
+    endif()
+
 else(WIN32)
     list(APPEND COREDAC_LIBRARIES
         mscorrc_debug

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -63,6 +63,13 @@ if(WIN32)
         ${STATIC_MT_CRT_LIB}
     )
 
+    # ARM64_TODO: Enable this for Windows Arm64
+    if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+        list(APPEND COREDBI_LIBRARIES 
+          ${STATIC_MT_VCRT_LIB}
+        )
+    endif()
+
     target_link_libraries(mscordbi ${COREDBI_LIBRARIES})
 
 elseif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/inc/longfilepathwrappers.h
+++ b/src/inc/longfilepathwrappers.h
@@ -77,12 +77,6 @@ CopyFileExWrapper(
 #endif //FEATURE_PAL
 
 BOOL
-MoveFileWrapper(
-    _In_ LPCWSTR lpExistingFileName,
-    _In_ LPCWSTR lpNewFileName
-    );
-
-BOOL
 MoveFileExWrapper(
     _In_     LPCWSTR lpExistingFileName,
     _In_opt_ LPCWSTR lpNewFileName,

--- a/src/inc/winwrap.h
+++ b/src/inc/winwrap.h
@@ -700,8 +700,8 @@
 #define WszFindNextFile        FindNextFileW
 #define WszCopyFile            CopyFileWrapper
 #define WszCopyFileEx          CopyFileExWrapper
-#define WszMoveFile            MoveFileWrapper
 #define WszMoveFileEx          MoveFileExWrapper
+#define WszMoveFile (lpExistingFileName, lpNewFileName) WszMoveFileEx(lpExistingFileName, lpNewFileName, 0)
 #define WszCreateDirectory     CreateDirectoryWrapper 
 #define WszRemoveDirectory     RemoveDirectoryWrapper
 #define WszCreateHardLink      CreateHardLinkWrapper

--- a/src/tools/GenClrDebugResource/CMakeLists.txt
+++ b/src/tools/GenClrDebugResource/CMakeLists.txt
@@ -4,3 +4,8 @@ add_executable(GenClrDebugResource GenClrDebugResource.cpp)
 target_link_libraries(GenClrDebugResource
     ${STATIC_MT_CRT_LIB}
 )
+
+# ARM64_TODO: Enable this for Windows Arm64
+if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+	target_link_libraries(GenClrDebugResource ${STATIC_MT_VCRT_LIB})
+endif()

--- a/src/tools/InjectResource/CMakeLists.txt
+++ b/src/tools/InjectResource/CMakeLists.txt
@@ -7,3 +7,8 @@ add_executable(InjectResource InjectResource.cpp)
 target_link_libraries(InjectResource
     ${STATIC_MT_CRT_LIB}
 )
+
+# ARM64_TODO: Enable this for Windows Arm64
+if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+    target_link_libraries(InjectResource ${STATIC_MT_VCRT_LIB})
+endif()

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -60,6 +60,11 @@ else()
         ${STATIC_MT_CRT_LIB}
     )
 
+    # ARM64_TODO: Enable this for Windows Arm64
+    if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+        target_link_libraries(crossgen ${STATIC_MT_VCRT_LIB})
+    endif()
+
     # We will generate PDB only for the debug configuration
     install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/crossgen.pdb DESTINATION PDB)
 

--- a/src/utilcode/longfilepathwrappers.cpp
+++ b/src/utilcode/longfilepathwrappers.cpp
@@ -382,56 +382,6 @@ CopyFileWrapper(
     return ret;
 }
 
-
-BOOL
-MoveFileWrapper(
-        _In_ LPCWSTR lpExistingFileName,
-        _In_ LPCWSTR lpNewFileName
-        )
-{
-    CONTRACTL
-    {
-        NOTHROW;
-    SO_TOLERANT;
-    }
-    CONTRACTL_END;
-
-    HRESULT hr  = S_OK;
-    BOOL    ret = FALSE;
-    DWORD lastError;
-
-    BEGIN_SO_INTOLERANT_CODE_NO_THROW_CHECK_THREAD(SetLastError(COR_E_STACKOVERFLOW); return FALSE;)
-
-    EX_TRY
-    {
-        LongPathString Existingpath(LongPathString::Literal, lpExistingFileName);
-        LongPathString Newpath(LongPathString::Literal, lpNewFileName);
-
-        if (SUCCEEDED(LongFile::NormalizePath(Existingpath)) && SUCCEEDED(LongFile::NormalizePath(Newpath)))
-        {
-            ret = MoveFileW(
-                    Existingpath.GetUnicode(),
-                    Newpath.GetUnicode()
-                    );
-        }
-            
-        lastError = GetLastError();
-    }
-    EX_CATCH_HRESULT(hr);
-    END_SO_INTOLERANT_CODE
-
-    if (hr != S_OK )
-    {
-        SetLastError(hr);
-    }
-    else if(ret == FALSE)
-    {
-        SetLastError(lastError);
-    }
-
-    return ret;
-}
-
 BOOL
 MoveFileExWrapper(
         _In_     LPCWSTR lpExistingFileName,


### PR DESCRIPTION
With uCRT, CRT is now split between three libraries (details at https://msdn.microsoft.com/en-us/library/abx4dbyh.aspx and https://blogs.msdn.microsoft.com/vcblog/2015/03/03/introducing-the-universal-crt/):

1) Startup code CRT (e.g. libcmt)
2) Compiler helpers (e.g. libvcruntime)
3) C99 CRT (libucrt)

The first two have to go hand-in-hand. (3) needs to be linked when consuming CRT functions. This change fixes the static linking pieces for the first two. I have validated using DependencyWalker that the correct  linkages are inplace (or not when statically linking).

Also removed the need for MoveFile, redefining it to MoveFileEx.