### PR TITLE
Inliner: initial data gathering for code size estimates

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2521,10 +2521,15 @@ public :
     unsigned             lvaPSPSym;           // variable representing the PSPSym
 #endif
 
-    InlineInfo         * impInlineInfo;      
+    InlineInfo*          impInlineInfo;
 
     // Get the maximum IL size allowed for an inline
     unsigned             getImpInlineSize() const { return impInlineSize; }
+
+#ifdef DEBUG
+    unsigned             getInlinedCount() const { return fgInlinedCount; }
+    InlinePolicy*        inlLastSuccessfulPolicy;
+#endif
 
     // The Compiler* that is the root of the inlining tree of which "this" is a member.
     Compiler*            impInlineRoot();
@@ -7565,6 +7570,7 @@ public :
 #ifdef DEBUG
 
     static bool             s_dspMemStats;    // Display per-phase memory statistics for every function
+    static bool             s_inlDumpDataHeader;  // Print header schema for inline data
 
     template<typename T>
     T dspPtr(T p)

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -137,6 +137,7 @@ INLINE_OBSERVATION(LDFLD_NEEDS_HELPER,        bool,   "ldfld needs helper",     
 INLINE_OBSERVATION(LDVIRTFN_ON_NON_VIRTUAL,   bool,   "ldvirtfn on non-virtual",       FATAL,       CALLSITE)
 INLINE_OBSERVATION(NOT_CANDIDATE,             bool,   "not inline candidate",          FATAL,       CALLSITE)
 INLINE_OBSERVATION(NOT_PROFITABLE_INLINE,     bool,   "unprofitable inline",           FATAL,       CALLSITE)
+INLINE_OBSERVATION(OVER_INLINE_LIMIT,         bool,   "limited by JitInlineLimit",     FATAL,       CALLSITE)
 INLINE_OBSERVATION(RANDOM_REJECT,             bool,   "random reject",                 FATAL,       CALLSITE)
 INLINE_OBSERVATION(REQUIRES_SAME_THIS,        bool,   "requires same this",            FATAL,       CALLSITE)
 INLINE_OBSERVATION(RETURN_TYPE_MISMATCH,      bool,   "return type mismatch",          FATAL,       CALLSITE)

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -248,6 +248,10 @@ public:
 #ifdef DEBUG
     // Name of the policy
     virtual const char* GetName() const = 0;
+    // Detailed data value dump
+    virtual void DumpData() const { }
+    // Detailed data name dump
+    virtual void DumpSchema() const { }
 #endif
 
 protected:
@@ -412,15 +416,21 @@ public:
     }
 
     // String describing the decision made
-    const char * ResultString() const
+    const char* ResultString() const
     {
         return InlGetDecisionString(m_Policy->GetDecision());
     }
 
     // String describing the reason for the decision
-    const char * ReasonString() const
+    const char* ReasonString() const
     {
         return InlGetObservationString(m_Policy->GetObservation());
+    }
+
+    // Get the policy that evaluated this result.
+    InlinePolicy* GetPolicy() const
+    {
+        return m_Policy;
     }
 
     // SetReported indicates that this particular result doesn't need
@@ -559,8 +569,11 @@ public:
                                      GenTree*      stmt,
                                      InlineResult* inlineResult);
 
-    // Dump the context and all descendants
+    // Dump the full subtree, including failures
     void Dump(Compiler* compiler, int indent = 0);
+
+    // Dump only the success subtree, with rich data
+    void DumpData(Compiler* compiler, int indent = 0);
 
 #endif
 
@@ -590,8 +603,10 @@ private:
     InlineObservation     m_Observation; // what lead to this inline
 
 #ifdef DEBUG
+    InlinePolicy*         m_Policy;      // policy that evaluated this inline
     CORINFO_METHOD_HANDLE m_Callee;      // handle to the method
     unsigned              m_TreeID;      // ID of the GenTreeCall
+    unsigned              m_Ordinal;     // Ordinal number of this inline
     bool                  m_Success;     // true if this was a successful inline
 #endif
 

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -48,6 +48,9 @@ public:
         , m_CallsiteFrequency(InlineCallsiteFrequency::UNUSED)
         , m_InstructionCount(0)
         , m_LoadStoreCount(0)
