### PR TITLE
ARM64: Fix for handling GC register for call site

### DIFF
--- a/src/jit/emitinl.h
+++ b/src/jit/emitinl.h
@@ -252,72 +252,105 @@ ssize_t             emitter::emitGetInsAmdAny(instrDesc *id)
     assert(REGNUM_BITS >= 3);
     encodeMask = 0;
 
-    if  (regmask & RBM_ESI)
-                             encodeMask |= 0x01;
-    if  (regmask & RBM_EDI)     
-                             encodeMask |= 0x02;
-    if  (regmask & RBM_EBX)     
-                             encodeMask |= 0x04;
+    if ((regmask & RBM_ESI) != RBM_NONE)
+        encodeMask |= 0x01;
+    if ((regmask & RBM_EDI) != RBM_NONE)
+        encodeMask |= 0x02;
+    if ((regmask & RBM_EBX) != RBM_NONE)
+        encodeMask |= 0x04;
 
     id->idReg1((regNumber)encodeMask);  // Save in idReg1
-#endif
 
-#ifdef _TARGET_AMD64_
+#elif defined(_TARGET_AMD64_)
     assert(REGNUM_BITS >= 4);
     encodeMask = 0;
 
-    if  (regmask & RBM_RSI)
-                             encodeMask |= 0x01;
-    if  (regmask & RBM_RDI)     
-                             encodeMask |= 0x02;
-    if  (regmask & RBM_RBX)     
-                             encodeMask |= 0x04;
-    if  (regmask & RBM_RBP)     
-                             encodeMask |= 0x08;
+    if ((regmask & RBM_RSI) != RBM_NONE)
+        encodeMask |= 0x01;
+    if ((regmask & RBM_RDI) != RBM_NONE)
+        encodeMask |= 0x02;
+    if ((regmask & RBM_RBX) != RBM_NONE)
+        encodeMask |= 0x04;
+    if ((regmask & RBM_RBP) != RBM_NONE)
+        encodeMask |= 0x08;
 
     id->idReg1((regNumber)encodeMask);  // Save in idReg1
 
     encodeMask = 0;
 
-    if  (regmask & RBM_R12)
-                             encodeMask |= 0x01;
-    if  (regmask & RBM_R13)     
-                             encodeMask |= 0x02;
-    if  (regmask & RBM_R14)     
-                             encodeMask |= 0x04;
-    if  (regmask & RBM_R15)     
-                             encodeMask |= 0x08;
+    if ((regmask & RBM_R12) != RBM_NONE)
+        encodeMask |= 0x01;
+    if ((regmask & RBM_R13) != RBM_NONE)
+        encodeMask |= 0x02;
+    if ((regmask & RBM_R14) != RBM_NONE)
+        encodeMask |= 0x04;
+    if ((regmask & RBM_R15) != RBM_NONE)
+        encodeMask |= 0x08;
 
     id->idReg2((regNumber)encodeMask);  // Save in idReg2
-#endif
 
-#ifdef _TARGET_ARM_
+#elif defined(_TARGET_ARM_)
     assert(REGNUM_BITS >= 4);
     encodeMask = 0;
 
-    if  (regmask & RBM_R4)
-                             encodeMask |= 0x01;
-    if  (regmask & RBM_R5)     
-                             encodeMask |= 0x02;
-    if  (regmask & RBM_R6)     
-                             encodeMask |= 0x04;
-    if  (regmask & RBM_R7)     
-                             encodeMask |= 0x08;
+    if ((regmask & RBM_R4) != RBM_NONE)
+        encodeMask |= 0x01;
+    if ((regmask & RBM_R5) != RBM_NONE)
+        encodeMask |= 0x02;
+    if ((regmask & RBM_R6) != RBM_NONE)
+        encodeMask |= 0x04;
+    if ((regmask & RBM_R7) != RBM_NONE)
+        encodeMask |= 0x08;
 
     id->idReg1((regNumber)encodeMask);  // Save in idReg1
 
     encodeMask = 0;
 
-    if  (regmask & RBM_R8)
-                             encodeMask |= 0x01;
-    if  (regmask & RBM_R9)     
-                             encodeMask |= 0x02;
-    if  (regmask & RBM_R10)     
-                             encodeMask |= 0x04;
-    if  (regmask & RBM_R11)     
-                             encodeMask |= 0x08;
+    if ((regmask & RBM_R8) != RBM_NONE)
+        encodeMask |= 0x01;
+    if ((regmask & RBM_R9) != RBM_NONE)
+        encodeMask |= 0x02;
+    if ((regmask & RBM_R10) != RBM_NONE)
+        encodeMask |= 0x04;
+    if ((regmask & RBM_R11) != RBM_NONE)
+        encodeMask |= 0x08;
 
      id->idReg2((regNumber)encodeMask);  // Save in idReg2
