### PR TITLE
ARM64: Fix genJumpToThrowHlpBlk

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -2674,15 +2674,22 @@ void            CodeGen::genJumpToThrowHlpBlk(emitJumpKind          jumpKind,
         /* The code to throw the exception will be generated inline, and
            we will jump around it in the normal non-exception case */
 
-        BasicBlock * tgtBlk = genCreateTempLabel();
-        jumpKind = emitter::emitReverseJumpKind(jumpKind);
-        inst_JMP(jumpKind, tgtBlk);
+        BasicBlock * tgtBlk = nullptr;
+        emitJumpKind reverseJumpKind = emitter::emitReverseJumpKind(jumpKind);
+        if (reverseJumpKind != jumpKind)
+        {
+            tgtBlk = genCreateTempLabel();
+            inst_JMP(reverseJumpKind, tgtBlk);
+        }
 
         genEmitHelperCall(compiler->acdHelper(codeKind), 0, EA_UNKNOWN);
 
         /* Define the spot for the normal non-exception case to jump to */
-
-        genDefineTempLabel(tgtBlk);
+        if (tgtBlk != nullptr)
+        {
+            assert(reverseJumpKind != jumpKind);
+            genDefineTempLabel(tgtBlk);
+        }
     }
 }
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -34479,7 +34479,7 @@ RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43121\b43121\b43121.exe
 WorkingDir=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43121\b43121
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;ISSUE_3667
+Categories=Pri0;JIT;EXPECTED_PASS
 HostStyle=Any
 [b43160.exe_4926]
 RelativePath=JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43160\b43160\b43160.exe


### PR DESCRIPTION
This is additional fix to https://github.com/dotnet/coreclr/issues/3667.
When JIT invokes this API with direct jump (EJ_jmp), JIT also tries to
circumvent the target by reversing the jump kind in debug path.
In this case, actually we should directly invoke the target.

Before (Fail)
```
 b       G_M36945_IG03
 bl      CORINFO_HELP_THROWDIVZERO
G_M36945_IG03:
```

After (Pass)
```
 bl      CORINFO_HELP_THROWDIVZERO
```