### PR TITLE
Remove nugetbuild myget feed

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -74,7 +74,6 @@
    <ItemGroup> 
      <!-- Need to escape double forward slash (%2F) or MSBuild will normalize to one slash on Unix. --> 
      <DnuSourceList Include="https:%2F%2Fdotnet.myget.org/F/dotnet-core/api/v3/index.json" /> 
-     <DnuSourceList Include="https:%2F%2Fwww.myget.org/F/nugetbuild/api/v3/index.json" /> 
      <DnuSourceList Include="https:%2F%2Fapi.nuget.org/v3/index.json" /> 
    </ItemGroup> 
 


### PR DESCRIPTION
Fixes an intermittent restore issue from myget.org observed in at least these CI builds: [73](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/73/), [74](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/74/), [84](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/84/), [85](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/85/), [90](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/90/), [91](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/91/), [96](http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/checked_windows_nt_bld_prtest/96/). As far as I can tell the feed isn't necessary.

/cc @weshaggard @rahku