### PR TITLE
Arm64 Windows timeout increase

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -963,9 +963,15 @@ combinedScenarios.each { scenario ->
                                     break
                                 case 'arm64':
                                     assert scenario == 'default'
+
+                                    // Up the timeout for arm64 jobs.
+                                    Utilities.setJobTimeout(newJob, 360);
                                     buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} /toolset_dir C:\\ats"
 
-                                    buildCommands += "C:\\arm64PostBuild.cmd %WORKSPACE% ${architecture} ${lowerConfiguration}"
+                                    // Debug runs take too long to run.
+                                    if (lowerConfiguration != "debug") {
+                                       buildCommands += "C:\\arm64PostBuild.cmd %WORKSPACE% ${architecture} ${lowerConfiguration}"
+                                    }
                                     
                                     // Add archival.  No xunit results for arm64 windows
                                     Utilities.addArchival(newJob, "bin/Product/**")


### PR DESCRIPTION
Currently the arm64 jobs are timing out after 2 hours. When this happens the arm64 machines are left in a undefined state. Increasing the timeout to avoid this.

@mmitche @sejongoh @adiaaida PTAL