### PR TITLE
Using StackString to improve memory consumption in Lttng EventProvider

### DIFF
--- a/src/pal/src/include/pal/stackstring.hpp
+++ b/src/pal/src/include/pal/stackstring.hpp
@@ -5,8 +5,6 @@
 #ifndef __STACKSTRING_H_
 #define __STACKSTRING_H_
 
-#include "pal/malloc.hpp"
-
 template <SIZE_T STACKCOUNT, class T>
 class StackString
 {


### PR DESCRIPTION
The new generated code  is 
```C++
#define __STACKSTRING_H_STANDLONE_ 1
#include "stdlib.h"
#include "pal_mstypes.h"
#include "pal_error.h"
#include "pal.h"
#define PAL_free free
#define PAL_realloc realloc
#include "pal/stackstring.hpp"
#include "tpdotnetruntime.h"

extern "C" ULONG  FireEtXplatGCAllocationTick_V2(
                  const unsigned int AllocationAmount,
                  const unsigned int AllocationKind,
                  const unsigned short ClrInstanceID,
                  const unsigned __int64 AllocationAmount64,
                  const void* TypeID,
                  PCWSTR TypeName,
                  const unsigned int HeapIndex
)
{
  ULONG Error = ERROR_WRITE_FAULT;
    if (!EventXplatEnabledGCAllocationTick_V2()){ return ERROR_SUCCESS;}
    INT TypeName_path_size = -1;
    PathCharString TypeName_PS;
    INT TypeName_full_name_path_size = (PAL_wcslen(TypeName) + 1)*sizeof(WCHAR);
    CHAR* TypeName_full_name = TypeName_PS.OpenStringBuffer(TypeName_full_name_path_size );
    if(TypeName_full_name == NULL){return ERROR_WRITE_FAULT;}

    TypeName_path_size = WideCharToMultiByte( CP_ACP, 0, TypeName, -1, TypeName_full_name, TypeName_full_name_path_size, NULL, NULL );
    _ASSERTE(TypeName_path_size < TypeName_full_name_path_size );
    TypeName_PS.CloseBuffer(TypeName_path_size );
    if( TypeName_path_size == 0 ){ return ERROR_INVALID_PARAMETER; }

     tracepoint(
        DotNETRuntime,
        GCAllocationTick_V2,
        AllocationAmount,
        AllocationKind,
        ClrInstanceID,
        AllocationAmount64,
        (const size_t) TypeID,
        TypeName_full_name,
        HeapIndex
        );
        Error = ERROR_SUCCESS;

return Error;
}
```
The old generated code is 
```C++
extern "C" ULONG  FireEtXplatGCAllocationTick_V2(
                  const unsigned int AllocationAmount,
                  const unsigned int AllocationKind,
                  const unsigned short ClrInstanceID,
                  const unsigned __int64 AllocationAmount64,
                  const void* TypeID,
                  PCWSTR TypeName,
                  const unsigned int HeapIndex
)
{
  ULONG Error = ERROR_WRITE_FAULT;
    if (!EventXplatEnabledGCAllocationTick_V2()){ return ERROR_SUCCESS;}
    INT TypeName_path_size = -1;
    INT TypeName_full_name_path_size = WideCharToMultiByte( CP_ACP, 0, TypeName, -1, NULL, 0, NULL, NULL );
    CHAR* TypeName_full_name = NULL;

    TypeName_full_name = (CHAR*)malloc(TypeName_full_name_path_size*sizeof(CHAR));
    _ASSERTE(TypeName_full_name != NULL);
    if(TypeName_full_name == NULL){goto LExit;}

    TypeName_path_size = WideCharToMultiByte( CP_ACP, 0, TypeName, -1, TypeName_full_name, TypeName_full_name_path_size, NULL, NULL );
    _ASSERTE(TypeName_path_size == TypeName_full_name_path_size );
    if( TypeName_path_size == 0 ){ Error = ERROR_INVALID_PARAMETER; goto LExit;}

     tracepoint(
        DotNETRuntime,
        GCAllocationTick_V2,
        AllocationAmount,
        AllocationKind,
        ClrInstanceID,
        AllocationAmount64,
        (const size_t) TypeID,
        TypeName_full_name,
        HeapIndex
        );
        Error = ERROR_SUCCESS;
LExit:
        if (TypeName_full_name != NULL) {free(TypeName_full_name);}

return Error;
}
```