### PR TITLE
ARM64: Prepend toolset path

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -682,7 +682,7 @@ if /i "%__ToolsetDir%" == "" (
     exit /b 1
 )
 
-set PATH=%PATH%;%__ToolsetDir%\cpp\bin
+set PATH=%__ToolsetDir%\cpp\bin;%PATH%
 set LIB=%__ToolsetDir%\OS\lib;%__ToolsetDir%\cpp\lib
 set INCLUDE=^
 %__ToolsetDir%\cpp\inc;^


### PR DESCRIPTION
Currently ARM64 build requires a plain CMD environment which often causes
a trouble when we use a different CMD or other native tools are in the path.
The fix is to simply prepend the tool path instead of appending it.