### PR TITLE
Fixed problem with bpmd not working sometimes.

### DIFF
--- a/src/ToolBox/SOS/Strike/WatchCmd.cpp
+++ b/src/ToolBox/SOS/Strike/WatchCmd.cpp
@@ -92,16 +92,8 @@ HRESULT WatchCmd::Remove(int index)
 HRESULT WatchCmd::Print(int expansionIndex, __in_z WCHAR* expansionPath, __in_z WCHAR* pFilterName)
 {
     HRESULT Status = S_OK;
-    if ((Status = CheckEEDll()) != S_OK)
-    {
-        EENotLoadedMessage(Status);
-        return Status;
-    }                                                           
-    if ((Status = LoadClrDebugDll()) != S_OK)
-    {
-        DACMessage(Status);
-        return Status;
-    } 
+    INIT_API_EE();
+    INIT_API_DAC();
     EnableDMLHolder dmlHolder(TRUE);
     IfFailRet(InitCorDebugInterface());
 
@@ -214,6 +206,8 @@ HRESULT WatchCmd::RenameList(__in_z WCHAR* pOldName, __in_z WCHAR* pNewName)
 HRESULT WatchCmd::SaveList(__in_z WCHAR* pSaveName)
 {
     HRESULT Status = S_OK;
+    INIT_API_EE();
+    INIT_API_DAC();
     IfFailRet(InitCorDebugInterface());
 
     RemoveList(pSaveName);

--- a/src/debug/daccess/daccess.cpp
+++ b/src/debug/daccess/daccess.cpp
@@ -7232,6 +7232,10 @@ ClrDataAccess::GetDacGlobals()
     {
         return CORDBG_E_MISSING_DEBUGGER_EXPORTS;
     }
+    if (g_dacGlobals.ThreadStore__s_pThreadStore == NULL)
+    {
+        return CORDBG_E_UNSUPPORTED;
+    }
     return S_OK;
 #else
     HRESULT status = E_FAIL;

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1439,11 +1439,11 @@ HRESULT EEStartup(COINITIEE fFlags)
     PAL_TRY(COINITIEE *, pfFlags, &fFlags)
     {
 #ifndef CROSSGEN_COMPILE
-#ifdef FEATURE_PAL
-        DacGlobals::Initialize();
-        InitializeJITNotificationTable();
-#endif
         InitializeClrNotifications();
+#ifdef FEATURE_PAL
+        InitializeJITNotificationTable();
+        DacGlobals::Initialize();
+#endif
 #endif // CROSSGEN_COMPILE
 
         EEStartupHelper(*pfFlags);


### PR DESCRIPTION
Fix some too earlier SOS initialization problem. Now returns an error.

The DAC interface (IXCLRDataProcess) was being created everytime an command was run and the JIT and GC notification tables where being reinitialized each time losing any JIT notifications needed to resolve a breakpoint. Only create the DAC interface instance once. It does need to be flushed each time sos is entered though.

Enable the module load and unload and exception callbacks when the DAC instance is created. This is what windbg does on Windows (along with flushing the DAC each time the target is restarted). It simplifies the breakpoint code; it no longer needs to enable/disable these notification flags.

Cleaned up places where the DAC instance (direct calls to LoadClrDebugDll) and not released properly.