### PR TITLE
Implement GenericPInvokeCalliHelper on ARM

### DIFF
--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -2,6 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+.macro LEAF_ENTRY Name, Section
+        .thumb_func
+        .global C_FUNC(\Name)
+        .type \Name, %function
+C_FUNC(\Name):
+        .fnstart
+.endm
+
 .macro NESTED_ENTRY Name, Section, Handler
         LEAF_ENTRY \Name, \Section
         .ifnc \Handler, NoHandler
@@ -17,14 +25,6 @@
         .thumb_func
         .global C_FUNC(\Name)
 C_FUNC(\Name):
-.endm
-
-.macro LEAF_ENTRY Name, Section
-        .thumb_func
-        .global C_FUNC(\Name)
-        .type \Name, %function
-C_FUNC(\Name):
-        .fnstart
 .endm
 
 .macro LEAF_END_MARKED Name, Section
@@ -204,8 +204,20 @@ C_FUNC(\Name\()_End):
         mov \Register, sp
 .endm
 
+.macro EPILOG_STACK_FREE Size
+        add sp, sp, \Size
+.endm
+
 .macro EPILOG_STACK_RESTORE Register
         mov sp, \Register
+.endm
+
+.macro EPILOG_BRANCH Target
+        b \Target
+.endm
+
+.macro EPILOG_BRANCH_REG reg
+        bx \reg
 .endm
 
 .macro EPILOG_POP RegList

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -355,11 +355,12 @@ elseif(CLR_CMAKE_PLATFORM_ARCH_I386)
     )
 elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
     set(VM_SOURCES_WKS_ARCH_ASM
-    ${ARCH_SOURCES_DIR}/AsmHelpers.asm
-    ${ARCH_SOURCES_DIR}/CallDescrWorkerARM64.asm
-    ${ARCH_SOURCES_DIR}/CrtHelpers.asm
-    ${ARCH_SOURCES_DIR}/PInvokeStubs.asm
+        ${ARCH_SOURCES_DIR}/AsmHelpers.asm
+        ${ARCH_SOURCES_DIR}/CallDescrWorkerARM64.asm
+        ${ARCH_SOURCES_DIR}/CrtHelpers.asm
+        ${ARCH_SOURCES_DIR}/PInvokeStubs.asm
     )
+
 endif()
 
 else(WIN32)
@@ -386,6 +387,7 @@ else(WIN32)
             ${ARCH_SOURCES_DIR}/ehhelpers.S
             ${ARCH_SOURCES_DIR}/memcpy.S
             ${ARCH_SOURCES_DIR}/patchedcode.S
