### PR TITLE
Remove the the RBM_LOWINT define. Change the LsraLimitSmallIntSet to have a better representation of callee saved

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -432,7 +432,13 @@ private:
     // Hence the "SmallFPSet" has 5 elements.
 
 #if defined(_TARGET_AMD64_)
-    static const regMaskTP  LsraLimitSmallIntSet = RBM_LOWINT;
+#ifdef UNIX_AMD64_ABI
+    // On System V the RDI and RSI are not callee saved. Use R12 ans R13 as callee saved registers.
+    static const regMaskTP  LsraLimitSmallIntSet = (RBM_EAX | RBM_ECX | RBM_EBX | RBM_ETW_FRAMED_EBP | RBM_R12 | RBM_R13);
+#else // !UNIX_AMD64_ABI
+    // On Windows Amd64 use the RDI and RSI as callee saved registers.
+    static const regMaskTP  LsraLimitSmallIntSet = (RBM_EAX | RBM_ECX | RBM_EBX | RBM_ETW_FRAMED_EBP | RBM_ESI | RBM_EDI);
+#endif // !UNIX_AMD64_ABI
     static const regMaskTP  LsraLimitSmallFPSet  = (RBM_XMM0 | RBM_XMM1 | RBM_XMM2 | RBM_XMM6 | RBM_XMM7 );
 #elif defined(_TARGET_ARM_)
     static const regMaskTP  LsraLimitSmallIntSet = (RBM_R0|RBM_R1|RBM_R2|RBM_R3|RBM_R4);

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -788,11 +788,6 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define RBM_CALLEE_TRASH_NOGC   RBM_CALLEE_TRASH
 
   #define RBM_ALLINT              (RBM_INT_CALLEE_SAVED | RBM_INT_CALLEE_TRASH)
-#ifdef UNIX_AMD64_ABI
-  #define RBM_LOWINT              (RBM_EAX|RBM_RDI|RBM_RSI|RBM_EDX|RBM_ECX|RBM_EBX|RBM_ETW_FRAMED_EBP)
-#else // !UNIX_AMD64_ABI
-  #define RBM_LOWINT              (RBM_EAX|RBM_ECX|RBM_EBX|RBM_ETW_FRAMED_EBP|RBM_ESI|RBM_EDI)
-#endif // !UNIX_AMD64_ABI
 
 #if 0
 #define REG_VAR_ORDER            REG_EAX,REG_EDX,REG_ECX,REG_ESI,REG_EDI,REG_EBX,REG_ETW_FRAMED_EBP_LIST \


### PR DESCRIPTION
register for stress mode testing on System V OSs.

Remove the register mask for RBM_LOWINT. Change the LsraLimitSmallIntSet for System V OSs to provide a good ratio between caller and calles saved register for the purposes of stress
testing.
