### PR TITLE
Speed up StringBuilder.Append(char, int) for null chars

### DIFF
--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -582,8 +582,9 @@ namespace System.Text {
                 {
                     if (idx < m_ChunkChars.Length)
                     {
-                        idx++;
-                        --repeatCount;
+                        int diff = m_ChunkChars.Length - idx;
+                        idx += diff;
+                        repeatCount -= diff;
                     }
                     else
                     {

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -558,19 +558,40 @@ namespace System.Text {
                 return this;
             }
             int idx = m_ChunkLength;
-            while (repeatCount > 0)
+            if (value != '\0')
             {
-                if (idx < m_ChunkChars.Length)
+                while (repeatCount > 0)
                 {
-                    m_ChunkChars[idx++] = value;
-                    --repeatCount;
+                    if (idx < m_ChunkChars.Length)
+                    {
+                        m_ChunkChars[idx++] = value;
+                        --repeatCount;
+                    }
+                    else
+                    {
+                        m_ChunkLength = idx;
+                        ExpandByABlock(repeatCount);
+                        Contract.Assert(m_ChunkLength == 0, "Expand should create a new block");
+                        idx = 0;
+                    }
                 }
-                else
+            }
+            else
+            {
+                while (repeatCount > 0)
                 {
-                    m_ChunkLength = idx;
-                    ExpandByABlock(repeatCount);
-                    Contract.Assert(m_ChunkLength == 0, "Expand should create a new block");
-                    idx = 0;
+                    if (idx++ < m_ChunkChars.Length)
+                    {
+                        idx++;
+                        --repeatCount;
+                    }
+                    else
+                    {
+                        m_ChunkLength = idx;
+                        ExpandByABlock(repeatCount);
+                        Contract.Assert(m_ChunkLength == 0, "Expand should create a new block");
+                        idx = 0;
+                    }
                 }
             }
             m_ChunkLength = idx;

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -580,8 +580,9 @@ namespace System.Text {
             {
                 while (repeatCount > 0)
                 {
-                    if (idx++ < m_ChunkChars.Length)
+                    if (idx < m_ChunkChars.Length)
                     {
+                        idx++;
                         --repeatCount;
                     }
                     else

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -582,7 +582,6 @@ namespace System.Text {
                 {
                     if (idx++ < m_ChunkChars.Length)
                     {
-                        idx++;
                         --repeatCount;
                     }
                     else


### PR DESCRIPTION
Supplants #3277 by addressing the issue at its root; if a null char is passed into `Append`, we don't have to fill the array with it since the memory is already zero-initialized.