### PR TITLE
Fix generic struct delegate in ReadyToRun (#3690)

### DIFF
--- a/src/vm/prestub.cpp
+++ b/src/vm/prestub.cpp
@@ -2349,6 +2349,14 @@ PCODE DynamicHelperFixup(TransitionBlock * pTransitionBlock, TADDR * pCell, DWOR
         fReliable = true;
     case ENCODE_DELEGATE_CTOR:
         pMD = ZapSig::DecodeMethod(pModule, pInfoModule, pBlob, &th);
+        if (pMD->RequiresInstArg())
+        {
+            pMD = MethodDesc::FindOrCreateAssociatedMethodDesc(pMD,
+                th.AsMethodTable(),
+                FALSE /* forceBoxedEntryPoint */,
+                pMD->GetMethodInstantiation(),
+                FALSE /* allowInstParam */);
+        }
         pMD->EnsureActive();
         break;
     default:


### PR DESCRIPTION
Port commit 70aee6c from master branch to release/1.0.0-rc2 branch

The following code pattern triggers a crash when compiled into Ready To Run:

    struct S<T>
    {
        public void M() { ... }
    }

    class C { }

    Then create a delegate using S<C>.M

The cause of the crash is calling S<C>.M normally reaches a shared generic
method S<__Canon>.M, but for delegate creation we need to use the actual
S<C>.M. Ready To Run generated code that attempts to create delegate using
S<__Canon>.M, which is not allowed.