### PR TITLE
Fix x86 exception stack unwinding issue

### DIFF
--- a/src/vm/i386/gmsx86.cpp
+++ b/src/vm/i386/gmsx86.cpp
@@ -114,6 +114,11 @@ static bool shouldEnterCall(PTR_BYTE ip) {
     // just work.
     for (int i = 0; i < 48; i++) {
         switch(*ip) {
+            case 0xF2:              // repne
+            case 0xF3:              // repe
+                ip++;
+                break;
+
             case 0x68:              // push 0xXXXXXXXX
                 ip += 5;
 


### PR DESCRIPTION
This change fixes x86 exception stack unwinding issue in release build
when the function epilog contains a call to _EH_epilog3_catch_GS. This
function has repne prefix on a call and jmp instructions and that
prevented the instruction interpreter code from entering the call, which
is vital for correct stack unwinding.