### PR TITLE
Fix calculating the calendar year in JapaneseLunisolarCalendar

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/mscorlib/corefx/System/Globalization/GregorianCalendarHelper.cs
@@ -526,7 +526,12 @@ namespace System.Globalization
             long ticks = time.Ticks;
             for (int i = 0; i < m_EraInfo.Length; i++)
             {
-                if (ticks >= m_EraInfo[i].ticks)
+                // while calculating dates with JapaneseLuniSolarCalendar, we can run into cases right after the start of the era  
+                // and still belong to the month which is started in previous era. Calculating equivalent calendar date will cause  
+                // using the new era info which will have the year offset equal to the year we are calculating year = m_EraInfo[i].yearOffset  
+                // which will end up with zero as calendar year.
+                // We should use the previous era info instead to get the right year number. Example of such date is Feb 2nd 1989
+                if (ticks >= m_EraInfo[i].ticks && year > m_EraInfo[i].yearOffset)                
                 {
                     return (year - m_EraInfo[i].yearOffset);
                 }

--- a/src/mscorlib/src/System/Globalization/GregorianCalendarHelper.cs
+++ b/src/mscorlib/src/System/Globalization/GregorianCalendarHelper.cs
@@ -513,7 +513,12 @@ namespace System.Globalization {
         {
             long ticks = time.Ticks;
             for (int i = 0; i < m_EraInfo.Length; i++) {
-                if (ticks >= m_EraInfo[i].ticks) {
+                // while calculating dates with JapaneseLuniSolarCalendar, we can run into cases right after the start of the era  
+                // and still belong to the month which is started in previous era. Calculating equivalent calendar date will cause  
+                // using the new era info which will have the year offset equal to the year we are calculating year = m_EraInfo[i].yearOffset  
+                // which will end up with zero as calendar year.
+                // We should use the previous era info instead to get the right year number. Example of such date is Feb 2nd 1989
+                if (ticks >= m_EraInfo[i].ticks && year > m_EraInfo[i].yearOffset) {
                     return (year - m_EraInfo[i].yearOffset);
                 }
             }


### PR DESCRIPTION
The months in this calendar is lunar months. We can have the case when a new era
starts in the middle of a month which means part of the month will belong to one
era and the rest will belong to the new era. When calculating the calendar year
number for dates which in the rest of the month and exist in the new started era,
we should still use the old era info instead of the new era info because
the rest of the month still belong to the year of last era.

Example of such date is Feb 2nd 1989. Using such date while the era starts
on Jan 8th 1989 make this date belong to that new era which it is part of
the month started with previous era. Using the new era info will have the year
we are calculating equal to the era offset (i.e. year = m_EraInfo[i].yearOffset)
and we’ll end returning zero for the year. The fix is to use the previous era
info to calculate the year

issue https://github.com/dotnet/corefx/issues/6775