### PR TITLE
Enable CrossGen Compilation for ARM64

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4751,20 +4751,6 @@ int           Compiler::compCompileHelper (CORINFO_MODULE_HANDLE            clas
         }
 #endif // ALT_JIT
 
-#if defined(CROSSGEN_COMPILE) && defined(_TARGET_ARM64_)
-
-        // Make this return conditional, so that we don't get warnings/errors for unreachable code
-        // We expect that compIsForInlining will always be false.
-        if (!compIsForInlining())
-        {
-            // TODO-ARM64-NYI: enable crossgen
-            // This is the Mock-Crossgen fix
-            // We just need crossgen to succeed so that layouts will work, so we always return CORJIT_SKIPPED
-            return CORJIT_SKIPPED;
-        }
-
-#endif  // defined(CROSSGEN_COMPILE) && defined(_TARGET_ARM64_)
-
 #ifdef DEBUG
 
         if (verbose)


### PR DESCRIPTION
This simply removes the blocking code that prevents ARM64 crossgen
compilation. Otherwise, we got InvalidProgramExceptions for all methods.
I've validated this allows crossgen to compiles all mscorlib methods.
Toward the end, there is NYI assertion in Zap which is expected.