### PR TITLE
Strip symbols on release builds into separate binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,27 @@ else()
     if (AWK STREQUAL "AWK-NOTFOUND")
         message(FATAL_ERROR "AWK not found")
     endif()
+ 
+    if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+      # Ensure that dsymutil and strip is present
+      find_program(DSYMUTIL dsymutil)
+      if (DSYMUTIL STREQUAL "DSYMUTIL-NOTFOUND")
+          message(FATAL_ERROR "dsymutil not found")
+      endif()
+      find_program(STRIP strip)
+      if (STRIP STREQUAL "STRIP-NOTFOUND")
+          message(FATAL_ERROR "strip not found")
+      endif()
+
+    else (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+      # Ensure that objcopy is present
+      find_program(OBJCOPY objcopy)
+      if (OBJCOPY STREQUAL "OBJCOPY-NOTFOUND")
+          message(FATAL_ERROR "objcopy not found")
+      endif()
+    endif (CMAKE_SYSTEM_NAME STREQUAL Darwin)
 endif(WIN32)
 
 # Build a list of compiler definitions by putting -D in front of each define.
@@ -240,6 +261,69 @@ function(add_precompiled_header header cppFile targetSources)
     # Add cppFile to SourcesVar
     set(${targetSources} ${${targetSources}} ${cppFile} PARENT_SCOPE)
   endif(MSVC)
+endfunction()
+
+function(strip_symbols targetName outputFilename)
+  if(CLR_CMAKE_PLATFORM_UNIX)
+    if(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+
+      # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
+      # generator expression doesn't work correctly returning the wrong path and on
+      # the newer cmake versions the LOCATION property isn't supported anymore.
+      if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+          set(strip_source_file $<TARGET_FILE:${targetName}>)
+      else()
+          get_property(strip_source_file TARGET ${targetName} PROPERTY LOCATION)
+      endif()
+
+      if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set(strip_destination_file ${strip_source_file}.dwarf)
+
+        add_custom_command(
+          TARGET ${targetName}
+          POST_BUILD
+          VERBATIM 
+          COMMAND ${DSYMUTIL} --flat --minimize ${strip_source_file}
+          COMMAND ${STRIP} -u -r ${strip_source_file}
+          COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+        )
+      else(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set(strip_destination_file ${strip_source_file}.dbg)
+
+        add_custom_command(
+          TARGET ${targetName}
+          POST_BUILD
+          VERBATIM 
+          COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
+          COMMAND ${OBJCOPY} --strip-unneeded ${strip_source_file}
+          COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
+          COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
+        )
+      endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
+      set(${outputFilename} ${strip_destination_file} PARENT_SCOPE)
+    endif(UPPERCASE_CMAKE_BUILD_TYPE STREQUAL RELEASE)
+  endif(CLR_CMAKE_PLATFORM_UNIX)
+endfunction()
+
+function(install_clr targetName)
+  strip_symbols(${targetName} strip_destination_file)
+
+  # On the older version of cmake (2.8.12) used on Ubuntu 14.04 the TARGET_FILE
+  # generator expression doesn't work correctly returning the wrong path and on
+  # the newer cmake versions the LOCATION property isn't supported anymore.
+  if(CMAKE_VERSION VERSION_EQUAL 3.0 OR CMAKE_VERSION VERSION_GREATER 3.0)
+      set(install_source_file $<TARGET_FILE:${targetName}>)
+  else()
+      get_property(install_source_file TARGET ${targetName} PROPERTY LOCATION)
+  endif()
+
+  install(PROGRAMS ${install_source_file} DESTINATION .)
+  if(WIN32)
+      install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${targetName}.pdb DESTINATION PDB)
+  else()
+      install(FILES ${strip_destination_file} DESTINATION .)
+  endif()
 endfunction()
 
 # Includes

--- a/dir.props
+++ b/dir.props
@@ -147,7 +147,7 @@
 
   <!-- Packaging properties -->
   <PropertyGroup>
-    <PreReleaseLabel>rc3</PreReleaseLabel>
+    <PreReleaseLabel>rc2</PreReleaseLabel>
     <PackageDescriptionFile>$(SourceDir).nuget/descriptions.json</PackageDescriptionFile>
     <PackageLicenseFile>$(SourceDir).nuget/dotnet_library_license.txt</PackageLicenseFile>
     <PackageThirdPartyNoticesFile>$(SourceDir).nuget/ThirdPartyNotices.txt</PackageThirdPartyNoticesFile>

--- a/src/ToolBox/SOS/Strike/CMakeLists.txt
+++ b/src/ToolBox/SOS/Strike/CMakeLists.txt
@@ -146,9 +146,8 @@ add_dependencies(sos mscordaccore)
 target_link_libraries(sos ${SOS_LIBRARY})
 
 # add the install targets
-install (TARGETS sos DESTINATION .)
-if(WIN32)
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/sos.pdb DESTINATION PDB)
-else(WIN32)
-  install (FILES sosdocsunix.txt DESTINATION .)
-endif(WIN32)
+install_clr(sos)
+
+if(NOT WIN32)
+  install(FILES sosdocsunix.txt DESTINATION .)
+endif(NOT WIN32)

--- a/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
+++ b/src/ToolBox/SOS/lldbplugin/CMakeLists.txt
@@ -93,4 +93,4 @@ if (CLR_CMAKE_PLATFORM_UNIX)
 endif()
 
 # add the install targets
-install (TARGETS sosplugin DESTINATION .)
+install_clr(sosplugin)

--- a/src/coreclr/hosts/coreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/coreconsole/CMakeLists.txt
@@ -27,8 +27,6 @@ else()
     )
 
     # Can't compile on linux yet so only add for windows
