### PR TITLE
Creates RunTime Dependency Layout as a seperate step

### DIFF
--- a/tests/runtest.cmd
+++ b/tests/runtest.cmd
@@ -54,6 +54,7 @@ if /i "%1" == "Exclude"             (set __Exclude=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "Exclude0"            (set __Exclude0=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "TestEnv"             (set __TestEnv=%2&shift&shift&goto Arg_Loop)
 if /i "%1" == "sequential"          (set __BuildSequential=1&shift&goto Arg_Loop)
+if /i "%1" == "GenerateLayoutOnly"  (set __GenerateLayoutOnly=1&set __SkipWrapperGeneration=true&shift&goto Arg_Loop)
 
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
@@ -65,6 +66,7 @@ goto CollectMsbuildArgs
 :SkipMsbuildArgs
 
 set CORE_ROOT=%1
+echo %__MsgPrefix%CORE_ROOT is initially set to: "%CORE_ROOT%"
 shift 
 :ArgsDone
 
@@ -126,47 +128,7 @@ if not defined __BuildSequential (
     set __msbuildCommonArgs=%__msbuildCommonArgs% /maxcpucount
 )
 
-if not defined CORE_ROOT (
-    set noCore_RootSet=true
-    set "CORE_ROOT=%__BinDir%"
-)
-
-::Check if the test Binaries are built
-if not exist %XunitTestBinBase% (
-    echo %__MsgPrefix%Error: Ensure the Test Binaries are built and are present at %XunitTestBinBase%.
-    echo %__MsgPrefix%Run "buildtest.cmd %__BuildArch% %__BuildType%" to build the tests first.
-    exit /b 1
-)
-
-if "%CORE_ROOT%" == "" (
-    echo %__MsgPrefix%Error: Ensure you have done a successful build of the Product and Run - runtest BuildArch BuildType {path to product binaries}.
-    exit /b 1
-)
-
-if not exist %CORE_ROOT%\coreclr.dll (
-    echo %__MsgPrefix%Error: Ensure you have done a successful build of the Product and %CORE_ROOT% contains runtime binaries.
-    exit /b 1
-)
-
-if defined __Exclude (if not exist %__Exclude% echo %__MsgPrefix%Error: Exclusion .targets file not found && exit /b 1)
-if defined __TestEnv (if not exist %__TestEnv% echo %__MsgPrefix%Error: Test Environment script not found && exit /b 1)
-
-REM These log files are created automatically by the test run process. Q: what do they depend on being set?
-set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.html
-set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.xml
-
-echo %__MsgPrefix%CORE_ROOT that will be used is: %CORE_ROOT%
-echo %__MsgPrefix%Starting the test run ...
-
-if "%__SkipWrapperGeneration%"=="true" goto SkipWrapperGeneration
-
-set __BuildLogRootName=Tests_XunitWrapper
-call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:NoRun=true
-if errorlevel 1 exit /b 1
-
-:SkipWrapperGeneration
-
-if not "%noCore_RootSet%"=="true" goto SkipCoreRootSetup
+if defined CORE_ROOT goto SkipCoreRootSetup
 
 set "CORE_ROOT=%XunitTestBinBase%\Tests\Core_Root"
 echo %__MsgPrefix%Using Default CORE_ROOT as %CORE_ROOT%
@@ -177,17 +139,45 @@ xcopy /s "%__BinDir%" "%CORE_ROOT%"
 
 :SkipCoreRootSetup
 
-:: Pull down dependent packages needed for testing
-setlocal
-if defined __TestEnv call %__TestEnv%
-if defined COMPlus_GCStress set __Result=true
-endlocal & set __IsGCTest=%__Result%
-if "%__IsGCTest%"=="true" (
-    call tests\setup-runtime-dependencies.cmd /outputdir %CORE_ROOT%
+
+if defined __Exclude (if not exist %__Exclude% echo %__MsgPrefix%Error: Exclusion .targets file not found && exit /b 1)
+if defined __TestEnv (if not exist %__TestEnv% echo %__MsgPrefix%Error: Test Environment script not found && exit /b 1)
+
+REM These log files are created automatically by the test run process. Q: what do they depend on being set?
+set __TestRunHtmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.html
+set __TestRunXmlLog=%__LogsDir%\TestRun_%__BuildOS%__%__BuildArch%__%__BuildType%.xml
+
+
+if "%__SkipWrapperGeneration%"=="true" goto SkipWrapperGeneration
+
+set __BuildLogRootName=Tests_XunitWrapper
+call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:BuildWrappers=true
+if errorlevel 1 exit /b 1
+
+:SkipWrapperGeneration
+
+call :ResolveDependecies
+
+if  defined __GenerateLayoutOnly (
+    exit /b 1
 )
 
+if not exist %CORE_ROOT%\coreclr.dll (
+    echo %__MsgPrefix%Error: Ensure you have done a successful build of the Product and %CORE_ROOT% contains runtime binaries.
+    exit /b 1
+)
+
+::Check if the test Binaries are built
+if not exist %XunitTestBinBase% (
+    echo %__MsgPrefix%Error: Ensure the Test Binaries are built and are present at %XunitTestBinBase%.
+    echo %__MsgPrefix%Run "buildtest.cmd %__BuildArch% %__BuildType%" to build the tests first.
+    exit /b 1
+)
+echo %__MsgPrefix%CORE_ROOT that will be used is: %CORE_ROOT%
+echo %__MsgPrefix%Starting the test run ...
+
 set __BuildLogRootName=TestRunResults
-call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:NoBuild=true /clp:showcommandline
+call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:Runtests=true /clp:showcommandline
 
 if errorlevel 1 (
     echo Test Run failed. Refer to the following:
@@ -252,6 +242,29 @@ if errorlevel 1 (
 
 exit /b 0
 
+:ResolveDependecies:
+
+if "%CORE_ROOT%" == "" (
+    echo %__MsgPrefix%Error: Ensure you have done a successful build of the Product and Run - runtest BuildArch BuildType {path to product binaries}.
+    exit /b 1
+)
+:: Pull down dependent packages needed for testing
+setlocal
+if defined __TestEnv call %__TestEnv%
+if defined COMPlus_GCStress set __Result=true
+endlocal & set __IsGCTest=%__Result%
+if "%__IsGCTest%"=="true" (
+    call tests\setup-runtime-dependencies.cmd /outputdir %CORE_ROOT%
+)
+call :msbuild "%__ProjectFilesDir%\runtest.proj" /p:GeneraRuntimeLayout=true 
+echo %__MsgPrefix% Created the runtime layout with all dependencies in:%CORE_ROOT%
+exit /b 0
+
+if errorlevel 1 (
+    echo Test Depenedevy Resolution Failed
+    exit /b 1
+)
+
 :Usage
 echo.
 echo Usage:
@@ -267,6 +280,7 @@ echo                                Set to "" to disable default exclusion file.
 echo Exclude-  Optional parameter - this will exclude individual tests from running, specified by ExcludeList ItemGroup in an .targets file.
 echo TestEnv- Optional parameter - this will run a custom script to set custom test environment settings.
 echo VSVersion- Optional parameter - VS2013 or VS2015 ^(default: VS2015^)
+echo GenerateLayoutOnly - If specified will not run the tests and will only create the Runtime Dependency Layout
 echo CORE_ROOT The path to the runtime  
 exit /b 1
 

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="src\dir.props" />
-  <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets') AND '$(NoBuild)' != 'true'" /> 
+  <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets') AND '$(BuildWrappers)' == 'true'" /> 
 
   <PropertyGroup>
     <XunitTestBinBase Condition="'$(XunitTestBinBase)'==''" >$(BaseOutputPathWithConfig)</XunitTestBinBase>
@@ -393,29 +393,29 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
     <!-- generate project.json for runtime dependency -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CreateTestRuntimeJsonFile"
-             Condition=" '$(NoBuild)'!='true' " />
+             Condition=" '$(BuildWrappers)'=='true' " />
 
     <!-- generate project.lock.json file corresponding to above json file -->
     <MSBuild Projects="src\Common\test_runtime\test_runtime.csproj"
-             Condition=" '$(NoBuild)'!='true' " />
+             Condition=" '$(BuildWrappers)'=='true' " />
 
     <!-- Default for building -->
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CreateAllWrappers"
              Properties="_CMDDIR=%(TestDirectories.Identity)"
-             Condition=" '$(NoBuild)'!='true' " />
+             Condition=" '$(BuildWrappers)'=='true' " />
 
     <!-- Execution -->
 
     <MSBuild Projects="$(MSBuildProjectFile)"
              Targets="CreateTestOverlay"
-             Condition=" '$(NoRun)'!='true' "/>
+             Condition=" '$(GeneraRuntimeLayout)'=='true' "/>
 
     <MSBuild Projects="$(MSBuildProjectFile)" Targets="RunTests"
-             Condition=" '$(NoRun)'!='true' "/>
+             Condition=" '$(RunTests)'=='true' "/>
   </Target>
 
   <Target Name="Clean">
-    <RemoveDir Condition=" '$(NoBuild)'!='true'" Directories="$(XunitWrapperGeneratedCSDirBase);$(XunitWrapperOutputIntermediatedDirBase)" ContinueOnError="WarnAndContinue" /> 
+    <RemoveDir Condition=" '$(BuildWrappers)'=='true'" Directories="$(XunitWrapperGeneratedCSDirBase);$(XunitWrapperOutputIntermediatedDirBase)" ContinueOnError="WarnAndContinue" /> 
   </Target>
 </Project>


### PR DESCRIPTION
@gkhanna79 @briansull @rahku PTAL

Usage to get flat dependency is : 
tests\runtest.cmd GenerateLayoutOnly

to get only the dependencies and not the runtime itself : 
tests\runtest.cmd GenerateLayoutOnly C:\temp\dependencies 