### PR TITLE
ARM: Remove Distro/OS that have not been tested

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -212,13 +212,7 @@ isMSBuildOnNETCoreSupported()
         if [ "$__BuildOS" == "Linux" ]; then
             if [ "$__DistroName" == "ubuntu" ]; then
                 __isMSBuildOnNETCoreSupported=1
-            elif [ "$__DistroName" == "rhel" ]; then
-                __isMSBuildOnNETCoreSupported=1
-            elif [ "$__DistroName" == "debian" ]; then
-                __isMSBuildOnNETCoreSupported=1
             fi
-        elif [ "$__BuildOS" == "OSX" ]; then
-            __isMSBuildOnNETCoreSupported=1
         fi
 
     fi


### PR DESCRIPTION
Let's remove rest Distro/OSes in isMSBuildOnNETCoreSupported() 
to keep only the Distro/OS that have been tested
until someone actually start using/testing CoreCLR on RHEL, Debian, OSX, and so on.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>