### PR TITLE
Inline refactoring: move profitability assessment to LegacyPolicy

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3108,10 +3108,8 @@ private:
 
     static BOOL         impIsAddressInLocal(GenTreePtr tree, GenTreePtr * lclVarTreeOut);
 
-    void                impCanInlineNative(int              callsiteNativeEstimate, 
-                                           int              calleeNativeSizeEstimate,
-                                           InlineInfo*      pInlineInfo,
-                                           InlineResult*    inlineResult);
+    void                impMakeDiscretionaryInlineObservations(InlineInfo*   pInlineInfo,
+                                                               InlineResult* inlineResult);
 
     // STATIC inlining decision based on the IL code. 
     void                impCanInlineIL(CORINFO_METHOD_HANDLE  fncHandle,
@@ -8569,10 +8567,6 @@ public:
                                                     // This can be overwritten by setting complus_JITInlineSize env variable.
 #define IMPLEMENTATION_MAX_INLINE_SIZE  _UI16_MAX   // Maximum method size supported by this implementation 
                                          
-#define NATIVE_SIZE_INVALID  (-10000)                
-
-    int                     compNativeSizeEstimate;     // The estimated native size of this method.
-
 private:
 #ifdef FEATURE_JIT_METHOD_PERF
     JitTimer*                     pCompJitTimer;           // Timer data structure (by phases) for current compilation.

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -35,7 +35,7 @@ INLINE_OBSERVATION(HAS_DELEGATE_INVOKE,       bool,   "delegate invoke",        
 INLINE_OBSERVATION(HAS_EH,                    bool,   "has exception handling",        FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_ENDFILTER,             bool,   "has endfilter",                 FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_ENDFINALLY,            bool,   "has endfinally",                FATAL,       CALLEE)
-INLINE_OBSERVATION(HAS_LEAVE,                 bool,   "has leave"    ,                 FATAL,       CALLEE)
+INLINE_OBSERVATION(HAS_LEAVE,                 bool,   "has leave",                     FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_MANAGED_VARARGS,       bool,   "managed varargs",               FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_NATIVE_VARARGS,        bool,   "native varargs",                FATAL,       CALLEE)
 INLINE_OBSERVATION(HAS_NO_BODY,               bool,   "has no body",                   FATAL,       CALLEE)
@@ -54,6 +54,7 @@ INLINE_OBSERVATION(MARKED_AS_SKIPPED,         bool,   "skipped by complus reques
 INLINE_OBSERVATION(MAXSTACK_TOO_BIG,          bool,   "maxstack too big"  ,            FATAL,       CALLEE)
 INLINE_OBSERVATION(NEEDS_SECURITY_CHECK,      bool,   "needs security check",          FATAL,       CALLEE)
 INLINE_OBSERVATION(NO_METHOD_INFO,            bool,   "cannot get method info",        FATAL,       CALLEE)
+INLINE_OBSERVATION(NOT_PROFITABLE_INLINE,     bool,   "unprofitable inline",           FATAL,       CALLEE)
 INLINE_OBSERVATION(RETURN_TYPE_IS_COMPOSITE,  bool,   "has composite return type",     FATAL,       CALLEE)
 INLINE_OBSERVATION(STACK_CRAWL_MARK,          bool,   "uses stack crawl mark",         FATAL,       CALLEE)
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLEE)
@@ -84,9 +85,9 @@ INLINE_OBSERVATION(IS_DISCRETIONARY_INLINE,   bool,   "can inline, check heurist
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_INSTANCE_CTOR,          bool,   "instance constructor",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_MOSTLY_LOAD_STORE,      bool,   "method is mostly load/store",   INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLEE)
 INLINE_OBSERVATION(LOOKS_LIKE_WRAPPER,        bool,   "thin wrapper around a call",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
-INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(OPCODE,                    int,    "next opcode in IL stream",      INFORMATION, CALLEE)
 INLINE_OBSERVATION(OPCODE_NORMED,             int,    "next opcode in IL stream",      INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",           INFORMATION, CALLEE)
@@ -134,6 +135,7 @@ INLINE_OBSERVATION(LDARGA_NOT_LOCAL_VAR,      bool,   "ldarga not on local var",
 INLINE_OBSERVATION(LDFLD_NEEDS_HELPER,        bool,   "ldfld needs helper",            FATAL,       CALLSITE)
 INLINE_OBSERVATION(LDVIRTFN_ON_NON_VIRTUAL,   bool,   "ldvirtfn on non-virtual",       FATAL,       CALLSITE)
 INLINE_OBSERVATION(NOT_CANDIDATE,             bool,   "not inline candidate",          FATAL,       CALLSITE)
+INLINE_OBSERVATION(NOT_PROFITABLE_INLINE,     bool,   "unprofitable inline",           FATAL,       CALLSITE)
 INLINE_OBSERVATION(REQUIRES_SAME_THIS,        bool,   "requires same this",            FATAL,       CALLSITE)
 INLINE_OBSERVATION(RETURN_TYPE_MISMATCH,      bool,   "return type mismatch",          FATAL,       CALLSITE)
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLSITE)
@@ -144,12 +146,10 @@ INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",        
 
 // ------ Call Site Information ------- 
 
-INLINE_OBSERVATION(BENEFIT_MULTIPLIER,        double, "benefit multiplier",            INFORMATION, CALLSITE)
 INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds test",  INFORMATION, CALLSITE)
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
 INLINE_OBSERVATION(FREQUENCY,                 int,    "execution frequency",           INFORMATION, CALLSITE)
-INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE,      double, "native size estimate",          INFORMATION, CALLSITE)
-INLINE_OBSERVATION(NATIVE_SIZE_ESTIMATE_OK,   bool,   "native size estimate ok",       INFORMATION, CALLSITE)
+INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLSITE)
 
 // ------ Final Sentinel ------- 
 

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -241,9 +241,7 @@ public:
     virtual void NoteDouble(InlineObservation obs, double value) = 0;
 
     // Policy determinations
-    virtual double DetermineMultiplier() = 0;
-    virtual int DetermineNativeSizeEstimate() = 0;
-    virtual int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) = 0;
+    virtual void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) = 0;
 
     // Policy policies
     virtual bool PropagateNeverToRuntime() const = 0;
