### PR TITLE
Fix timeout determination for tests

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -279,8 +279,18 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
 
                 if (ret != CoreclrTestWrapperLib.EXIT_SUCCESS_CODE)
                 {
+                    string sErrorText = null%3B
+                    try
+                    {
+                        sErrorText = System.IO.File.ReadAllText(errorFile)%3B
+                    }
+                    catch(Exception ex)
+                    {
+                      sErrorText = "Unable to read error file: " + errorFile%3B
+                    }
+
                     string msg = infraEx != null ? "Test Infrastructure Failure: " + infraEx.Message
-                                                 : System.IO.File.ReadAllText(errorFile) + "\n\n" +
+                                                 : sErrorText + "\n\n" +
                                                    "Raw output:      " + outputFile + "\n" +
                                                    "To run the test:\n" +
                                                    "> set CORE_ROOT=" + _Global.coreRoot + "\n" +

--- a/tests/src/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
+++ b/tests/src/Common/Coreclr.TestWrapper/CoreclrTestWrapperLib.cs
@@ -41,9 +41,9 @@ namespace CoreclrTestLib
                 Task copyOutput = process.StandardOutput.BaseStream.CopyToAsync(outputStream);
                 Task copyError = process.StandardError.BaseStream.CopyToAsync(errorStream);
 
-                bool completed = process.WaitForExit(timeout) &&
-                    copyOutput.Wait(timeout) &&
-                    copyError.Wait(timeout);
+                bool completed = process.WaitForExit(timeout);
+                copyOutput.Wait(timeout);
+                copyError.Wait(timeout);
 
                 if (completed)
                 {


### PR DESCRIPTION
Mark test as timed out only if the primary process invocation times out, instead of clubbing it with output and error file timeouts. This results in less false negatives.

@ramarag PTAL