### PR TITLE
Fix ARM64 lib toolchain

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -683,7 +683,7 @@ if /i "%__ToolsetDir%" == "" (
 )
 
 set PATH=%__ToolsetDir%\cpp\bin;%PATH%
-set LIB=%__ToolsetDir%\OS\lib;%__ToolsetDir%\cpp\lib
+set LIB=%__ToolsetDir%\cpp\libWin9CoreSystem;%__ToolsetDir%\OS\lib;%__ToolsetDir%\cpp\lib
 set INCLUDE=^
 %__ToolsetDir%\cpp\inc;^
 %__ToolsetDir%\OS\inc\Windows;^


### PR DESCRIPTION
This fixes path for the right libs that are consistent with tools.
With this, crossgen.exe can run natively on arm64 -- there is an assertion toward the end, https://github.com/dotnet/coreclr/issues/3827.