### PR TITLE
Inline refactoring: move native callsite estimator

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4869,7 +4869,8 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
                     assert(compNativeSizeEstimate != NATIVE_SIZE_INVALID);
 
                     // Estimate the call site impact
-                    int callsiteNativeSizeEstimate = impEstimateCallsiteNativeSize(methodInfo);
+                    int callsiteNativeSizeEstimate =
+                        prejitResult.determineCallsiteNativeSizeEstimate(methodInfo);
 
                     // See if we're willing to pay for inlining this method
                     impCanInlineNative(callsiteNativeSizeEstimate,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3108,8 +3108,6 @@ private:
 
     static BOOL         impIsAddressInLocal(GenTreePtr tree, GenTreePtr * lclVarTreeOut);
 
-    int                 impEstimateCallsiteNativeSize (CORINFO_METHOD_INFO *  methInfo);
-
     void                impCanInlineNative(int              callsiteNativeEstimate, 
                                            int              calleeNativeSizeEstimate,
                                            InlineInfo*      pInlineInfo,
@@ -7651,6 +7649,13 @@ public :
 
     bool                compStressCompile(compStressArea    stressArea,
                                           unsigned          weightPercentage);
+
+#ifdef DEBUG
+    bool                compInlineStress()
+    {
+        return compStressCompile(STRESS_INLINE, 50);
+    }
+#endif // DEBUG
 
     bool                compTailCallStress()
     {

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -147,6 +147,7 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 INLINE_OBSERVATION(BENEFIT_MULTIPLIER,        double, "benefit multiplier",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds test",  INFORMATION, CALLSITE)
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
+INLINE_OBSERVATION(FREQUENCY,                 int,    "execution frequency",           INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLSITE)
 INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE_OK,   bool,   "native size estimate ok",       INFORMATION, CALLSITE)
 

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -44,6 +44,7 @@ public:
         , inlStateMachine(nullptr)
         , inlCodeSize(0)
         , inlNativeSizeEstimate(NATIVE_SIZE_INVALID)
+        , inlCallsiteFrequency(InlineCallsiteFrequency::UNUSED)
         , inlIsForceInline(false)
         , inlIsForceInlineKnown(false)
         , inlIsInstanceCtor(false)
@@ -68,7 +69,7 @@ public:
     // Policy determinations
     double determineMultiplier() override;
     int determineNativeSizeEstimate() override;
-    bool hasNativeSizeEstimate() override;
+    int determineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) override;
 
     // Policy policies
     bool propagateNeverToRuntime() const override { return true; }
@@ -89,20 +90,21 @@ private:
     const unsigned MAX_BASIC_BLOCKS = 5;
 
     // Data members
-    Compiler*  inlCompiler;
-    CodeSeqSM* inlStateMachine;
-    unsigned   inlCodeSize;
-    int        inlNativeSizeEstimate;
-    bool       inlIsForceInline :1;
-    bool       inlIsForceInlineKnown :1;
-    bool       inlIsInstanceCtor :1;
-    bool       inlIsFromPromotableValueClass :1;
-    bool       inlHasSimd :1;
-    bool       inlLooksLikeWrapperMethod :1;
-    bool       inlArgFeedsConstantTest :1;
-    bool       inlMethodIsMostlyLoadStore :1;
-    bool       inlArgFeedsRangeCheck :1;
-    bool       inlConstantFeedsConstantTest :1;
+    Compiler*               inlCompiler;
+    CodeSeqSM*              inlStateMachine;
+    unsigned                inlCodeSize;
+    int                     inlNativeSizeEstimate;
+    InlineCallsiteFrequency inlCallsiteFrequency;
+    bool                    inlIsForceInline :1;
+    bool                    inlIsForceInlineKnown :1;
+    bool                    inlIsInstanceCtor :1;
+    bool                    inlIsFromPromotableValueClass :1;
+    bool                    inlHasSimd :1;
+    bool                    inlLooksLikeWrapperMethod :1;
+    bool                    inlArgFeedsConstantTest :1;
+    bool                    inlMethodIsMostlyLoadStore :1;
+    bool                    inlArgFeedsRangeCheck :1;
+    bool                    inlConstantFeedsConstantTest :1;
 };
 
 #endif // _INLINE_POLICY_H_


### PR DESCRIPTION
Move the native call site estimation logic into `LegacyPolicy`. Rework
the remaining per-callsite bonus multipliers so that they fit into the
observation framework. Remove `hasNativeSizeEstimate` and instead
check that the inline is a candidate and its observation is a
discretionary inline. Fix header comment in `fgFindJumpTargets`.