### PR TITLE
ARM64: Fix ZeroInit of Locals

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -6727,7 +6727,14 @@ void        CodeGen::genZeroInitFrame(int        untrLclHi,
 #ifdef _TARGET_ARM_
             getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, rZero1, rAddr, 0);
 #else // _TARGET_ARM_
-            getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_ZR, rAddr, (uCntBytes - REGSIZE_BYTES) == 0 ? 0 : INS_OPTS_POST_INDEX);
+            if ((uCntBytes - REGSIZE_BYTES) == 0)
+            {
+                getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_ZR, rAddr, 0);
+            }
+            else
+            {
+                getEmitter()->emitIns_R_R_I(INS_str, EA_PTRSIZE, REG_ZR, rAddr, REGSIZE_BYTES, INS_OPTS_POST_INDEX);
+            }
 #endif // !_TARGET_ARM_
             uCntBytes -= REGSIZE_BYTES;
         }

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -5415,7 +5415,7 @@ RelativePath=JIT\Directed\zeroinit\init_int32\init_int32.exe
 WorkingDir=JIT\Directed\zeroinit\init_int32
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;ISSUE_3665
+Categories=Pri0;JIT;EXPECTED_PASS
 HostStyle=Any
 [init_int64.exe_774]
 RelativePath=JIT\Directed\zeroinit\init_int64\init_int64.exe
@@ -5436,7 +5436,7 @@ RelativePath=JIT\Directed\zeroinit\init_uint32\init_uint32.exe
 WorkingDir=JIT\Directed\zeroinit\init_uint32
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;ISSUE_3665
+Categories=Pri0;JIT;EXPECTED_PASS
 HostStyle=Any
 [init_uint64.exe_777]
 RelativePath=JIT\Directed\zeroinit\init_uint64\init_uint64.exe


### PR DESCRIPTION
When zero-initializing locals, JIT emits wrong instruction sequence --
e.g, 28 byte zero-intialization as shown below.
The issue was JIT passed wrong arguments to emitIns_R_R_I.

Before (Fail)
```
 stp     xzr, xzr, [x2],#16
 str     xzr, [x2,#2]  --> just two byte offset (no x2 post-increment)
 str     wzr, [x2]
```

After (Pass)
```
 stp     xzr, xzr, [x2],#16
 str     xzr, [x2],#8
 str     wzr, [x2]
```