+        , m_CalleeNativeSizeEstimate(0)
+        , m_CallsiteNativeSizeEstimate(0)
+        , m_Multiplier(0.0)
         , m_IsForceInline(false)
         , m_IsForceInlineKnown(false)
         , m_IsInstanceCtor(false)
@@ -99,6 +102,9 @@ protected:
     InlineCallsiteFrequency m_CallsiteFrequency;
     unsigned                m_InstructionCount;
     unsigned                m_LoadStoreCount;
+    int                     m_CalleeNativeSizeEstimate;
+    int                     m_CallsiteNativeSizeEstimate;
+    double                  m_Multiplier;
     bool                    m_IsForceInline :1;
     bool                    m_IsForceInlineKnown :1;
     bool                    m_IsInstanceCtor :1;
@@ -168,12 +174,32 @@ public:
     DiscretionaryPolicy(Compiler* compiler, bool isPrejitRoot);
 
     // Policy observations
+    void NoteBool(InlineObservation obs, bool value) override;
     void NoteInt(InlineObservation obs, int value) override;
 
     // Policy policies
     bool PropagateNeverToRuntime() const override;
 
+    // Policy determinations
+    void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
+
+    // Externalize data
+    void DumpData() const override;
+    void DumpSchema() const override;
+
+    // Miscellaneous
     const char* GetName() const override { return "DiscretionaryPolicy"; }
+
+private:
+
+    unsigned    m_Depth;
+    unsigned    m_BlockCount;
+    unsigned    m_Maxstack;
+    unsigned    m_ArgCount;
+    unsigned    m_LocalCount;
+    CorInfoType m_ReturnType;
+    unsigned    m_ThrowCount;
+    unsigned    m_CallCount;
 };
 
 #endif // DEBUG

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -55,6 +55,8 @@ CONFIG_INTEGER(JitHashDump, W("JitHashDump"), -1) // Same as JitDump, but for a 
 CONFIG_INTEGER(JitHashDumpIR, W("JitHashDumpIR"), -1) // Same as JitDumpIR, but for a method hash
 CONFIG_INTEGER(JitHashHalt, W("JitHashHalt"), -1) // Same as JitHalt, but for a method hash
 CONFIG_INTEGER(JitInlineAdditionalMultiplier, W("JitInlineAdditionalMultiplier"), 0)
+CONFIG_INTEGER(JitInlineDumpData, W("JitInlineDumpData"), 0)
+CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePrintStats, W("JitInlinePrintStats"), 0)
 CONFIG_INTEGER(JitInlineSize, W("JITInlineSize"), DEFAULT_MAX_INLINE_SIZE)


### PR DESCRIPTION
Some initial work to gather data to drive the modelling of inline
code size impact. See #3775 for context.

Update the `DiscretionaryPolicy` to capture more observations.

Add a limit feature `JitInlineLimit` so the jit will stop inlining after
a given number of successful inlines.

Add a `DumpData` method to `InlinePolicy` which will display all the
observations that were made to evaluate an inline. Implement this for the
`DiscretionaryPolicy`. Add a matching `DumpSchema` that writes out
column headers for each of the observations.

Modify `InlineResult` to cache the last successful policy on the root
compiler instance. Use that along with the `JitInlineLimit` and
`DumpData` to display detailed information about the last sucessful
inline along with the code size for the method. All this is displayed
if `JitInlineDumpData ` is enabled.

This allows for isolating code size measurements as follows. Compile or
jit something with `JitInlineLimit = 0` and `JitInlineDumpData =1` (and
for now, `JitInlinePolicyDiscretionary = 1`, since other policies do not
implement any interesting data dumping).

Record the this root set of method sizes and IDs. Repeat with
`JitInlineLimit=1`. For each method where there was an inline, the size
impact of that inline can be computed by comparing this version versus
the version from the root set. Repeat with `JitInlineLimit=2`, comparing
versus the `=1` versions.

Currently the method token is used to identify the root method. This is
not sufficiently unique but unfortunately there currently aren't
substantially better alternatives. See #1957 for some discussion.