### PR TITLE
Inliner: create DiscretionaryPolicy

### DIFF
--- a/src/jit/inline.cpp
+++ b/src/jit/inline.cpp
@@ -678,7 +678,6 @@ void InlineResult::Report()
         }
     }
 
-
     if (IsDecided())
     {
         const char* format = "INLINER: during '%s' result '%s' reason '%s'\n";

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -238,7 +238,6 @@ public:
     virtual void NoteBool(InlineObservation obs, bool value) = 0;
     virtual void NoteFatal(InlineObservation obs) = 0;
     virtual void NoteInt(InlineObservation obs, int value) = 0;
-    virtual void NoteDouble(InlineObservation obs, double value) = 0;
 
     // Policy determinations
     virtual void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) = 0;
@@ -373,12 +372,6 @@ public:
     void NoteInt(InlineObservation obs, int value)
     {
         m_Policy->NoteInt(obs, value);
-    }
-
-    // Make an observation with a double value
-    void NoteDouble(InlineObservation obs, double value)
-    {
-        m_Policy->NoteDouble(obs, value);
     }
 
     // Determine if this inline is profitable

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -55,6 +55,7 @@ CONFIG_INTEGER(JitHashDump, W("JitHashDump"), -1) // Same as JitDump, but for a 
 CONFIG_INTEGER(JitHashDumpIR, W("JitHashDumpIR"), -1) // Same as JitDumpIR, but for a method hash
 CONFIG_INTEGER(JitHashHalt, W("JitHashHalt"), -1) // Same as JitHalt, but for a method hash
 CONFIG_INTEGER(JitInlineAdditionalMultiplier, W("JitInlineAdditionalMultiplier"), 0)
+CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePrintStats, W("JitInlinePrintStats"), 0)
 CONFIG_INTEGER(JitInlineSize, W("JITInlineSize"), DEFAULT_MAX_INLINE_SIZE)
 CONFIG_INTEGER(JitLargeBranches, W("JitLargeBranches"), 0) // Force using the largest conditional branch format


### PR DESCRIPTION
The `DiscretionaryPolicy` is similar to the `LegacyPolicy`, but does not
use size limits. So there is no "always" inline class and no "too big to
inline" class. Also, discretionary failures do not trigger noinline
stamping.

It is installed if `JitInlinePolicyDiscretionary` is set nonzero.

See #3775 for some background on where this new policy will be used.
This is a first cut and further refinement is likely.

Also removed the unused `NoteDouble` methods since the double-valued
observations now are kept internally within `LegacyPolicy` and it's
not very likely we'll introduce new cases where doubles are needed.