### PR TITLE
Fix Stack Alignment Check

### DIFF
--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -3938,7 +3938,7 @@ RelativePath=JIT\Directed\perffix\primitivevt\mixed1_cs_ro\mixed1_cs_ro.exe
 WorkingDir=JIT\Directed\perffix\primitivevt\mixed1_cs_ro
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_3747;DBG_PASS;REL_PASS
+Categories=Pri0;EXPECTED_PASS
 HostStyle=Any
 [mixed2_cs_d.exe_563]
 RelativePath=JIT\Directed\perffix\primitivevt\mixed2_cs_d\mixed2_cs_d.exe
@@ -24322,7 +24322,7 @@ RelativePath=JIT\Methodical\fp\exgen\10w5d_cs_do\10w5d_cs_do.exe
 WorkingDir=JIT\Methodical\fp\exgen\10w5d_cs_do
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_3747;REL_PASS
+Categories=Pri0;EXPECTED_PASS
 HostStyle=Any
 [10w5d_cs_r.exe_3475]
 RelativePath=JIT\Methodical\fp\exgen\10w5d_cs_r\10w5d_cs_r.exe
@@ -24336,7 +24336,7 @@ RelativePath=JIT\Methodical\fp\exgen\10w5d_cs_ro\10w5d_cs_ro.exe
 WorkingDir=JIT\Methodical\fp\exgen\10w5d_cs_ro
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_3774;REL_PASS
+Categories=Pri0;EXPECTED_PASS
 HostStyle=Any
 [200w1d-01_cs_d.exe_3477]
 RelativePath=JIT\Methodical\fp\exgen\200w1d-01_cs_d\200w1d-01_cs_d.exe


### PR DESCRIPTION
This fixes https://github.com/dotnet/coreclr/issues/3747.
If JIT saves the first single store (not pair store) with stack adjustment
required (```spDelta != 0```), we expect the offset to be 8 to account for alignment.
This API ```genPrologSaveReg``` is invoked twice from INT and FP saving respectively
while JIT stores/allocates stacks once for these saving registers back to back.
So, the assertion is not quite right. For instance when we have 1 INT and
1 FP registers to be saved, JIT failed to assert the offset to be 8 in the
first invocation for INT. In fact, for this case, the offset should be 0
(no alignment is required) since we store 2 registers which are already
aligned on 16 byte.

We should consider whether or not the total number of saved registers is odd.
Not only that, even for the pair store, we should assert the offset either
0 or 8 depending on the total number of saved registers. For instance, 2
INT and 3 FP, we want the offset to be 8 when we store the first pair with
stack adjustment required (```spDelta != 0```).
I refactored the code to reflect this issue in ```genSaveCalleeSavedRegistersHelp``` while taking out the
existing assertion in ```genPrologSaveReg``` which is too local.
Similar change is made for the restore case.