### PR TITLE
Inline refactoring: revise candidacy determination

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5059,11 +5059,6 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
 
         if (compIsForInlining())
         {
-            if (forceInline)
-            {
-                compInlineResult->noteCandidate(InlineObservation::CALLEE_IS_FORCE_INLINE);
-            }
-
             compInlineResult->noteInt(InlineObservation::CALLEE_NUMBER_OF_BASIC_BLOCKS, fgBBcount);
 
             if (compInlineResult->isFailure())

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -544,7 +544,8 @@ InlineResult::InlineResult(Compiler*    compiler,
     , inlReported(false)
 {
     // Set the policy
-    inlPolicy = InlinePolicy::getPolicy(compiler);
+    const bool isPrejitRoot = false;
+    inlPolicy = InlinePolicy::getPolicy(compiler, isPrejitRoot);
 
     // Get method handle for caller
     inlCaller = inlCompiler->info.compMethodHnd;
@@ -558,7 +559,7 @@ InlineResult::InlineResult(Compiler*    compiler,
 
 //------------------------------------------------------------------------
 // InlineResult: Construct an InlineResult to evaluate a particular
-// method as a possible inline candidate.
+// method as a possible inline candidate, while prejtting.
 //
 // Arguments:
 //    compiler - the compiler instance doing the prejitting
@@ -584,7 +585,8 @@ InlineResult::InlineResult(Compiler*              compiler,
     , inlReported(false)
 {
     // Set the policy
-    inlPolicy = InlinePolicy::getPolicy(compiler);
+    const bool isPrejitRoot = true;
+    inlPolicy = InlinePolicy::getPolicy(compiler, isPrejitRoot);
 }
 
 //------------------------------------------------------------------------

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -74,20 +74,19 @@ INLINE_OBSERVATION(TOO_MUCH_IL,               bool,   "too many il bytes",      
 INLINE_OBSERVATION(ARG_FEEDS_CONSTANT_TEST,   bool,   "argument feeds constant test",  INFORMATION, CALLEE)
 INLINE_OBSERVATION(ARG_FEEDS_RANGE_CHECK,     bool,   "argument feeds range check",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(BELOW_ALWAYS_INLINE_SIZE,  bool,   "below ALWAYS_INLINE size",      INFORMATION, CALLEE)
-INLINE_OBSERVATION(CAN_INLINE_IL,             bool,   "IL passes basic checks",        INFORMATION, CALLEE)
-INLINE_OBSERVATION(CHECK_CAN_INLINE_IL,       bool,   "IL passes detailed checks",     INFORMATION, CALLEE)
 INLINE_OBSERVATION(CLASS_PROMOTABLE,          bool,   "promotable value class",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SIMD,                  bool,   "has SIMD arg, local, or ret",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(HAS_SWITCH,                bool,   "has switch",                    INFORMATION, CALLEE)
+INLINE_OBSERVATION(IL_CODE_SIZE,              int,    "number of bytes of IL",         INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_DISCRETIONARY_INLINE,   bool,   "can inline, check heuristics",  INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_INSTANCE_CTOR,          bool,   "instance constructor",          INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_MOSTLY_LOAD_STORE,      bool,   "method is mostly load/store",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(LOOKS_LIKE_WRAPPER,        bool,   "thin wrapper around a call",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
-INLINE_OBSERVATION(IS_MOSTLY_LOAD_STORE,      bool,   "method is mostly load/store",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",           INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_BASIC_BLOCKS,    int,    "number of basic blocks",        INFORMATION, CALLEE)
-INLINE_OBSERVATION(NUMBER_OF_IL_BYTES,        int,    "number of bytes of IL",         INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_LOCALS,          int,    "number of locals",              INFORMATION, CALLEE)
 
 // ------ Caller Corectness ------- 
@@ -141,11 +140,9 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 
 // ------ Call Site Information ------- 
 
-INLINE_OBSERVATION(ARGS_OK,                   bool,   "arguments suitable",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(BENEFIT_MULTIPLIER,        double, "benefit multiplier",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds test",  INFORMATION, CALLSITE)
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
-INLINE_OBSERVATION(LOCALS_OK,                 bool,   "locals suitable",               INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE_OK,   bool,   "native size estimate ok",       INFORMATION, CALLSITE)
 

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -36,10 +36,11 @@ class LegacyPolicy : public InlinePolicy
 public:
 
     // Construct a LegacyPolicy
-    LegacyPolicy(Compiler* compiler)
-        : InlinePolicy()
+    LegacyPolicy(Compiler* compiler, bool isPrejitRoot)
+        : InlinePolicy(isPrejitRoot)
         , inlCompiler(compiler)
         , inlIsForceInline(false)
+        , inlIsForceInlineKnown(false)
         , inlIsInstanceCtor(false)
         , inlIsFromPromotableValueClass(false)
         , inlHasSimd(false)
@@ -53,10 +54,9 @@ public:
     }
 
     // Policy observations
-    void noteCandidate(InlineObservation obs) override;
     void noteSuccess() override;
-    void note(InlineObservation obs) override;
     void noteFatal(InlineObservation obs) override;
+    void noteBool(InlineObservation obs, bool value) override;
     void noteInt(InlineObservation obs, int value) override;
     void noteDouble(InlineObservation obs, double value) override;
 
@@ -74,15 +74,9 @@ private:
 
     // Helper methods
     void noteInternal(InlineObservation obs);
+    void setCandidate(InlineObservation obs);
     void setFailure(InlineObservation obs);
     void setNever(InlineObservation obs);
-
-    // True if this policy is being used to scan a method during
-    // prejitting.
-    bool isPrejitScan() const 
-    { 
-        return !inlCompiler->compIsForInlining(); 
-    }
 
     // Constants
     const unsigned MAX_BASIC_BLOCKS = 5;
@@ -90,6 +84,7 @@ private:
     // Data members
     Compiler* inlCompiler;
     bool      inlIsForceInline :1;
+    bool      inlIsForceInlineKnown :1;
     bool      inlIsInstanceCtor :1;
     bool      inlIsFromPromotableValueClass :1;
     bool      inlHasSimd :1;


### PR DESCRIPTION
Rework the code to determine the key aspects of candidacy up front
rather than figuring it out eventually. In particular this ensures
that the two stages of evaulation for inlines both start at the same
point for candidates.

This will help streamline subsequent work to move the state machine
into the policy, since the state machine is only needed for the
case where the candidate is a discretionary inline, and the policy
now tracks this directly.

For the `LegacyPolicy`, if an inline is both smaller than the always
inline size and marked force inline, attribute its inlining to its
small size.

Remove bulk of the of the "evaluation in progress" candidate
observations since they don't add much value. As a result `noteCandidate`
is not needed as an external API, and can be repurposed internally as
`setCandidate`.

Change how the prejit root case is tracked to make it explicit
from the context rather than a callback to the compiler.