### PR TITLE
Performance improvements for Enum.ToString()

### DIFF
--- a/src/mscorlib/src/System/Enum.cs
+++ b/src/mscorlib/src/System/Enum.cs
@@ -137,7 +137,7 @@ namespace System
             if (!eT.IsDefined(typeof(System.FlagsAttribute), false)) // Not marked with Flags attribute
             {
                 // Try to see if its one of the enum values, then we return a String back else the value
-                String retval = GetName(eT, value);
+                String retval = eT.GetEnumName(value);
                 if (retval == null)
                     return value.ToString();
                 else

--- a/src/mscorlib/src/System/Type.cs
+++ b/src/mscorlib/src/System/Type.cs
@@ -1537,12 +1537,13 @@ namespace System {
             if (!(valueType.IsEnum || Type.IsIntegerType(valueType)))
                 throw new ArgumentException(Environment.GetResourceString("Arg_MustBeEnumBaseTypeOrEnum"), "value");
 
-            Array values = GetEnumRawConstantValues();
+            string[] names;
+            Array values;
+            GetEnumData(out names, out values);
             int index = BinarySearch(values, value);
 
             if (index >= 0)
             {
-                string[] names = GetEnumNames();
                 return names[index];
             }
 


### PR DESCRIPTION
From Exchange performance analysis, Enum.ToString() is allocating a non-trivial amount of memory every time you call it, and it does not store/cache its values.  

Turns out that InternalFormat in Enum.ToString() can just call RuntimeType.GetEnumName which does cache names and doesn't have extra allocations.

For those callers of the public API Type.GetEnumName, we can at least skip sorting and allocating twice (and only do it once) by saving the return values of a single call to GetEnumData.

Issue #3565