### PR TITLE
Fix various naming convention issues in inliner code

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4233,7 +4233,7 @@ int           Compiler::compCompile(CORINFO_METHOD_HANDLE methodHnd,
     {
         if (compIsForInlining())
         {
-            compInlineResult->noteFatal(InlineObservation::CALLEE_MARKED_AS_SKIPPED);
+            compInlineResult->NoteFatal(InlineObservation::CALLEE_MARKED_AS_SKIPPED);
         }
         return CORJIT_SKIPPED;
     }
@@ -4858,10 +4858,10 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
 
             // If this method is still a viable inline candidate,
             // do the profitability screening.
-            if (prejitResult.isCandidate())
+            if (prejitResult.IsCandidate())
             {
                 // Only needed if the inline is discretionary.
-                InlineObservation obs = prejitResult.getObservation();
+                InlineObservation obs = prejitResult.GetObservation();
                 if (obs == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE)
                 {
                     // We should have run the CodeSeq state machine
@@ -4870,7 +4870,7 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
 
                     // Estimate the call site impact
                     int callsiteNativeSizeEstimate =
-                        prejitResult.determineCallsiteNativeSizeEstimate(methodInfo);
+                        prejitResult.DetermineCallsiteNativeSizeEstimate(methodInfo);
 
                     // See if we're willing to pay for inlining this method
                     impCanInlineNative(callsiteNativeSizeEstimate,
@@ -4882,11 +4882,11 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
             else
             {
                 // If it's not a candidate, it should be a failure.
-                assert(prejitResult.isFailure());
+                assert(prejitResult.IsFailure());
             }
 
             // Handle the results of the inline analysis.
-            if (prejitResult.isFailure())
+            if (prejitResult.IsFailure())
             {
                 // This method is a bad inlinee according to our
                 // analysis.  We will let the InlineResult destructor
@@ -4894,13 +4894,13 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
                 // jit some work.
                 //
                 // This decision better not be context-dependent.
-                assert(prejitResult.isNever());
+                assert(prejitResult.IsNever());
             }
             else
             {
                 // This looks like a viable inline candidate.  Since
                 // we're not actually inlining, don't report anything.
-                prejitResult.setReported();
+                prejitResult.SetReported();
             }
         }
         else
@@ -4952,9 +4952,9 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
 
         if (compIsForInlining())
         {
-            compInlineResult->noteInt(InlineObservation::CALLEE_NUMBER_OF_BASIC_BLOCKS, fgBBcount);
+            compInlineResult->NoteInt(InlineObservation::CALLEE_NUMBER_OF_BASIC_BLOCKS, fgBBcount);
 
-            if (compInlineResult->isFailure())
+            if (compInlineResult->IsFailure())
             {
                 goto _Next;
             }
@@ -5624,7 +5624,7 @@ START:
         {
             // Note that we failed to compile the inlinee, and that
             // there's no point trying to inline it again anywhere else.
-            inlineInfo->inlineResult->noteFatal(InlineObservation::CALLEE_COMPILATION_ERROR);
+            inlineInfo->inlineResult->NoteFatal(InlineObservation::CALLEE_COMPILATION_ERROR);
         }
         param.result = __errc;       
     }

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1585,7 +1585,7 @@ inline unsigned     Compiler::lvaGrabTemp(bool shortLifetime
         if (pComp->lvaHaveManyLocals())
         {
             // Don't create more LclVar with inlining 
-            compInlineResult->noteFatal(InlineObservation::CALLSITE_TOO_MANY_LOCALS);
+            compInlineResult->NoteFatal(InlineObservation::CALLSITE_TOO_MANY_LOCALS);
         }
 
         unsigned tmpNum = pComp->lvaGrabTemp(shortLifetime DEBUGARG(reason));
@@ -4291,7 +4291,7 @@ bool                Compiler::compDonotInline()
     if (compIsForInlining())
     {
        assert(compInlineResult != nullptr);
-       return compInlineResult->isFailure();
+       return compInlineResult->IsFailure();
     }
     else
     {

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4218,11 +4218,11 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr,
     if (compInlineResult != nullptr)
     {
         // Observe force inline state and code size.
-        compInlineResult->noteBool(InlineObservation::CALLEE_IS_FORCE_INLINE, isForceInline);
-        compInlineResult->noteInt(InlineObservation::CALLEE_IL_CODE_SIZE, codeSize);
+        compInlineResult->NoteBool(InlineObservation::CALLEE_IS_FORCE_INLINE, isForceInline);
+        compInlineResult->NoteInt(InlineObservation::CALLEE_IL_CODE_SIZE, codeSize);
 
         // note that we're starting to look at the opcodes.
-        compInlineResult->note(InlineObservation::CALLEE_BEGIN_OPCODE_SCAN);
+        compInlineResult->Note(InlineObservation::CALLEE_BEGIN_OPCODE_SCAN);
     }
 
     while (codeAddr < codeEndp)
@@ -4302,7 +4302,7 @@ DECODE_OPCODE:
                 noway_assert(codeAddr < codeEndp - sz);
                 if ((OPCODE) getU1LittleEndian(codeAddr + sz) == CEE_RET)
                 {
-                    compInlineResult->note(InlineObservation::CALLEE_LOOKS_LIKE_WRAPPER);
+                    compInlineResult->Note(InlineObservation::CALLEE_LOOKS_LIKE_WRAPPER);
                 }
             }
             break;
@@ -4381,8 +4381,8 @@ DECODE_OPCODE:
 
             if (compIsForInlining())
             {
-                compInlineResult->note(InlineObservation::CALLEE_HAS_SWITCH);
-                if (compInlineResult->isFailure()) 
+                compInlineResult->Note(InlineObservation::CALLEE_HAS_SWITCH);
+                if (compInlineResult->IsFailure()) 
                 {
                     return;
                 }
@@ -4497,7 +4497,7 @@ DECODE_OPCODE:
             //Consider making this only for not force inline.
             if (compIsForInlining())
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_UNSUPPORTED_OPCODE);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_UNSUPPORTED_OPCODE);
                 return;
             }
             break;
@@ -4559,13 +4559,13 @@ INL_HANDLE_COMPARE:
                             unsigned slot0 = pushedStack.getSlot0();
                             if (fgStack::isArgument(slot0))
                             {
-                                compInlineResult->note(InlineObservation::CALLEE_ARG_FEEDS_CONSTANT_TEST);
+                                compInlineResult->Note(InlineObservation::CALLEE_ARG_FEEDS_CONSTANT_TEST);
                                 //Check for the double whammy of an incoming constant argument feeding a
                                 //constant test.
                                 varNum = fgStack::slotTypeToArgNum(slot0);
                                 if (impInlineInfo->inlArgInfo[varNum].argNode->OperIsConst())
                                 {
-                                    compInlineResult->note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
+                                    compInlineResult->Note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
                                 }
                             }
                         }
@@ -4580,13 +4580,13 @@ INL_HANDLE_COMPARE:
                 if ((fgStack::isConstant(slot0) && fgStack::isArgument(slot1))
                     ||(fgStack::isConstant(slot1) && fgStack::isArgument(slot0)))
                 {
-                    compInlineResult->note(InlineObservation::CALLEE_ARG_FEEDS_CONSTANT_TEST);
+                    compInlineResult->Note(InlineObservation::CALLEE_ARG_FEEDS_CONSTANT_TEST);
                 }
                 //Arg feeds range check
                 if ((fgStack::isArrayLen(slot0) && fgStack::isArgument(slot1))
                     ||(fgStack::isArrayLen(slot1) && fgStack::isArgument(slot0)))
                 {
-                    compInlineResult->note(InlineObservation::CALLEE_ARG_FEEDS_RANGE_CHECK);
+                    compInlineResult->Note(InlineObservation::CALLEE_ARG_FEEDS_RANGE_CHECK);
                 }
 
                 //Check for an incoming arg that's a constant.
@@ -4595,7 +4595,7 @@ INL_HANDLE_COMPARE:
                     varNum = fgStack::slotTypeToArgNum(slot0);
                     if (impInlineInfo->inlArgInfo[varNum].argNode->OperIsConst())
                     {
-                        compInlineResult->note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
+                        compInlineResult->Note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
                     }
                 }
                 if (fgStack::isArgument(slot1))
@@ -4603,7 +4603,7 @@ INL_HANDLE_COMPARE:
                     varNum = fgStack::slotTypeToArgNum(slot1);
                     if (impInlineInfo->inlArgInfo[varNum].argNode->OperIsConst())
                     {
-                        compInlineResult->note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
+                        compInlineResult->Note(InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST);
                     }
                 }
             }
@@ -4720,7 +4720,7 @@ ARG_WRITE:
                 /* The inliner keeps the args as trees and clones them.  Storing the arguments breaks that
                  * simplification.  To allow this, flag the argument as written to and spill it before
                  * inlining.  That way the STARG in the inlinee is trivial. */
-                compInlineResult->noteFatal(InlineObservation::CALLEE_STORES_TO_ARGUMENT);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_STORES_TO_ARGUMENT);
                 return;
             }
             else
@@ -4751,7 +4751,7 @@ _SkipCodeAddrAdjustment:
         {
             InlineObservation obs = typeIsNormed ?
                 InlineObservation::CALLEE_OPCODE_NORMED : InlineObservation::CALLEE_OPCODE;
-            compInlineResult->noteInt(obs, opcode);
+            compInlineResult->NoteInt(obs, opcode);
         }
     }
 
@@ -4774,20 +4774,20 @@ TOO_FAR:
         // cares about, and when.
         if (compInlineResult != nullptr)
         {
-            compInlineResult->note(InlineObservation::CALLEE_IS_MOSTLY_LOAD_STORE);
+            compInlineResult->Note(InlineObservation::CALLEE_IS_MOSTLY_LOAD_STORE);
         }
     }
 
     if (compInlineResult != nullptr)
     {
-        compInlineResult->note(InlineObservation::CALLEE_END_OPCODE_SCAN);
+        compInlineResult->Note(InlineObservation::CALLEE_END_OPCODE_SCAN);
 
         // If the inline is viable and discretionary, we need to get
         // an estimate for the callee native code size.
-        if (compInlineResult->isCandidate()
-            && (compInlineResult->getObservation() == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE))
+        if (compInlineResult->IsCandidate()
+            && (compInlineResult->GetObservation() == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE))
         {
-            compNativeSizeEstimate = compInlineResult->determineNativeSizeEstimate();
+            compNativeSizeEstimate = compInlineResult->DetermineNativeSizeEstimate();
             noway_assert(compNativeSizeEstimate != NATIVE_SIZE_INVALID);
             JITDUMP("\n\ncompNativeSizeEstimate=%d\n", compNativeSizeEstimate);
 
@@ -4801,7 +4801,7 @@ TOO_FAR:
             {
                 // Make an inlining decision based on the estimated native size.
                 int callsiteNativeSizeEstimate =
-                    compInlineResult->determineCallsiteNativeSizeEstimate(
+                    compInlineResult->DetermineCallsiteNativeSizeEstimate(
                         &impInlineInfo->inlineCandidateInfo->methInfo);
 
                 impCanInlineNative(callsiteNativeSizeEstimate,
@@ -4809,14 +4809,14 @@ TOO_FAR:
                                    impInlineInfo,
                                    compInlineResult);
 
-                if (compInlineResult->isFailure())
+                if (compInlineResult->IsFailure())
                 {
 #ifdef DEBUG
                     if (verbose)
                     {
                         printf("\n\nInline expansion aborted because of impCanInlineNative: %s %s\n",
-                               compInlineResult->resultString(),
-                               compInlineResult->reasonString());
+                               compInlineResult->ResultString(),
+                               compInlineResult->ReasonString());
                     }
 #endif
 
@@ -21264,27 +21264,27 @@ unsigned     Compiler::fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo)
     const DWORD MAX_INLINING_RECURSION_DEPTH = 20;
     DWORD depth = 0;
 
-    for (; inlineContext != nullptr; inlineContext = inlineContext->getParent())
+    for (; inlineContext != nullptr; inlineContext = inlineContext->GetParent())
     {
         // Hard limit just to catch pathological cases
         depth++;
 
-        if (inlineContext->getCode() == candidateCode)
+        if (inlineContext->GetCode() == candidateCode)
         {
             // This inline candidate has the same IL code buffer as an already
             // inlined method does.
-            inlineResult->noteFatal(InlineObservation::CALLSITE_IS_RECURSIVE);
+            inlineResult->NoteFatal(InlineObservation::CALLSITE_IS_RECURSIVE);
             break;
         }
 
         if (depth > MAX_INLINING_RECURSION_DEPTH)
         {
-            inlineResult->noteFatal(InlineObservation::CALLSITE_IS_TOO_DEEP);
+            inlineResult->NoteFatal(InlineObservation::CALLSITE_IS_TOO_DEEP);
             break;
         }
     }
 
-    inlineResult->noteInt(InlineObservation::CALLSITE_DEPTH, depth);
+    inlineResult->NoteInt(InlineObservation::CALLSITE_DEPTH, depth);
     return depth;
 }
 
@@ -21308,7 +21308,7 @@ void                Compiler::fgInline()
     noway_assert(block != nullptr);
 
     // Set the root inline context on all statements
-    InlineContext* rootContext = InlineContext::newRoot(this);
+    InlineContext* rootContext = InlineContext::NewRoot(this);
 
     for (; block != nullptr; block = block->bbNext)
     {
@@ -21475,7 +21475,7 @@ void Compiler::fgNoteNonInlineCandidate(GenTreePtr   tree,
     // this call was not a candidate.
     InlineObservation priorObservation = call->gtInlineObservation;
 
-    if (inlIsValidObservation(priorObservation))
+    if (InlIsValidObservation(priorObservation))
     {
         currentObservation = priorObservation;
     }
@@ -21485,23 +21485,23 @@ void Compiler::fgNoteNonInlineCandidate(GenTreePtr   tree,
     // here too.  Also note there's no need to re-report these
     // failures, since we reported them during the initial
     // candidate scan.
-    InlineImpact impact = inlGetImpact(currentObservation);
+    InlineImpact impact = InlGetImpact(currentObservation);
 
     if (impact == InlineImpact::FATAL)
     {
-        inlineResult.noteFatal(currentObservation);
+        inlineResult.NoteFatal(currentObservation);
     }
     else
     {
-        inlineResult.note(currentObservation);
+        inlineResult.Note(currentObservation);
     }
 
-    inlineResult.setReported();
+    inlineResult.SetReported();
 
     if (call->gtCallType == CT_USER_FUNC)
     {
         // Create InlineContext for the failure
-        InlineContext::newFailure(this, tree, &inlineResult);
+        InlineContext::NewFailure(this, tree, &inlineResult);
     }
 }
 
@@ -21802,7 +21802,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
 
     unsigned inlineDepth = fgCheckInlineDepthAndRecursion(&inlineInfo);
 
-    if (inlineResult->isFailure())
+    if (inlineResult->IsFailure())
     {
 #ifdef DEBUG
         if (verbose)
@@ -21833,7 +21833,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
         // Init the local var info of the inlinee
         pParam->pThis->impInlineInitVars(pParam->inlineInfo);
 
-        if (pParam->inlineInfo->inlineResult->isCandidate())
+        if (pParam->inlineInfo->inlineResult->IsCandidate())
         {
             /* Clear the temp table */
             memset(pParam->inlineInfo->lclTmpNum, -1, sizeof(pParam->inlineInfo->lclTmpNum));
@@ -21888,9 +21888,9 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
                 // a catch-all something bad happened observation.
                 InlineResult* innerInlineResult = pParam->inlineInfo->inlineResult;
 
-                if (!innerInlineResult->isFailure())
+                if (!innerInlineResult->IsFailure())
                 {
-                    innerInlineResult->noteFatal(InlineObservation::CALLSITE_COMPILATION_FAILURE);
+                    innerInlineResult->NoteFatal(InlineObservation::CALLSITE_COMPILATION_FAILURE);
                 }
             }
         }
@@ -21907,14 +21907,14 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
 
         // If we haven't yet determined why this inline fails, use
         // a catch-all something bad happened observation.
-        if (!inlineResult->isFailure())
+        if (!inlineResult->IsFailure())
         {
-            inlineResult->noteFatal(InlineObservation::CALLSITE_COMPILATION_ERROR);
+            inlineResult->NoteFatal(InlineObservation::CALLSITE_COMPILATION_ERROR);
         }
     }
     endErrorTrap();
 
-    if (inlineResult->isFailure())
+    if (inlineResult->IsFailure())
     {
 #if defined(DEBUG) || MEASURE_INLINING
         ++Compiler::jitInlineInitVarsFailureCount;
@@ -21944,7 +21944,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
                     eeGetMethodFullName(fncHandle));
         }
 #endif // DEBUG
-        inlineResult->noteFatal(InlineObservation::CALLEE_LACKS_RETURN);
+        inlineResult->NoteFatal(InlineObservation::CALLEE_LACKS_RETURN);
         return;
     }
 
@@ -21955,7 +21955,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
         if (!(info.compCompHnd->initClass(NULL /* field */, fncHandle /* method */,
                 inlineCandidateInfo->exactContextHnd /* context */) & CORINFO_INITCLASS_INITIALIZED))
         {
-            inlineResult->noteFatal(InlineObservation::CALLEE_CLASS_INIT_FAILURE);
+            inlineResult->NoteFatal(InlineObservation::CALLEE_CLASS_INIT_FAILURE);
             return;
         }
     }
