### PR TITLE
Add test mode exclusions

### DIFF
--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -135,6 +135,22 @@ fi
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
     <PropertyGroup>        
+      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(GCStressIncompatible)' == 'true'"><![CDATA[
+$(BashCLRTestEnvironmentCompatibilityCheck)
+if [ ! -z "$COMPlus_GCStress" ]
+then
+  echo SKIPPING EXECUTION BECAUSE COMPlus_GCStress IS SET
+  exit 0
+fi
+      ]]></BashCLRTestEnvironmentCompatibilityCheck>
+      <BashCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
+$(BashCLRTestEnvironmentCompatibilityCheck)
+if [ \( ! -z "$COMPlus_JitStress" \) -o \( ! -z "$COMPlus_JitStressRegs" \) -o \( ! -z "$COMPlus_JITMinOpts" \) ]
+then
+  echo SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET
+  exit 0
+fi
+      ]]></BashCLRTestEnvironmentCompatibilityCheck>
       <BashCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
 <![CDATA[CLRTestExpectedExitCode=$(CLRTestExitCode)
 echo BEGIN EXECUTION]]>
@@ -280,6 +296,7 @@ cd "$%28dirname "$0")"
 # The __TestEnv variable may be used to specify something to run before the test.
 $__TestEnv
 
+$(BashCLRTestEnvironmentCompatibilityCheck)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
 # CrossGen Script (when /p:CrossGen=true)

--- a/tests/src/CLRTest.Execute.Batch.targets
+++ b/tests/src/CLRTest.Execute.Batch.targets
@@ -125,6 +125,20 @@ IF NOT "!ERRORLEVEL!"=="0" (
     <Message Text="Project depends on $(_CLRTestToRunFileFullPath)." Condition="'$(_CLRTestNeedsProjectToRun)' == 'True'" />
 
     <PropertyGroup>
+      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(GCStressIncompatible)' == 'true'"><![CDATA[
+$(BatchCLRTestEnvironmentCompatibilityCheck)
+IF NOT "%COMPlus_GCStress%"=="" (
+  ECHO SKIPPING EXECUTION BECAUSE COMPlus_GCStress IS SET
+  Exit /b 0
+)
+      ]]></BatchCLRTestEnvironmentCompatibilityCheck>
+      <BatchCLRTestEnvironmentCompatibilityCheck Condition="'$(JitOptimizationSensitive)' == 'true'"><![CDATA[
+$(BatchCLRTestEnvironmentCompatibilityCheck)
+IF "%COMPlus_JitStress%"=="" IF "%COMPlus_JitStressRegs%"=="" IF "%COMPlus_JITMinOpts%"=="" goto :Compatible1
+  ECHO SKIPPING EXECUTION BECAUSE ONE OR MORE OF (COMPlus_JitStress, COMPlus_JitStressRegs, COMPlus_JITMinOpts) IS SET
+  Exit /b 0
+:Compatible1
+      ]]></BatchCLRTestEnvironmentCompatibilityCheck>
 
       <BatchCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
         <![CDATA[
@@ -299,6 +313,8 @@ $(BatchCLRTestExitCodePrep)
 
 REM The __TestEnv variable may be used to specify something to run before the test.
 IF NOT "%__TestEnv%"=="" call %__TestEnv%
+
+$(BatchCLRTestEnvironmentCompatibilityCheck)
 
 REM Environment Variables
 $(BatchEnvironmentVariables)

--- a/tests/src/JIT/Directed/IL/Tailcall/JitTailcall2.ilproj
+++ b/tests/src/JIT/Directed/IL/Tailcall/JitTailcall2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>    
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="JitTailcall2.il" />

--- a/tests/src/JIT/Directed/forceinlining/AttributeConflict.ilproj
+++ b/tests/src/JIT/Directed/forceinlining/AttributeConflict.ilproj
@@ -28,6 +28,9 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
+  <PropertyGroup>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="AttributeConflict.il" />
   </ItemGroup>

--- a/tests/src/JIT/Directed/forceinlining/PositiveCases.ilproj
+++ b/tests/src/JIT/Directed/forceinlining/PositiveCases.ilproj
@@ -28,6 +28,9 @@
   <PropertyGroup>
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
+  <PropertyGroup>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="PositiveCases.il" />
   </ItemGroup>

--- a/tests/src/JIT/Methodical/tailcall_v4/hijacking.ilproj
+++ b/tests/src/JIT/Methodical/tailcall_v4/hijacking.ilproj
@@ -29,6 +29,9 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
+  <PropertyGroup>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="hijacking.il" />
   </ItemGroup>

--- a/tests/src/JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/devdiv_902271/DevDiv_902271.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DevDiv_902271.il" />

--- a/tests/src/JIT/jit64/regress/ddb/87766/ddb87766.csproj
+++ b/tests/src/JIT/jit64/regress/ddb/87766/ddb87766.csproj
@@ -29,6 +29,9 @@
     <DebugType>PdbOnly</DebugType>
     <Optimize>True</Optimize>
   </PropertyGroup>
+  <PropertyGroup>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="ddb87766.cs" />
   </ItemGroup>


### PR DESCRIPTION
Add the ability to exclude individual tests that are incompatible with
certain test modes.  If a test is incompatible with or too slow under
GCStress, add

    <GCStressIncompatible>true</GCStressIncompatible>

as a property to the test's project file.  If a test requires optimization
or is sensitive to precise optimization patterns, use

    <JitOptimizationSensitive>true</JitOptimizationSensitive>
