### PR TITLE
Replace all uses of __LINUX__ with the lower case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,7 +293,6 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   add_definitions(-DPLATFORM_UNIX=1)
 
   if(CLR_CMAKE_PLATFORM_LINUX)
-    add_definitions(-D__LINUX__=1)
     if(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64)
       message("Detected Linux x86_64")
       add_definitions(-DLINUX64)

--- a/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
+++ b/src/coreclr/hosts/unixcoreruncommon/coreruncommon.cpp
@@ -53,7 +53,7 @@ typedef int (*ExecuteAssemblyFunction)(
             const char* managedAssemblyPath,
             unsigned int* exitCode);
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 #define symlinkEntrypointExecutable "/proc/self/exe"
 #elif !defined(__APPLE__)
 #define symlinkEntrypointExecutable "/proc/curproc/exe"
@@ -67,7 +67,7 @@ bool GetEntrypointExecutableAbsolutePath(std::string& entrypointExecutable)
 
     // Get path to the executable for the current process using
     // platform specific means.
-#if defined(__LINUX__)
+#if defined(__linux__)
     // On Linux, fetch the entry point EXE absolute path, inclusive of filename.
     char exe[PATH_MAX];
     ssize_t res = readlink(symlinkEntrypointExecutable, exe, PATH_MAX - 1);

--- a/src/inc/pedecoder.h
+++ b/src/inc/pedecoder.h
@@ -96,7 +96,7 @@ inline CHECK CheckOverflow(RVA value1, COUNT_T value2)
 #define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0x4644
 #elif defined(__FreeBSD__)
 #define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0xADC4
-#elif defined(__LINUX__)
+#elif defined(__linux__)
 #define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0x7B79
 #elif defined(__NetBSD__)
 #define IMAGE_FILE_MACHINE_NATIVE_OS_OVERRIDE 0x1993

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -3488,11 +3488,11 @@ PALIMPORT BOOL PALAPI PAL_VirtualUnwindOutOfProc(CONTEXT *context,
 #define PAL_CS_NATIVE_DATA_SIZE 24
 #elif defined(__hpux__) && (defined(__hppa__) || defined (__ia64__))
 #define PAL_CS_NATIVE_DATA_SIZE 148
-#elif defined(__LINUX__) && defined(_ARM_)
+#elif defined(__linux__) && defined(_ARM_)
 #define PAL_CS_NATIVE_DATA_SIZE 80
-#elif defined(__LINUX__) && defined(_ARM64_)
+#elif defined(__linux__) && defined(_ARM64_)
 #define PAL_CS_NATIVE_DATA_SIZE 116
-#elif defined(__LINUX__) && defined(__x86_64__)
+#elif defined(__linux__) && defined(__x86_64__)
 #define PAL_CS_NATIVE_DATA_SIZE 96
 #elif defined(__NetBSD__) && defined(__amd64__)
 #define PAL_CS_NATIVE_DATA_SIZE 96

--- a/src/pal/inc/pal_mstypes.h
+++ b/src/pal/inc/pal_mstypes.h
@@ -571,7 +571,7 @@ typedef LONG_PTR SSIZE_T, *PSSIZE_T;
 #endif
 
 #ifndef PAL_STDCPP_COMPAT
-#if defined(__APPLE_CC__) || defined(__LINUX__)
+#if defined(__APPLE_CC__) || defined(__linux__)
 #ifdef BIT64
 typedef unsigned long size_t;
 typedef long ptrdiff_t;
@@ -608,7 +608,7 @@ typedef char16_t WCHAR;
 #else // PAL_STDCPP_COMPAT
 
 typedef wchar_t WCHAR;
-#if defined(__LINUX__) 
+#if defined(__linux__) 
 #ifdef BIT64
 typedef long int intptr_t;
 typedef unsigned long int uintptr_t;

--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -47,10 +47,6 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   )
 endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  add_definitions(-D__LINUX__=1)
-endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
-
 add_definitions(-DPLATFORM_UNIX=1)
 add_definitions(-DLP64COMPATIBLE=1)
 add_definitions(-DFEATURE_PAL=1)

--- a/src/pal/src/exception/seh-unwind.cpp
+++ b/src/pal/src/exception/seh-unwind.cpp
@@ -29,15 +29,15 @@ Abstract:
 #include <exception>
     
 #if HAVE_LIBUNWIND_H
-#ifndef __LINUX__
+#ifndef __linux__
 #define UNW_LOCAL_ONLY
-#endif // !__LINUX__       
+#endif // !__linux__       
 #include <libunwind.h>
-#ifdef __LINUX__
+#ifdef __linux__
 #ifdef HAVE_LIBUNWIND_PTRACE
 #include <libunwind-ptrace.h>
 #endif // HAVE_LIBUNWIND_PTRACE
-#endif // __LINUX__    
+#endif // __linux__    
 #endif // HAVE_LIBUNWIND_H
 
 