@@ -21977,7 +21977,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
                eeGetMethodFullName(fncHandle),
                inlineCandidateInfo->methInfo.ILCodeSize,
                inlineDepth,
-               inlineResult->reasonString());
+               inlineResult->ReasonString());
     }
 
     if (verbose)
@@ -21991,7 +21991,7 @@ void       Compiler::fgInvokeInlineeCompiler(GenTreeCall*  call,
 #endif
 
     // We inlined...
-    inlineResult->noteSuccess();
+    inlineResult->NoteSuccess();
 }
 
 // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -22041,7 +22041,7 @@ void Compiler::fgInsertInlineeBlocks(InlineInfo* pInlineInfo)
     //
     // Create a new inline context and mark the inlined statements with it
     //
-    InlineContext* calleeContext = InlineContext::newSuccess(this, pInlineInfo);
+    InlineContext* calleeContext = InlineContext::NewSuccess(this, pInlineInfo);
 
     for (block = InlineeCompiler->fgFirstBB;
          block != nullptr;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1597,7 +1597,7 @@ GenTreePtr          Compiler::impLookupToTree(CORINFO_LOOKUP *pLookup, unsigned 
     {
         // Don't import runtime lookups when inlining
         // Inlining has to be aborted in such a case
-        compInlineResult->noteFatal(InlineObservation::CALLSITE_GENERIC_DICTIONARY_LOOKUP);
+        compInlineResult->NoteFatal(InlineObservation::CALLSITE_GENERIC_DICTIONARY_LOOKUP);
         return nullptr;
     }
     else
@@ -1677,7 +1677,7 @@ GenTreePtr Compiler::impMethodPointer(CORINFO_RESOLVED_TOKEN * pResolvedToken, C
         {
             // Don't import runtime lookups when inlining
             // Inlining has to be aborted in such a case
-            compInlineResult->noteFatal(InlineObservation::CALLSITE_GENERIC_DICTIONARY_LOOKUP);
+            compInlineResult->NoteFatal(InlineObservation::CALLSITE_GENERIC_DICTIONARY_LOOKUP);
             return nullptr;
         }
 
@@ -5702,7 +5702,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 
             if (impInlineInfo->inlineCandidateInfo->dwRestrictions & INLINE_RESPECT_BOUNDARY)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLSITE_CROSS_BOUNDARY_SECURITY);
+                compInlineResult->NoteFatal(InlineObservation::CALLSITE_CROSS_BOUNDARY_SECURITY);
                 return callRetTyp;
             }
 
@@ -5710,7 +5710,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 
             if (mflags & CORINFO_FLG_SECURITYCHECK)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_NEEDS_SECURITY_CHECK);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_NEEDS_SECURITY_CHECK);
                 return callRetTyp;
             }
 
@@ -5718,7 +5718,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 
             if (mflags & CORINFO_FLG_DONT_INLINE_CALLER)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_STACK_CRAWL_MARK);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_STACK_CRAWL_MARK);
                 return callRetTyp;
             }
 
@@ -5726,26 +5726,26 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 
             if (mflags & CORINFO_FLG_DELEGATE_INVOKE)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_DELEGATE_INVOKE);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_DELEGATE_INVOKE);
                 return callRetTyp;
             }
 
             /* For now ignore varargs */
             if ((sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_NATIVEVARARG)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_NATIVE_VARARGS);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_NATIVE_VARARGS);
                 return callRetTyp;
             }
 
             if  ((sig->callConv & CORINFO_CALLCONV_MASK) == CORINFO_CALLCONV_VARARG)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_MANAGED_VARARGS);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_MANAGED_VARARGS);
                 return callRetTyp;
             }
 
             if ((mflags & CORINFO_FLG_VIRTUAL) && (sig->sigInst.methInstCount != 0) && (opcode == CEE_CALLVIRT))
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_IS_GENERIC_VIRTUAL);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_IS_GENERIC_VIRTUAL);
                 return callRetTyp;
             }
         }
@@ -5873,7 +5873,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
                          * always have a handle lookup.  These lookups are safe intra-module, but we're just
                          * failing here.
                          */
-                        compInlineResult->noteFatal(InlineObservation::CALLSITE_HAS_COMPLEX_HANDLE);
+                        compInlineResult->NoteFatal(InlineObservation::CALLSITE_HAS_COMPLEX_HANDLE);
                         return callRetTyp;
                     }                            
         
@@ -5950,7 +5950,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
             {
                 if (compIsForInlining())
                 {
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_HAS_CALL_VIA_LDVIRTFTN);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_HAS_CALL_VIA_LDVIRTFTN);
                     return callRetTyp;
                 }
                 
@@ -6227,7 +6227,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
             // Cannot handle this if the method being imported is an inlinee by itself.
             // Because inlinee method does not have its own frame.
 
-            compInlineResult->noteFatal(InlineObservation::CALLEE_NEEDS_SECURITY_CHECK);
+            compInlineResult->NoteFatal(InlineObservation::CALLEE_NEEDS_SECURITY_CHECK);
             return callRetTyp;
         }
         else
@@ -6285,7 +6285,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
             // so instead we fallback to JIT.
             if (compIsForInlining())
             {
-                compInlineResult->noteFatal(InlineObservation::CALLSITE_CANT_EMBED_PINVOKE_COOKIE);
+                compInlineResult->NoteFatal(InlineObservation::CALLSITE_CANT_EMBED_PINVOKE_COOKIE);
             }
             else
             {
@@ -6336,7 +6336,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
         void *          varCookie, *pVarCookie;
         if (!info.compCompHnd->canGetVarArgsHandle(sig))
         {
-            compInlineResult->noteFatal(InlineObservation::CALLSITE_CANT_EMBED_VARARGS_COOKIE);
+            compInlineResult->NoteFatal(InlineObservation::CALLSITE_CANT_EMBED_VARARGS_COOKIE);
             return callRetTyp;
         }
 
@@ -6416,7 +6416,7 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
 
             if (compIsForInlining() && (clsFlags & CORINFO_FLG_ARRAY) != 0)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLEE_IS_ARRAY_METHOD);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_IS_ARRAY_METHOD);
                 return callRetTyp;
             }
                             
@@ -8894,7 +8894,7 @@ PUSH_I4CON:
             {
                 if (impInlineInfo->inlineCandidateInfo->dwRestrictions & INLINE_NO_CALLEE_LDSTR)
                 {                    
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_HAS_LDSTR_RESTRICTION);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_HAS_LDSTR_RESTRICTION);
                     return;
                 }
             }
@@ -9241,7 +9241,7 @@ _PopValue:
                 op1 = impInlineFetchArg(lclNum, impInlineInfo->inlArgInfo, impInlineInfo->lclVarInfo);
                 if (op1->gtOper != GT_LCL_VAR)
                 {                    
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_LDARGA_NOT_LOCAL_VAR);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_LDARGA_NOT_LOCAL_VAR);
                     return;
                 }
 
@@ -9322,7 +9322,7 @@ _PUSH_ADRVAR:
             if (compIsForInlining())
             {
                 assert(!"Shouldn't have exception handlers in the inliner!");
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_ENDFINALLY);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_ENDFINALLY);
                 return;
             }
             
@@ -9342,7 +9342,7 @@ _PUSH_ADRVAR:
             if (compIsForInlining())
             {
                 assert(!"Shouldn't have exception handlers in the inliner!");
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_ENDFILTER);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_ENDFILTER);
                 return;
             }
 
@@ -9642,7 +9642,7 @@ ARR_LD_POST_VERIFY:
             {                
                 if (op1->gtOper == GT_CNS_INT)
                 {
-                    compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_NULL_FOR_LDELEM);
+                    compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_NULL_FOR_LDELEM);
                     return;
                 }
             }
@@ -10159,7 +10159,7 @@ CEE_SH_OP2:
 
             if (compIsForInlining())
             {                
-                compInlineResult->noteFatal(InlineObservation::CALLEE_HAS_LEAVE);
+                compInlineResult->NoteFatal(InlineObservation::CALLEE_HAS_LEAVE);
                 return;
             }
 
@@ -11088,7 +11088,7 @@ DO_LDFTN:
             {
                 if (mflags & (CORINFO_FLG_FINAL|CORINFO_FLG_STATIC) || !(mflags & CORINFO_FLG_VIRTUAL))
                 {
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_LDVIRTFN_ON_NON_VIRTUAL);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_LDVIRTFN_ON_NON_VIRTUAL);
                     return;
                 }
             }
@@ -11239,7 +11239,7 @@ DO_LDFTN:
                 if (impInlineInfo->inlineCandidateInfo->dwRestrictions & INLINE_RESPECT_BOUNDARY)
                 {
                     //Check to see if this call violates the boundary.
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_CROSS_BOUNDARY_SECURITY);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_CROSS_BOUNDARY_SECURITY);
                     return;
                 }
             }
@@ -11305,7 +11305,7 @@ DO_LDFTN:
                 {
                     if (varTypeIsComposite(JITtype2varType(callInfo.sig.retType)) && callInfo.sig.retTypeClass == NULL)
                     {
-                        compInlineResult->noteFatal(InlineObservation::CALLEE_RETURN_TYPE_IS_COMPOSITE);
+                        compInlineResult->NoteFatal(InlineObservation::CALLEE_RETURN_TYPE_IS_COMPOSITE);
                         return;
                     }
                 }
@@ -11444,7 +11444,7 @@ DO_LDFTN:
                 //CALLI doesn't have a method handle, so assume the worst.
                 if (impInlineInfo->inlineCandidateInfo->dwRestrictions & INLINE_RESPECT_BOUNDARY)
                 {
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_CROSS_BOUNDARY_CALLI);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_CROSS_BOUNDARY_CALLI);
                     return;
                 }
             }
@@ -11692,13 +11692,13 @@ DO_LDFTN:
                 case CORINFO_FIELD_STATIC_ADDR_HELPER:
                 case CORINFO_FIELD_STATIC_TLS:
 
-                    compInlineResult->noteFatal(InlineObservation::CALLEE_LDFLD_NEEDS_HELPER);
+                    compInlineResult->NoteFatal(InlineObservation::CALLEE_LDFLD_NEEDS_HELPER);
                     return;
 
                 case CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER:
 
                     /* We may be able to inline the field accessors in specific instantiations of generic methods */
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_LDFLD_NEEDS_HELPER);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_LDFLD_NEEDS_HELPER);
                     return;
 
                 default:
@@ -11715,9 +11715,9 @@ DO_LDFTN:
                     {
                         // Loading a static valuetype field usually will cause a JitHelper to be called
                         // for the static base. This will bloat the code.
-                        compInlineResult->note(InlineObservation::CALLEE_LDFLD_STATIC_VALUECLASS);
+                        compInlineResult->Note(InlineObservation::CALLEE_LDFLD_STATIC_VALUECLASS);
 
-                        if (compInlineResult->isFailure())
+                        if (compInlineResult->IsFailure())
                         {
                             return;
                         }
@@ -12036,13 +12036,13 @@ FIELD_DONE:
                 case CORINFO_FIELD_STATIC_ADDR_HELPER:
                 case CORINFO_FIELD_STATIC_TLS:
 
-                    compInlineResult->noteFatal(InlineObservation::CALLEE_STFLD_NEEDS_HELPER);
+                    compInlineResult->NoteFatal(InlineObservation::CALLEE_STFLD_NEEDS_HELPER);
                     return;
 
                 case CORINFO_FIELD_STATIC_GENERICS_STATIC_HELPER:
 
                     /* We may be able to inline the field accessors in specific instantiations of generic methods */
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_STFLD_NEEDS_HELPER);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_STFLD_NEEDS_HELPER);
                     return;
 
                 default:
@@ -12929,7 +12929,7 @@ FIELD_DONE:
                 {
                     /* if not, just don't inline the method */
 
-                    compInlineResult->noteFatal(InlineObservation::CALLEE_THROW_WITH_INVALID_STACK);
+                    compInlineResult->NoteFatal(InlineObservation::CALLEE_THROW_WITH_INVALID_STACK);
                     return;
                 }
                 
@@ -12943,7 +12943,7 @@ FIELD_DONE:
      
                 if  (seenConditionalJump && (impInlineInfo->inlineCandidateInfo->fncRetType != TYP_VOID))
                 {
-                    compInlineResult->noteFatal(InlineObservation::CALLSITE_CONDITIONAL_THROW);
+                    compInlineResult->NoteFatal(InlineObservation::CALLSITE_CONDITIONAL_THROW);
                     return;
                 }               
                 
