### PR TITLE
Strip symbols on release builds into separate binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,27 @@ else()
     if (AWK STREQUAL "AWK-NOTFOUND")
         message(FATAL_ERROR "AWK not found")
     endif()
+ 
+    if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+      # Ensure that dsymutil and strip is present
+      find_program(DSYMUTIL dsymutil)
+      if (DSYMUTIL STREQUAL "DSYMUTIL-NOTFOUND")
+          message(FATAL_ERROR "dsymutil not found")
+      endif()
+      find_program(STRIP strip)
+      if (STRIP STREQUAL "STRIP-NOTFOUND")
+          message(FATAL_ERROR "strip not found")
+      endif()
+
+    else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+      # Ensure that objcopy is present
+      find_program(OBJCOPY objcopy)
+      if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND")
+          message(FATAL_ERROR "objcopy not found")
+      endif()
+    endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(WIN32)
 
 # Build a list of compiler definitions by putting -D in front of each define.
@@ -240,6 +261,41 @@ function(add_precompiled_header header cppFile targetSources)
     # Add cppFile to SourcesVar
     set(${targetSources} ${${targetSources}} ${cppFile} PARENT_SCOPE)
   endif(MSVC)
+endfunction()
+
+function(strip_symbols targetName outputFilename)
+  if (CLR_CMAKE_PLATFORM_UNIX)
+    if (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+      set(STRIP_SOURCE_FILE $<TARGET_FILE:${targetName}>)
+
+      if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set(STRIP_DESTINATION_FILE ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:${targetName}>.dSYM)
+
+        add_custom_command(
+          TARGET ${targetName}
+          POST_BUILD
+          VERBATIM 
+          COMMAND ${DSYMUTIL} --flat ${STRIP_SOURCE_FILE} --out=${STRIP_DESTINATION_FILE}
+          COMMAND ${STRIP} -S ${STRIP_SOURCE_FILE}
+          COMMENT Stripping symbols from ${STRIP_SOURCE_FILE} into file ${STRIP_DESTINATION_FILE}
+        )
+      else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set(STRIP_DESTINATION_FILE ${CMAKE_CURRENT_BINARY_DIR}/$<TARGET_FILE_NAME:${targetName}>.dbg)
+
+        add_custom_command(
+          TARGET ${targetName}
+          POST_BUILD
+          VERBATIM 
+          COMMAND ${OBJCOPY} --only-keep-debug ${STRIP_SOURCE_FILE} ${STRIP_DESTINATION_FILE}
+          COMMAND ${OBJCOPY} --strip-unneeded ${STRIP_SOURCE_FILE}
+          COMMAND ${OBJCOPY} --add-gnu-debuglink=${STRIP_DESTINATION_FILE} ${STRIP_SOURCE_FILE}
+          COMMENT Stripping symbols from ${STRIP_SOURCE_FILE} into file ${STRIP_DESTINATION_FILE}
+        )
+      endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+      set(${outputFilename} ${STRIP_DESTINATION_FILE} PARENT_SCOPE)
+    endif (UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+  endif (CLR_CMAKE_PLATFORM_UNIX)
 endfunction()
 
 # Includes

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -145,10 +145,13 @@ add_library_clr(sos SHARED ${SOS_SOURCES})
 add_dependencies(sos mscordaccore)
 target_link_libraries(sos ${SOS_LIBRARY})
 
+strip_symbols(sos STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS sos DESTINATION .)
+install(FILES $<TARGET_FILE:sos> DESTINATION .)
 if(WIN32)
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/sos.pdb DESTINATION PDB)
-else(WIN32)
-  install (FILES sosdocsunix.txt DESTINATION .)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/sos.pdb DESTINATION PDB)
+else()
+  install(FILES sosdocsunix.txt DESTINATION .)
+  install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
 endif(WIN32)

--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -92,5 +92,8 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     target_link_libraries(sosplugin ${LLDB})
 endif()
 
+strip_symbols(sosplugin STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS sosplugin DESTINATION .)
+install(FILES $<TARGET_FILE:sosplugin> DESTINATION .)
+install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)

