### PR TITLE
Patch the runtests.sh script to work around an issue with corefx assemblies

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -339,7 +339,7 @@ function create_core_overlay {
     fi
     mkdir "$coreOverlayDir"
 
-    (cd $coreFxBinDir && find . -iname '*.dll' \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' \! -iwholename '*RemoteExecutorConsoleApp*' -exec cp -f '{}' "$coreOverlayDir/" \;)
+    (cd $coreFxBinDir && find . -iname '*.dll' \! -iwholename '*netstandard13aot*'  \! -iwholename '*test*' \! -iwholename '*/ToolRuntime/*' \! -iwholename '*RemoteExecutorConsoleApp*' -exec cp -f '{}' "$coreOverlayDir/" \;)
     cp -f "$coreFxNativeBinDir/Native/"*."$libExtension" "$coreOverlayDir/" 2>/dev/null
 
     cp -f "$coreClrBinDir/"* "$coreOverlayDir/" 2>/dev/null


### PR DESCRIPTION
Change https://github.com/dotnet/corefx/pull/6779 in CoreFx added corert assemblies to the mix of assemblies that are built for CoreCLR on Unix which broke the logic in runtest.sh that creates an overlay for running tests. As a result, CoreCLR tests started failing on Unix platforms. This change creates a work around for the problem.