-    # add the install targets
-    install (TARGETS CoreConsole DESTINATION .)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$ENV{__BuildType}/CoreConsole.pdb DESTINATION PDB)
+    install_clr(CoreConsole)
 
 endif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -32,10 +32,6 @@ else()
     )
 
     # Can't compile on linux yet so only add for windows
-    # add the install targets
-    install (TARGETS CoreRun DESTINATION .)
+    install_clr(CoreRun)
     
-    # We will generate PDB only for the debug configuration
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/CoreRun.pdb DESTINATION PDB)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)

--- a/src/coreclr/hosts/osxbundlerun/CMakeLists.txt
+++ b/src/coreclr/hosts/osxbundlerun/CMakeLists.txt
@@ -21,4 +21,4 @@ add_dependencies(osxbundlerun
     coreclr
 )
 
-install (TARGETS osxbundlerun DESTINATION .)
+install_clr(osxbundlerun)

--- a/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcoreconsole/CMakeLists.txt
@@ -30,4 +30,4 @@ add_dependencies(coreconsole
     coreclr
 )
 
-install (TARGETS coreconsole DESTINATION .)
+install_clr(coreconsole)

--- a/src/coreclr/hosts/unixcorerun/CMakeLists.txt
+++ b/src/coreclr/hosts/unixcorerun/CMakeLists.txt
@@ -30,4 +30,4 @@ add_dependencies(corerun
     coreclr
 )
 
-install (TARGETS corerun DESTINATION .)
+install_clr(corerun)

--- a/src/corefx/System.Globalization.Native/CMakeLists.txt
+++ b/src/corefx/System.Globalization.Native/CMakeLists.txt
@@ -73,4 +73,5 @@ else()
     add_definitions(-DU_DISABLE_RENAMING=1)
 endif()
 
-install (TARGETS System.Globalization.Native DESTINATION .)
+# add the install targets
+install_clr(System.Globalization.Native)

--- a/src/dlls/clretwrc/CMakeLists.txt
+++ b/src/dlls/clretwrc/CMakeLists.txt
@@ -20,8 +20,4 @@ add_library_clr(clretwrc SHARED
 )
 
 # add the install targets
-install (TARGETS clretwrc DESTINATION .)
-
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/clretwrc.pdb DESTINATION PDB)
-endif(WIN32)
+install_clr(clretwrc)

--- a/src/dlls/dbgshim/CMakeLists.txt
+++ b/src/dlls/dbgshim/CMakeLists.txt
@@ -71,7 +71,4 @@ endif(WIN32)
 target_link_libraries(dbgshim ${DBGSHIM_LIBRARIES})
 
 # add the install targets
-install (TARGETS dbgshim DESTINATION .)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/dbgshim.pdb DESTINATION PDB)
-endif(WIN32)
+install_clr(dbgshim)

--- a/src/dlls/mscordac/CMakeLists.txt
+++ b/src/dlls/mscordac/CMakeLists.txt
@@ -106,7 +106,4 @@ endif(WIN32)
 target_link_libraries(mscordaccore ${COREDAC_LIBRARIES})
 
 # add the install targets
-install (TARGETS mscordaccore DESTINATION .)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordaccore.pdb DESTINATION PDB)
-endif(WIN32)
+install_clr(mscordaccore)

--- a/src/dlls/mscordbi/CMakeLists.txt
+++ b/src/dlls/mscordbi/CMakeLists.txt
@@ -95,7 +95,4 @@ elseif(CLR_CMAKE_PLATFORM_UNIX)
 endif(WIN32)
 
 # add the install targets
-install (TARGETS mscordbi DESTINATION .)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mscordbi.pdb DESTINATION PDB)
-endif(WIN32)
+install_clr(mscordbi)

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -140,7 +140,8 @@ if(WIN32)
         clr_unknown_arch()
     endif()
 