@@ -13415,7 +13415,7 @@ void Compiler::impLoadArg(unsigned ilArgNum, IL_OFFSET offset)
     {
         if (ilArgNum >= info.compArgsCount)
         {
-            compInlineResult->noteFatal(InlineObservation::CALLEE_BAD_ARGUMENT_NUMBER);
+            compInlineResult->NoteFatal(InlineObservation::CALLEE_BAD_ARGUMENT_NUMBER);
             return;
         }
 
@@ -13457,7 +13457,7 @@ void Compiler::impLoadLoc(unsigned ilLclNum, IL_OFFSET offset)
     {
         if (ilLclNum >= info.compMethodInfo->locals.numArgs)
         {
-            compInlineResult->noteFatal(InlineObservation::CALLEE_BAD_LOCAL_NUMBER);
+            compInlineResult->NoteFatal(InlineObservation::CALLEE_BAD_LOCAL_NUMBER);
             return;
         }
 
@@ -13662,7 +13662,7 @@ bool Compiler::impReturnInstruction(BasicBlock *block, int prefixFlags, OPCODE &
                    
             if (returnType != originalCallType)
             {
-                compInlineResult->noteFatal(InlineObservation::CALLSITE_RETURN_TYPE_MISMATCH);
+                compInlineResult->NoteFatal(InlineObservation::CALLSITE_RETURN_TYPE_MISMATCH);
                 return false;
             }
 
@@ -15485,7 +15485,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
     // If this is a "forceinline" method, the JIT probably shouldn't have gone
     // to the trouble of estimating the native code size. Even if it did, it
     // shouldn't be relying on the result of this method.
-    assert(inlineResult->getObservation() == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
+    assert(inlineResult->GetObservation() == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
 
     JITDUMP("\ncalleeNativeSizeEstimate=%d, callsiteNativeEstimate=%d.\n", calleeNativeSizeEstimate, callsiteNativeEstimate);
 
@@ -15493,7 +15493,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
     if ((info.compFlags & CORINFO_FLG_CONSTRUCTOR) != 0 &&
         (info.compFlags & CORINFO_FLG_STATIC)      == 0)
     {
-        inlineResult->note(InlineObservation::CALLEE_IS_INSTANCE_CTOR);
+        inlineResult->Note(InlineObservation::CALLEE_IS_INSTANCE_CTOR);
     }
 
     // Note if this method's class is a promotable struct
@@ -15503,7 +15503,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
         lvaCanPromoteStructType(info.compClassHnd, &structPromotionInfo, false);
         if (structPromotionInfo.canPromote)
         {
-            inlineResult->note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
+            inlineResult->Note(InlineObservation::CALLEE_CLASS_PROMOTABLE);
         }
     }               
 
@@ -15512,7 +15512,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
     // Note if this method is has SIMD args or return value
     if (pInlineInfo != nullptr && pInlineInfo->hasSIMDTypeArgLocalOrReturn)
     {
-        inlineResult->note(InlineObservation::CALLEE_HAS_SIMD);
+        inlineResult->Note(InlineObservation::CALLEE_HAS_SIMD);
     }
 
 #endif // FEATURE_SIMD
@@ -15548,15 +15548,15 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
         frequency = InlineCallsiteFrequency::BORING;
     }
 
-    inlineResult->noteInt(InlineObservation::CALLSITE_FREQUENCY, static_cast<int>(frequency));
+    inlineResult->NoteInt(InlineObservation::CALLSITE_FREQUENCY, static_cast<int>(frequency));
 
     // Determine multiplier given the various observations.
-    double multiplier = inlineResult->determineMultiplier();
+    double multiplier = inlineResult->DetermineMultiplier();
 
     // Note the various estimates we've obtained.
-    inlineResult->noteInt(InlineObservation::CALLEE_NATIVE_SIZE_ESTIMATE, calleeNativeSizeEstimate);
-    inlineResult->noteInt(InlineObservation::CALLSITE_NATIVE_SIZE_ESTIMATE, callsiteNativeEstimate);
-    inlineResult->noteDouble(InlineObservation::CALLSITE_BENEFIT_MULTIPLIER, multiplier);
+    inlineResult->NoteInt(InlineObservation::CALLEE_NATIVE_SIZE_ESTIMATE, calleeNativeSizeEstimate);
+    inlineResult->NoteInt(InlineObservation::CALLSITE_NATIVE_SIZE_ESTIMATE, callsiteNativeEstimate);
+    inlineResult->NoteDouble(InlineObservation::CALLSITE_BENEFIT_MULTIPLIER, multiplier);
 
     int threshold = (int)(callsiteNativeEstimate * multiplier);
 
@@ -15577,12 +15577,12 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
 
         if (pInlineInfo != nullptr) 
         {
-            inlineResult->noteFatal(InlineObservation::CALLSITE_EXCEEDS_THRESHOLD);
+            inlineResult->NoteFatal(InlineObservation::CALLSITE_EXCEEDS_THRESHOLD);
         }
         else 
         {
             // Static hint case.... here the "callee" is the function being assessed.
-            inlineResult->noteFatal(InlineObservation::CALLEE_EXCEEDS_THRESHOLD);
+            inlineResult->NoteFatal(InlineObservation::CALLEE_EXCEEDS_THRESHOLD);
         }
     }
     else 
@@ -15592,7 +15592,7 @@ void             Compiler::impCanInlineNative(int           callsiteNativeEstima
                  threshold / NATIVE_CALL_SIZE_MULTIPLIER, multiplier));
 
        // Candidate has passed the profitability screen, update candidacy.
-       inlineResult->note(InlineObservation::CALLSITE_NATIVE_SIZE_ESTIMATE_OK);
+       inlineResult->Note(InlineObservation::CALLSITE_NATIVE_SIZE_ESTIMATE_OK);
     }
 
 #undef NATIVE_CALL_SIZE_MULTIPLIER
@@ -15614,17 +15614,17 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE    fncHandle,
     unsigned codeSize = methInfo->ILCodeSize;
 
     // We shouldn't have made up our minds yet...
-    assert(!inlineResult->isDecided());
+    assert(!inlineResult->IsDecided());
 
     if (methInfo->EHcount)
     {
-        inlineResult->noteFatal(InlineObservation::CALLEE_HAS_EH);
+        inlineResult->NoteFatal(InlineObservation::CALLEE_HAS_EH);
         return;
     }
 
     if ((methInfo->ILCode == 0) || (codeSize == 0))
     {
-        inlineResult->noteFatal(InlineObservation::CALLEE_HAS_NO_BODY);
+        inlineResult->NoteFatal(InlineObservation::CALLEE_HAS_NO_BODY);
         return;
     }
 
@@ -15632,7 +15632,7 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE    fncHandle,
 
     if (methInfo->args.isVarArg())
     {
-        inlineResult->noteFatal(InlineObservation::CALLEE_HAS_MANAGED_VARARGS);
+        inlineResult->NoteFatal(InlineObservation::CALLEE_HAS_MANAGED_VARARGS);
         return;
     }
 
@@ -15640,11 +15640,11 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE    fncHandle,
     // This is currently an implementation limit due to fixed-size arrays in the
     // inline info, rather than a performance heuristic.
 
-    inlineResult->noteInt(InlineObservation::CALLEE_NUMBER_OF_LOCALS, methInfo->locals.numArgs);
+    inlineResult->NoteInt(InlineObservation::CALLEE_NUMBER_OF_LOCALS, methInfo->locals.numArgs);
 
     if (methInfo->locals.numArgs > MAX_INL_LCLS)
     {
-        inlineResult->noteFatal(InlineObservation::CALLEE_TOO_MANY_LOCALS);
+        inlineResult->NoteFatal(InlineObservation::CALLEE_TOO_MANY_LOCALS);
         return;
     }
     
@@ -15652,32 +15652,32 @@ void Compiler::impCanInlineIL(CORINFO_METHOD_HANDLE    fncHandle,
     // This is currently an implementation limit due to fixed-size arrays in the
     // inline info, rather than a performance heuristic.
 
-    inlineResult->noteInt(InlineObservation::CALLEE_NUMBER_OF_ARGUMENTS, methInfo->args.numArgs);
+    inlineResult->NoteInt(InlineObservation::CALLEE_NUMBER_OF_ARGUMENTS, methInfo->args.numArgs);
     
     if (methInfo->args.numArgs > MAX_INL_ARGS)
     {
-        inlineResult->noteFatal(InlineObservation::CALLEE_TOO_MANY_ARGUMENTS);
+        inlineResult->NoteFatal(InlineObservation::CALLEE_TOO_MANY_ARGUMENTS);
         return;
     }
 
     // Note force inline state
 
-    inlineResult->noteBool(InlineObservation::CALLEE_IS_FORCE_INLINE, forceInline);
+    inlineResult->NoteBool(InlineObservation::CALLEE_IS_FORCE_INLINE, forceInline);
 
     // Note IL code size
 
-    inlineResult->noteInt(InlineObservation::CALLEE_IL_CODE_SIZE, codeSize);
+    inlineResult->NoteInt(InlineObservation::CALLEE_IL_CODE_SIZE, codeSize);
 
-    if (inlineResult->isFailure())
+    if (inlineResult->IsFailure())
     {
         return;
     }
 
     // Make sure maxstack is not too big
 
-    inlineResult->noteInt(InlineObservation::CALLEE_MAXSTACK, methInfo->maxStack);
+    inlineResult->NoteInt(InlineObservation::CALLEE_MAXSTACK, methInfo->maxStack);
 
-    if (inlineResult->isFailure())
+    if (inlineResult->IsFailure())
     {
         return;
     }
@@ -15731,7 +15731,7 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
 
         if (JitConfig.JitNoInline())
         {
-            pParam->result->noteFatal(InlineObservation::CALLEE_IS_JIT_NOINLINE);
+            pParam->result->NoteFatal(InlineObservation::CALLEE_IS_JIT_NOINLINE);
             goto _exit;
         }
 #endif
@@ -15745,7 +15745,7 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
         CORINFO_METHOD_INFO methInfo;    
         if (!pParam->pThis->info.compCompHnd->getMethodInfo(pParam->fncHandle, &methInfo))
         {
-            pParam->result->noteFatal(InlineObservation::CALLEE_NO_METHOD_INFO);
+            pParam->result->NoteFatal(InlineObservation::CALLEE_NO_METHOD_INFO);
             goto _exit;
         }
 
@@ -15757,9 +15757,9 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
                                       forceInline,
                                       pParam->result);
 
-        if (pParam->result->isFailure())
+        if (pParam->result->IsFailure())
         {
-            assert(pParam->result->isNever());
+            assert(pParam->result->IsNever());
             goto _exit;            
         }
 
@@ -15777,7 +15777,7 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
 
         if (initClassResult & CORINFO_INITCLASS_DONT_INLINE)
         {
-            pParam->result->noteFatal(InlineObservation::CALLSITE_CLASS_INIT_FAILURE_SPEC);
+            pParam->result->NoteFatal(InlineObservation::CALLSITE_CLASS_INIT_FAILURE_SPEC);
             goto _exit;
         }
 
@@ -15794,17 +15794,17 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
 
         if (vmResult == INLINE_FAIL) 
         {
-            pParam->result->noteFatal(InlineObservation::CALLSITE_IS_VM_NOINLINE);
+            pParam->result->NoteFatal(InlineObservation::CALLSITE_IS_VM_NOINLINE);
         } 
         else if (vmResult == INLINE_NEVER) 
         {
-            pParam->result->noteFatal(InlineObservation::CALLEE_IS_VM_NOINLINE);
+            pParam->result->NoteFatal(InlineObservation::CALLEE_IS_VM_NOINLINE);
         }
         
-        if (pParam->result->isFailure())
+        if (pParam->result->IsFailure())
         {
             // Make sure not to report this one.  It was already reported by the VM.
-            pParam->result->setReported();
+            pParam->result->SetReported();
             goto _exit;
         }
     
@@ -15818,7 +15818,7 @@ void  Compiler::impCheckCanInline(GenTreePtr                call,
             
             if (!pParam->pThis->impIsThis(thisArg))
             {
-                pParam->result->noteFatal(InlineObservation::CALLSITE_REQUIRES_SAME_THIS);
+                pParam->result->NoteFatal(InlineObservation::CALLSITE_REQUIRES_SAME_THIS);
                 goto _exit;
             }
         }
@@ -15870,7 +15870,7 @@ _exit:
     }
     impErrorTrap()
     {
-        param.result->noteFatal(InlineObservation::CALLSITE_COMPILATION_ERROR);
+        param.result->NoteFatal(InlineObservation::CALLSITE_COMPILATION_ERROR);
     }
     endErrorTrap();
 }
@@ -15884,7 +15884,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo *  pInlineInfo,
 
     if (curArgVal->gtOper == GT_MKREFANY)
     {
-        inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_IS_MKREFANY);
+        inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_IS_MKREFANY);
         return;
     }
 
@@ -15907,7 +15907,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo *  pInlineInfo,
     {
         // Right now impInlineSpillLclRefs and impInlineSpillGlobEffects don't take
         // into account special side effects, so we disallow them during inlining.
-        inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_HAS_SIDE_EFFECT);
+        inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_HAS_SIDE_EFFECT);
         return;
     }
 
@@ -15934,7 +15934,7 @@ void Compiler::impInlineRecordArgInfo(InlineInfo *  pInlineInfo,
             (curArgVal->gtIntCon.gtIconVal == 0)  )
         {
             /* Abort, but do not mark as not inlinable */
-            inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_HAS_NULL_THIS);
+            inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_HAS_NULL_THIS);
             return;
         }
     }
@@ -16006,7 +16006,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
         
         impInlineRecordArgInfo(pInlineInfo, thisArg, argCnt, inlineResult);
         
-        if (inlineResult->isFailure())
+        if (inlineResult->IsFailure())
         {
            return;
         }
@@ -16041,7 +16041,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
 
         impInlineRecordArgInfo(pInlineInfo, argVal, argCnt,  inlineResult);
 
-        if (inlineResult->isFailure())
+        if (inlineResult->IsFailure())
         {
             return;
         }
@@ -16097,7 +16097,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
             if (sigType == TYP_REF)
             {
                 /* The argument cannot be bashed into a ref (see bug 750871) */
-                inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_REF);
+                inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_REF);
                 return;
             }
 
@@ -16124,7 +16124,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
                 else
                 {
                     /* Arguments 'int <- byref' cannot be bashed */
-                    inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
+                    inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
                     return;
                 }
             }
@@ -16180,7 +16180,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
 
             if (!isPlausibleTypeMatch)
             {
-                inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_TYPES_INCOMPATIBLE);
+                inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_TYPES_INCOMPATIBLE);
                 return;
             }
 
@@ -16207,7 +16207,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
                     else
                     {
                         /* Arguments 'int <- byref' cannot be changed */
-                        inlineResult->noteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
+                        inlineResult->NoteFatal(InlineObservation::CALLSITE_ARG_NO_BASH_TO_INT);
                         return;
                     }
                 }
