### PR TITLE
ARM64: Fix casting unsigned int to double

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -6225,13 +6225,8 @@ CodeGen::genIntToFloatCast(GenTreePtr treeNode)
     emitAttr srcSize = EA_ATTR(genTypeSize(srcType));
     noway_assert((srcSize == EA_4BYTE) ||(srcSize == EA_8BYTE));
 
-    instruction ins = INS_scvtf;            // default to sign converts
+    instruction ins = varTypeIsUnsigned(srcType) ? INS_ucvtf : INS_scvtf;
     insOpts     cvtOption = INS_OPTS_NONE;  // invalid value
-
-    if (varTypeIsUnsigned(dstType))
-    {
-        ins = INS_ucvtf;             // use unsigned converts
-    }
 
     if (dstType == TYP_DOUBLE)
     {

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -36404,7 +36404,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68045\b68045\b68045.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68045\b68045
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;ISSUE_3667
+Categories=Pri0;JIT;EXPECTED_PASS
 HostStyle=Any
 [b68361.exe_5201]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68361\b68361\b68361.exe


### PR DESCRIPTION
When casting unsigned int to double, JIT emitted ```scvtf``` instead of ```uscvtf```.
The issue was JIT used dst type instead of src type for checking the sign.
This fixes a part of https://github.com/dotnet/coreclr/issues/3667.