### PR TITLE
Fix some tests in the EHPatternTests on Unix

### DIFF
--- a/tests/src/baseservices/exceptions/unittests/EHPatternTests.cs
+++ b/tests/src/baseservices/exceptions/unittests/EHPatternTests.cs
@@ -27,7 +27,7 @@ public class Trace
   public void WriteLine(string str)
   {
     _actual += str;
-    _actual += "\r\n";
+    _actual += Environment.NewLine;
 
     // Console.WriteLine(str);
   }

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -1,4 +1,3 @@
-baseservices/exceptions/unittests/EHPatternTests/EHPatternTests.sh
 baseservices/threading/paramthreadstart/ThreadStartString_1/ThreadStartString_1.sh
 CoreMangLib/cti/system/multicastdelegate/MulticastDelegateCtor/MulticastDelegateCtor.sh
 CoreMangLib/cti/system/runtime/interopservices/marshal/MarshalGetLastWin32Error_PSC/MarshalGetLastWin32Error_PSC.sh


### PR DESCRIPTION
Two of the tests in this suite were failing on Unix due to the incorrect
line endings generated to the trace output.
The fix was to replace `"\r\n"` with Environment.NewLine.