### PR TITLE
Exclude doublearray/* from GCStress runs

### DIFF
--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_d.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_do.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_r.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray1_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray1_cs_ro.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray1.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_d.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_do.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_r.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray2_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray2_cs_ro.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray2.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray3_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3_cs_d.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray3_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3_cs_do.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray3_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3_cs_r.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray3_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray3_cs_ro.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray3.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>Full</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>False</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
@@ -28,6 +28,7 @@
   <PropertyGroup>
     <DebugType>None</DebugType>
     <Optimize>True</Optimize>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dblarray4.cs" />


### PR DESCRIPTION
Doublearray tests are incompatible with GCStress.  This takes advantage of the new exclusion supported added by #3659.

Fixes #2759