### PR TITLE
Documentation: Remove the "patching Urcu" section

### DIFF
--- a/Documentation/building/cross-building.md
+++ b/Documentation/building/cross-building.md
@@ -36,30 +36,6 @@ and if you wanted to generate the rootfs elsewhere:
 
     ben@ubuntu ~/git/coreclr/ $ sudo ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build-rootfs.sh arm
 
-Patching Urcu
--------------
-After generating the rootfs, a final step is required before you can manage the cross compilation. The Urcu library in Ubuntu 14.04, the reference target, is incorrect and it needs a manual patching otherwise you will get the following errors:
-
-```
-In file included from ~/coreclr/cross/rootfs/arm/usr/include/urcu/uatomic.h:41:
-~/coreclr/cross/rootfs/arm/usr/include/urcu/uatomic/generic.h:75:10: error: address
-      argument to atomic builtin must be a pointer to integer or pointer ('void *' invalid)
-                return __sync_val_compare_and_swap_4(addr, old, _new);
-                       ^                             ~~~~
-~/coreclr/cross/rootfs/arm/usr/include/urcu/uatomic/generic.h:112:3: error: address
-      argument to atomic builtin must be a pointer to integer or pointer ('void *' invalid)
-                __sync_and_and_fetch_4(addr, val);
-                ^                      ~~~~
-~/coreclr/cross/rootfs/arm/usr/include/urcu/uatomic/generic.h:151:3: error: address
-      argument to atomic builtin must be a pointer to integer or pointer ('void *' invalid)
-                __sync_or_and_fetch_4(addr, val);
-                ^                     ~~~~
-~/coreclr/cross/rootfs/arm/usr/include/urcu/uatomic/generic.h:190:10: error: address
-      argument to atomic builtin must be a pointer to integer or pointer ('void *' invalid)
-                return __sync_add_and_fetch_4(addr, val);
-```
-
-You can read more about this issue [here](http://lists.openembedded.org/pipermail/openembedded-core/2015-August/109294.html). The workaround is to use a more recent version of this [header file from the Urcu repository](https://github.com/urcu/userspace-rcu/blob/v0.7.15/urcu/uatomic/generic.h).
 
 Cross compiling CoreCLR
 -----------------------
@@ -74,6 +50,7 @@ And with:
     ben@ubuntu ~/git/coreclr/ $ ROOTFS_DIR=/home/ben/coreclr-cross/arm ./build.sh arm debug verbose clean cross
 
 As usual the resulting binaries will be found in `bin/Product/BuildOS.BuildArch.BuildType/`
+
 
 Cross Compilation for Linux, FreeBSD, or OS X
 =============================================


### PR DESCRIPTION
Atomic function parameter types of Userspace RCU (Urcu) is already fixed.
We don't need any manual patching for the cross build.
Let's remove this section from now on.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com
Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com