+
+#elif defined(_TARGET_ARM64_)
+     assert(REGNUM_BITS >= 5);
+     encodeMask = 0;
+
+     if ((regmask & RBM_R19) != RBM_NONE)
+         encodeMask |= 0x01;
+     if ((regmask & RBM_R20) != RBM_NONE)
+         encodeMask |= 0x02;
+     if ((regmask & RBM_R21) != RBM_NONE)
+         encodeMask |= 0x04;
+     if ((regmask & RBM_R22) != RBM_NONE)
+         encodeMask |= 0x08;
+     if ((regmask & RBM_R23) != RBM_NONE)
+         encodeMask |= 0x10;
+
+     id->idReg1((regNumber)encodeMask);  // Save in idReg1
+
+     encodeMask = 0;
+
+     if ((regmask & RBM_R24) != RBM_NONE)
+         encodeMask |= 0x01;
+     if ((regmask & RBM_R25) != RBM_NONE)
+         encodeMask |= 0x02;
+     if ((regmask & RBM_R26) != RBM_NONE)
+         encodeMask |= 0x04;
+     if ((regmask & RBM_R27) != RBM_NONE)
+         encodeMask |= 0x08;
+     if ((regmask & RBM_R28) != RBM_NONE)
+         encodeMask |= 0x10;
+
+     id->idReg2((regNumber)encodeMask);  // Save in idReg2
+
+#else
+    NYI("unknown target");
 #endif
 }
 
@@ -330,62 +363,90 @@ ssize_t             emitter::emitGetInsAmdAny(instrDesc *id)
     assert(REGNUM_BITS >= 3);
     encodeMask = id->idReg1();
 
-    if  (encodeMask & 0x01)
-                             regmask |= RBM_ESI;
-    if  (encodeMask & 0x02)     
-                             regmask |= RBM_EDI;
-    if  (encodeMask & 0x04)     
-                             regmask |= RBM_EBX;
-#endif
-
-#ifdef _TARGET_AMD64_
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_ESI;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_EDI;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_EBX;
+#elif defined(_TARGET_AMD64_)
     assert(REGNUM_BITS >= 4);
     encodeMask = id->idReg1();
 
-    if  (encodeMask & 0x01)
-                             regmask |= RBM_RSI;
-    if  (encodeMask & 0x02)     
-                             regmask |= RBM_RDI;
-    if  (encodeMask & 0x04)     
-                             regmask |= RBM_RBX;
-    if  (encodeMask & 0x08)     
-                             regmask |= RBM_RBP;
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_RSI;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_RDI;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_RBX;
+    if ((encodeMask & 0x08) != 0)
+        regmask |= RBM_RBP;
 
     encodeMask = id->idReg2();
 
-    if  (encodeMask & 0x01)
-                             regmask |= RBM_R12;
-    if  (encodeMask & 0x02)     
-                             regmask |= RBM_R13;
-    if  (encodeMask & 0x04)     
-                             regmask |= RBM_R14;
-    if  (encodeMask & 0x08)     
-                             regmask |= RBM_R15;
-#endif
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_R12;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_R13;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_R14;
+    if ((encodeMask & 0x08) != 0)
+        regmask |= RBM_R15;
 
-#ifdef _TARGET_ARM_
+#elif defined(_TARGET_ARM_)
     assert(REGNUM_BITS >= 4);
     encodeMask = id->idReg1();
 
-    if  (encodeMask & 0x01)
-                             regmask |= RBM_R4;
-    if  (encodeMask & 0x02)     
-                             regmask |= RBM_R5;
-    if  (encodeMask & 0x04)     
-                             regmask |= RBM_R6;
-    if  (encodeMask & 0x08)     
-                             regmask |= RBM_R7;
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_R4;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_R5;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_R6;
+    if ((encodeMask & 0x08) != 0)
+        regmask |= RBM_R7;
 
     encodeMask = id->idReg2();
 
