### PR TITLE
Inliner: make more observations unconditional

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -59,11 +59,9 @@ INLINE_OBSERVATION(RANDOM_REJECT,             bool,   "random reject",          
 INLINE_OBSERVATION(RETURN_TYPE_IS_COMPOSITE,  bool,   "has composite return type",     FATAL,       CALLEE)
 INLINE_OBSERVATION(STACK_CRAWL_MARK,          bool,   "uses stack crawl mark",         FATAL,       CALLEE)
 INLINE_OBSERVATION(STFLD_NEEDS_HELPER,        bool,   "stfld needs helper",            FATAL,       CALLEE)
-INLINE_OBSERVATION(STORES_TO_ARGUMENT,        bool,   "stores to argument",            FATAL,       CALLEE)
 INLINE_OBSERVATION(THROW_WITH_INVALID_STACK,  bool,   "throw with invalid stack",      FATAL,       CALLEE)
 INLINE_OBSERVATION(TOO_MANY_ARGUMENTS,        bool,   "too many arguments",            FATAL,       CALLEE)
 INLINE_OBSERVATION(TOO_MANY_LOCALS,           bool,   "too many locals",               FATAL,       CALLEE)
-INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",            FATAL,       CALLEE)
 
 // ------ Callee Performance ------- 
 
@@ -85,7 +83,6 @@ INLINE_OBSERVATION(IL_CODE_SIZE,              int,    "number of bytes of IL",  
 INLINE_OBSERVATION(IS_DISCRETIONARY_INLINE,   bool,   "can inline, check heuristics",  INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_INSTANCE_CTOR,          bool,   "instance constructor",          INFORMATION, CALLEE)
-INLINE_OBSERVATION(IS_MOSTLY_LOAD_STORE,      bool,   "method is mostly load/store",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLEE)
 INLINE_OBSERVATION(LOOKS_LIKE_WRAPPER,        bool,   "thin wrapper around a call",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
@@ -95,6 +92,8 @@ INLINE_OBSERVATION(NUMBER_OF_ARGUMENTS,       int,    "number of arguments",    
 INLINE_OBSERVATION(NUMBER_OF_BASIC_BLOCKS,    int,    "number of basic blocks",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(NUMBER_OF_LOCALS,          int,    "number of locals",              INFORMATION, CALLEE)
 INLINE_OBSERVATION(RANDOM_ACCEPT,             bool,   "random accept",                 INFORMATION, CALLEE)
+INLINE_OBSERVATION(STORES_TO_ARGUMENT,        bool,   "stores to argument",            INFORMATION, CALLEE)
+INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",            INFORMATION, CALLEE)
 
 // ------ Caller Corectness ------- 
 

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -46,6 +46,8 @@ public:
         , m_StateMachine(nullptr)
         , m_CodeSize(0)
         , m_CallsiteFrequency(InlineCallsiteFrequency::UNUSED)
+        , m_InstructionCount(0)
+        , m_LoadStoreCount(0)
         , m_IsForceInline(false)
         , m_IsForceInlineKnown(false)
         , m_IsInstanceCtor(false)
@@ -95,6 +97,8 @@ protected:
     CodeSeqSM*              m_StateMachine;
     unsigned                m_CodeSize;
     InlineCallsiteFrequency m_CallsiteFrequency;
+    unsigned                m_InstructionCount;
+    unsigned                m_LoadStoreCount;
     bool                    m_IsForceInline :1;
     bool                    m_IsForceInlineKnown :1;
     bool                    m_IsInstanceCtor :1;


### PR DESCRIPTION
There are still some observations within `fgFindJumpTargets` that are
only made when inlining. This change enables them to also be made for
the prejit root case. This partially addresses the inconsistencies
noted in #3482.

Most notably, the simple stack model is now fully enabled for the
prejit root case, and the policy is able to more broadly observe
things like `CALLEE_LOOKS_LIKE_WRAPPER` and
`CALLEE_ARG_FEEDS_CONSTANT_TEST`.  As before, the `LegacyPolicy`
ignores these observations for the prejit root. Forthcoming policies
will likely behave differently.

Two observations that were fatal -- `CALLEE_UNSUPPORTED_OPCODE` and
`CALLEE_STORES_TO_ARGUMENT` -- are now conditionally fatal, since they
do not cause failure for the prejit root case (though arguably they
should).

The `CALLEE_IS_MOSTLY_LOAD_STORE` observation has been removed, and
the conditions under which it fired have been encapsulated within the
`LegacyPolicy`.

No change in behavior is expected. I verified crossgen of mscorlib
still makes all the same inline decisions for the same reasons.