### PR TITLE
Unsuppress same-reg zero-extending mov (x64)

### DIFF
--- a/src/jit/emitxarch.cpp
+++ b/src/jit/emitxarch.cpp
@@ -3707,10 +3707,16 @@ void                emitter::emitIns_R_R   (instruction ins,
                                             regNumber   reg1,
                                             regNumber   reg2)
 {
-    /* We don't want to generate any useless mov instructions! */
-    assert(ins != INS_mov || reg1 != reg2);
-
     emitAttr   size = EA_SIZE(attr);
+
+    /* We don't want to generate any useless mov instructions! */
+#ifdef _TARGET_AMD64_
+    // Same-reg 4-byte mov can be useful because it performs a
+    // zero-extension to 8 bytes.
+    assert(ins != INS_mov || reg1 != reg2 || size == EA_4BYTE);
+#else
+    assert(ins != INS_mov || reg1 != reg2);
+#endif // _TARGET_AMD64_
 
     assert(size <= EA_32BYTE);
     noway_assert(emitVerifyEncodable(ins, size, reg1, reg2));

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_200492/DevDiv_200492.cs
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_200492/DevDiv_200492.cs
@@ -1,0 +1,102 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Regression test for bug 200492, in which the x64 codegen for
+// integer casts would unconditionally suppress same-register
+// 'mov's, which is incorrect for 32-bit same-register 'mov's
+// that are needed to clear the upper 32 bits of a 64-bit
+// register.  The top bits aren't guaranteed to be clear across
+// function boundaries, and the runtime code that invokes
+// custom attribute constructors passes garbage in those bits,
+// so this test (like the original code in the bug report)
+// uses custom attribute constructor arguments as the sources
+// of the casts in question.
+internal class Program
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    class TestDoubleAttribute : System.Attribute
+    {
+        public double Field;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        static double PickDouble(double d, int dummy)
+        {
+            return d;
+        }
+        public TestDoubleAttribute(uint f)
+        {
+            // Need to clear any garbage in the top half of f's
+            // register before converting to double.
+            this.Field = PickDouble((double)f, 0);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [Program.TestDouble(6)]
+    public static bool DoubleTest()
+    {
+        var methodInfo = typeof(Program).GetTypeInfo().GetDeclaredMethod("DoubleTest");
+        var attribute = methodInfo.GetCustomAttribute<TestDoubleAttribute>();
+
+        return (attribute.Field == (double)6u);
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    class TestUlongAttribute : System.Attribute
+    {
+        public ulong Field;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        void Store(ulong l)
+        {
+            Field = l;
+        }
+
+        public TestUlongAttribute(int i)
+        {
+            checked {
+                // Need to clear any garbage in the top half
+                // of i's register before passing to Store.
+                Store((ulong)i);
+            }
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    [Program.TestUlong(6)]
+    public static bool UlongTest()
+    {
+        var methodInfo = typeof(Program).GetTypeInfo().GetDeclaredMethod("UlongTest");
+        var attribute = methodInfo.GetCustomAttribute<TestUlongAttribute>();
+
+        return (attribute.Field == (ulong)6);
+    }
+
+    private static int Main()
+    {
+        int errors = 0;
+
+        if (!Program.DoubleTest()) {
+            errors += 1;
+        }
+
+        if (!Program.UlongTest()) {
+            errors += 1;
+        }
+
+        if (errors > 0) {
+            Console.WriteLine("Fail");
+        }
+        else
+        {
+            Console.WriteLine("Pass");
+        }
+
+        return 100 + errors;
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_200492/DevDiv_200492.csproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_200492/DevDiv_200492.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{E2C84853-0100-4C5D-88C0-355F70483779}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)extra\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)extra\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_200492/app.config
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_200492/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/tests/src/JIT/config/extra/project.json
+++ b/tests/src/JIT/config/extra/project.json
@@ -10,6 +10,7 @@
     "System.IO": "4.0.11-rc2-23816",
     "System.IO.FileSystem": "4.0.0",
     "System.Reflection": "4.1.0-rc2-23816",
+    "System.Reflection.Extensions": "4.0.1-rc2-23816",
     "System.Reflection.TypeExtensions": "4.0.0",
     "System.Runtime": "4.1.0-rc2-23816",
     "System.Runtime.Extensions": "4.0.10",


### PR DESCRIPTION
Update CodeGen::genIntToIntCast to stop suppressing 32-bit same-register
`mov`s, and to stop assuming that 32-bit enregistered sources already have
the top half of their register clear.  This latter assumption is usually
true, but is not guaranteed across function boundaries by the ABI.  As it
happens, the runtime code that invokes custom attribute constructors can
pass garbage in the top half of such parameters; this change adds a
testcase that fails on that path without this fix.