### PR TITLE
Special-case hashcode of empty length string on Unix

### DIFF
--- a/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
+++ b/src/mscorlib/corefx/System/Globalization/CompareInfo.Unix.cs
@@ -252,6 +252,11 @@ namespace System.Globalization
             Contract.Assert(source != null);
             Contract.Assert((options & (CompareOptions.Ordinal | CompareOptions.OrdinalIgnoreCase)) == 0);
 
+            if (source.Length == 0)
+            {
+                return 0;
+            }
+
             int sortKeyLength = Interop.GlobalizationInterop.GetSortKey(m_sortHandle, source, source.Length, null, 0, options);
 
             // As an optimization, for small sort keys we allocate the buffer on the stack.


### PR DESCRIPTION
This is special-cased in the Windows build, but not currently in the Unix build.  For comparison:
https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/Globalization/CompareInfo.cs#L1241-L1243
and
https://github.com/dotnet/coreclr/blob/master/src/mscorlib/corefx/System/Globalization/CompareInfo.Win32.cs#L46-L49

Contributes to https://github.com/dotnet/corefx/issues/5463.
cc: @ellismg