### PR TITLE
Remove the define of FEATURE_INTERPRETER for ARM64

### DIFF
--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -267,9 +267,5 @@
 #define FEATURE_STACK_SAMPLING
 #endif // defined (ALLOW_SXS_JIT)
 
-#if defined(_TARGET_ARM64_)
-#define FEATURE_INTERPRETER
-#endif // defined(_TARGET_ARM64_)
-
 #endif // !defined(CROSSGEN_COMPILE)
 


### PR DESCRIPTION
This will remove some extra conditional code that is only use to
support the IL bytecode interpreter and will disable the fallback
to the interpreter on ARM64