### PR TITLE
Remove empty phase lvaAdjustRefCnts

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3883,17 +3883,6 @@ void                 Compiler::compCompile(void * * methodCodePtr,
     fgDebugCheckLinks();
 #endif
 
-    if  (!opts.MinOpts() && !opts.compDbgCode)
-    {
-        /* Adjust ref counts based on interference levels */
-
-        lvaAdjustRefCnts();
-        EndPhase(PHASE_LVA_ADJUST_REF_COUNTS);
-    }
-
-#ifdef DEBUG
-    fgDebugCheckBBlist();
-#endif
 
     /* Enable this to gather statistical data such as
      * call and register argument info, flowgraph and loop info, etc. */

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2407,8 +2407,6 @@ public :
     void                lvaRecursiveDecRefCounts(GenTreePtr tree);
     void                lvaRecursiveIncRefCounts(GenTreePtr tree);
 
-    void                lvaAdjustRefCnts    ();
-
 #ifdef  DEBUG
     struct lvaStressLclFldArgs
     {

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2530,10 +2530,6 @@ var_types          Compiler::lvaGetRealType(unsigned lclNum)
     return lvaTable[lclNum].TypeGet();
 }
 
-/*****************************************************************************/
-inline void         Compiler::lvaAdjustRefCnts() {}
-
-
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -70,8 +70,6 @@ CompPhaseNameMacro(PHASE_LCLVARLIVENESS_INIT,    "Local var liveness init",     
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS_PERBLOCK,"Per block local var liveness",   "LIV-BLK",  false, PHASE_LCLVARLIVENESS)
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS_INTERBLOCK,  "Global local var liveness",  "LIV-GLBL", false, PHASE_LCLVARLIVENESS)
 
-CompPhaseNameMacro(PHASE_LVA_ADJUST_REF_COUNTS,  "LVA adjust ref counts",          "REF-CNT",  false, -1)
-
 #ifdef LEGACY_BACKEND
 CompPhaseNameMacro(PHASE_RA_ASSIGN_VARS,         "RA assign vars",                 "REGALLOC", false, -1)
 #endif // LEGACY_BACKEND


### PR DESCRIPTION
This phase is left over from something that was only prototyped but never enabled for the JIT32.
It will never be used in the RyuJIT codebase.

This pull request removes it from the codebase, and removes an extra call to fgDebugCheckBBlist();


@dotnet/jit-contrib PTAL