### PR TITLE
Fix to Huffman benchmark decompression loop has unnecessary spills and reloads

### DIFF
--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -981,9 +981,10 @@ private:
     // included in the blockSeuqence above, during setBlockSequence().
     bool                        verifiedAllBBs;
     void                        setBlockSequence();
+    int                         compareBlocksForSequencing(BasicBlock* block1, BasicBlock* block2, bool useBlockWeights);
     BasicBlockList*             blockSequenceWorkList;
     bool                        blockSequencingDone;
-    void                        addToBlockSequenceWorkList(BasicBlock* block);
+    void                        addToBlockSequenceWorkList(BlockSet sequencedBlockSet, BasicBlock* block);
     void                        removeFromBlockSequenceWorkList(BasicBlockList* listNode, BasicBlockList* prevNode);
     BasicBlock*                 getNextCandidateFromWorkList();
 


### PR DESCRIPTION
**Code generated for inner most while(hufftree[i].left != -1) loop:**
G_M33459_IG35:       
IN00e3: 0003AC mov      dword ptr [V14 rsp+3CH], ecx  <-- unnecessary spill due to kill by call node
spill textoffset
IN00e4: 0003B0 mov      dword ptr [V15 rsp+38H], r11d  <-- unnecessary spill due to kill by call node
spill maxbitoffset

**Code generated for do-while loop condition:**
    IN010a: 00043D mov      dword ptr [V14 rsp+3CH], ecx  <--- unnecessary spill
    IN010b: 000441 mov      dword ptr [V15 rsp+38H], r11d <--- unnecessary spill
    spill textoffset
    spill maxbitoffset
    IN010c: 000446 cmp      r10d, r11d
    IN010d: 000449 mov      ecx, dword ptr [V14 rsp+3CH]  <-- unnecessary reload
    IN010e: 00044D mov      r11d, dword ptr [V15 rsp+38H] <-- unnecessary reload
    reload textoffset
    reload maxbitoffset
    IN010f: 000452 jl       G_M33459_IG33
    while(bitoffset < maxbitoffset)


Given below is Huffman decompression nested loop indicating at a high-level which statments end up in which basic blocks (based on jit dump):

```
// BB41
maxbitoffset=bitoffset;
bitoffset=0;
textoffset=0;

do {
        // BB42 -> always branches to BB47
	i=root;
	
	// BB47 -> conditional branch to BB43, fall-thru to BB48
	while(hufftree[i].left!=-1)	
	{
	          // BB43
		if(GetCompBit(comparray,bitoffset)==0)
		          // BB44 -> always branches to BB46
			i=hufftree[i].left;
		Else
		          // BB45 -> falls through to BB46
			i=hufftree[i].right;
			
		// BB46 --> falls-thru to BB47
		bitoffset++;
	}
	
	// BB48 --> Conditional branch to BB42, fall-thru to BB49
	decomparray[textoffset]=hufftree[i].c;
	textoffset++;
} while(bitoffset<maxbitoffset);
```

LSRA allocation order: BB42, BB38, BB47 , BB48, BB43, BB44, BB45, BB46

As we can see register allocation for BB48 is done ahead of BB43.  BB43 is part of inner-most loop and has higher block weight than BB48.  The reason is that LSRA while sequencing succ blocks of BB47 favors layout order successor BB48.  Anther issue is that blocks are added to blockSequenceWorkList based on block number alone.

**Reason for unnecessary spills and reloads of textOffset and maxbitOffset:**
In BB41, textOffset and maxBitOffset get allocated to rcx and r11.  On entry to BB47 (from BB42) and BB48 (from BB47) textOffset and maxBitOffset are in reg rcx and r11 respectively.  Later when BB43 gets allocated, it kills rcx and r11 hence they get spilled in the inner loop.  Therefore on edge from BB46 to BB47, textOffset/maxBitOffset are in memory. In summary, from one edge textOffset/MaxBitOffset are in registers and from another edge they are in memory.  Block resolution logic would end up generating unnecessary spill/reloads towards the end of do-while loop.

**Fix:**
While sequencing blocks in pred order, LSRA will stop favoring layout order (favouring BB48 over BB43 above).  Further while adding blocks to blockSequenceWorkList, block weight is taken into account provided all its preds are already sequenced. For the above case since BB43 will be sequenced ahead of BB48.   With the fix, textOffset/maxBitOffset get spilled before entering the inner most loop and gets reloaded at the end of outer most do-while loop.

Benchmark perf measurements indicate: Huffman got improved by 6% and shell srt by 4%.
Rest of the perf benchmark numbers are within noise range and a couple of benchmark regressions are not consistent when run individually.

Asm diffs: Very minor code size improvement or regression.
For e.g. mscorlib shows 70bytes improvement whereas cqPerf shows 629 bytes of regression.

Since allocation order has changed most of the diffs are of the kind: a different register got assigned that in turn resulted in instruction size encoding differences, an additional mov got generated, less frequently one additional callee saved register was used in the method that resulted in prolog/epilog size increase.

Desktop Full DDR run is green.
