### PR TITLE
Fix exception to string in case of exception in callstack extraction

### DIFF
--- a/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
+++ b/src/mscorlib/src/System/Diagnostics/Stacktrace.cs
@@ -560,25 +560,41 @@ namespace System.Diagnostics {
                         sb.Append(']');    
                     }
 
-                    // arguments printing
-                    sb.Append('(');
-                    ParameterInfo[] pi = mb.GetParameters();
-                    bool fFirstParam = true;
-                    for (int j = 0; j < pi.Length; j++)
+                    ParameterInfo[] pi = null;
+#if FEATURE_CORECLR
+                    try
                     {
-                        if (fFirstParam == false)
-                            sb.Append(", ");
-                        else
-                            fFirstParam = false;
+#endif
+                        pi = mb.GetParameters();
+#if FEATURE_CORECLR
+                    }
+                    catch
+                    {
+                        // The parameter info cannot be loaded, so we don't
+                        // append the parameter list.
+                    }
+#endif
+                    if (pi != null)
+                    {
+                        // arguments printing
+                        sb.Append('(');
+                        bool fFirstParam = true;
+                        for (int j = 0; j < pi.Length; j++)
+                        {
+                            if (fFirstParam == false)
+                                sb.Append(", ");
+                            else
+                                fFirstParam = false;
 
-                        String typeName = "<UnknownType>";
-                        if (pi[j].ParameterType != null)
-                            typeName = pi[j].ParameterType.Name;
-                        sb.Append(typeName);
-                        sb.Append(' ');
-                        sb.Append(pi[j].Name);
-                    }   
-                    sb.Append(')');
+                            String typeName = "<UnknownType>";
+                            if (pi[j].ParameterType != null)
+                                typeName = pi[j].ParameterType.Name;
+                            sb.Append(typeName);
+                            sb.Append(' ');
+                            sb.Append(pi[j].Name);
+                        }   
+                        sb.Append(')');
+                    }
 
                     // source location printing
                     if (displayFilenames && (sf.GetILOffset() != -1))


### PR DESCRIPTION
This change fixes a problem when exception happens while converting an exception
call stack to string. Without this change, Exception.ToString would fail and
if the exception was unhandled, it would just print "Cannot print exception string
because Exception.ToString() failed." without any details on what exception happened.
The problem happens e.g. in case when a method on the call stack has a parameter
that contains members of types from an assembly that cannot be resolved.

The fix was to catch exception from parameter info extraction and if it happens,
just exclude the parameter list from the reported frame.