### PR TITLE
Don't use symbolic link 'sh'(/bin/sh) in ./coreclr/init-tools.sh

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -107,6 +107,8 @@ if [ ! -e $__PROJECT_JSON_FILE ]; then
     $__DOTNET_CMD restore "$__PROJECT_JSON_FILE" --packages $__PACKAGES_DIR --source $__BUILDTOOLS_SOURCE
  fi
 
- sh $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR
+ # On ubuntu 14.04, /bin/sh (symbolic link) calls /bin/dash by default.
+ $__BUILD_TOOLS_PATH/init-tools.sh $__scriptpath $__DOTNET_CMD $__TOOLRUNTIME_DIR
+
  chmod a+x $__TOOLRUNTIME_DIR/corerun
 fi


### PR DESCRIPTION
The up-to-date Ubuntu distribution uses /bin/dash without /bin/bash by default.
Also, the /bin/sh command has been using as a symbolic link without the original
/bin/sh in the some popular Linux distributions such as Ubuntu 14.04.

Let's replace a symbolic 'sh' with same shell command such as
"#!/usr/bin/env bash" declaration (shebang) of ./coreclr/init-tools.sh

lgs@u14.04:~$ ls -l `which sh`
lrwxrwxrwx 1 root root 4 12 21 17:01 /bin/sh -> dash
lgs@u14.04:~$

Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com
Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com