### PR TITLE
Fix  for Issue 3778

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4785,6 +4785,9 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
 #ifdef  DEBUG
         compCurBB               = 0;
         lvaTable                = 0;
+
+        // Reset node ID counter
+        compGenTreeID           = 0;
 #endif
 
         /* Initialize emitter */
@@ -4939,9 +4942,6 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
         {
             s_compMethodsCount++;
         }
-
-        // Reset node ID counter
-        compGenTreeID = 0;
 #endif
 
         if (compIsForInlining())


### PR DESCRIPTION
Move the initialization of compGenTreeID to occur earlier in compCompileHelper.
It must come before compInitDebuggingInfo() as that method can create a new GT_NOP node.

See #3778