### PR TITLE
Remove static lib dependency on CrossGen

### DIFF
--- a/crossgen.cmake
+++ b/crossgen.cmake
@@ -18,10 +18,6 @@ remove_definitions(
     -DFEATURE_VERSIONING_LOG
 )
 
-if(WIN32)
-    add_definitions(-MT)
-endif(WIN32)
-
 if(FEATURE_READYTORUN)
     add_definitions(-DFEATURE_READYTORUN_COMPILER)
 endif(FEATURE_READYTORUN)

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -57,13 +57,9 @@ else()
         shlwapi
         bcrypt
         mdwinmd_crossgen
-        ${STATIC_MT_CRT_LIB}
+        msvcrt
     )
 
-    # ARM64_TODO: Enable this for Windows Arm64
-    if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
-        target_link_libraries(crossgen ${STATIC_MT_VCRT_LIB})
-    endif()
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 add_subdirectory(../../zap/crossgen ../../zap/crossgen)


### PR DESCRIPTION
The motivation is for enabling ARM64 which does not have correct static
lib with the current toolset.
But looking at other console apps (ilasm/ildasm/coreconsole/corerun) or
coreclr.dll, they also have dependency on msvcrt for Windows.
So, I've decided to make crossgen.exe with the same flavor.
This changes reduces the binary size -- 10M -> 9M (Debug). Release binary
is slightly smaller.
I've validated this by comparing .ni.dll for all FX assemblies that we use for
tests (under CORE_ROOT), which are identical before and after.