### PR TITLE
Fallback to JIT for explicit tailcalls in R2R

### DIFF
--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -3588,7 +3588,15 @@ bool ZapInfo::canTailCall(CORINFO_METHOD_HANDLE caller,
 #ifdef FEATURE_READYTORUN_COMPILER
     // READYTORUN: FUTURE: Delay load fixups for tailcalls
     if (IsReadyToRunCompilation())
+    {
+        if (fIsTailPrefix)
+        {
+            m_zapper->Warning(W("ReadyToRun: Explicit tailcalls not supported\n"));
+            ThrowHR(E_NOTIMPL);
+        }
+
         return false;
+    }
 #endif
 
     return m_pEEJitInfo->canTailCall(caller, declaredCallee, exactCallee, fIsTailPrefix);


### PR DESCRIPTION
Tests that are verifying explicit tailcalls are failing when compiled as R2R. This will make them pass.