--- a/src/pal/src/exception/seh.cpp
+++ b/src/pal/src/exception/seh.cpp
@@ -201,7 +201,7 @@ PAL_ERROR SEHEnable(CPalThread *pthrCurrent)
 {
 #if HAVE_MACH_EXCEPTIONS
     return pthrCurrent->EnableMachExceptions();
-#elif __LINUX__ || defined(__FreeBSD__) || defined(__NetBSD__)
+#elif __linux__ || defined(__FreeBSD__) || defined(__NetBSD__)
     // TODO: This needs to be implemented. Cannot put an ASSERT here
     // because it will make other parts of PAL fail.
     return NO_ERROR;
@@ -230,7 +230,7 @@ PAL_ERROR SEHDisable(CPalThread *pthrCurrent)
     return pthrCurrent->DisableMachExceptions();
     // TODO: This needs to be implemented. Cannot put an ASSERT here
     // because it will make other parts of PAL fail.
-#elif __LINUX__ || defined(__FreeBSD__) || defined(__NetBSD__)
+#elif __linux__ || defined(__FreeBSD__) || defined(__NetBSD__)
     return NO_ERROR;
 #else // HAVE_MACH_EXCEPTIONS
 #error not yet implemented

--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -820,7 +820,7 @@ Abstract:
   linux we need to use gettid(). 
 
 --*/
-#if defined(__LINUX__)
+#if defined(__linux__)
 #define THREADSilentGetCurrentThreadId() (SIZE_T)syscall(SYS_gettid)
 #elif defined(__APPLE__)
 inline SIZE_T THREADSilentGetCurrentThreadId() {

--- a/src/pal/src/init/pal.cpp
+++ b/src/pal/src/init/pal.cpp
@@ -670,7 +670,7 @@ BOOL
 PALAPI
 PAL_IsDebuggerPresent()
 {
-#if defined(__LINUX__)
+#if defined(__linux__)
     BOOL debugger_present = FALSE;
     char buf[2048];
 

--- a/src/pal/src/loader/module.cpp
+++ b/src/pal/src/loader/module.cpp
@@ -54,7 +54,7 @@ Abstract:
 #include <sys/types.h>
 #include <sys/mman.h>
 
-#if defined(__LINUX__)
+#if defined(__linux__)
 #include <gnu/lib-names.h>
 #endif
 

--- a/src/pal/src/misc/sysinfo.cpp
+++ b/src/pal/src/misc/sysinfo.cpp
@@ -171,7 +171,7 @@ GetSystemInfo(
 
 #ifdef VM_MAXUSER_ADDRESS
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) VM_MAXUSER_ADDRESS;
-#elif defined(__sun__) || defined(_AIX) || defined(__hppa__) || ( defined (_IA64_) && defined (_HPUX_) ) || defined(__LINUX__)
+#elif defined(__sun__) || defined(_AIX) || defined(__hppa__) || ( defined (_IA64_) && defined (_HPUX_) ) || defined(__linux__)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) -1;
 #elif defined(USERLIMIT)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) USERLIMIT;
@@ -346,7 +346,7 @@ PAL_GetLogicalProcessorCacheSizeFromOS()
 {
     size_t cacheSize = 0;
 
-#if HAVE_SYSCONF && defined(__LINUX__)
+#if HAVE_SYSCONF && defined(__linux__)
     cacheSize = max(cacheSize, sysconf(_SC_LEVEL1_DCACHE_SIZE));
     cacheSize = max(cacheSize, sysconf(_SC_LEVEL1_ICACHE_SIZE));
     cacheSize = max(cacheSize, sysconf(_SC_LEVEL2_CACHE_SIZE));

--- a/src/pal/src/misc/tracepointprovider.cpp
+++ b/src/pal/src/misc/tracepointprovider.cpp
@@ -35,7 +35,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 Initialization logic for LTTng tracepoint providers.
 
 --*/
-#if defined(__LINUX__)
+#if defined(__linux__)
 
 static const char tpLibName[] = "libcoreclrtraceptprovider.so";
 

--- a/src/pal/tests/CMakeLists.txt
+++ b/src/pal/tests/CMakeLists.txt
@@ -10,7 +10,6 @@ endif()
 
 # Compile options
 add_definitions(-DPLATFORM_UNIX=1)
-add_definitions(-D__LINUX__=1)
 add_definitions(-DLP64COMPATIBLE=1)
 add_definitions(-DFEATURE_PAL=1)
 add_definitions(-DCORECLR=1)


### PR DESCRIPTION
According to https://sourceforge.net/p/predef/wiki/OperatingSystems/
(Pre-defined Compiler Macros) and http://www.faqs.org/docs/Linux-HOWTO/GCC-HOWTO.html
(Porting and compiling:Automatically defined symbols), the `__linux__` marcro is the
right way to detect systems based on the Linux kernel and is the POSIX compliant.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>