@@ -320,6 +318,16 @@ public:
         return InlDecisionIsCandidate(m_Policy->GetDecision());
     }
 
+    // Has the policy determined this inline attempt is still viable
+    // and is a discretionary inline?
+    bool IsDiscretionaryCandidate() const
+    {
+        bool result = InlDecisionIsCandidate(m_Policy->GetDecision()) &&             
+            (m_Policy->GetObservation() == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
+
+        return result;
+    }
+
     // Has the policy made a determination?
     bool IsDecided() const
     {
@@ -373,22 +381,10 @@ public:
         m_Policy->NoteDouble(obs, value);
     }
 
-    // Determine the benfit multiplier for this inline.
-    double DetermineMultiplier()
+    // Determine if this inline is profitable
+    void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
     {
-        return m_Policy->DetermineMultiplier();
-    }
-
-    // Determine the native size estimate for this inline
-    int DetermineNativeSizeEstimate()
-    {
-        return m_Policy->DetermineNativeSizeEstimate();
-    }
-
-    // Determine the native size estimate for this call site
-    int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo)
-    {
-        return m_Policy->DetermineCallsiteNativeSizeEstimate(methodInfo);
+        return m_Policy->DetermineProfitability(methodInfo);
     }
 
     // Ensure details of this inlining process are appropriately

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -43,7 +43,6 @@ public:
         , m_Compiler(compiler)
         , m_StateMachine(nullptr)
         , m_CodeSize(0)
-        , m_NativeSizeEstimate(NATIVE_SIZE_INVALID)
         , m_CallsiteFrequency(InlineCallsiteFrequency::UNUSED)
         , m_IsForceInline(false)
         , m_IsForceInlineKnown(false)
@@ -67,9 +66,7 @@ public:
     void NoteDouble(InlineObservation obs, double value) override;
 
     // Policy determinations
-    double DetermineMultiplier() override;
-    int DetermineNativeSizeEstimate() override;
-    int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo) override;
+    void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
 
     // Policy policies
     bool PropagateNeverToRuntime() const override { return true; }
@@ -85,6 +82,9 @@ private:
     void SetCandidate(InlineObservation obs);
     void SetFailure(InlineObservation obs);
     void SetNever(InlineObservation obs);
+    double DetermineMultiplier();
+    int DetermineNativeSizeEstimate();
+    int DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methodInfo);
 
     // Constants
     const unsigned MAX_BASIC_BLOCKS = 5;
@@ -93,7 +93,6 @@ private:
     Compiler*               m_Compiler;
     CodeSeqSM*              m_StateMachine;
     unsigned                m_CodeSize;
-    int                     m_NativeSizeEstimate;
     InlineCallsiteFrequency m_CallsiteFrequency;
     bool                    m_IsForceInline :1;
     bool                    m_IsForceInlineKnown :1;


### PR DESCRIPTION
LegacyPolicy now encapsulates all the computations needed to evaluate
whether an inline is profitable or not.

This completes the main objective of the refactoring effort, which
was to preserve and encapsulate the current inliner's behavior.