### PR TITLE
Use Default Stack Size for Multi-Core JIT Playback Thread

### DIFF
--- a/src/vm/multicorejitplayer.cpp
+++ b/src/vm/multicorejitplayer.cpp
@@ -1469,13 +1469,7 @@ HRESULT MulticoreJitProfilePlayer::ProcessProfile(const wchar_t * pFileName)
 
         _ASSERTE(m_pThread != NULL);
 
-        unsigned stackSize = 64 * sizeof(SIZE_T) * 1024; // 256 Kb for 32-bit, 512 Kb for 64-bit
-
-#ifdef _DEBUG
-        stackSize *= 2;   // Double it for CHK build
-#endif
-
-        if (m_pThread->CreateNewThread(stackSize, StaticJITThreadProc, this))
+        if (m_pThread->CreateNewThread(0, StaticJITThreadProc, this))
         {
             int t = (int) m_pThread->StartThread();
 


### PR DESCRIPTION
Multi-Core JIT currently specifies a 512K stack size for it's playback thread.  RyuJIT sometimes needs more than 512K resulting in stack overflow.  The solution is to specify 0 for the stack size, which will use the default (generally 1MB), which can be overridden in the DLL.

In addition to avoiding the stack overflow, this also helps to bring the feature closer to compatibility by using the same stack size that would have been used if Multi-Core JIT were disabled.

cc: @briansull, @vancem 