### PR TITLE
ARM: skip generating native image for mscorlib in case of cross build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -245,14 +245,16 @@ build_mscorlib()
         exit 1
     fi
 
-    if [ $__SkipCoreCLR == 0 -a -e $__BinDir/crossgen ]; then
-        echo "Generating native image for mscorlib."
-        $__BinDir/crossgen $__BinDir/mscorlib.dll
-        if [ $? -ne 0 ]; then
-            echo "Failed to generate native image for mscorlib."
-            exit 1
-        fi
-    fi
+    if [ $__CrossBuild != 1 ]; then
+       if [ $__SkipCoreCLR == 0 -a -e $__BinDir/crossgen ]; then
+           echo "Generating native image for mscorlib."
+           $__BinDir/crossgen $__BinDir/mscorlib.dll
+           if [ $? -ne 0 ]; then
+               echo "Failed to generate native image for mscorlib."
+               exit 1
+           fi
+       fi
+    fi 
 }
 
 generate_NugetPackages()


### PR DESCRIPTION
We need to skip generating native image for mscorlib in build_mscorlib()
of ./coreclr/build.sh when we do cross build for Linux/ARM on Ubuntu
14.04 x86 64bit PC.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com
Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com