### PR TITLE
Fix a GC hole in a Ready-to-Run helper

### DIFF
--- a/src/vm/amd64/ExternalMethodFixupThunk.asm
+++ b/src/vm/amd64/ExternalMethodFixupThunk.asm
@@ -60,8 +60,7 @@ NESTED_ENTRY DelayLoad_Helper&suffix, _TEXT
 
         PROLOG_WITH_TRANSITION_BLOCK 8h, 10h, r8, r9
 
-        mov     rcx, frameFlags
-        mov     [rsp], rcx
+        mov     qword ptr [rsp + SIZEOF_MAX_OUTGOING_ARGUMENT_HOMES], frameFlags
         lea     rcx, [rsp + __PWTB_TransitionBlock] ; pTransitionBlock
         mov     rdx, rax                            ; pIndirection
 


### PR DESCRIPTION
Assembly routines DelayLoad_Helper* were putting an argument at a
wrong location on the stack. This resulted in a GC hole that caused
random crashes, such as dotnet/cli#1785 and dotnet/roslyn#9632.