--- a/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
@@ -30,4 +30,7 @@ add_dependencies(coreconsole
     coreclr
 )
 
-install (TARGETS coreconsole DESTINATION .)
+strip_symbols(coreconsole STRIP_DESTINATION_FILE)
+
+install(TARGETS coreconsole DESTINATION .)
+install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)

--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -30,4 +30,7 @@ add_dependencies(corerun
     coreclr
 )
 
-install (TARGETS corerun DESTINATION .)
+strip_symbols(corerun STRIP_DESTINATION_FILE)
+
+install(TARGETS corerun DESTINATION .)
+install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -73,4 +73,8 @@ else()
     add_definitions(-DU_DISABLE_RENAMING=1)
 endif()
 
-install (TARGETS System.Globalization.Native DESTINATION .)
+strip_symbols(System.Globalization.Native STRIP_DESTINATION_FILE)
+
+# add the install targets
+install(FILES $<TARGET_FILE:System.Globalization.Native> DESTINATION .)
+install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -76,5 +76,5 @@ endif()
 strip_symbols(System.Globalization.Native STRIP_DESTINATION_FILE)
 
 # add the install targets
-install(FILES $<TARGET_FILE:System.Globalization.Native> DESTINATION .)
+install(TARGETS System.Globalization.Native DESTINATION .)
 install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)

--- a/src/dlls/dbgshim/CMakeLists.txt
+++ b/src/dlls/dbgshim/CMakeLists.txt
@@ -70,8 +70,12 @@ endif(WIN32)
 
 target_link_libraries(dbgshim ${DBGSHIM_LIBRARIES})
 
+strip_symbols(dbgshim STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS dbgshim DESTINATION .)
+install(FILES $<TARGET_FILE:dbgshim> DESTINATION .)
 if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/dbgshim.pdb DESTINATION PDB)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/dbgshim.pdb DESTINATION PDB)
+else()
+    install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
 endif(WIN32)

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -105,8 +105,12 @@ endif(WIN32)
 
 target_link_libraries(mscordaccore ${COREDAC_LIBRARIES})
 
+strip_symbols(mscordaccore STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS mscordaccore DESTINATION .)
+install(FILES $<TARGET_FILE:mscordaccore> DESTINATION .)
 if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.pdb DESTINATION PDB)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.pdb DESTINATION PDB)
+else()
+    install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
 endif(WIN32)

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -94,8 +94,12 @@ elseif(CLR_CMAKE_PLATFORM_UNIX)
     add_dependencies(mscordbi mscordaccore)
 endif(WIN32)
 
+strip_symbols(mscordbi STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS mscordbi DESTINATION .)
+install(FILES $<TARGET_FILE:mscordbi> DESTINATION .)
 if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordbi.pdb DESTINATION PDB)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordbi.pdb DESTINATION PDB)
+else()
+    install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
 endif(WIN32)

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -140,7 +140,8 @@ if(WIN32)
         clr_unknown_arch()
     endif()
 
-    add_custom_command(TARGET coreclr
+    add_custom_command(
+        TARGET coreclr
         POST_BUILD
         COMMAND ${CMAKE_CXX_COMPILER} /P /EP /TP ${PREPROCESS_DEFINITIONS} ${INC_DIR} /Fi${CMAKE_CURRENT_BINARY_DIR}/daccess.i  ${CLR_DIR}/src/debug/daccess/daccess.cpp
         COMMAND ${BuildToolsDir}/dactablegen.exe /dac:${CMAKE_CURRENT_BINARY_DIR}/daccess.i /pdb:${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/coreclr.pdb /dll:$<TARGET_FILE:coreclr> /bin:${CMAKE_CURRENT_BINARY_DIR}/wks.bin
@@ -159,8 +160,12 @@ else()
     )
 endif(WIN32)
 
+strip_symbols(coreclr STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS coreclr DESTINATION .)
+install(FILES $<TARGET_FILE:coreclr> DESTINATION .)
 if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/coreclr.pdb DESTINATION PDB)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/coreclr.pdb DESTINATION PDB)
+else()
+    install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
 endif(WIN32)