@@ -16281,7 +16281,7 @@ void  Compiler::impInlineInitVars(InlineInfo * pInlineInfo)
 
         if (isPinned)
         {
-            inlineResult->noteFatal(InlineObservation::CALLEE_HAS_PINNED_LOCALS);
+            inlineResult->NoteFatal(InlineObservation::CALLEE_HAS_PINNED_LOCALS);
             return;
         }
 
@@ -16614,7 +16614,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
     /* Don't inline if not optimized code */
     if  (opts.compDbgCode)
     {
-        inlineResult.noteFatal(InlineObservation::CALLER_DEBUG_CODEGEN);
+        inlineResult.NoteFatal(InlineObservation::CALLER_DEBUG_CODEGEN);
         return;
     }
 
@@ -16622,7 +16622,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
     // Inlining takes precedence over implicit tail call optimization (if the call is not directly recursive).
     if (call->IsTailPrefixedCall())
     {
-        inlineResult.noteFatal(InlineObservation::CALLSITE_EXPLICIT_TAIL_PREFIX);
+        inlineResult.NoteFatal(InlineObservation::CALLSITE_EXPLICIT_TAIL_PREFIX);
         return;
     }
 
@@ -16632,13 +16632,13 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
     // as a fast tail call or turned into a loop.
     if (gtIsRecursiveCall(call) && call->IsImplicitTailCall())
     {
-        inlineResult.noteFatal(InlineObservation::CALLSITE_IMPLICIT_REC_TAIL_CALL);
+        inlineResult.NoteFatal(InlineObservation::CALLSITE_IMPLICIT_REC_TAIL_CALL);
         return;
     }
 
     if ((call->gtFlags & GTF_CALL_VIRT_KIND_MASK) != GTF_CALL_NONVIRT)
     {
-        inlineResult.noteFatal(InlineObservation::CALLSITE_IS_NOT_DIRECT);
+        inlineResult.NoteFatal(InlineObservation::CALLSITE_IS_NOT_DIRECT);
         return;
     }
 
@@ -16646,14 +16646,14 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
 
     if  (call->gtCallType == CT_HELPER)
     {
-        inlineResult.noteFatal(InlineObservation::CALLSITE_IS_CALL_TO_HELPER);
+        inlineResult.NoteFatal(InlineObservation::CALLSITE_IS_CALL_TO_HELPER);
         return;
     }
 
     /* Ignore indirect calls */
     if  (call->gtCallType == CT_INDIRECT)
     {
-        inlineResult.noteFatal(InlineObservation::CALLSITE_IS_NOT_DIRECT_MANAGED);
+        inlineResult.NoteFatal(InlineObservation::CALLSITE_IS_NOT_DIRECT_MANAGED);
         return;
     }
 
@@ -16693,7 +16693,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
             
 #endif
 
-            inlineResult.noteFatal(InlineObservation::CALLSITE_IS_WITHIN_CATCH);
+            inlineResult.NoteFatal(InlineObservation::CALLSITE_IS_WITHIN_CATCH);
             return;
         }
 
@@ -16706,7 +16706,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
             }
 #endif
 
-            inlineResult.noteFatal(InlineObservation::CALLSITE_IS_WITHIN_FILTER);
+            inlineResult.NoteFatal(InlineObservation::CALLSITE_IS_WITHIN_FILTER);
             return;
         }
     }
@@ -16715,7 +16715,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
 
     if (opts.compNeedSecurityCheck)
     {
-        inlineResult.noteFatal(InlineObservation::CALLER_NEEDS_SECURITY_CHECK);
+        inlineResult.NoteFatal(InlineObservation::CALLER_NEEDS_SECURITY_CHECK);
         return;
     }
 
@@ -16723,7 +16723,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
 
     if (methAttr & CORINFO_FLG_DONT_INLINE)
     {
-        inlineResult.noteFatal(InlineObservation::CALLEE_IS_NOINLINE);
+        inlineResult.NoteFatal(InlineObservation::CALLEE_IS_NOINLINE);
         return;
     }
 
@@ -16731,13 +16731,13 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
 
     if  (methAttr & CORINFO_FLG_NATIVE)
     {
-        inlineResult.noteFatal(InlineObservation::CALLEE_IS_NATIVE);
+        inlineResult.NoteFatal(InlineObservation::CALLEE_IS_NATIVE);
         return;
     }
 
     if  (methAttr & CORINFO_FLG_SYNCH)
     {
-        inlineResult.noteFatal(InlineObservation::CALLEE_IS_SYNCHRONIZED);
+        inlineResult.NoteFatal(InlineObservation::CALLEE_IS_SYNCHRONIZED);
         return;
     }
 
@@ -16745,14 +16745,14 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
 
     if (methAttr & CORINFO_FLG_SECURITYCHECK)
     {
-        inlineResult.noteFatal(InlineObservation::CALLEE_NEEDS_SECURITY_CHECK);
+        inlineResult.NoteFatal(InlineObservation::CALLEE_NEEDS_SECURITY_CHECK);
         return;
     }
 
     InlineCandidateInfo * inlineCandidateInfo = nullptr;
     impCheckCanInline(call, fncHandle, methAttr, exactContextHnd, &inlineCandidateInfo, &inlineResult);
 
-    if (inlineResult.isFailure())
+    if (inlineResult.IsFailure())
     {
 #if defined(DEBUG) || MEASURE_INLINING
         ++Compiler::jitCheckCanInlineFailureCount;    // This is actually the number of methods that starts the inline attempt.
@@ -16775,7 +16775,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
 
     // Since we're not actually inlining yet, and this call site is
     // still just an inline candidate, there's nothing to report.
-    inlineResult.setReported();
+    inlineResult.SetReported();
 }
 
 /******************************************************************************/

--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -37,7 +37,7 @@ static const InlineImpact InlineImpacts[] =
 #ifdef DEBUG
 
 //------------------------------------------------------------------------
-// inlIsValidObservation: run a validity check on an inline observation
+// InlIsValidObservation: run a validity check on an inline observation
 //
 // Arguments:
 //    obs - the observation in question
@@ -45,7 +45,7 @@ static const InlineImpact InlineImpacts[] =
 // Return Value:
 //    true if the observation is valid
 