-    if  (encodeMask & 0x01)
-                             regmask |= RBM_R8;
-    if  (encodeMask & 0x02)     
-                             regmask |= RBM_R9;
-    if  (encodeMask & 0x04)     
-                             regmask |= RBM_R10;
-    if  (encodeMask & 0x08)     
-                             regmask |= RBM_R11;
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_R8;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_R9;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_R10;
+    if ((encodeMask & 0x08) != 0)
+        regmask |= RBM_R11;
+
+#elif defined(_TARGET_ARM64_)
+    assert(REGNUM_BITS >= 5);
+    encodeMask = id->idReg1();
+
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_R19;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_R20;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_R21;
+    if ((encodeMask & 0x08) != 0)
+        regmask |= RBM_R22;
+    if ((encodeMask & 0x10) != 0)
+        regmask |= RBM_R23;
+
+    encodeMask = id->idReg2();
+
+    if ((encodeMask & 0x01) != 0)
+        regmask |= RBM_R24;
+    if ((encodeMask & 0x02) != 0)
+        regmask |= RBM_R25;
+    if ((encodeMask & 0x04) != 0)
+        regmask |= RBM_R26;
+    if ((encodeMask & 0x08) != 0)
+        regmask |= RBM_R27;
+    if ((encodeMask & 0x10) != 0)
+        regmask |= RBM_R28;
+
+#else
+    NYI("unknown target");
 #endif
 
     return  regmask;

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -349,8 +349,7 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
         case GT_MUL:
             if (tree->gtOverflow())
             {
-                // Need a register different from target reg to check
-                // for signed overflow.
+                // Need a register different from target reg to check for overflow.
                 info->internalIntCount = 2;
             }
             __fallthrough;

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -5135,7 +5135,7 @@ WorkingDir=JIT\Methodical\VT\port\_speed_dbglcs
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [largeobjectalloc.exe_2577]
 RelativePath=GC\Coverage\LargeObjectAlloc\LargeObjectAlloc.exe
 WorkingDir=GC\Coverage\LargeObjectAlloc
@@ -7578,7 +7578,7 @@ WorkingDir=JIT\Methodical\Arrays\lcs\_speed_rellcs
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [opcodesclt.exe_1700]
 RelativePath=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesClt\OpCodesClt.exe
 WorkingDir=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesClt
@@ -19457,7 +19457,7 @@ WorkingDir=JIT\Methodical\Arrays\misc\_speed_dbggcarr
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_PASS
 [arraysort1b.exe_334]
 RelativePath=CoreMangLib\cti\system\array\ArraySort1b\ArraySort1b.exe
 WorkingDir=CoreMangLib\cti\system\array\ArraySort1b
@@ -23384,7 +23384,7 @@ WorkingDir=JIT\Methodical\Arrays\lcs\_speed_dbglcs
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PAS
 [iconvertibletoint16.exe_1282]
 RelativePath=CoreMangLib\cti\system\iconvertible\IConvertibleToInt16\IConvertibleToInt16.exe
 WorkingDir=CoreMangLib\cti\system\iconvertible\IConvertibleToInt16
@@ -24497,7 +24497,7 @@ WorkingDir=JIT\Methodical\Arrays\lcs\_il_dbglcs_ldlen
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [converttostring1.exe_840]
 RelativePath=CoreMangLib\cti\system\convert\ConvertToString1\ConvertToString1.exe
 WorkingDir=CoreMangLib\cti\system\convert\ConvertToString1
@@ -28529,7 +28529,7 @@ WorkingDir=JIT\Methodical\Arrays\misc\_speed_relgcarr
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;NEED_TRIAGE
+Categories=JIT;EXPECTED_PASS
 [threadstartcast_2.exe_185]
 RelativePath=baseservices\threading\paramthreadstart\ThreadStartCast_2\ThreadStartCast_2.exe
 WorkingDir=baseservices\threading\paramthreadstart\ThreadStartCast_2
@@ -32351,7 +32351,7 @@ WorkingDir=JIT\Methodical\Arrays\lcs\_speed_dbglcsbas
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [cgrecurseaca_ro.exe_3451]
 RelativePath=JIT\jit64\opt\cg\CGRecurse\CGRecurseACA_ro\CGRecurseACA_ro.exe
 WorkingDir=JIT\jit64\opt\cg\CGRecurse\CGRecurseACA_ro
@@ -35088,7 +35088,7 @@ WorkingDir=JIT\Methodical\Arrays\lcs\_speed_rellcsbas
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [b56349.exe_5292]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56349\b56349\b56349.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56349\b56349
@@ -37433,7 +37433,7 @@ WorkingDir=JIT\Methodical\Arrays\lcs\_il_rellcs_ldlen
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [initobj.exe_2990]
 RelativePath=JIT\Directed\PREFIX\unaligned\2\initobj\initobj.exe
 WorkingDir=JIT\Directed\PREFIX\unaligned\2\initobj
@@ -39414,7 +39414,7 @@ WorkingDir=JIT\Methodical\VT\port\_speed_rellcs
 MaxAllowedDurationSeconds=600
 HostStyle=Any
 Expected=100
-Categories=JIT;EXPECTED_FAIL;ISSUE_2731
+Categories=JIT;EXPECTED_PASS
 [opcodescgt.exe_1697]
 RelativePath=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesCgt\OpCodesCgt.exe
 WorkingDir=CoreMangLib\cti\system\reflection\emit\opcodes\OpCodesCgt


### PR DESCRIPTION
This fixes https://github.com/dotnet/coreclr/issues/2731.
Looking at GC heap corruption, JIT incorrectly reports the live range of
GC references so GC swept the live objects.
The issue was when JIT emits call instruction, GC live register is not
processed at all, which JIT treated them as dead.
The fix is to implement this missing part for ARM64.