### PR TITLE
Fix priority 1 tests: add missing dependencies

### DIFF
--- a/tests/src/Loader/binding/assemblies/assemblybugs/102140/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/102140/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
     "System.Console": "4.0.0-rc2-23816",
+    "System.Reflection": "4.0.10",
     "System.Runtime": "4.1.0-rc2-23816",
     "System.Runtime.Extensions": "4.0.10"
   },

--- a/tests/src/Loader/binding/assemblies/assemblybugs/177066w/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/177066w/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
     "System.Console": "4.0.0-rc2-23816",
+    "System.Reflection": "4.0.10",
     "System.Runtime": "4.1.0-rc2-23816",
     "System.Runtime.Extensions": "4.0.10"
   },

--- a/tests/src/Loader/binding/assemblies/assemblybugs/203962w/project.json
+++ b/tests/src/Loader/binding/assemblies/assemblybugs/203962w/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
     "System.Console": "4.0.0-rc2-23816",
+    "System.Reflection": "4.0.10",
     "System.Runtime": "4.1.0-rc2-23816",
     "System.Runtime.Extensions": "4.0.10"
   },

--- a/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/project.json
+++ b/tests/src/Loader/binding/assemblies/basicapi/assemblynamector/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
     "System.Console": "4.0.0-rc2-23816",
+    "System.Reflection": "4.0.10",
     "System.Runtime": "4.1.0-rc2-23816",
     "System.Runtime.Extensions": "4.0.10"
   },

--- a/tests/src/Loader/classloader/regressions/359519/project.json
+++ b/tests/src/Loader/classloader/regressions/359519/project.json
@@ -3,7 +3,8 @@
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
     "System.Console": "4.0.0-rc2-23816",
     "System.Runtime": "4.1.0-rc2-23816",
-    "System.Runtime.Extensions": "4.0.10"
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.InteropServices": "4.1.0-rc2-23816"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/project.json
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_support/project.json
@@ -24,6 +24,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc2-23816",
+    "System.Threading.ThreadPool": "4.0.10-rc2-23816",
     "System.Xml.ReaderWriter": "4.0.11-rc2-23816",
     "System.Xml.XDocument": "4.0.11-rc2-23816",
     "System.Xml.XmlDocument": "4.0.1-rc2-23816",

--- a/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_threadpoolnullchecks/project.json
+++ b/tests/src/baseservices/regression/v1/threads/functional/threadpool/cs_threadpoolnullchecks/project.json
@@ -24,6 +24,7 @@
     "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc2-23816",
+    "System.Threading.ThreadPool": "4.0.10-rc2-23816",
     "System.Xml.ReaderWriter": "4.0.11-rc2-23816",
     "System.Xml.XDocument": "4.0.11-rc2-23816",
     "System.Xml.XmlDocument": "4.0.1-rc2-23816",


### PR DESCRIPTION
I only ran the default tests in https://github.com/dotnet/coreclr/pull/3589 where I upgraded packages to make them fit validation rules. This resulted in http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/x64_release_windows_nt_pri1_bld/562/consoleFull#67707927a82fefab-f698-416f-8fca-58544c94cd4e

This fixes those errors by adding dependencies for types that were missing during compilation.

I'm not certain that it will work yet (working on going through the full build process) but I want to get this in front of eyes and CI.

/cc @wtgodbe