### PR TITLE
Remove __cdecl__ calling convention for [-Werror,-Wignored-attributes]

### DIFF
--- a/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
+++ b/src/pal/tests/palsuite/exception_handling/pal_sxs/test1/exceptionsxs.cpp
@@ -71,7 +71,7 @@ void sigsegv_handler(int code, siginfo_t *siginfo, void *context)
 
 #endif
 
-int __cdecl main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
 #if !defined(__FreeBSD__) && !defined(__NetBSD__)
     struct sigaction newAction;

--- a/tests/src/Interop/common/xplatform.h
+++ b/tests/src/Interop/common/xplatform.h
@@ -54,9 +54,11 @@
 #if __i386__
 #define __stdcall __attribute__((stdcall))
 #define _cdecl __attribute__((cdecl))
+#define __cdecl __attribute__((cdecl))
 #else
 #define __stdcall
 #define _cdecl
+#define __cdecl
 #endif
 #endif
 


### PR DESCRIPTION
The cross build for Linux/ARM is broken while doing the compilation
by the `[-Werror,-Wignored-attributes]` policy of the cross compiler.
Let's remove `__cdecl__` calling convention from ./test/src/Interop folder.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com
Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com