### PR TITLE
Disable OpenSourceSign

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00177
+1.0.25-prerelease-00196

--- a/build.cmd
+++ b/build.cmd
@@ -57,6 +57,7 @@ set __DoCrossgen=
 set __BuildSequential=
 set __msbuildCleanBuildArgs=
 set __msbuildExtraArgs=
+set __SignTypeReal=
 
 set __BuildAll=
 
@@ -114,6 +115,7 @@ if /i "%1" == "skipnative"          (set __SkipNativeBuild=1&shift&goto Arg_Loop
 if /i "%1" == "skiptests"           (set __SkipTestBuild=1&shift&goto Arg_Loop)
 if /i "%1" == "docrossgen"          (set __DoCrossgen=1&shift&goto Arg_Loop)
 if /i "%1" == "sequential"          (set __BuildSequential=1&shift&goto Arg_Loop)
+if /i "%1" == "disableoss"          (set __SignTypeReal="/p:SignType=real"&shift&goto Arg_Loop)
 if /i "%1" == "priority"            (set __TestPriority=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
 
 @REM For backwards compatibility, continue accepting "skiptestbuild", which was the original name of the option.
@@ -139,7 +141,7 @@ goto Usage
 :ArgsDone
 
 if defined __ConfigureOnly if defined __SkipConfigure (
-    echo "Error: option 'configureonly' is incompatible with 'skipconfigure'
+    echo "Error: option 'configureonly' is incompatible with 'skipconfigure'"
     goto Usage
 )
 
@@ -409,7 +411,7 @@ set __msbuildLogArgs=^
 /consoleloggerparameters:Summary ^
 /verbosity:minimal
 
-set __msbuildArgs="%__ProjectFilesDir%\build.proj" %__msbuildCommonArgs% %__msbuildLogArgs%
+set __msbuildArgs="%__ProjectFilesDir%\build.proj" %__msbuildCommonArgs% %__msbuildLogArgs% %__SignTypeReal%
 
 set __BuildNugetPackage=true
 if defined __MscorlibOnly       set __BuildNugetPackage=false
@@ -640,6 +642,7 @@ echo skipconfigure: skip CMake ^(default: CMake is run^)
 echo skipmscorlib: skip building mscorlib ^(default: mscorlib is built^).
 echo skipnative: skip building native components ^(default: native components are built^).
 echo skiptests: skip building tests ^(default: tests are built^).
+echo disableoss: Disable Open Source Signing for mscorlib.
 echo toolset_dir ^<dir^> : set the toolset directory -- Arm64 use only. Required for Arm64 builds.
 echo.
 echo If "all" is specified, then all build architectures and types are built. If, in addition,

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@ usage()
     echo "skipnative - do not build native components."
     echo "skipmscorlib - do not build mscorlib.dll."
     echo "skiptests - skip the tests in the 'tests' subdirectory."
+    echo "disableoss - Disable Open Source Signing for mscorlib."
     echo "cmakeargs - user-settable additional arguments passed to CMake."
 
     exit 1
@@ -238,7 +239,7 @@ build_mscorlib()
     echo "Commencing build of mscorlib components for $__BuildOS.$__BuildArch.$__BuildType"
 
     # Invoke MSBuild
-    $__ProjectRoot/Tools/corerun "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__BuildArch /p:__BuildType=$__BuildType /p:__IntermediatesDir=$__IntermediatesDir /p:UseRoslynCompiler=true /p:BuildNugetPackage=false /p:UseSharedCompilation=false
+    $__ProjectRoot/Tools/corerun "$__MSBuildPath" /nologo "$__ProjectRoot/build.proj" /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__LogsDir/MSCorLib_$__BuildOS__$__BuildArch__$__BuildType.log" /t:Build /p:__BuildOS=$__BuildOS /p:__BuildArch=$__BuildArch /p:__BuildType=$__BuildType /p:__IntermediatesDir=$__IntermediatesDir /p:UseRoslynCompiler=true /p:BuildNugetPackage=false /p:UseSharedCompilation=false ${__SignTypeReal}
 
     if [ $? -ne 0 ]; then
         echo "Failed to build mscorlib."
@@ -384,6 +385,7 @@ __SkipCoreCLR=0
 __SkipMSCorLib=0
 __CleanBuild=0
 __VerboseBuild=0
+__SignTypeReal=""
 __CrossBuild=0
 __ClangMajorVersion=3
 __ClangMinorVersion=5
@@ -497,6 +499,10 @@ while :; do
 
         skiptests)
             __IncludeTests=
+            ;;
+
+        disableoss)
+            __SignTypeReal="/p:SignType=real"
             ;;
 
         cmakeargs)


### PR DESCRIPTION
Disabling open source sign so that we produce a valid delayed signed mscorlib.dll

Cc: @weshaggard @gkhanna79 @jhendrixMSFT