### PR TITLE
Add dependency to apisets correctly

### DIFF
--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,6 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- ApiSets are only applicable for Windows. 
+         Despite the unconditioned package dependency it is constrained by runtime IDs within it's own package -->
+    <Dependency Include="Microsoft.NETCore.Windows.ApiSets">
+      <Version>1.0.1-rc3-23915</Version>
+    </Dependency>
     <ProjectReference Include="win\Microsoft.NETCore.Runtime.CoreCLR.pkgproj">
       <Platform>amd64</Platform>
     </ProjectReference>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,12 +11,6 @@
   </PropertyGroup>
   
   <ItemGroup>
-
-    <!-- Windows nuget package will depend upon the APISet package -->
-    <Dependency Include="Microsoft.NETCore.Windows.ApiSets">
-      <Version>1.0.1-rc3-23803</Version>
-    </Dependency>
-
     <ArchitectureSpecificNativeFile Include="$(BinDir)clretwrc.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)coreclr.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)dbgshim.dll"/>


### PR DESCRIPTION
Dependency to apisets should be in redirection package and not in win nuget package