### PR TITLE
Use root compiler instance for inline result and policy

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -4222,6 +4222,16 @@ void Compiler::fgFindJumpTargets(const BYTE* codeAddr,
         compInlineResult->NoteBool(InlineObservation::CALLEE_IS_FORCE_INLINE, isForceInline);
         compInlineResult->NoteInt(InlineObservation::CALLEE_IL_CODE_SIZE, codeSize);
 
+#ifdef DEBUG
+
+        // If inlining, this method should still be a candidate.
+        if (compIsForInlining())
+        {
+            assert(compInlineResult->IsCandidate());
+        }
+
+#endif // DEBUG
+
         // note that we're starting to look at the opcodes.
         compInlineResult->Note(InlineObservation::CALLEE_BEGIN_OPCODE_SCAN);
     }

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -322,7 +322,7 @@ public:
     // and is a discretionary inline?
     bool IsDiscretionaryCandidate() const
     {
-        bool result = InlDecisionIsCandidate(m_Policy->GetDecision()) &&             
+        bool result = InlDecisionIsCandidate(m_Policy->GetDecision()) &&
             (m_Policy->GetObservation() == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
 
         return result;
@@ -433,9 +433,9 @@ public:
     // SetReported indicates that this particular result doesn't need
     // to be reported back to the runtime, either because the runtime
     // already knows, or we aren't actually inlining yet.
-    void SetReported() 
-    { 
-        m_Reported = true; 
+    void SetReported()
+    {
+        m_Reported = true;
     }
 
 private:
@@ -447,10 +447,10 @@ private:
     // Report/log/dump decision as appropriate
     void Report();
 
-    Compiler*               m_Compiler;
+    Compiler*               m_RootCompiler;
     InlinePolicy*           m_Policy;
     GenTreeCall*            m_Call;
-    CORINFO_METHOD_HANDLE   m_Caller;
+    CORINFO_METHOD_HANDLE   m_Caller;     // immediate caller's handle
     CORINFO_METHOD_HANDLE   m_Callee;
     const char*             m_Context;
     bool                    m_Reported;

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -40,7 +40,7 @@ public:
     // Construct a LegacyPolicy
     LegacyPolicy(Compiler* compiler, bool isPrejitRoot)
         : InlinePolicy(isPrejitRoot)
-        , m_Compiler(compiler)
+        , m_RootCompiler(compiler)
         , m_StateMachine(nullptr)
         , m_CodeSize(0)
         , m_CallsiteFrequency(InlineCallsiteFrequency::UNUSED)
@@ -90,7 +90,7 @@ private:
     const unsigned MAX_BASIC_BLOCKS = 5;
 
     // Data members
-    Compiler*               m_Compiler;
+    Compiler*               m_RootCompiler;                      // root compiler instance
     CodeSeqSM*              m_StateMachine;
     unsigned                m_CodeSize;
     InlineCallsiteFrequency m_CallsiteFrequency;
@@ -142,7 +142,7 @@ private:
     void SetNever(InlineObservation obs);
 
     // Data members
-    Compiler*               m_Compiler;
+    Compiler*               m_RootCompiler;
     CLRRandom*              m_Random;
     unsigned                m_CodeSize;
     bool                    m_IsForceInline :1;


### PR DESCRIPTION
When constructing an InlineResult (and subsequent InlinePolicy)
always use the root compiler instance, so that all policy evaluations
done in a method are consistent.

Add an assert that the initial fact replay during `fgFindJumpTargets`
(force inline state and code size) doesn't change the candidacy when
inlining -- it should just be re-establishing what we knew in the
initial candidate scan.

Closes #3760.