### PR TITLE
Fix some JIT disassembly issues

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -6933,11 +6933,11 @@ PRINT_CONSTANT:
 
         if (IsAVXInstruction(ins))
         {
-            printf("%s, %s", emitYMMregName((unsigned)id->idReg1()), sstr);
+            printf(", %s", emitYMMregName((unsigned)id->idReg1()));
         }
         else if (IsSSE2Instruction(ins))
         {
-            printf(", %s", emitXMMregName((unsigned)id->idReg1()), sstr);
+            printf(", %s", emitXMMregName((unsigned)id->idReg1()));
         }
         else
         {
@@ -7026,7 +7026,17 @@ PRINT_CONSTANT:
         {
             printf("%s, %s", emitRegName(id->idReg2(), attr), emitXMMregName((unsigned)id->idReg1()));
         }
-        else if  (ins == INS_cvttsd2si)
+#ifndef LEGACY_BACKEND
+        else if  ((ins == INS_cvtsi2ss) || (ins == INS_cvtsi2sd))
+        {
+            printf(" %s, %s",  emitXMMregName((unsigned)id->idReg1()), emitRegName(id->idReg2(), attr));
+        }
+#endif
+        else if  ((ins == INS_cvttsd2si) 
+#ifndef LEGACY_BACKEND
+                  || (ins == INS_cvtss2si) || (ins == INS_cvtsd2si) || (ins == INS_cvttss2si)
+#endif
+                 )
         {
             printf(" %s, %s",  emitRegName(id->idReg1(), attr), emitXMMregName((unsigned)id->idReg2()));
         }


### PR DESCRIPTION
1. (v)movsd operands were messed up in disassembly:
`vmovsd   qword ptr [rsp+28H]ymm0, qword ptr`
instead of
`vmovsd   qword ptr [rsp+28H], ymm0`

2. cvtxx2yy insructions had GPR names prefixed with x/y:
`vcvtsi2ss ymm0, yrcx`
`vcvttss2si yrsi, ymm6`