### PR TITLE
Fix typo causing an "unary operator expected"

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -654,7 +654,7 @@ coverageOutputDir=
 
 # Handle arguments
 verbose=0
-doCrossGen=0
+doCrossgen=0
 
 for i in "$@"
 do


### PR DESCRIPTION
The default initialization value for doCrossgen was mispelled causing a warning at
./tests/runtest.sh: line 351: [: ==: unary operator expected