### PR TITLE
Fix for a bug in GetCORSystemDirectoryInternaL

### DIFF
--- a/src/dlls/mscoree/mscoree.cpp
+++ b/src/dlls/mscoree/mscoree.cpp
@@ -941,13 +941,13 @@ STDAPI GetCORSystemDirectoryInternaL(SString& pBuffer)
     return hr;
 
 #else // FEATURE_CORECLR || CROSSGEN_COMPILE
-    DWORD cchBuffer;
+    DWORD cchBuffer = MAX_PATH - 1;
     // Simply forward the call to the ICLRRuntimeInfo implementation.
     STATIC_CONTRACT_WRAPPER;
     HRESULT hr = S_OK;
     if (g_pCLRRuntime)
     {
-        WCHAR* temp = pBuffer.OpenUnicodeBuffer(MAX_PATH - 1);
+        WCHAR* temp = pBuffer.OpenUnicodeBuffer(cchBuffer);
         hr = g_pCLRRuntime->GetRuntimeDirectory(temp, &cchBuffer);
         pBuffer.CloseBuffer(cchBuffer - 1);
     }


### PR DESCRIPTION
Change 7045ca7a6de381b382a709dc0a61f49ca713d160 introduced a bug in
GetCORSystemDirectoryInternaL. The second parameter of GetRuntimeDirectory
is in/out so passing a pointer to an uninitialized cchBuffer was wrong.
The fix is to initialize cchBuffer to MAX_PATH - 1.

This was causing failures in some non-CoreClr ngen scenarios.