-bool inlIsValidObservation(InlineObservation obs)
+bool InlIsValidObservation(InlineObservation obs)
 {
     return((obs > InlineObservation::CALLEE_UNUSED_INITIAL) &&
            (obs < InlineObservation::CALLEE_UNUSED_FINAL));
@@ -54,7 +54,7 @@ bool inlIsValidObservation(InlineObservation obs)
 #endif // DEBUG
 
 //------------------------------------------------------------------------
-// inlGetObservationString: get a string describing this inline observation
+// InlGetObservationString: get a string describing this inline observation
 //
 // Arguments:
 //    obs - the observation in question
@@ -62,14 +62,14 @@ bool inlIsValidObservation(InlineObservation obs)
 // Return Value:
 //    string describing the observation
 
-const char* inlGetObservationString(InlineObservation obs)
+const char* InlGetObservationString(InlineObservation obs)
 {
-    assert(inlIsValidObservation(obs));
+    assert(InlIsValidObservation(obs));
     return InlineDescriptions[static_cast<int>(obs)];
 }
 
 //------------------------------------------------------------------------
-// inlGetTarget: get the target of an inline observation
+// InlGetTarget: get the target of an inline observation
 //
 // Arguments:
 //    obs - the observation in question
@@ -77,14 +77,14 @@ const char* inlGetObservationString(InlineObservation obs)
 // Return Value:
 //    enum describing the target
 
-InlineTarget inlGetTarget(InlineObservation obs)
+InlineTarget InlGetTarget(InlineObservation obs)
 {
-    assert(inlIsValidObservation(obs));
+    assert(InlIsValidObservation(obs));
     return InlineTargets[static_cast<int>(obs)];
 }
 
 //------------------------------------------------------------------------
-// inlGetTargetString: get a string describing the target of an inline observation
+// InlGetTargetString: get a string describing the target of an inline observation
 //
 // Arguments:
 //    obs - the observation in question
@@ -92,9 +92,9 @@ InlineTarget inlGetTarget(InlineObservation obs)
 // Return Value:
 //    string describing the target
 
-const char* inlGetTargetString(InlineObservation obs)
+const char* InlGetTargetString(InlineObservation obs)
 {
-    InlineTarget t = inlGetTarget(obs);
+    InlineTarget t = InlGetTarget(obs);
     switch (t)
     {
     case InlineTarget::CALLER:
@@ -109,7 +109,7 @@ const char* inlGetTargetString(InlineObservation obs)
 }
 
 //------------------------------------------------------------------------
-// inlGetImpact: get the impact of an inline observation
+// InlGetImpact: get the impact of an inline observation
 //
 // Arguments:
 //    obs - the observation in question
@@ -117,14 +117,14 @@ const char* inlGetTargetString(InlineObservation obs)
 // Return Value:
 //    enum value describing the impact
 
-InlineImpact inlGetImpact(InlineObservation obs)
+InlineImpact InlGetImpact(InlineObservation obs)
 {
-    assert(inlIsValidObservation(obs));
+    assert(InlIsValidObservation(obs));
     return InlineImpacts[static_cast<int>(obs)];
 }
 
 //------------------------------------------------------------------------
-// inlGetImpactString: get a string describing the impact of an inline observation
+// InlGetImpactString: get a string describing the impact of an inline observation
 //
 // Arguments:
 //    obs - the observation in question
@@ -132,9 +132,9 @@ InlineImpact inlGetImpact(InlineObservation obs)
 // Return Value:
 //    string describing the impact
 
-const char* inlGetImpactString(InlineObservation obs)
+const char* InlGetImpactString(InlineObservation obs)
 {
-    InlineImpact i = inlGetImpact(obs);
+    InlineImpact i = InlGetImpact(obs);
     switch (i)
     {
     case InlineImpact::FATAL:
@@ -153,7 +153,7 @@ const char* inlGetImpactString(InlineObservation obs)
 }
 
 //------------------------------------------------------------------------
-// inlGetCorInfoInlineDecision: translate decision into a CorInfoInline
+// InlGetCorInfoInlineDecision: translate decision into a CorInfoInline
 //
 // Arguments:
 //    d - the decision in question
@@ -161,7 +161,7 @@ const char* inlGetImpactString(InlineObservation obs)
 // Return Value:
 //    CorInfoInline value representing the decision
 
-CorInfoInline inlGetCorInfoInlineDecision(InlineDecision d)
+CorInfoInline InlGetCorInfoInlineDecision(InlineDecision d)
 {
     switch (d) {
     case InlineDecision::SUCCESS:
@@ -177,7 +177,7 @@ CorInfoInline inlGetCorInfoInlineDecision(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlGetDecisionString: get a string representing this decision
+// InlGetDecisionString: get a string representing this decision
 //
 // Arguments:
 //    d - the decision in question
@@ -185,7 +185,7 @@ CorInfoInline inlGetCorInfoInlineDecision(InlineDecision d)
 // Return Value:
 //    string representing the decision
 
-const char* inlGetDecisionString(InlineDecision d)
+const char* InlGetDecisionString(InlineDecision d)
 {
     switch (d) {
     case InlineDecision::SUCCESS:
@@ -205,7 +205,7 @@ const char* inlGetDecisionString(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsFailure: check if this decision describes a failing inline
+// InlDecisionIsFailure: check if this decision describes a failing inline
 //
 // Arguments:
 //    d - the decision in question
@@ -213,7 +213,7 @@ const char* inlGetDecisionString(InlineDecision d)
 // Return Value:
 //    true if the inline is definitely a failure
 
-bool inlDecisionIsFailure(InlineDecision d)
+bool InlDecisionIsFailure(InlineDecision d)
 {
     switch (d) {
     case InlineDecision::SUCCESS:
@@ -230,7 +230,7 @@ bool inlDecisionIsFailure(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsSuccess: check if this decision describes a sucessful inline
+// InlDecisionIsSuccess: check if this decision describes a sucessful inline
 //
 // Arguments:
 //    d - the decision in question
@@ -238,7 +238,7 @@ bool inlDecisionIsFailure(InlineDecision d)
 // Return Value:
 //    true if the inline is definitely a success
 
-bool inlDecisionIsSuccess(InlineDecision d)
+bool InlDecisionIsSuccess(InlineDecision d)
 {
     switch (d) {
     case InlineDecision::SUCCESS:
@@ -255,7 +255,7 @@ bool inlDecisionIsSuccess(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsNever: check if this decision describes a never inline
+// InlDecisionIsNever: check if this decision describes a never inline
 //
 // Arguments:
 //    d - the decision in question
@@ -263,7 +263,7 @@ bool inlDecisionIsSuccess(InlineDecision d)
 // Return Value:
 //    true if the inline is a never inline case
 
-bool inlDecisionIsNever(InlineDecision d)
+bool InlDecisionIsNever(InlineDecision d)
 {
     switch (d) {
     case InlineDecision::NEVER:
@@ -280,7 +280,7 @@ bool inlDecisionIsNever(InlineDecision d)
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsCandidate: check if this decision describes a viable candidate
+// InlDecisionIsCandidate: check if this decision describes a viable candidate
 //
 // Arguments:
 //    d - the decision in question
@@ -288,13 +288,13 @@ bool inlDecisionIsNever(InlineDecision d)
 // Return Value:
 //    true if this inline still might happen
 
-bool inlDecisionIsCandidate(InlineDecision d)
+bool InlDecisionIsCandidate(InlineDecision d)
 {
-    return !inlDecisionIsFailure(d);
+    return !InlDecisionIsFailure(d);
 }
 
 //------------------------------------------------------------------------
-// inlDecisionIsDecided: check if this decision has been made
+// InlDecisionIsDecided: check if this decision has been made
 //
 // Arguments:
 //    d - the decision in question
@@ -302,7 +302,7 @@ bool inlDecisionIsCandidate(InlineDecision d)
 // Return Value:
 //    true if this inline has been decided one way or another
 
-bool inlDecisionIsDecided(InlineDecision d)
+bool InlDecisionIsDecided(InlineDecision d)
 {
     switch (d) {
     case InlineDecision::NEVER:
@@ -322,23 +322,23 @@ bool inlDecisionIsDecided(InlineDecision d)
 // InlineContext: default constructor
 
 InlineContext::InlineContext()
-    : inlParent(nullptr)
-    , inlChild(nullptr)
-    , inlSibling(nullptr)
-    , inlOffset(BAD_IL_OFFSET)
-    , inlCode(nullptr)
-    , inlObservation(InlineObservation::CALLEE_UNUSED_INITIAL)
+    : m_Parent(nullptr)
+    , m_Child(nullptr)
+    , m_Sibling(nullptr)
+    , m_Offset(BAD_IL_OFFSET)
+    , m_Code(nullptr)
+    , m_Observation(InlineObservation::CALLEE_UNUSED_INITIAL)
 #ifdef DEBUG
-    , inlCallee(nullptr)
-    , inlTreeID(0)
-    , inlSuccess(true)
+    , m_Callee(nullptr)
+    , m_TreeID(0)
+    , m_Success(true)
 #endif
 {
     // Empty
 }
 
 //------------------------------------------------------------------------
-// newRoot: construct an InlineContext for the root method
+// NewRoot: construct an InlineContext for the root method
 //
 // Arguments:
 //   compiler - compiler doing the inlining
@@ -351,19 +351,19 @@ InlineContext::InlineContext()
 //    address of the root method) to preserve existing behavior, which
 //    is to allow one recursive inline.
 
-InlineContext* InlineContext::newRoot(Compiler* compiler)
+InlineContext* InlineContext::NewRoot(Compiler* compiler)
 {
     InlineContext* rootContext = new (compiler, CMK_Inlining) InlineContext;
 
 #if defined(DEBUG)
-    rootContext->inlCallee = compiler->info.compMethodHnd;
+    rootContext->m_Callee = compiler->info.compMethodHnd;
 #endif
 
     return rootContext;
 }
 
 //------------------------------------------------------------------------
-// newSuccess: construct an InlineContext for a successful inline
+// NewSuccess: construct an InlineContext for a successful inline
 // and link it into the context tree
 //
 // Arguments:
@@ -375,7 +375,7 @@ InlineContext* InlineContext::newRoot(Compiler* compiler)
 //    A new InlineContext for statements brought into the method by
 //    this inline.
 
-InlineContext* InlineContext::newSuccess(Compiler*   compiler,
+InlineContext* InlineContext::NewSuccess(Compiler*   compiler,
                                          InlineInfo* inlineInfo)
 {
     InlineContext* calleeContext = new (compiler, CMK_Inlining) InlineContext;
@@ -386,18 +386,18 @@ InlineContext* InlineContext::newSuccess(Compiler*   compiler,
 
     noway_assert(parentContext != nullptr);
 
-    calleeContext->inlCode = calleeIL;
-    calleeContext->inlParent = parentContext;
+    calleeContext->m_Code = calleeIL;
+    calleeContext->m_Parent = parentContext;
     // Push on front here will put siblings in reverse lexical
     // order which we undo in the dumper
-    calleeContext->inlSibling = parentContext->inlChild;
-    parentContext->inlChild = calleeContext;
-    calleeContext->inlChild = nullptr;
-    calleeContext->inlOffset = stmt->AsStmt()->gtStmtILoffsx;
-    calleeContext->inlObservation = inlineInfo->inlineResult->getObservation();
+    calleeContext->m_Sibling = parentContext->m_Child;
+    parentContext->m_Child = calleeContext;
+    calleeContext->m_Child = nullptr;
+    calleeContext->m_Offset = stmt->AsStmt()->gtStmtILoffsx;
+    calleeContext->m_Observation = inlineInfo->inlineResult->GetObservation();
 #ifdef DEBUG
-    calleeContext->inlCallee = inlineInfo->fncHandle;
-    calleeContext->inlTreeID = inlineInfo->inlineResult->getCall()->gtTreeID;
+    calleeContext->m_Callee = inlineInfo->fncHandle;
+    calleeContext->m_TreeID = inlineInfo->inlineResult->GetCall()->gtTreeID;
 #endif
 
     return calleeContext;
@@ -406,7 +406,7 @@ InlineContext* InlineContext::newSuccess(Compiler*   compiler,
 #ifdef DEBUG
 
 //------------------------------------------------------------------------
-// newFailure: construct an InlineContext for a failing inline
+// NewFailure: construct an InlineContext for a failing inline
 // and link it into the context tree
 //
 // Arguments:
@@ -415,11 +415,10 @@ InlineContext* InlineContext::newSuccess(Compiler*   compiler,
 //    inlineResult - inlineResult for the attempt
 //
 // Return Value:
-//
 //    A new InlineContext for diagnostic purposes, or nullptr if
 //    the desired context could not be created.
 
-InlineContext* InlineContext::newFailure(Compiler*     compiler,
+InlineContext* InlineContext::NewFailure(Compiler*     compiler,
                                          GenTree*      stmt,
                                          InlineResult* inlineResult)
 {
@@ -443,17 +442,17 @@ InlineContext* InlineContext::newFailure(Compiler*     compiler,
 
     InlineContext* failedContext = new (compiler, CMK_Inlining) InlineContext;
 
-    failedContext->inlParent = parentContext;
+    failedContext->m_Parent = parentContext;
     // Push on front here will put siblings in reverse lexical
     // order which we undo in the dumper
-    failedContext->inlSibling = parentContext->inlChild;
-    parentContext->inlChild = failedContext;
-    failedContext->inlChild = nullptr;
-    failedContext->inlOffset = stmt->AsStmt()->gtStmtILoffsx;
-    failedContext->inlObservation = inlineResult->getObservation();
-    failedContext->inlCallee = inlineResult->getCallee();
-    failedContext->inlSuccess = false;
-    failedContext->inlTreeID = inlineResult->getCall()->gtTreeID;
+    failedContext->m_Sibling = parentContext->m_Child;
+    parentContext->m_Child = failedContext;
+    failedContext->m_Child = nullptr;
+    failedContext->m_Offset = stmt->AsStmt()->gtStmtILoffsx;
+    failedContext->m_Observation = inlineResult->GetObservation();
+    failedContext->m_Callee = inlineResult->GetCallee();
+    failedContext->m_Success = false;
+    failedContext->m_TreeID = inlineResult->GetCall()->gtTreeID;
 
     return failedContext;
 }
@@ -468,26 +467,26 @@ InlineContext* InlineContext::newFailure(Compiler*     compiler,
 void InlineContext::Dump(Compiler* compiler, int indent)
 {
     // Handle fact that siblings are in reverse order.
-    if (inlSibling != nullptr)
+    if (m_Sibling != nullptr)
     {
-        inlSibling->Dump(compiler, indent);
+        m_Sibling->Dump(compiler, indent);
     }
 
     // We may not know callee name in some of the failing cases
     const char* calleeName = nullptr;
 
-    if (inlCallee == nullptr)
+    if (m_Callee == nullptr)
     {
-        assert(!inlSuccess);
+        assert(!m_Success);
         calleeName = "<unknown>";
     }
     else
     {
-        calleeName = compiler->eeGetMethodFullName(inlCallee);
+        calleeName = compiler->eeGetMethodFullName(m_Callee);
     }
 
     // Dump this node
-    if (inlParent == nullptr)
+    if (m_Parent == nullptr)
     {
         // Root method
         printf("Inlines into %s\n", calleeName);
@@ -495,29 +494,29 @@ void InlineContext::Dump(Compiler* compiler, int indent)
     else
     {
         // Inline attempt.
-        const char* inlineReason = inlGetObservationString(inlObservation);
-        const char* inlineResult = inlSuccess ? "" : "FAILED: ";
+        const char* inlineReason = InlGetObservationString(m_Observation);
+        const char* inlineResult = m_Success ? "" : "FAILED: ";
 
         for (int i = 0; i < indent; i++)
         {
             printf(" ");
         }
 
-        if (inlOffset == BAD_IL_OFFSET)
+        if (m_Offset == BAD_IL_OFFSET)
         {
-            printf("[IL=???? TR=%06u] [%s%s] %s\n", inlTreeID, inlineResult, inlineReason, calleeName);
+            printf("[IL=???? TR=%06u] [%s%s] %s\n", m_TreeID, inlineResult, inlineReason, calleeName);
         }
         else
         {
-            IL_OFFSET offset = jitGetILoffs(inlOffset);
-            printf("[IL=%04d TR=%06u] [%s%s] %s\n", offset, inlTreeID, inlineResult, inlineReason, calleeName);
+            IL_OFFSET offset = jitGetILoffs(m_Offset);
+            printf("[IL=%04d TR=%06u] [%s%s] %s\n", offset, m_TreeID, inlineResult, inlineReason, calleeName);
         }
     }
 
     // Recurse to first child
-    if (inlChild != nullptr)
+    if (m_Child != nullptr)
     {
-        inlChild->Dump(compiler, indent + 2);
+        m_Child->Dump(compiler, indent + 2);
     }
 }
 
@@ -535,25 +534,25 @@ void InlineContext::Dump(Compiler* compiler, int indent)
 InlineResult::InlineResult(Compiler*    compiler,
                            GenTreeCall* call,
                            const char*  context)
-    : inlCompiler(compiler)
-    , inlPolicy(nullptr)
-    , inlCall(call)
-    , inlCaller(nullptr)
-    , inlCallee(nullptr)
-    , inlContext(context)
-    , inlReported(false)
+    : m_Compiler(compiler)
+    , m_Policy(nullptr)
+    , m_Call(call)
+    , m_Caller(nullptr)
+    , m_Callee(nullptr)
+    , m_Context(context)
+    , m_Reported(false)
 {
     // Set the policy
     const bool isPrejitRoot = false;
-    inlPolicy = InlinePolicy::getPolicy(compiler, isPrejitRoot);
+    m_Policy = InlinePolicy::GetPolicy(m_Compiler, isPrejitRoot);
 
     // Get method handle for caller
-    inlCaller = inlCompiler->info.compMethodHnd;
+    m_Caller = m_Compiler->info.compMethodHnd;
 
     // Get method handle for callee, if known
-    if (inlCall->gtCall.gtCallType == CT_USER_FUNC)
+    if (m_Call->gtCall.gtCallType == CT_USER_FUNC)
     {
-        inlCallee = call->gtCall.gtCallMethHnd;
+        m_Callee = m_Call->gtCall.gtCallMethHnd;
     }
 }
 
@@ -576,21 +575,21 @@ InlineResult::InlineResult(Compiler*    compiler,
 InlineResult::InlineResult(Compiler*              compiler,
                            CORINFO_METHOD_HANDLE  method,
                            const char*            context)
-    : inlCompiler(compiler)
-    , inlPolicy(nullptr)
-    , inlCall(nullptr)
-    , inlCaller(nullptr)
-    , inlCallee(method)
-    , inlContext(context)
-    , inlReported(false)
+    : m_Compiler(compiler)
+    , m_Policy(nullptr)
+    , m_Call(nullptr)
+    , m_Caller(nullptr)
+    , m_Callee(method)
+    , m_Context(context)
+    , m_Reported(false)
 {
     // Set the policy
     const bool isPrejitRoot = true;
-    inlPolicy = InlinePolicy::getPolicy(compiler, isPrejitRoot);
+    m_Policy = InlinePolicy::GetPolicy(m_Compiler, isPrejitRoot);
 }
 
 //------------------------------------------------------------------------
-// report: Dump, log, and report information about an inline decision.
+// Report: Dump, log, and report information about an inline decision.
 //
 // Notes:
 //    Called (automatically via the InlineResult dtor) when the
@@ -604,15 +603,15 @@ InlineResult::InlineResult(Compiler*              compiler,
 //    All this can be suppressed if desired by calling setReported()
 //    before the InlineResult goes out of scope.
 
-void InlineResult::report()
+void InlineResult::Report()
 {
     // User may have suppressed reporting via setReported(). If so, do nothing.
-    if (inlReported)
+    if (m_Reported)
     {
         return;
     }
 
-    inlReported = true;
+    m_Reported = true;
 
 #ifdef DEBUG
 
@@ -622,21 +621,21 @@ void InlineResult::report()
     if (VERBOSE)
     {
         const char* format = "INLINER: during '%s' result '%s' reason '%s' for '%s' calling '%s'\n";
-        const char* caller = (inlCaller == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlCaller);
+        const char* caller = (m_Caller == nullptr) ? "n/a" : m_Compiler->eeGetMethodFullName(m_Caller);
 
-        callee = (inlCallee == nullptr) ? "n/a" : inlCompiler->eeGetMethodFullName(inlCallee);
+        callee = (m_Callee == nullptr) ? "n/a" : m_Compiler->eeGetMethodFullName(m_Callee);
 
-        JITDUMP(format, inlContext, resultString(), reasonString(), caller, callee);
+        JITDUMP(format, m_Context, ResultString(), ReasonString(), caller, callee);
     }
 
     // If the inline failed, leave information on the call so we can
     // later recover what observation lead to the failure.
-    if (isFailure() && (inlCall != nullptr))
+    if (IsFailure() && (m_Call != nullptr))
     {
         // compiler should have revoked candidacy on the call by now
-        assert((inlCall->gtFlags & GTF_CALL_INLINE_CANDIDATE) == 0);
+        assert((m_Call->gtFlags & GTF_CALL_INLINE_CANDIDATE) == 0);
 
-        inlCall->gtInlineObservation = inlPolicy->getObservation();
+        m_Call->gtInlineObservation = m_Policy->GetObservation();
     }
 
 #endif // DEBUG
@@ -644,7 +643,7 @@ void InlineResult::report()
     // Was the result NEVER? If so we might want to propagate this to
     // the runtime.
 
-    if (isNever() && inlPolicy->propagateNeverToRuntime())
+    if (IsNever() && m_Policy->PropagateNeverToRuntime())
     {
         // If we know the callee, and if the observation that got us
         // to this Never inline state is something *other* than
@@ -652,32 +651,32 @@ void InlineResult::report()
         // can't ever be inlined. Update the callee method attributes
         // so that future inline attempts for this callee fail faster.
 
-        InlineObservation obs = inlPolicy->getObservation();
+        InlineObservation obs = m_Policy->GetObservation();
 
-        if ((inlCallee != nullptr) && (obs != InlineObservation::CALLEE_IS_NOINLINE))
+        if ((m_Callee != nullptr) && (obs != InlineObservation::CALLEE_IS_NOINLINE))
         {
 
 #ifdef DEBUG
 
             if (VERBOSE)
             {
-                const char* obsString = inlGetObservationString(obs);
+                const char* obsString = InlGetObservationString(obs);
                 JITDUMP("\nINLINER: Marking %s as NOINLINE because of %s\n", callee, obsString);
             }
 
 #endif  // DEBUG
 
-            COMP_HANDLE comp = inlCompiler->info.compCompHnd;
-            comp->setMethodAttribs(inlCallee, CORINFO_FLG_BAD_INLINEE);
+            COMP_HANDLE comp = m_Compiler->info.compCompHnd;
+            comp->setMethodAttribs(m_Callee, CORINFO_FLG_BAD_INLINEE);
         }
     }
 
 
-    if (isDecided())
+    if (IsDecided())
     {
         const char* format = "INLINER: during '%s' result '%s' reason '%s'\n";
-        JITLOG_THIS(inlCompiler, (LL_INFO100000, format, inlContext, resultString(), reasonString()));
-        COMP_HANDLE comp = inlCompiler->info.compCompHnd;
-        comp->reportInliningDecision(inlCaller, inlCallee, result(), reasonString());
+        JITLOG_THIS(m_Compiler, (LL_INFO100000, format, m_Context, ResultString(), ReasonString()));
+        COMP_HANDLE comp = m_Compiler->info.compCompHnd;
+        comp->reportInliningDecision(m_Caller, m_Callee, Result(), ReasonString());
     }
 }

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -131,31 +131,31 @@ enum class InlineDecision
 
 // Translate a decision into a CorInfoInline for reporting back to the runtime.
 
-CorInfoInline inlGetCorInfoInlineDecision(InlineDecision d);
+CorInfoInline InlGetCorInfoInlineDecision(InlineDecision d);
 
 // Get a string describing this InlineDecision
 
-const char* inlGetDecisionString(InlineDecision d);
+const char* InlGetDecisionString(InlineDecision d);
 
 // True if this InlineDecsion describes a failing inline
 
-bool inlDecisionIsFailure(InlineDecision d);
+bool InlDecisionIsFailure(InlineDecision d);
 
 // True if this decision describes a successful inline
 
-bool inlDecisionIsSuccess(InlineDecision d);
+bool InlDecisionIsSuccess(InlineDecision d);
 
 // True if this InlineDecision is a never inline decision
 
-bool inlDecisionIsNever(InlineDecision d);
+bool InlDecisionIsNever(InlineDecision d);
 
 // True if this InlineDecision describes a viable candidate
 
-bool inlDecisionIsCandidate(InlineDecision d);
+bool InlDecisionIsCandidate(InlineDecision d);
 
 // True if this InlineDecsion describes a decision
 
-bool inlDecisionIsDecided(InlineDecision d);
+bool InlDecisionIsDecided(InlineDecision d);
 
 // InlineTarget describes the possible targets of an inline observation.
 
@@ -190,29 +190,29 @@ enum class InlineObservation
 
 // Sanity check the observation value
 
-bool inlIsValidObservation(InlineObservation obs);
+bool InlIsValidObservation(InlineObservation obs);
 
 #endif // DEBUG
 
 // Get a string describing this observation
 
-const char* inlGetObservationString(InlineObservation obs);
+const char* InlGetObservationString(InlineObservation obs);
 
 // Get a string describing the target of this observation
 
-const char* inlGetTargetString(InlineObservation obs);
+const char* InlGetTargetString(InlineObservation obs);
 
 // Get a string describing the impact of this observation
 
-const char* inlGetImpactString(InlineObservation obs);
+const char* InlGetImpactString(InlineObservation obs);
 
 // Get the target of this observation
 
-InlineTarget inlGetTarget(InlineObservation obs);
+InlineTarget InlGetTarget(InlineObservation obs);
 
 // Get the impact of this observation
 
-InlineImpact inlGetImpact(InlineObservation obs);
+InlineImpact InlGetImpact(InlineObservation obs);
 
 // InlinePolicy is an abstract base class for a family of inline
 // policies.
@@ -222,43 +222,43 @@ class InlinePolicy
 public:
 
     // Factory method for getting policies
-    static InlinePolicy* getPolicy(Compiler* compiler, bool isPrejitRoot);
+    static InlinePolicy* GetPolicy(Compiler* compiler, bool isPrejitRoot);
 
     // Obligatory virtual dtor
     virtual ~InlinePolicy() {}
 
     // Get the current decision
-    InlineDecision getDecision() const { return inlDecision; }
+    InlineDecision GetDecision() const { return m_Decision; }
 
     // Get the observation responsible for the result
-    InlineObservation getObservation() const { return inlObservation; }
+    InlineObservation GetObservation() const { return m_Observation; }
 
     // Policy observations
-    virtual void noteSuccess() = 0;
-    virtual void noteBool(InlineObservation obs, bool value) = 0;
-    virtual void noteFatal(InlineObservation obs) = 0;
-    virtual void noteInt(InlineObservation obs, int value) = 0;
-    virtual void noteDouble(InlineObservation obs, double value) = 0;
+    virtual void NoteSuccess() = 0;
+    virtual void NoteBool(InlineObservation obs, bool value) = 0;
+    virtual void NoteFatal(InlineObservation obs) = 0;
+    virtual void NoteInt(InlineObservation obs, int value) = 0;
+    virtual void NoteDouble(InlineObservation obs, double value) = 0;
 
     // Policy determinations
-    virtual double determineMultiplier() = 0;
-    virtual int determineNativeSizeEstimate() = 0;
-    virtual int determineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) = 0;
+    virtual double DetermineMultiplier() = 0;
+    virtual int DetermineNativeSizeEstimate() = 0;
+    virtual int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) = 0;
 
     // Policy policies
-    virtual bool propagateNeverToRuntime() const = 0;
+    virtual bool PropagateNeverToRuntime() const = 0;
 
 #ifdef DEBUG
     // Name of the policy
-    virtual const char* getName() const = 0;
+    virtual const char* GetName() const = 0;
 #endif
 
 protected:
 
     InlinePolicy(bool isPrejitRoot)
-        : inlDecision(InlineDecision::UNDECIDED)
-        , inlObservation(InlineObservation::CALLEE_UNUSED_INITIAL)
-        , inlIsPrejitRoot(isPrejitRoot)
+        : m_Decision(InlineDecision::UNDECIDED)
+        , m_Observation(InlineObservation::CALLEE_UNUSED_INITIAL)
+        , m_IsPrejitRoot(isPrejitRoot)
     {
         // empty
     }
@@ -271,9 +271,9 @@ private:
 
 protected:
 
-    InlineDecision    inlDecision;
-    InlineObservation inlObservation;
-    bool              inlIsPrejitRoot;
+    InlineDecision    m_Decision;
+    InlineObservation m_Observation;
+    bool              m_IsPrejitRoot;
 };
 
 // InlineResult summarizes what is known about the viability of a
@@ -296,42 +296,42 @@ public:
                  const char*            context);
 
     // Has the policy determined this inline should fail?
-    bool isFailure() const
+    bool IsFailure() const
     {
-        return inlDecisionIsFailure(inlPolicy->getDecision());
+        return InlDecisionIsFailure(m_Policy->GetDecision());
     }
 
     // Has the policy determined this inline will succeed?
-    bool isSuccess() const
+    bool IsSuccess() const
     {
-        return inlDecisionIsSuccess(inlPolicy->getDecision());
+        return InlDecisionIsSuccess(m_Policy->GetDecision());
     }
 
     // Has the policy determined this inline will fail,
     // and that the callee should never be inlined?
-    bool isNever() const
+    bool IsNever() const
     {
-        return inlDecisionIsNever(inlPolicy->getDecision());
+        return InlDecisionIsNever(m_Policy->GetDecision());
     }
 
     // Has the policy determined this inline attempt is still viable?
-    bool isCandidate() const
+    bool IsCandidate() const
     {
-        return inlDecisionIsCandidate(inlPolicy->getDecision());
+        return InlDecisionIsCandidate(m_Policy->GetDecision());
     }
 
     // Has the policy made a determination?
-    bool isDecided() const
+    bool IsDecided() const
     {
-        return inlDecisionIsDecided(inlPolicy->getDecision());
+        return InlDecisionIsDecided(m_Policy->GetDecision());
     }
 
-    // noteSuccess means the all the various checks have passed and
+    // NoteSuccess means the all the various checks have passed and
     // the inline can happen.
-    void noteSuccess()
+    void NoteSuccess()
     {
-        assert(isCandidate());
-        inlPolicy->noteSuccess();
+        assert(IsCandidate());
+        m_Policy->NoteSuccess();
     }
 
     // Make a true observation, and update internal state
@@ -339,9 +339,9 @@ public:
     //
     // Caller is expected to call isFailure after this to see whether
     // more observation is desired.
-    void note(InlineObservation obs)
+    void Note(InlineObservation obs)
     {
-        inlPolicy->noteBool(obs, true);
+        m_Policy->NoteBool(obs, true);
     }
 
     // Make a boolean observation, and update internal state
@@ -349,95 +349,98 @@ public:
     //
     // Caller is expected to call isFailure after this to see whether
     // more observation is desired.
-    void noteBool(InlineObservation obs, bool value)
+    void NoteBool(InlineObservation obs, bool value)
     {
-        inlPolicy->noteBool(obs, value);
+        m_Policy->NoteBool(obs, value);
     }
 
     // Make an observation that must lead to immediate failure.
-    void noteFatal(InlineObservation obs)
+    void NoteFatal(InlineObservation obs)
     {
-        inlPolicy->noteFatal(obs);
-        assert(isFailure());
+        m_Policy->NoteFatal(obs);
+        assert(IsFailure());
     }
 
     // Make an observation with an int value
-    void noteInt(InlineObservation obs, int value)
+    void NoteInt(InlineObservation obs, int value)
     {
-        inlPolicy->noteInt(obs, value);
+        m_Policy->NoteInt(obs, value);
     }
 
     // Make an observation with a double value
-    void noteDouble(InlineObservation obs, double value)
+    void NoteDouble(InlineObservation obs, double value)
     {
-        inlPolicy->noteDouble(obs, value);
+        m_Policy->NoteDouble(obs, value);
     }
 
     // Determine the benfit multiplier for this inline.
-    double determineMultiplier()
+    double DetermineMultiplier()
     {
-        return inlPolicy->determineMultiplier();
+        return m_Policy->DetermineMultiplier();
     }
 
     // Determine the native size estimate for this inline
-    int determineNativeSizeEstimate()
+    int DetermineNativeSizeEstimate()
     {
-        return inlPolicy->determineNativeSizeEstimate();
+        return m_Policy->DetermineNativeSizeEstimate();
     }
 
     // Determine the native size estimate for this call site
-    int determineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo)
+    int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo)
     {
-        return inlPolicy->determineCallsiteNativeSizeEstimate(methodInfo);
+        return m_Policy->DetermineCallsiteNativeSizeEstimate(methodInfo);
     }
 
     // Ensure details of this inlining process are appropriately
     // reported when the result goes out of scope.
     ~InlineResult()
     {
-        report();
+        Report();
     }
 
     // The observation leading to this particular result
-    InlineObservation getObservation() const
+    InlineObservation GetObservation() const
     {
-        return inlPolicy->getObservation();
+        return m_Policy->GetObservation();
     }
 
     // The callee handle for this result
-    CORINFO_METHOD_HANDLE getCallee() const
+    CORINFO_METHOD_HANDLE GetCallee() const
     {
-        return inlCallee;
+        return m_Callee;
     }
 
     // The call being considered
-    GenTreeCall* getCall() const
+    GenTreeCall* GetCall() const
     {
-        return inlCall;
+        return m_Call;
     }
 
     // Result that can be reported back to the runtime
-    CorInfoInline result() const
+    CorInfoInline Result() const
     {
-        return inlGetCorInfoInlineDecision(inlPolicy->getDecision());
+        return InlGetCorInfoInlineDecision(m_Policy->GetDecision());
     }
 
     // String describing the decision made
-    const char * resultString() const
+    const char * ResultString() const
     {
-        return inlGetDecisionString(inlPolicy->getDecision());
+        return InlGetDecisionString(m_Policy->GetDecision());
     }
 
     // String describing the reason for the decision
-    const char * reasonString() const
+    const char * ReasonString() const
     {
-        return inlGetObservationString(inlPolicy->getObservation());
+        return InlGetObservationString(m_Policy->GetObservation());
     }
 
-    // setReported indicates that this particular result doesn't need
+    // SetReported indicates that this particular result doesn't need
     // to be reported back to the runtime, either because the runtime
     // already knows, or we aren't actually inlining yet.
-    void setReported() { inlReported = true; }
+    void SetReported() 
+    { 
+        m_Reported = true; 
+    }
 
 private:
 
@@ -446,15 +449,15 @@ private:
     InlineResult& operator=(const InlineResult&) = delete;
 
     // Report/log/dump decision as appropriate
-    void report();
+    void Report();
 
-    Compiler*               inlCompiler;
-    InlinePolicy*           inlPolicy;
-    GenTreeCall*            inlCall;
-    CORINFO_METHOD_HANDLE   inlCaller;
-    CORINFO_METHOD_HANDLE   inlCallee;
-    const char*             inlContext;
-    bool                    inlReported;
+    Compiler*               m_Compiler;
+    InlinePolicy*           m_Policy;
+    GenTreeCall*            m_Call;
+    CORINFO_METHOD_HANDLE   m_Caller;
+    CORINFO_METHOD_HANDLE   m_Callee;
+    const char*             m_Context;
+    bool                    m_Reported;
 };
 
 // InlineCandidateInfo provides basic information about a particular
@@ -554,16 +557,16 @@ class InlineContext
 public:
 
     // New context for the root instance
-    static InlineContext* newRoot(Compiler* compiler);
+    static InlineContext* NewRoot(Compiler* compiler);
 
     // New context for a successful inline
-    static InlineContext* newSuccess(Compiler*   compiler,
+    static InlineContext* NewSuccess(Compiler*   compiler,
                                      InlineInfo* inlineInfo);
 
 #ifdef DEBUG
 
     // New context for a failing inline
-    static InlineContext* newFailure(Compiler *    compiler,
+    static InlineContext* NewFailure(Compiler *    compiler,
                                      GenTree*      stmt,
                                      InlineResult* inlineResult);
 
@@ -573,15 +576,15 @@ public:
 #endif
 
     // Get the parent context for this context.
-    InlineContext* getParent() const
+    InlineContext* GetParent() const
     {
-        return inlParent;
+        return m_Parent;
     }
 
     // Get the code pointer for this context.
-    BYTE* getCode() const
+    BYTE* GetCode() const
     {
-        return inlCode;
+        return m_Code;
     }
 
 private:
@@ -590,17 +593,17 @@ private:
 
 private:
 
-    InlineContext*        inlParent;      // logical caller (parent)
-    InlineContext*        inlChild;       // first child
-    InlineContext*        inlSibling;     // next child of the parent
-    IL_OFFSETX            inlOffset;      // call site location within parent
-    BYTE*                 inlCode;        // address of IL buffer for the method
-    InlineObservation     inlObservation; // what lead to this inline
+    InlineContext*        m_Parent;      // logical caller (parent)
+    InlineContext*        m_Child;       // first child
+    InlineContext*        m_Sibling;     // next child of the parent
+    IL_OFFSETX            m_Offset;      // call site location within parent
+    BYTE*                 m_Code;        // address of IL buffer for the method
+    InlineObservation     m_Observation; // what lead to this inline
 
 #ifdef DEBUG
-    CORINFO_METHOD_HANDLE inlCallee;      // handle to the method
-    unsigned              inlTreeID;      // ID of the GenTreeCall
-    bool                  inlSuccess;     // true if this was a successful inline
+    CORINFO_METHOD_HANDLE m_Callee;      // handle to the method
+    unsigned              m_TreeID;      // ID of the GenTreeCall
+    bool                  m_Success;     // true if this was a successful inline
 #endif
 
 };

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -24,7 +24,7 @@
 //    Determines which of the various policies should apply,
 //    and creates (or reuses) a policy instance to use.
 
-InlinePolicy* InlinePolicy::getPolicy(Compiler* compiler, bool isPrejitRoot)
+InlinePolicy* InlinePolicy::GetPolicy(Compiler* compiler, bool isPrejitRoot)
 {
     // For now, always create a Legacy policy.
     InlinePolicy* policy = new (compiler, CMK_Inlining) LegacyPolicy(compiler, isPrejitRoot);
@@ -33,24 +33,24 @@ InlinePolicy* InlinePolicy::getPolicy(Compiler* compiler, bool isPrejitRoot)
 }
 
 //------------------------------------------------------------------------
-// noteSuccess: handle finishing all the inlining checks successfully
+// NoteSuccess: handle finishing all the inlining checks successfully
 
-void LegacyPolicy::noteSuccess()
+void LegacyPolicy::NoteSuccess()
 {
-    assert(inlDecisionIsCandidate(inlDecision));
-    inlDecision = InlineDecision::SUCCESS;
+    assert(InlDecisionIsCandidate(m_Decision));
+    m_Decision = InlineDecision::SUCCESS;
 }
 
 //------------------------------------------------------------------------
-// noteBool: handle a boolean observation with non-fatal impact
+// NoteBool: handle a boolean observation with non-fatal impact
 //
 // Arguments:
 //    obs      - the current obsevation
 //    value    - the value of the observation
-void LegacyPolicy::noteBool(InlineObservation obs, bool value)
+void LegacyPolicy::NoteBool(InlineObservation obs, bool value)
 {
     // Check the impact
-    InlineImpact impact = inlGetImpact(obs);
+    InlineImpact impact = InlGetImpact(obs);
 
     // As a safeguard, all fatal impact must be
     // reported via noteFatal.
@@ -67,53 +67,53 @@ void LegacyPolicy::noteBool(InlineObservation obs, bool value)
         case InlineObservation::CALLEE_IS_FORCE_INLINE:
             // We may make the force-inline observation more than
             // once.  All observations should agree.
-            assert(!inlIsForceInlineKnown || (inlIsForceInline == value));
-            inlIsForceInline = value;
-            inlIsForceInlineKnown = true;
+            assert(!m_IsForceInlineKnown || (m_IsForceInline == value));
+            m_IsForceInline = value;
+            m_IsForceInlineKnown = true;
             break;
         case InlineObservation::CALLEE_IS_INSTANCE_CTOR:
-            inlIsInstanceCtor = value;
+            m_IsInstanceCtor = value;
             break;
         case InlineObservation::CALLEE_CLASS_PROMOTABLE:
-            inlIsFromPromotableValueClass = value;
+            m_IsFromPromotableValueClass = value;
             break;
         case InlineObservation::CALLEE_HAS_SIMD:
-            inlHasSimd = value;
+            m_HasSimd = value;
             break;
         case InlineObservation::CALLEE_LOOKS_LIKE_WRAPPER:
-            inlLooksLikeWrapperMethod = value;
+            m_LooksLikeWrapperMethod = value;
             break;
         case InlineObservation::CALLEE_ARG_FEEDS_CONSTANT_TEST:
-            inlArgFeedsConstantTest = value;
+            m_ArgFeedsConstantTest = value;
             break;
         case InlineObservation::CALLEE_ARG_FEEDS_RANGE_CHECK:
-            inlArgFeedsRangeCheck = value;
+            m_ArgFeedsRangeCheck = value;
             break;
         case InlineObservation::CALLEE_IS_MOSTLY_LOAD_STORE:
-            inlMethodIsMostlyLoadStore = value;
+            m_MethodIsMostlyLoadStore = value;
             break;
         case InlineObservation::CALLEE_HAS_SWITCH:
             // Pass this one on, it should cause inlining to fail.
             propagate = true;
             break;
         case InlineObservation::CALLSITE_CONSTANT_ARG_FEEDS_TEST:
-            inlConstantFeedsConstantTest = value;
+            m_ConstantFeedsConstantTest = value;
             break;
         case InlineObservation::CALLSITE_NATIVE_SIZE_ESTIMATE_OK:
             // Passed the profitability screen. Update candidacy.
-            setCandidate(obs);
+            SetCandidate(obs);
             break;
         case InlineObservation::CALLEE_BEGIN_OPCODE_SCAN:
             {
                 // Set up the state machine, if this inline is
                 // discretionary and is still a candidate.
-                if (inlDecisionIsCandidate(inlDecision)
-                    && (inlObservation == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE))
+                if (InlDecisionIsCandidate(m_Decision)
+                    && (m_Observation == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE))
                 {
                     // Better not have a state machine already.
-                    assert(inlStateMachine == nullptr);
-                    inlStateMachine = new (inlCompiler, CMK_Inlining) CodeSeqSM;
-                    inlStateMachine->Start(inlCompiler);
+                    assert(m_StateMachine == nullptr);
+                    m_StateMachine = new (m_Compiler, CMK_Inlining) CodeSeqSM;
+                    m_StateMachine->Start(m_Compiler);
                 }
                 break;
             }
@@ -122,15 +122,15 @@ void LegacyPolicy::noteBool(InlineObservation obs, bool value)
             {
                 // We only expect to see this observation once, so the
                 // native size estimate should have its initial value.
-                assert(inlNativeSizeEstimate == NATIVE_SIZE_INVALID);
+                assert(m_NativeSizeEstimate == NATIVE_SIZE_INVALID);
 
                 // If we were using the state machine, get it to kick
                 // out a size estimate.
-                if (inlStateMachine != nullptr)
+                if (m_StateMachine != nullptr)
                 {
-                    inlStateMachine->End();
-                    inlNativeSizeEstimate = inlStateMachine->NativeSize;
-                    assert(inlNativeSizeEstimate != NATIVE_SIZE_INVALID);
+                    m_StateMachine->End();
+                    m_NativeSizeEstimate = m_StateMachine->NativeSize;
+                    assert(m_NativeSizeEstimate != NATIVE_SIZE_INVALID);
                 }
 
                 break;
@@ -144,23 +144,23 @@ void LegacyPolicy::noteBool(InlineObservation obs, bool value)
 
     if (propagate)
     {
-        noteInternal(obs);
+        NoteInternal(obs);
     }
 }
 
 //------------------------------------------------------------------------
-// noteFatal: handle an observation with fatal impact
+// NoteFatal: handle an observation with fatal impact
 //
 // Arguments:
 //    obs      - the current obsevation
 
-void LegacyPolicy::noteFatal(InlineObservation obs)
+void LegacyPolicy::NoteFatal(InlineObservation obs)
 {
     // As a safeguard, all fatal impact must be
     // reported via noteFatal.
-    assert(inlGetImpact(obs) == InlineImpact::FATAL);
-    noteInternal(obs);
-    assert(inlDecisionIsFailure(inlDecision));
+    assert(InlGetImpact(obs) == InlineImpact::FATAL);
+    NoteInternal(obs);
+    assert(InlDecisionIsFailure(m_Decision));
 }
 
 //------------------------------------------------------------------------
@@ -170,19 +170,19 @@ void LegacyPolicy::noteFatal(InlineObservation obs)
 //    obs      - the current obsevation
 //    value    - the value being observed
 
-void LegacyPolicy::noteInt(InlineObservation obs, int value)
+void LegacyPolicy::NoteInt(InlineObservation obs, int value)
 {
     switch (obs)
     {
     case InlineObservation::CALLEE_MAXSTACK:
         {
-            assert(inlIsForceInlineKnown);
+            assert(m_IsForceInlineKnown);
 
             unsigned calleeMaxStack = static_cast<unsigned>(value);
 
-            if (!inlIsForceInline && (calleeMaxStack > SMALL_STACK_SIZE))
+            if (!m_IsForceInline && (calleeMaxStack > SMALL_STACK_SIZE))
             {
-                setNever(InlineObservation::CALLEE_MAXSTACK_TOO_BIG);
+                SetNever(InlineObservation::CALLEE_MAXSTACK_TOO_BIG);
             }
 
             break;
@@ -190,14 +190,14 @@ void LegacyPolicy::noteInt(InlineObservation obs, int value)
 
     case InlineObservation::CALLEE_NUMBER_OF_BASIC_BLOCKS:
         {
-            assert(inlIsForceInlineKnown);
+            assert(m_IsForceInlineKnown);
             assert(value != 0);
 
             unsigned basicBlockCount = static_cast<unsigned>(value);
 
-            if (!inlIsForceInline && (basicBlockCount > MAX_BASIC_BLOCKS))
+            if (!m_IsForceInline && (basicBlockCount > MAX_BASIC_BLOCKS))
             {
-                setNever(InlineObservation::CALLEE_TOO_MANY_BASIC_BLOCKS);
+                SetNever(InlineObservation::CALLEE_TOO_MANY_BASIC_BLOCKS);
             }
 
             break;
@@ -205,31 +205,31 @@ void LegacyPolicy::noteInt(InlineObservation obs, int value)
 
     case InlineObservation::CALLEE_IL_CODE_SIZE:
         {
-            assert(inlIsForceInlineKnown);
+            assert(m_IsForceInlineKnown);
             assert(value != 0);
-            inlCodeSize = static_cast<unsigned>(value);
+            m_CodeSize = static_cast<unsigned>(value);
 
             // Now that we know size and forceinline state,
             // update candidacy.
-            if (inlCodeSize <= ALWAYS_INLINE_SIZE)
+            if (m_CodeSize <= ALWAYS_INLINE_SIZE)
             {
                 // Candidate based on small size
-                setCandidate(InlineObservation::CALLEE_BELOW_ALWAYS_INLINE_SIZE);
+                SetCandidate(InlineObservation::CALLEE_BELOW_ALWAYS_INLINE_SIZE);
             }
-            else if (inlIsForceInline)
+            else if (m_IsForceInline)
             {
                 // Candidate based on force inline
-                setCandidate(InlineObservation::CALLEE_IS_FORCE_INLINE);
+                SetCandidate(InlineObservation::CALLEE_IS_FORCE_INLINE);
             }
-            else if (inlCodeSize <= inlCompiler->getImpInlineSize())
+            else if (m_CodeSize <= m_Compiler->getImpInlineSize())
             {
                 // Candidate, pending profitability evaluation
-                setCandidate(InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
+                SetCandidate(InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
             }
             else
             {
                 // Callee too big, not a candidate
-                setNever(InlineObservation::CALLEE_TOO_MUCH_IL);
+                SetNever(InlineObservation::CALLEE_TOO_MUCH_IL);
             }
 
             break;
@@ -238,7 +238,7 @@ void LegacyPolicy::noteInt(InlineObservation obs, int value)
     case InlineObservation::CALLEE_OPCODE_NORMED:
     case InlineObservation::CALLEE_OPCODE:
         {
-            if (inlStateMachine != nullptr)
+            if (m_StateMachine != nullptr)
             {
                 OPCODE opcode = static_cast<OPCODE>(value);
                 SM_OPCODE smOpcode = CodeSeqSM::MapToSMOpcode(opcode);
@@ -256,15 +256,15 @@ void LegacyPolicy::noteInt(InlineObservation obs, int value)
                     }
                 }
 
-                inlStateMachine->Run(smOpcode DEBUGARG(0));
+                m_StateMachine->Run(smOpcode DEBUGARG(0));
             }
             break;
         }
 
     case InlineObservation::CALLSITE_FREQUENCY:
-        assert(inlCallsiteFrequency == InlineCallsiteFrequency::UNUSED);
-        inlCallsiteFrequency = static_cast<InlineCallsiteFrequency>(value);
-        assert(inlCallsiteFrequency != InlineCallsiteFrequency::UNUSED);
+        assert(m_CallsiteFrequency == InlineCallsiteFrequency::UNUSED);
+        m_CallsiteFrequency = static_cast<InlineCallsiteFrequency>(value);
+        assert(m_CallsiteFrequency != InlineCallsiteFrequency::UNUSED);
         break;
 
     default:
@@ -274,13 +274,13 @@ void LegacyPolicy::noteInt(InlineObservation obs, int value)
 }
 
 //------------------------------------------------------------------------
-// noteDouble: handle an observed double value
+// NoteDouble: handle an observed double value
 //
 // Arguments:
 //    obs      - the current obsevation
 //    value    - the value being observed
 
-void LegacyPolicy::noteDouble(InlineObservation obs, double value)
+void LegacyPolicy::NoteDouble(InlineObservation obs, double value)
 {
     // Ignore for now...
     (void) value;
@@ -288,91 +288,91 @@ void LegacyPolicy::noteDouble(InlineObservation obs, double value)
 }
 
 //------------------------------------------------------------------------
-// noteInternal: helper for handling an observation
+// NoteInternal: helper for handling an observation
 //
 // Arguments:
 //    obs      - the current obsevation
 
-void LegacyPolicy::noteInternal(InlineObservation obs)
+void LegacyPolicy::NoteInternal(InlineObservation obs)
 {
     // Note any INFORMATION that reaches here will now cause failure.
     // Non-fatal INFORMATION observations must be handled higher up.
-    InlineTarget target = inlGetTarget(obs);
+    InlineTarget target = InlGetTarget(obs);
 
     if (target == InlineTarget::CALLEE)
     {
-        this->setNever(obs);
+        this->SetNever(obs);
     }
     else
     {
-        this->setFailure(obs);
+        this->SetFailure(obs);
     }
 }
 
 //------------------------------------------------------------------------
-// setFailure: helper for setting a failing decision
+// SetFailure: helper for setting a failing decision
 //
 // Arguments:
 //    obs      - the current obsevation
 
-void LegacyPolicy::setFailure(InlineObservation obs)
+void LegacyPolicy::SetFailure(InlineObservation obs)
 {
     // Expect a valid observation
-    assert(inlIsValidObservation(obs));
+    assert(InlIsValidObservation(obs));
 
-    switch (inlDecision)
+    switch (m_Decision)
     {
     case InlineDecision::FAILURE:
         // Repeated failure only ok if evaluating a prejit root
         // (since we can't fail fast because we're not inlining)
         // or if inlining and the observation is CALLSITE_TOO_MANY_LOCALS
         // (since we can't fail fast from lvaGrabTemp).
-        assert(inlIsPrejitRoot ||
+        assert(m_IsPrejitRoot ||
                (obs == InlineObservation::CALLSITE_TOO_MANY_LOCALS));
         break;
     case InlineDecision::UNDECIDED:
     case InlineDecision::CANDIDATE:
-        inlDecision = InlineDecision::FAILURE;
-        inlObservation = obs;
+        m_Decision = InlineDecision::FAILURE;
+        m_Observation = obs;
         break;
     default:
         // SUCCESS, NEVER, or ??
-        assert(!"Unexpected inlDecision");
+        assert(!"Unexpected m_Decision");
         unreached();
     }
 }
 
 //------------------------------------------------------------------------
-// setNever: helper for setting a never decision
+// SetNever: helper for setting a never decision
 //
 // Arguments:
 //    obs      - the current obsevation
 
-void LegacyPolicy::setNever(InlineObservation obs)
+void LegacyPolicy::SetNever(InlineObservation obs)
 {
     // Expect a valid observation
-    assert(inlIsValidObservation(obs));
+    assert(InlIsValidObservation(obs));
 
-    switch (inlDecision)
+    switch (m_Decision)
     {
     case InlineDecision::NEVER:
         // Repeated never only ok if evaluating a prejit root
-        assert(inlIsPrejitRoot);
+        assert(m_IsPrejitRoot);
         break;
     case InlineDecision::UNDECIDED:
     case InlineDecision::CANDIDATE:
-        inlDecision = InlineDecision::NEVER;
-        inlObservation = obs;
+        m_Decision = InlineDecision::NEVER;
+        m_Observation = obs;
         break;
     default:
         // SUCCESS, FAILURE or ??
-        assert(!"Unexpected inlDecision");
+        assert(!"Unexpected m_Decision");
         unreached();
     }
 }
 
 //------------------------------------------------------------------------
-// setCandidate: helper updating candidacy
+// SetCandidate: helper updating candidacy
 //
 // Arguments:
 //    obs      - the current obsevation
@@ -382,35 +382,35 @@ void LegacyPolicy::setNever(InlineObservation obs)
 //    failed, they're ignored. If there's already a candidate reason,
 //    this new reason trumps it.
 
-void LegacyPolicy::setCandidate(InlineObservation obs)
+void LegacyPolicy::SetCandidate(InlineObservation obs)
 {
     // Ignore if this inline is going to fail.
-    if (inlDecisionIsFailure(inlDecision))
+    if (InlDecisionIsFailure(m_Decision))
     {
         return;
     }
 
     // We should not have declared success yet.
-    assert(!inlDecisionIsSuccess(inlDecision));
+    assert(!InlDecisionIsSuccess(m_Decision));
 
     // Update, overriding any previous candidacy.
-    inlDecision = InlineDecision::CANDIDATE;
-    inlObservation = obs;
+    m_Decision = InlineDecision::CANDIDATE;
+    m_Observation = obs;
 }
 
 //------------------------------------------------------------------------
-// determineMultiplier: determine benefit multiplier for this inline
+// DetermineMultiplier: determine benefit multiplier for this inline
 //
 // Notes: uses the accumulated set of observations to compute a
 // profitability boost for the inline candidate.
 
-double LegacyPolicy::determineMultiplier()
+double LegacyPolicy::DetermineMultiplier()
 {
     double multiplier = 0;
 
     // Bump up the multiplier for instance constructors
 
-    if (inlIsInstanceCtor)
+    if (m_IsInstanceCtor)
     {
         multiplier += 1.5;
         JITDUMP("\nmultiplier in instance constructors increased to %g.", multiplier);
@@ -418,7 +418,7 @@ double LegacyPolicy::determineMultiplier()
 
     // Bump up the multiplier for methods in promotable struct
 
-    if (inlIsFromPromotableValueClass)
+    if (m_IsFromPromotableValueClass)
     {
         multiplier += 3;
         JITDUMP("\nmultiplier in methods of promotable struct increased to %g.", multiplier);
@@ -426,7 +426,7 @@ double LegacyPolicy::determineMultiplier()
 
 #ifdef FEATURE_SIMD
 
-    if (inlHasSimd)
+    if (m_HasSimd)
     {
         multiplier += JitConfig.JitInlineSIMDMultiplier();
         JITDUMP("\nInline candidate has SIMD type args, locals or return value.  Multiplier increased to %g.", multiplier);
@@ -434,37 +434,37 @@ double LegacyPolicy::determineMultiplier()
 
 #endif // FEATURE_SIMD
 
-    if (inlLooksLikeWrapperMethod)
+    if (m_LooksLikeWrapperMethod)
     {
         multiplier += 1.0;
         JITDUMP("\nInline candidate looks like a wrapper method.  Multiplier increased to %g.", multiplier);
     }
 
-    if (inlArgFeedsConstantTest)
+    if (m_ArgFeedsConstantTest)
     {
         multiplier += 1.0;
         JITDUMP("\nInline candidate has an arg that feeds a constant test.  Multiplier increased to %g.", multiplier);
     }
 
-    if (inlMethodIsMostlyLoadStore)
+    if (m_MethodIsMostlyLoadStore)
     {
         multiplier += 3.0;
         JITDUMP("\nInline candidate is mostly loads and stores.  Multiplier increased to %g.", multiplier);
     }
 
-    if (inlArgFeedsRangeCheck)
+    if (m_ArgFeedsRangeCheck)
     {
         multiplier += 0.5;
         JITDUMP("\nInline candidate has arg that feeds range check.  Multiplier increased to %g.", multiplier);
     }
 
-    if (inlConstantFeedsConstantTest)
+    if (m_ConstantFeedsConstantTest)
     {
         multiplier += 3.0;
         JITDUMP("\nInline candidate has const arg that feeds a conditional.  Multiplier increased to %g.", multiplier);
     }
 
-    switch (inlCallsiteFrequency)
+    switch (m_CallsiteFrequency)
     {
     case InlineCallsiteFrequency::RARE:
         // Note this one is not additive, it uses '=' instead of '+='
@@ -502,7 +502,7 @@ double LegacyPolicy::determineMultiplier()
         JITDUMP("\nmultiplier increased via JitInlineAdditonalMultiplier=%d to %g.", additionalMultiplier, multiplier);
     }
 
-    if (inlCompiler->compInlineStress())
+    if (m_Compiler->compInlineStress())
     {
         multiplier += 10;
         JITDUMP("\nmultiplier increased via inline stress to %g.", multiplier);
@@ -514,7 +514,7 @@ double LegacyPolicy::determineMultiplier()
 }
 
 //------------------------------------------------------------------------
-// determineNativeCodeSizeEstimate: return estimated native code size for
+// DetermineNativeCodeSizeEstimate: return estimated native code size for
 // this inline candidate.
 //
 // Notes:
@@ -522,18 +522,18 @@ double LegacyPolicy::determineMultiplier()
 //    candidates.  Should not be needed for forced or always
 //    candidates.
 
-int LegacyPolicy::determineNativeSizeEstimate()
+int LegacyPolicy::DetermineNativeSizeEstimate()
 {
     // Should be a discretionary candidate.
-    assert(inlObservation == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
+    assert(m_Observation == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
     // Should have a valid state machine estimate.
-    assert(inlNativeSizeEstimate != NATIVE_SIZE_INVALID);
+    assert(m_NativeSizeEstimate != NATIVE_SIZE_INVALID);
 
-    return inlNativeSizeEstimate;
+    return m_NativeSizeEstimate;
 }
 
 //------------------------------------------------------------------------
-// determineNativeCallsiteSizeEstimate: estimate native size for the
+// DetermineNativeCallsiteSizeEstimate: estimate native size for the
 // callsite.
 //
 // Arguments:
@@ -544,7 +544,7 @@ int LegacyPolicy::determineNativeSizeEstimate()
 //    call site. While the quiality of the estimate here is questionable
 //    (especially for x64) it is being left as is for legacy compatibility.
 
-int LegacyPolicy::determineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methInfo)
+int LegacyPolicy::DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methInfo)
 {
     int callsiteSize = 55;   // Direct call take 5 native bytes; indirect call takes 6 native bytes.
 
@@ -556,17 +556,17 @@ int LegacyPolicy::determineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methI
     }
 
     CORINFO_ARG_LIST_HANDLE argLst = methInfo->args.args;
-    COMP_HANDLE comp = inlCompiler->info.compCompHnd;
+    COMP_HANDLE comp = m_Compiler->info.compCompHnd;
 
     for (unsigned i = (hasThis ? 1 : 0);
          i < methInfo->args.totalILArgs();
          i++, argLst = comp->getArgNext(argLst))
     {
-        var_types sigType = (var_types) inlCompiler->eeGetArgType(argLst, &methInfo->args);
+        var_types sigType = (var_types) m_Compiler->eeGetArgType(argLst, &methInfo->args);
 
         if (sigType == TYP_STRUCT)
         {
-            typeInfo  verType  = inlCompiler->verParseArgSigToTypeInfo(&methInfo->args, argLst);
+            typeInfo  verType  = m_Compiler->verParseArgSigToTypeInfo(&methInfo->args, argLst);
 
             /*
 

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -40,71 +40,71 @@ public:
     // Construct a LegacyPolicy
     LegacyPolicy(Compiler* compiler, bool isPrejitRoot)
         : InlinePolicy(isPrejitRoot)
-        , inlCompiler(compiler)
-        , inlStateMachine(nullptr)
-        , inlCodeSize(0)
-        , inlNativeSizeEstimate(NATIVE_SIZE_INVALID)
-        , inlCallsiteFrequency(InlineCallsiteFrequency::UNUSED)
-        , inlIsForceInline(false)
-        , inlIsForceInlineKnown(false)
-        , inlIsInstanceCtor(false)
-        , inlIsFromPromotableValueClass(false)
-        , inlHasSimd(false)
-        , inlLooksLikeWrapperMethod(false)
-        , inlArgFeedsConstantTest(false)
-        , inlMethodIsMostlyLoadStore(false)
-        , inlArgFeedsRangeCheck(false)
-        , inlConstantFeedsConstantTest(false)
+        , m_Compiler(compiler)
+        , m_StateMachine(nullptr)
+        , m_CodeSize(0)
+        , m_NativeSizeEstimate(NATIVE_SIZE_INVALID)
+        , m_CallsiteFrequency(InlineCallsiteFrequency::UNUSED)
+        , m_IsForceInline(false)
+        , m_IsForceInlineKnown(false)
+        , m_IsInstanceCtor(false)
+        , m_IsFromPromotableValueClass(false)
+        , m_HasSimd(false)
+        , m_LooksLikeWrapperMethod(false)
+        , m_ArgFeedsConstantTest(false)
+        , m_MethodIsMostlyLoadStore(false)
+        , m_ArgFeedsRangeCheck(false)
+        , m_ConstantFeedsConstantTest(false)
     {
         // empty
     }
 
     // Policy observations
-    void noteSuccess() override;
-    void noteBool(InlineObservation obs, bool value) override;
-    void noteFatal(InlineObservation obs) override;
-    void noteInt(InlineObservation obs, int value) override;
-    void noteDouble(InlineObservation obs, double value) override;
+    void NoteSuccess() override;
+    void NoteBool(InlineObservation obs, bool value) override;
+    void NoteFatal(InlineObservation obs) override;
+    void NoteInt(InlineObservation obs, int value) override;
+    void NoteDouble(InlineObservation obs, double value) override;
 
     // Policy determinations
-    double determineMultiplier() override;
-    int determineNativeSizeEstimate() override;
-    int determineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) override;
+    double DetermineMultiplier() override;
+    int DetermineNativeSizeEstimate() override;
+    int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) override;
 
     // Policy policies
-    bool propagateNeverToRuntime() const override { return true; }
+    bool PropagateNeverToRuntime() const override { return true; }
 
 #ifdef DEBUG
-    const char* getName() const override { return "LegacyPolicy"; }
+    const char* GetName() const override { return "LegacyPolicy"; }
 #endif
 
 private:
 
     // Helper methods
-    void noteInternal(InlineObservation obs);
-    void setCandidate(InlineObservation obs);
-    void setFailure(InlineObservation obs);
-    void setNever(InlineObservation obs);
+    void NoteInternal(InlineObservation obs);
+    void SetCandidate(InlineObservation obs);
+    void SetFailure(InlineObservation obs);
+    void SetNever(InlineObservation obs);
 
     // Constants
     const unsigned MAX_BASIC_BLOCKS = 5;
 
     // Data members
-    Compiler*               inlCompiler;
-    CodeSeqSM*              inlStateMachine;
-    unsigned                inlCodeSize;
-    int                     inlNativeSizeEstimate;
-    InlineCallsiteFrequency inlCallsiteFrequency;
-    bool                    inlIsForceInline :1;
-    bool                    inlIsForceInlineKnown :1;
-    bool                    inlIsInstanceCtor :1;
-    bool                    inlIsFromPromotableValueClass :1;
-    bool                    inlHasSimd :1;
-    bool                    inlLooksLikeWrapperMethod :1;
-    bool                    inlArgFeedsConstantTest :1;
-    bool                    inlMethodIsMostlyLoadStore :1;
-    bool                    inlArgFeedsRangeCheck :1;
-    bool                    inlConstantFeedsConstantTest :1;
+    Compiler*               m_Compiler;
+    CodeSeqSM*              m_StateMachine;
+    unsigned                m_CodeSize;
+    int                     m_NativeSizeEstimate;
+    InlineCallsiteFrequency m_CallsiteFrequency;
+    bool                    m_IsForceInline :1;
+    bool                    m_IsForceInlineKnown :1;
+    bool                    m_IsInstanceCtor :1;
+    bool                    m_IsFromPromotableValueClass :1;
+    bool                    m_HasSimd :1;
+    bool                    m_LooksLikeWrapperMethod :1;
+    bool                    m_ArgFeedsConstantTest :1;
+    bool                    m_MethodIsMostlyLoadStore :1;
+    bool                    m_ArgFeedsRangeCheck :1;
+    bool                    m_ConstantFeedsConstantTest :1;
 };
 
 #endif // _INLINE_POLICY_H_

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5617,17 +5617,17 @@ void        Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineR
     fgMorphCallInlineHelper(call, inlineResult);
 
     // We should have made up our minds one way or another....
-    assert(inlineResult->isDecided());
+    assert(inlineResult->IsDecided());
 
     // If we failed to inline, we have a bit of work to do to cleanup
-    if (inlineResult->isFailure())
+    if (inlineResult->IsFailure())
     {
 
 #ifdef DEBUG
 
         // Before we do any cleanup, create a failing InlineContext to
         // capture details of the inlining attempt.
-        InlineContext::newFailure(this, fgMorphStmt, inlineResult);
+        InlineContext::NewFailure(this, fgMorphStmt, inlineResult);
 
 #endif
 
@@ -5659,7 +5659,7 @@ void        Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineR
 void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 {
     // Don't expect any surprises here.
-    assert(result->isCandidate());
+    assert(result->IsCandidate());
     
     if (lvaCount >= MAX_LV_NUM_COUNT_FOR_INLINING)
     {
@@ -5668,13 +5668,13 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
         // caller and prospective callee locals). We still might be
         // able to inline other callees into this caller, or inline
         // this callee in other callers.
-        result->noteFatal(InlineObservation::CALLSITE_TOO_MANY_LOCALS);
+        result->NoteFatal(InlineObservation::CALLSITE_TOO_MANY_LOCALS);
         return;
     }
 
     if (call->IsVirtual())
     {
-        result->noteFatal(InlineObservation::CALLSITE_IS_VIRTUAL);
+        result->NoteFatal(InlineObservation::CALLSITE_IS_VIRTUAL);
         return;
     }
 
@@ -5690,7 +5690,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
 
     if (opts.compNeedSecurityCheck)
     {
-        result->noteFatal(InlineObservation::CALLER_NEEDS_SECURITY_CHECK);
+        result->NoteFatal(InlineObservation::CALLER_NEEDS_SECURITY_CHECK);
         return;
     }
     
@@ -5718,7 +5718,7 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
     
     fgInvokeInlineeCompiler(call, result);
 
-    if (result->isFailure()) 
+    if (result->IsFailure()) 
     {
        // Undo some changes made in anticipation of inlining...
 


### PR DESCRIPTION
Per the jit coding conventions, rename all class member functions to be
CamelCase. Rename all class data members to begin with `m_`.