### PR TITLE
Don't use __cdecl on non x86

### DIFF
--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -71,7 +71,11 @@ void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 
 #endif
 
+#ifdef __i386__
 int __cdecl main(int argc, char *argv[])
+#else
+int main(int argc, char *argv[])
+#endif
 {
 #if !defined(__FreeBSD__) && !defined(__NetBSD__)
     struct sigaction newAction;


### PR DESCRIPTION
https://github.com/dotnet/coreclr/blob/master/src/pal/inc/pal_mstypes.h defines `__cdecl` to mean nothing on all platforms other than x86, however this test does not include that file. As such this changes the test so that on non x86 platforms we do not use `__cdecl`. This fixes #3526

cc: @mikem8361