### PR TITLE
ARM64: Fix Large Stack Allocation

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -416,13 +416,19 @@ void CodeGen::genSaveCalleeSavedRegistersHelp(regMaskTP   regsToSaveMask,
                                               int         lowestCalleeSavedOffset,
                                               int         spDelta)
 {
+    assert(spDelta <= 0);
     unsigned regsToSaveCount = genCountBits(regsToSaveMask);
     if (regsToSaveCount == 0)
     {
+        if (spDelta != 0)
+        {
+            // Currently this is the case for varargs only
+            // whose size is MAX_REG_ARG * REGSIZE_BYTES = 64 bytes.
+            genStackPointerAdjustment(spDelta, REG_NA, nullptr);
+        }
         return;
     }
 
-    assert(spDelta <= 0);
     assert((spDelta % 16) == 0);
     assert((regsToSaveMask & RBM_FP) == 0); // we never save FP here
     assert(regsToSaveCount <= genCountBits(RBM_CALLEE_SAVED | RBM_LR)); // We also save LR, even though it is not in RBM_CALLEE_SAVED.
@@ -570,13 +576,19 @@ void CodeGen::genRestoreCalleeSavedRegistersHelp(regMaskTP   regsToRestoreMask,
                                                  int         lowestCalleeSavedOffset,
                                                  int         spDelta)
 {
+    assert(spDelta >= 0);
     unsigned regsToRestoreCount = genCountBits(regsToRestoreMask);
     if (regsToRestoreCount == 0)
     {
+        if (spDelta != 0)
+        {
+            // Currently this is the case for varargs only
+            // whose size is MAX_REG_ARG * REGSIZE_BYTES = 64 bytes.
+            genStackPointerAdjustment(spDelta, REG_NA, nullptr);
+        }
         return;
     }
 
-    assert(spDelta >= 0);
     assert((spDelta % 16) == 0);
     assert((regsToRestoreMask & RBM_FP) == 0); // we never restore FP here
     assert(regsToRestoreCount <= genCountBits(RBM_CALLEE_SAVED | RBM_LR)); // We also save LR, even though it is not in RBM_CALLEE_SAVED.

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -28382,7 +28382,7 @@ RelativePath=JIT\Methodical\refany\_il_dbgseq\_il_dbgseq.exe
 WorkingDir=JIT\Methodical\refany\_il_dbgseq
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;ISSUE_2925;ISSUE_3666
+Categories=Pri0;JIT;EXPECTED_PASS
 HostStyle=Any
 [_il_dbgshortsig.exe_4055]
 RelativePath=JIT\Methodical\refany\_il_dbgshortsig\_il_dbgshortsig.exe
@@ -28466,7 +28466,7 @@ RelativePath=JIT\Methodical\refany\_il_relseq\_il_relseq.exe
 WorkingDir=JIT\Methodical\refany\_il_relseq
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;JIT;EXPECTED_FAIL;ISSUE_2925;ISSUE_3666
+Categories=Pri0;JIT;EXPECTED_PASS
 HostStyle=Any
 [_il_relshortsig.exe_4067]
 RelativePath=JIT\Methodical\refany\_il_relshortsig\_il_relshortsig.exe


### PR DESCRIPTION
This fixes https://github.com/dotnet/coreclr/issues/3666.
When frame size is greater than 512 (frametype=3), JIT saves
callee-save registers followed by var arg registers, and then handles the
remaining frames. When the first callee-save register is saved, the stack
size is expected to be grown including delta amount which is for var arg registers.
For this failing case, actually we don't have any callee-save registers to be
saved while we still need to home var arg registers.
This fix is to handle such case in
```genSaveCalleeSavedRegistersHelp/genRestoreCalleeSavedRegistersHelp``` to
ensure allocating/deallocating delta stack size.