### PR TITLE
Fix for disabling incremental build for ARM64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,11 +440,11 @@ if (WIN32)
     add_compile_options(/guard:cf) 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /guard:cf")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /guard:cf")
-
-    # Incremental linking with CFG is broken until next VS release.
-    # This needs to be appended to the last for each build type to override the default flag.
-    set(NO_INCREMENTAL_LINKER_FLAGS "/INCREMENTAL:NO")
   endif (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
+
+  # Incremental linking with CFG is broken until next VS release.
+  # This needs to be appended to the last for each build type to override the default flag.
+  set(NO_INCREMENTAL_LINKER_FLAGS "/INCREMENTAL:NO")
 
   # Linker flags
   #


### PR DESCRIPTION
The fix (d58885c9a37d857f10d90f6db7246630d4ce8980) broke ARM64 debug build.
The right fix is to disable such flag for all archs.