+            ${ARCH_SOURCES_DIR}/pinvokestubs.S
         )
     elseif(CLR_CMAKE_PLATFORM_ARCH_ARM64)
         set(VM_SOURCES_WKS_ARCH_ASM

--- a/src/vm/arm/pinvokestubs.S
+++ b/src/vm/arm/pinvokestubs.S
@@ -1,0 +1,106 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+//; ==++==
+//;
+
+//;
+//; ==--==
+#include "asmconstants.h"
+#include "unixasmmacros.inc"
+
+.syntax unified
+.thumb
+
+// ------------------------------------------------------------------
+// Macro to generate PInvoke Stubs.
+// Params :-
+// \__PInvokeStubFuncName : function which calls the actual stub obtained from VASigCookie
+// \__PInvokeGenStubFuncName : function which generates the IL stubs for PInvoke
+// \__PInvokeStubWorkerName : prefix of the function name for the stub
+// \VASigCookieReg : register which contains the VASigCookie
+// \SaveFPArgs : "1" or "0" . For varidic functions FP Args are not present in FP regs
+//                        So need not save FP Args registers for vararg Pinvoke
+.macro PINVOKE_STUB __PInvokeStubFuncName,__PInvokeGenStubFuncName,__PInvokeStubWorkerName,VASigCookieReg,SaveFPArgs
+
+    NESTED_ENTRY \__PInvokeStubFuncName, _TEXT, NoHandler
+
+        // save reg value before using the reg
+        PROLOG_PUSH         {\VASigCookieReg}
+
+        // get the stub
+        ldr                 \VASigCookieReg, [\VASigCookieReg,#VASigCookie__pNDirectILStub]
+
+        // if null goto stub generation
+        cbz                 \VASigCookieReg, \__PInvokeStubFuncName\()Label
+
+        EPILOG_STACK_FREE   4
+        EPILOG_BRANCH_REG   \VASigCookieReg
+
+\__PInvokeStubFuncName\()Label:
+        EPILOG_POP          {\VASigCookieReg}
+        EPILOG_BRANCH       \__PInvokeGenStubFuncName
+
+    NESTED_END \__PInvokeStubFuncName, _TEXT
+
+
+    NESTED_ENTRY \__PInvokeGenStubFuncName, _TEXT, NoHandler
+
+        PROLOG_WITH_TRANSITION_BLOCK 0, \SaveFPArgs
+
+        // r2 = UnmanagedTarget\ MethodDesc
+        mov                 r2, r12
+
+        // r1 = VaSigCookie
+        .ifnc \VASigCookieReg, r1
+        mov                 r1, \VASigCookieReg
+        .endif
+
+        // r0 =  pTransitionBlock
+        add                 r0, sp, #__PWTB_TransitionBlock
+
+        // save hidden arg
+        mov                 r4, r12
+
+        bl                  \__PInvokeStubWorkerName
+
+        // restore hidden arg (method desc or unmanaged target)
+        mov                 r12, r4
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+        EPILOG_BRANCH   \__PInvokeStubFuncName
+
+    NESTED_END \__PInvokeGenStubFuncName, _TEXT
+
+.endmacro
+
+// ------------------------------------------------------------------
+// VarargPInvokeStub & VarargPInvokeGenILStub
+// There is a separate stub when the method has a hidden return buffer arg.
+//
+// in:
+// r0 = VASigCookie*
+// r12 = MethodDesc *
+//
+PINVOKE_STUB VarargPInvokeStub, VarargPInvokeGenILStub, VarargPInvokeStubWorker, r0, 0
+
+// ------------------------------------------------------------------
+// GenericPInvokeCalliHelper & GenericPInvokeCalliGenILStub
+// Helper for generic pinvoke calli instruction
+//
+// in:
+// r4 = VASigCookie*
+// r12 = Unmanaged target
+//
+PINVOKE_STUB GenericPInvokeCalliHelper, GenericPInvokeCalliGenILStub, GenericPInvokeCalliStubWorker r4, 1
+
+// ------------------------------------------------------------------
+// VarargPInvokeStub_RetBuffArg & VarargPInvokeGenILStub_RetBuffArg
+// Vararg PInvoke Stub when the method has a hidden return buffer arg
+//
+// in:
+// r1 = VASigCookie*
+// r12 = MethodDesc*
+//
+PINVOKE_STUB VarargPInvokeStub_RetBuffArg, VarargPInvokeGenILStub_RetBuffArg, VarargPInvokeStubWorker, r1, 0

--- a/src/vm/arm/unixstubs.cpp
+++ b/src/vm/arm/unixstubs.cpp
@@ -11,26 +11,11 @@ extern "C"
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
-    void GenericPInvokeCalliHelper()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-
     void PInvokeStubForHostInner(DWORD dwStackSize, LPVOID pStackFrame, LPVOID pTarget)
     {
         PORTABILITY_ASSERT("Implement for PAL");
     }
 
-    void VarargPInvokeStub()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-    
-    void VarargPInvokeStub_RetBuffArg()
-    {
-        PORTABILITY_ASSERT("Implement for PAL");
-    }
-    
     void RedirectForThreadAbort()
     {
         PORTABILITY_ASSERT("Implement for PAL");


### PR DESCRIPTION
Add assemlby implementation for pinvoke stubs on ARM by porting the
Windows ARM code to Linux ARM assembly.