### PR TITLE
Remove Old NuGet RyuJit Package from Build

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -114,15 +114,6 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('\\'))"</DnuRestoreCommand>
   </PropertyGroup>
   
-  <!-- Setup Nuget properties -->
-  <ItemGroup>
-    <NuSpecSrcs Include="$(SourceDir)\.nuget\toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- Backslash appended, see note in dir.props about the PackagesBinDir property -->
-    <NuSpecs Include="$(PackagesBinDir)\toolchain.win7-x64.Microsoft.DotNet.RyuJit.nuspec" />
-  </ItemGroup>
-
   <!--
     Set up Roslyn predefines
   -->

--- a/src/build.proj
+++ b/src/build.proj
@@ -10,20 +10,6 @@
 
   <Import Project="..\dir.traversal.targets" />
 
-
-  <!-- Hook into the local publishing by providing the task that needs to run before we can do the local publishing -->
-  <Import Project="$(BuildToolsLocation)\lib\packages.targets" Condition="Exists('$(BuildToolsLocation)\lib\packages.targets')" />
-  <PropertyGroup>
-    <NugetPackageBuildTargets>BuildNuGetPackages</NugetPackageBuildTargets>
-  </PropertyGroup>
-
-  <!-- Generate RyuJIT nuget package - currently only supported for x64 -->
-  <Target Name="BuildNuGetPackages" AfterTargets="MovePDB" Condition="'$(BuildNugetPackage)' != 'false' and '$(BuildArch)' == 'x64'">
-    <MakeDir Directories="$(PackagesBinDir)" Condition="!Exists('$(PackagesBinDir)')" />
-    <Copy SourceFiles="@(NuSpecSrcs)" DestinationFolder="$(PackagesBinDir)" />
-    <Exec Command="&quot;$(NuGetToolPath)&quot; pack &quot;%(NuSpecs.Identity)&quot; -NoPackageAnalysis -NoDefaultExcludes -OutputDirectory &quot;$(PackagesBinDir)&quot;" />
-  </Target>
-
   <ItemGroup>
     <PDBSToMove Include="$(BinDir)mscorlib.pdb"/>
   </ItemGroup>


### PR DESCRIPTION
This eliminates the old way of nuget package creation from the build as a part of prep:
https://github.com/dotnet/coreclr/issues/3442.
But nuspec files are not eliminated on purpose until new way is implemented.