### PR TITLE
Restore linking debug corerun.exe with retail CRT

### DIFF
--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -28,7 +28,7 @@ else()
         oleaut32.lib
         uuid.lib
         user32.lib
-        msvcrt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib
+        msvcrt.lib
     )
 
     # Can't compile on linux yet so only add for windows


### PR DESCRIPTION
The long path support feature modified debug corerun.exe with debug
CRT (msvcrtd.dll). This made it more difficult to use corerun.exe,
since the debug CRT is not always available. It turns out this change
is no longer necessary, so reverting part of the change to link debug
corerun.exe with retail CRT (msvcrt.dll) again.