### PR TITLE
Add regression tests for two previously fixed bugs.

### DIFF
--- a/tests/src/JIT/Regression/JitBlue/DevDiv_150265/DevDiv_150265.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_150265/DevDiv_150265.cs
@@ -1,0 +1,81 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class Program
+{
+    static bool flag;
+
+    static int Main(string[] args)
+    {            
+        flag = true;
+        return Test();
+    }
+
+    public static int Test()
+    {
+        try
+        {
+            Repro();
+        }
+        catch (NullReferenceException)
+        {
+            Console.WriteLine("Failure");
+            return 101;                 
+        }
+        catch (Exception)
+        {
+            Console.WriteLine("Success");
+            return 100;
+        }
+
+        Console.WriteLine("Failure");
+        return 101;
+    }
+
+    private static void Repro()
+    {
+        string str = GetString();
+        object info = null;
+
+        if (str != null)
+        {
+            info = str.Length;
+        }
+        try
+        {
+            ThrowException();
+            if (str != null)
+            {
+                Console.WriteLine(info);
+            }
+        }
+        catch (Exception)
+        {
+            // The bug was that the jit was removing this check causing a NullReferenceException.
+            if (str != null)
+            {
+                Console.WriteLine(str.Length);
+            }
+            throw;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowException()
+    {
+        if (flag)
+        {
+            throw new Exception();
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static string GetString()
+    {
+        return flag ? (string) null : "test";
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_150265/DevDiv_150265.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_150265/DevDiv_150265.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_150265.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_150265/app.config
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_150265/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_150586/DevDiv_150586.il
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_150586/DevDiv_150586.il
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// This il tests importation of unbox[_any] when there are pending evaluations on the stack that side-effect
+// the arguments of the unbox.
+
+.assembly extern mscorlib { }
+
+.assembly extern System.Runtime
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:1:0:0
+}
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly DevDiv_150586
+{
+}
+
+
+.class private auto ansi beforefieldinit Bug.Program
+       extends [System.Runtime]System.Object
+{
+  .method private hidebysig static string 
+          GetResourceString(string category,
+                            [out] object& foundObj) cil managed
+  {
+    // Code size       20 (0x14)
+    .maxstack  8
+    IL_0000:  ldarg.1
+    IL_0001:  ldc.i4.0
+    IL_0002:  box        [System.Runtime]System.Boolean
+    IL_0007:  stind.ref
+    IL_0008:  ldstr      "Hello world"
+    IL_000d:  ldarg.0
+    IL_000e:  call       string [System.Runtime]System.String::Concat(string,
+                                                                      string)
+    IL_0013:  ret
+  } // end of method Program::GetResourceString
+
+  .method private hidebysig static string 
+          RString() cil managed
+  {
+    // Code size       38 (0x26)
+    .maxstack  2
+    .locals init ([0] object foundObj,
+             [1] bool V_1)
+    IL_0000:  ldstr      ""
+    IL_0005:  ldloca.s   foundObj
+    IL_0007:  call       string Bug.Program::GetResourceString(string,
+                                                               object&)
+    IL_000c:  ldloc.0
+    IL_000d:  unbox.any  [System.Runtime]System.Boolean
+    IL_0012:  stloc.1
+    IL_0013:  ldloca.s   V_1
+    IL_0015:  constrained. [System.Runtime]System.Boolean
+    IL_001b:  callvirt   instance string [System.Runtime]System.Object::ToString()
+    IL_0020:  call       string [System.Runtime]System.String::Concat(string,
+                                                                      string)
+    IL_0025:  ret
+  } // end of method Program::RString
+
+  .method private hidebysig static int32 
+          Main(string[] args) cil managed
+  {
+    .entrypoint
+    // Code size       39 (0x27)
+    .maxstack  1
+    .locals init ([0] int32 V_0)
+    .try
+    {
+      IL_0000:  call       string Bug.Program::RString()
+      IL_0005:  pop
+      IL_0006:  leave.s    IL_0018
+
+    }  // end .try
+    catch [System.Runtime]System.Exception 
+    {
+      IL_0008:  pop
+      IL_0009:  ldstr      "Fail"
+      IL_000e:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_0013:  ldc.i4.s   101
+      IL_0015:  stloc.0
+      IL_0016:  leave.s    IL_0025
+
+    }  // end handler
+    IL_0018:  ldstr      "Pass"
+    IL_001d:  call       void [System.Console]System.Console::WriteLine(string)
+    IL_0022:  ldc.i4.s   100
+    IL_0024:  ret
+
+    IL_0025:  ldloc.0
+    IL_0026:  ret
+  } // end of method Program::Main
+
+  .method public hidebysig specialname rtspecialname 
+          instance void  .ctor() cil managed
+  {
+    // Code size       7 (0x7)
+    .maxstack  8
+    IL_0000:  ldarg.0
+    IL_0001:  call       instance void [System.Runtime]System.Object::.ctor()
+    IL_0006:  ret
+  } // end of method Program::.ctor
+
+} // end of class Bug.Program

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_150586/DevDiv_150586.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_150586/DevDiv_150586.ilproj
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DevDiv_150586.il" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup> 
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_150586/app.config
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_150586/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
One of the repros is in il rather than C# because the
repro was sensitive to what different versions of C#
compiler generated.