### PR TITLE
Remove hardcoded versions from runtests.proj

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -21,6 +21,10 @@
     <BuildToolsTargets45>true</BuildToolsTargets45>   
   </PropertyGroup>  
 
+  <!-- Make the stable version of xunit that the tests depend on available to both the project.json generation and the validation task. -->
+  <PropertyGroup>
+    <XunitPackageVersion>2.1.0</XunitPackageVersion>
+  </PropertyGroup>
 
   <!-- Common repo directories -->
   <PropertyGroup>
@@ -42,8 +46,8 @@
     <ValidationPattern Include="^(?i)((System\..%2A)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
       <ExpectedPrerelease>rc2-23816</ExpectedPrerelease>
     </ValidationPattern>
-    <ValidationPattern Include="^(?i)(xunit(\.assert|\.runner\.(utility|msbuild)))$">
-      <ExpectedVersion>2.1.0</ExpectedVersion>
+    <ValidationPattern Include="^(?i)(xunit(\.assert|\.core|\.runner\.(utility|msbuild))?)$">
+      <ExpectedVersion>$(XunitPackageVersion)</ExpectedVersion>
     </ValidationPattern>
     <!-- Add a dummy value so that the item isn't removed by msbuild. Without the | this item doesn't show up later. -->
     <ValidationPattern Include="^(?i)(xunit\.console\.netcore|dummy value)$">

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -97,6 +97,7 @@ $(_XunitEpilog)
     <Compile Include="$(XunitWrapper).cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="%24(TestWrappersPackagesConfigFileDirectory)project.json" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -113,6 +114,10 @@ $(_XunitEpilog)
     <Reference Include="System.Runtime" />
     <Reference Include="mscorlib" />
   </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>%24(TestWrappersPackagesConfigFileDirectory)project.json</ProjectJson>
+    <ProjectLockJson>%24(TestWrappersPackagesConfigFileDirectory)project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <Import Project="%24([MSBuild]::GetDirectoryNameOfFileAbove(%24(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Import Project="%24([MSBuild]::GetDirectoryNameOfFileAbove(%24(MSBuildThisFileDirectory), helix.targets))\helix.targets" />
   <PropertyGroup>
@@ -121,22 +126,6 @@ $(_XunitEpilog)
 </Project>
         ]]>
       </XunitWrapperGenCsProj>
-      <XunitWrapperGenPackConfig>
-        <![CDATA[
-{
-  "dependencies": {
-    "xunit" : "2.1.0",
-    "xunit.assert" : "2.1.0",
-    "xunit.core" : "2.1.0",
-  },
-  "frameworks": {
-    "net45": {
-      "imports": "portable-net45+win8"
-    }
-  }
-}
-      ]]>
-      </XunitWrapperGenPackConfig>
 
     </PropertyGroup>
 
@@ -153,12 +142,6 @@ $(_XunitEpilog)
     <WriteLinesToFile
       File="$(XunitWrapperSrcDir)\$(XunitWrapper).csproj"
       Lines="$(XunitWrapperGenCsProj)"
-      Overwrite="true" />
-
-    <!-- Write the file -->
-    <WriteLinesToFile
-      File="$(XunitWrapperSrcDir)\project.json"
-      Lines="$(XunitWrapperGenPackConfig)"
       Overwrite="true" />
   </Target>
   
@@ -326,15 +309,13 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
   <Target Name="CreateAllWrappers" DependsOnTargets="GetListOfTestCmds;FindCmdDirectories">
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="CreateXunitWrapper" Properties="_CMDDIR=%(TestDirectories.Identity)" />
 
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
-
     <!--
       Contents of a project.json that will be restored once with errors turned off. This works
       around the package being incompatible with dotnet restore. Only the package contents are
       required so the compatibility errors can be ignored.
     -->
     <PropertyGroup>
-      <XunitRunnerRestoreGenConfig>{ "dependencies": { "xunit.runner.msbuild": "2.1.0" }, "frameworks": { "net45": {} } }</XunitRunnerRestoreGenConfig>
+      <XunitRunnerRestoreGenConfig>{ "dependencies": { "xunit.runner.msbuild": "$(XunitPackageVersion)" }, "frameworks": { "net45": {} } }</XunitRunnerRestoreGenConfig>
       <XunitRunnerRestoreProjectDir>$(BaseOutputPath)\tempRestoreProject</XunitRunnerRestoreProjectDir>
       <XunitRunnerRestoreProjectJsonPath>$(XunitRunnerRestoreProjectDir)\project.json</XunitRunnerRestoreProjectJsonPath>
     </PropertyGroup>
@@ -349,12 +330,6 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
           CustomErrorRegularExpression="^Unable to resolve .*"
           IgnoreExitCode="true" 
           IgnoreStandardErrorWarningFormat="true" />
-    
-    <!-- Restore all wrapper projects' project.jsons in one pass for perf & to avoid concurrency problems -->
-    <Exec Command="$(DnuRestoreCommand) &quot;$(XunitWrapperGeneratedCSDirBase.TrimEnd('\\'))&quot;"
-          StandardOutputImportance="Low" />
-    
-    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages...Done." />
 
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="BuildXunitWrapper" Properties="_CMDDIR=%(TestDirectories.Identity)" />
   </Target>

--- a/tests/src/TestWrappersConfig/project.json
+++ b/tests/src/TestWrappersConfig/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "xunit": "2.1.0",
+    "xunit.assert": "2.1.0",
+    "xunit.core": "2.1.0"
+  },
+  "frameworks": {
+    "net45": {
+      "imports": "portable-net45+win8"
+    }
+  }
+}

--- a/tests/src/dir.props
+++ b/tests/src/dir.props
@@ -12,6 +12,8 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <CLRTestKind>BuildAndRun</CLRTestKind>
     <SkipSigning Condition="'$(CrossGen)' == 'true'">true</SkipSigning>
+    <!-- Set the project.json directory for generated TestWrappers. -->
+    <TestWrappersPackagesConfigFileDirectory>$(MSBuildThisFileDirectory)TestWrappersConfig\</TestWrappersPackagesConfigFileDirectory>
   </PropertyGroup>
 
   <!-- Expose the target OS in a more convenient fashion -->


### PR DESCRIPTION
Fixes a few things discussed in https://github.com/dotnet/coreclr/pull/3589. This will make test dependency upgrades (specifically xunit upgrades) go more smoothly.

Put project.json for Xunit test wrappers in file system instead of generating. This lets dependency validation check the versions and reduces the number of project.json files to restore because all csproj's point to a single project.json and lockfile.

Adds XunitPackageVersion property that is used to always generate a valid project.json for `xunit.runner.msbuild`.

/cc @weshaggard