### PR TITLE
Add comment about disabling crossgen command for cross build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -248,8 +248,7 @@ build_mscorlib()
         exit 1
     fi
 
-    # The cross build generates exectuable 'crossgen' with arm architecture (without x86).
-    # It can not be run to make mscorlib.ni.dll from mscorlib.dll on X86-based build machine.
+    # The cross build generates a crossgen with the target architecture.
     if [ $__CrossBuild != 1 ]; then
        if [ $__SkipCoreCLR == 0 -a -e $__BinDir/crossgen ]; then
            echo "Generating native image for mscorlib."

--- a/build.sh
+++ b/build.sh
@@ -248,6 +248,8 @@ build_mscorlib()
         exit 1
     fi
 
+    # The cross build generates exectuable 'crossgen' with arm architecture (without x86).
+    # It can not be run to make mscorlib.ni.dll from mscorlib.dll on X86-based build machine.
     if [ $__CrossBuild != 1 ]; then
        if [ $__SkipCoreCLR == 0 -a -e $__BinDir/crossgen ]; then
            echo "Generating native image for mscorlib."


### PR DESCRIPTION
As we all know, the current cross build generates exectuable
'crossgen' with arm architecture (without x86 architecture).
So, it can not be run to make mscorlib.ni.dll from mscorlib.dll
on X86-based build machine.
Let's add a comment why we have to skip crossgen command in
build_mscorlib() of build.sh in case of the cross build for Linux/ARM.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>