### PR TITLE
Avoid Interval and RefPosition unnecessary initialization and copying

### DIFF
--- a/src/jit/jitstd.h
+++ b/src/jit/jitstd.h
@@ -5,6 +5,8 @@
 
 
 #include "allocator.h"
+#include "type_traits.h"
+#include "pair.h"
+#include "utility.h"
 #include "unordered_map.h"
 #include "unordered_set.h"
-#include "utility.h"

--- a/src/jit/jitstd/type_traits.h
+++ b/src/jit/jitstd/type_traits.h
@@ -37,6 +37,36 @@ struct remove_cv : remove_const<typename remove_volatile<T>::type>
 };
 
 template <typename T>
+struct remove_reference
+{
+    typedef T type;
+};
+
+template <typename T>
+struct remove_reference<T&>
+{
+    typedef T type;
+};
+
+template <typename T>
+struct remove_reference<T&&>
+{
+    typedef T type;
+};
+
+template <typename T>
+struct is_lvalue_reference
+{
+    enum { value = false };
+};
+
+template <typename T>
+struct is_lvalue_reference<T&>
+{
+    enum { value = true };
+};
+
+template <typename T>
 struct is_unqualified_pointer
 {
     enum { value = false };

--- a/src/jit/jitstd/utility.h
+++ b/src/jit/jitstd/utility.h
@@ -9,6 +9,21 @@
 namespace jitstd
 {
 
+template <typename T>
+inline 
+T&& forward(typename jitstd::remove_reference<T>::type& arg)
+{
+    return static_cast<T&&>(arg);
+}
+
+template <typename T>
+inline 
+T&& forward(typename jitstd::remove_reference<T>::type&& arg)
+{
+    static_assert(!jitstd::is_lvalue_reference<T>::value, "unexpected lvalue reference");
+    return static_cast<T&&>(arg);
+}
+
 namespace utility
 {
     // Template class for scoped execution of a lambda.

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -313,7 +313,7 @@ LinearScan::stressLimitRegs(RefPosition* refPosition, regMaskTP mask)
 Interval *
 LinearScan::newInterval(RegisterType theRegisterType)
 {
-    intervals.push_back(Interval());
+    intervals.emplace_back();
     Interval *newInt = &intervals.back();
     newInt->init();
 
@@ -332,9 +332,8 @@ LinearScan::newInterval(RegisterType theRegisterType)
 RefPosition *
 LinearScan::newRefPositionRaw()
 {
-    refPositions.push_back(RefPosition());
+    refPositions.emplace_back();
     RefPosition *newRP = &refPositions.back();
-    memset(newRP, 0, sizeof(RefPosition)); // TODO-Cleanup: call a RefPosition constructor instead?
 #ifdef DEBUG
     newRP->rpNum = refPositionCount;
 #endif // DEBUG

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -313,12 +313,8 @@ LinearScan::stressLimitRegs(RefPosition* refPosition, regMaskTP mask)
 Interval *
 LinearScan::newInterval(RegisterType theRegisterType)
 {
-    intervals.emplace_back();
+    intervals.emplace_back(theRegisterType, allRegs(theRegisterType));
     Interval *newInt = &intervals.back();
-    newInt->init();
-
-    newInt->registerType = theRegisterType;
-    newInt->registerPreferences = allRegs(theRegisterType);
 
 #ifdef DEBUG
     newInt->intervalIndex = intervalCount;

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -720,7 +720,7 @@ private:
     }
     RegRecord *     getRegisterRecord(regNumber regNum);
 
-    RefPosition *   newRefPositionRaw();
+    RefPosition *   newRefPositionRaw(LsraLocation nodeLocation, GenTree* treeNode, RefType refType);
 
     RefPosition *   newRefPosition(Interval * theInterval, LsraLocation theLocation,
                                    RefType theRefType, GenTree * theTreeNode,
@@ -1264,8 +1264,30 @@ public:
 
 class RefPosition
 {
-
 public:
+    RefPosition(unsigned int bbNum, LsraLocation nodeLocation, GenTree* treeNode, RefType refType)
+        : referent(nullptr)
+        , nextRefPosition(nullptr)
+        , treeNode(treeNode)
+        , bbNum(bbNum)
+        , nodeLocation(nodeLocation)
+        , registerAssignment(RBM_NONE)
+        , refType(refType)
+        , lastUse(false)
+        , reload(false)
+        , spillAfter(false)
+        , copyReg(false)
+        , moveReg(false)
+        , isPhysRegRef(false)
+        , isFixedRegRef(false)
+        , isLocalDefUse(false)
+        , delayRegFree(false)
+        , outOfOrder(false)
+#ifdef DEBUG
+        , rpNum(0)
+#endif
+    {
+    }
 
     // A RefPosition refers to either an Interval or a RegRecord. 'referent' points to one
     // of these types. If it refers to a RegRecord, then 'isPhysRegRef' is true. If it

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1049,10 +1049,28 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 class Interval : public Referenceable
 {
 public:
-    // Initialize the interval
-    void init()
+    Interval(RegisterType registerType, regMaskTP registerPreferences)
+        : registerPreferences(registerPreferences)
+        , relatedInterval(nullptr)
+        , assignedReg(nullptr)
+        , registerType(registerType)
+        , isLocalVar(false)
+        , isSplit(false)
+        , isSpilled(false)
+        , isInternal(false)
+        , isStructField(false)
+        , isPromotedStruct(false)
+        , hasConflictingDefUse(false)
+        , hasNonCommutativeRMWDef(false)
+        , isSpecialPutArg(false)
+        , preferCalleeSave(false)
+        , isConstant(false)
+        , physReg(REG_COUNT)
+#ifdef DEBUG
+        , intervalIndex(0)
+#endif
+        , varNum(0)
     {
-        physReg = REG_COUNT;
     }
 
 #ifdef DEBUG

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -1052,7 +1052,6 @@ public:
     // Initialize the interval
     void init()
     {
-        memset(this, 0, sizeof(Interval));
         physReg = REG_COUNT;
     }
 


### PR DESCRIPTION
`RefPosition()` initializes a temporary object by using `memset`. `push_back` copies the temporary object to the list node. `memset` is called again to zero out the newly created `RefPosition` object.

Add `emplace` methods to `jitstd::list` to avoid copying. Drop the redundant `memset` call.