### PR TITLE
Improve GetHashCode for IntPtr/UIntPtr on 64-bit.

### DIFF
--- a/src/mscorlib/src/System/IntPtr.cs
+++ b/src/mscorlib/src/System/IntPtr.cs
@@ -109,7 +109,16 @@ namespace System {
     
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
+#if FEATURE_CORECLR
+    #if WIN32
+            return unchecked((int)m_value);
+    #else
+            long l = (long)m_value;
+            return (unchecked((int)l) ^ (int)(l >> 32));
+    #endif
+#else
             return unchecked((int)((long)m_value));
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/UIntPtr.cs
+++ b/src/mscorlib/src/System/UIntPtr.cs
@@ -89,7 +89,16 @@ namespace System {
     
         [System.Security.SecuritySafeCritical]  // auto-generated
         public unsafe override int GetHashCode() {
+#if FEATURE_CORECLR
+    #if WIN32
+            return unchecked((int)m_value);
+    #else
+            ulong l = (ulong)m_value;
+            return (unchecked((int)l) ^ (int)(l >> 32));
+    #endif
+#else
             return unchecked((int)((long)m_value)) & 0x7fffffff;
+#endif
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/tests/src/CoreMangLib/cti/system/intptr/intptrgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/intptr/intptrgethashcode.cs
@@ -34,6 +34,7 @@ public class IntPtrGetHashCode
         retVal = PosTest1() && retVal;
         retVal = PosTest2() && retVal;
         retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
 
         return retVal;
     }
@@ -96,6 +97,42 @@ public class IntPtrGetHashCode
         catch (Exception e)
         {
             TestLibrary.TestFramework.LogError("003", "Unexpected exception: " + e);
+            retVal = false;
+        }
+        return retVal;
+    }
+    
+    public bool PosTest4()
+    {
+        bool retValue = true;
+        try
+        {
+            long addressOne = 0x123456FFFFFFFFL;
+            long addressTwo = 0x654321FFFFFFFFL;
+            System.IntPtr ipOne = new IntPtr(addressOne);
+            System.IntPtr ipTwo = new IntPtr(addressTwo);
+            if (ipOne.GetHashCode() == ipTwo.GetHashCode())
+            {
+                TestLibrary.TestFramework.LogError("004", "expect different hashcodes.")
+                retVal = false;
+            }
+        }
+        catch (System.OverflowException ex)
+        {
+            if (System.IntPtr.Size == 4)
+            {
+                // ok, that's what it should be
+                return retVal;
+            }
+            else
+		   	{
+                TestLibrary.TestFramework.LogError(id, String.Format("IntPtr should not have thrown an OverflowException for value {0}: ", i) + ex.ToString());
+                retVal = false;
+		   	}
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception: " + e);
             retVal = false;
         }
         return retVal;

--- a/tests/src/CoreMangLib/cti/system/uintptr/uintptrgethashcode.cs
+++ b/tests/src/CoreMangLib/cti/system/uintptr/uintptrgethashcode.cs
@@ -37,6 +37,7 @@ public class UIntPtrGetHashCode
         retVal = PosTest1() && retVal;
         retVal = PosTest2() && retVal;
         retVal = PosTest3() && retVal;
+        retVal = PosTest4() && retVal;
 
         return retVal;
     }
@@ -135,7 +136,7 @@ public class UIntPtrGetHashCode
         {
             UInt32 ui = (UInt32)Int32.MaxValue + (UInt32)TestLibrary.Generator.GetInt32(-55);
             uiPtr = new UIntPtr(ui);
-            expectedValue = unchecked((Int32)((Int64)ui)) & 0x7fffffff;
+            expectedValue = unchecked((Int32)((Int64)ui));
 
             actualValue = uiPtr.GetHashCode();
 
@@ -155,6 +156,42 @@ public class UIntPtrGetHashCode
             retVal = false;
         }
 
+        return retVal;
+    }
+    
+    public bool PosTest4()
+    {
+        bool retValue = true;
+        try
+        {
+            long addressOne = 0x123456FFFFFFFFL;
+            long addressTwo = 0x654321FFFFFFFFL;
+            System.UIntPtr ipOne = new UIntPtr(addressOne);
+            System.UIntPtr ipTwo = new UIntPtr(addressTwo);
+            if (ipOne.GetHashCode() == ipTwo.GetHashCode())
+            {
+                TestLibrary.TestFramework.LogError("004", "expect different hashcodes.")
+                retVal = false;
+            }
+        }
+        catch (System.OverflowException ex)
+        {
+            if (System.IntPtr.Size == 4)
+            {
+                // ok, that's what it should be
+                return retVal;
+            }
+            else
+		   	{
+                TestLibrary.TestFramework.LogError(id, String.Format("IntPtr should not have thrown an OverflowException for value {0}: ", i) + ex.ToString());
+                retVal = false;
+		   	}
+        }
+        catch (Exception e)
+        {
+            TestLibrary.TestFramework.LogError("004", "Unexpected exception: " + e);
+            retVal = false;
+        }
         return retVal;
     }
 }


### PR DESCRIPTION
The GetHashCode behavior on IntPtr and UIntPtr truncated the upper 32 bits.
This change uses the behavior of long and ulong, respectively, to generate
the hash code.

Fix #3506