--- a/src/ilasm/CMakeLists.txt
+++ b/src/ilasm/CMakeLists.txt
@@ -66,7 +66,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
       dl
     )
   endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
-
 else()
   target_link_libraries(ilasm
     ${ILASM_LINK_LIBRARIES}
@@ -76,8 +75,13 @@ else()
     oleaut32
     shell32
   )
-
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ilasm.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS ilasm DESTINATION .)
+strip_symbols(ilasm STRIP_DESTINATION_FILE)
+
+install(TARGETS ilasm DESTINATION .)
+if(WIN32)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ilasm.pdb DESTINATION PDB)
+else()
+  install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
+endif(WIN32)

--- a/src/ildasm/exe/CMakeLists.txt
+++ b/src/ildasm/exe/CMakeLists.txt
@@ -69,10 +69,13 @@ else()
         oleaut32
         shell32
     )
-
-    # We will generate PDB only for the debug configuration
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ildasm.pdb DESTINATION PDB)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS ildasm DESTINATION .)
+strip_symbols(ildasm STRIP_DESTINATION_FILE)
+
+install(TARGETS ildasm DESTINATION .)
+if(WIN32)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ildasm.pdb DESTINATION PDB)
+else()
+  install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
+endif(WIN32)

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -46,8 +46,12 @@ target_link_libraries(ryujit
    ${RYUJIT_LINK_LIBRARIES}
 )
 
+strip_symbols(ryujit STRIP_DESTINATION_FILE)
+
 # add the install targets
-install (TARGETS ryujit DESTINATION .)
+install(FILES $<TARGET_FILE:ryujit> DESTINATION .)
 if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ryujit.pdb DESTINATION PDB)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ryujit.pdb DESTINATION PDB)
+else()
+    install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
 endif(WIN32)

--- a/src/scripts/genXplatLttng.py
+++ b/src/scripts/genXplatLttng.py
@@ -444,7 +444,7 @@ def generateLttngFiles(etwmanifest,eventprovider_directory):
     add_subdirectory(tracepointprovider)
 
     # Install the static eventprovider library
-    install (TARGETS eventprovider DESTINATION lib)
+    install(TARGETS eventprovider DESTINATION lib)
     """)
     topCmake.close()
 
@@ -481,11 +481,14 @@ def generateLttngFiles(etwmanifest,eventprovider_directory):
     tracepointprovider_Cmake.write("""    )
 
     target_link_libraries(coreclrtraceptprovider
-                         -llttng-ust
+                          -llttng-ust
     )
 
-   #Install the static coreclrtraceptprovider library
-   install (TARGETS coreclrtraceptprovider DESTINATION .)
+    strip_symbols(coreclrtraceptprovider STRIP_DESTINATION_FILE)
+
+    # Install the static coreclrtraceptprovider library
+    install(FILES $<TARGET_FILE:coreclrtraceptprovider> DESTINATION .)
+    install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
    """)
     tracepointprovider_Cmake.close()
 

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -64,13 +64,16 @@ else()
     if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
         target_link_libraries(crossgen ${STATIC_MT_VCRT_LIB})
     endif()
-
-    # We will generate PDB only for the debug configuration
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/crossgen.pdb DESTINATION PDB)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS crossgen DESTINATION .)
+strip_symbols(crossgen STRIP_DESTINATION_FILE)
+
+install(TARGETS crossgen DESTINATION .)
+if(WIN32)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/crossgen.pdb DESTINATION PDB)
+else()
+  install(FILES ${STRIP_DESTINATION_FILE} DESTINATION .)
+endif(WIN32)
 
 add_subdirectory(../../zap/crossgen ../../zap/crossgen)
 add_subdirectory(../../vm/crossgen ../../vm/crossgen)


### PR DESCRIPTION
Issue #3669

Created a common cmake strip_symbols function that all the modules and programs
use to strip the symbols out of the main into a separate .dbg (Linux) or .dSYM (OSX)
file.

Changed all the library module cmake install lines from a TARGETS to a FILES one. The
TARGETS based install directives caused cmake to relink the binary and copy the unstripped
version to the install path. Left the all programs like corerun or ildasm as TARGETS
installs because on OSX FILES type installs don't get marked as executable.