-    add_custom_command(TARGET coreclr
+    add_custom_command(
+        TARGET coreclr
         POST_BUILD
         COMMAND ${CMAKE_CXX_COMPILER} /P /EP /TP ${PREPROCESS_DEFINITIONS} ${INC_DIR} /Fi${CMAKE_CURRENT_BINARY_DIR}/daccess.i  ${CLR_DIR}/src/debug/daccess/daccess.cpp
         COMMAND ${BuildToolsDir}/dactablegen.exe /dac:${CMAKE_CURRENT_BINARY_DIR}/daccess.i /pdb:${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/coreclr.pdb /dll:$<TARGET_FILE:coreclr> /bin:${CMAKE_CURRENT_BINARY_DIR}/wks.bin
@@ -160,7 +161,4 @@ else()
 endif(WIN32)
 
 # add the install targets
-install (TARGETS coreclr DESTINATION .)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/coreclr.pdb DESTINATION PDB)
-endif(WIN32)
+install_clr(coreclr)

--- a/src/ilasm/CMakeLists.txt
+++ b/src/ilasm/CMakeLists.txt
@@ -66,7 +66,6 @@ if(CLR_CMAKE_PLATFORM_UNIX)
       dl
     )
   endif(NOT CMAKE_SYSTEM_NAME STREQUAL FreeBSD AND NOT CMAKE_SYSTEM_NAME STREQUAL NetBSD)
-
 else()
   target_link_libraries(ilasm
     ${ILASM_LINK_LIBRARIES}
@@ -76,8 +75,6 @@ else()
     oleaut32
     shell32
   )
-
-  install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ilasm.pdb DESTINATION PDB)
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS ilasm DESTINATION .)
+install_clr(ilasm)

--- a/src/ildasm/exe/CMakeLists.txt
+++ b/src/ildasm/exe/CMakeLists.txt
@@ -69,10 +69,6 @@ else()
         oleaut32
         shell32
     )
-
-    # We will generate PDB only for the debug configuration
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ildasm.pdb DESTINATION PDB)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-install (TARGETS ildasm DESTINATION .)
+install_clr(ildasm)

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -47,7 +47,4 @@ target_link_libraries(ryujit
 )
 
 # add the install targets
-install (TARGETS ryujit DESTINATION .)
-if(WIN32)
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/ryujit.pdb DESTINATION PDB)
-endif(WIN32)
+install_clr(ryujit)

--- a/src/scripts/genXplatLttng.py
+++ b/src/scripts/genXplatLttng.py
@@ -444,7 +444,7 @@ def generateLttngFiles(etwmanifest,eventprovider_directory):
     add_subdirectory(tracepointprovider)
 
     # Install the static eventprovider library
-    install (TARGETS eventprovider DESTINATION lib)
+    install(TARGETS eventprovider DESTINATION lib)
     """)
     topCmake.close()
 
@@ -481,11 +481,11 @@ def generateLttngFiles(etwmanifest,eventprovider_directory):
     tracepointprovider_Cmake.write("""    )
 
     target_link_libraries(coreclrtraceptprovider
-                         -llttng-ust
+                          -llttng-ust
     )
 
-   #Install the static coreclrtraceptprovider library
-   install (TARGETS coreclrtraceptprovider DESTINATION .)
+    # Install the static coreclrtraceptprovider library
+    install_clr(coreclrtraceptprovider)
    """)
     tracepointprovider_Cmake.close()
 

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -64,14 +64,11 @@ else()
     if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
         target_link_libraries(crossgen ${STATIC_MT_VCRT_LIB})
     endif()
-
-    # We will generate PDB only for the debug configuration
-    install (FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/crossgen.pdb DESTINATION PDB)
-
 endif(CLR_CMAKE_PLATFORM_UNIX)
-
-install (TARGETS crossgen DESTINATION .)
 
 add_subdirectory(../../zap/crossgen ../../zap/crossgen)
 add_subdirectory(../../vm/crossgen ../../vm/crossgen)
 add_subdirectory(../../vm/crossgen_mscorlib ../../vm/crossgen_mscorlib)
+
+# add the install targets
+install_clr(crossgen)


### PR DESCRIPTION
Issue #3669

Created a common cmake strip_symbols function that all the modules and programs
use to strip the symbols out of the main into a separate .dbg (Linux) or .dSYM (OSX)
file.

Added an install_clr cmake function to encapsulate the install logic.

Changed all the library module cmake install lines from a TARGETS to a FILES one. The
TARGETS based install directives caused cmake to relink the binary and copy the unstripped
version to the install path. Left the all programs like corerun or ildasm as TARGETS
installs because on OSX FILES type installs don't get marked as executable.

Need to use "get_property(strip_source_file TARGET ${targetName} PROPERTY LOCATION)" for
the older versions of cmake and "set(strip_source_file $<TARGET_FILE:${targetName}>)" on
newer versions (v3 or greater).