### PR TITLE
Remove a duplicate address tree consumption.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5803,8 +5803,6 @@ void CodeGen::genCallInstruction(GenTreePtr node)
             }
             else
             {
-                GenTree* addr = target->gtGetOp1();
-                genConsumeAddress(addr);
                 genEmitCall(emitter::EC_INDIR_ARD,
                             methHnd,
                             INDEBUG_LDISASM_COMMA(sigInfo)


### PR DESCRIPTION
In void CodeGen::genEmitCallvoid CodeGen::genEmitCall override that takes
a GenTreeIndir AST we consume the indir addr node. Same thing is done in
codegenxarch.cpp just before this method is called. This PR removes the
later and thus leaving one consumption of the indirTree->Addr() tree.