### PR TITLE
Inliner: fix assert about repeated failing observations

### DIFF
--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -259,7 +259,11 @@ void LegacyPolicy::setFailure(InlineObservation obs)
     {
     case InlineDecision::FAILURE:
         // Repeated failure only ok if evaluating a prejit root
-        assert(inlIsPrejitRoot);
+        // (since we can't fail fast because we're not inlining)
+        // or if inlining and the observation is CALLSITE_TOO_MANY_LOCALS
+        // (since we can't fail fast from lvaGrabTemp).
+        assert(inlIsPrejitRoot ||
+               (obs == InlineObservation::CALLSITE_TOO_MANY_LOCALS));
         break;
     case InlineDecision::UNDECIDED:
     case InlineDecision::CANDIDATE:


### PR DESCRIPTION
When an inlining attempt is going to fail, the jit aims to bail out of
the attempt as quickly as possible, since any further work on this
inline will just waste time and memory. The jit monitors this in part
by asserting that it only makes one failing observation.

However, there are as few places where failing fast during inlining is
not currently possible, and repeated failing observations may occur.

This change loosens the assertion check to allow repeated
`CALLSITE_TOO_MANY_LOCALS` observations. This observation is made
at a fairly deep stack in `lvaGrabTemp` with no easy route to bail
out in case of imminent failure.

Closes #3586.