### PR TITLE
Remove conditional definition and references to lvIsMultiRegArgOrRet

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -3883,17 +3883,6 @@ void                 Compiler::compCompile(void * * methodCodePtr,
     fgDebugCheckLinks();
 #endif
 
-    if  (!opts.MinOpts() && !opts.compDbgCode)
-    {
-        /* Adjust ref counts based on interference levels */
-
-        lvaAdjustRefCnts();
-        EndPhase(PHASE_LVA_ADJUST_REF_COUNTS);
-    }
-
-#ifdef DEBUG
-    fgDebugCheckBBlist();
-#endif
 
     /* Enable this to gather statistical data such as
      * call and register argument info, flowgraph and loop info, etc. */

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -275,9 +275,7 @@ public:
     unsigned char       lvOverlappingFields :1;  // True when we have a struct with possibly overlapping fields
     unsigned char       lvContainsHoles     :1;  // True when we have a promoted struct that contains holes
     unsigned char       lvCustomLayout      :1;  // True when this struct has "CustomLayout"
-#if FEATURE_MULTIREG_ARGS_OR_RET
-    unsigned char       lvIsMultiRegArgOrRet:1; // Is this argument variable holding a value passed or returned in multiple registers?
-#endif
+    unsigned char       lvIsMultiRegArgOrRet:1;  // Is this a variable something that would be passed or returned in multiple registers?
 #ifdef _TARGET_ARM_
     // TODO-Cleanup: Can this be subsumed by the above?
     unsigned char       lvIsHfaRegArg:1;        // Is this argument variable holding a HFA register argument.

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2407,8 +2407,6 @@ public :
     void                lvaRecursiveDecRefCounts(GenTreePtr tree);
     void                lvaRecursiveIncRefCounts(GenTreePtr tree);
 
-    void                lvaAdjustRefCnts    ();
-
 #ifdef  DEBUG
     struct lvaStressLclFldArgs
     {

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -2530,10 +2530,6 @@ var_types          Compiler::lvaGetRealType(unsigned lclNum)
     return lvaTable[lclNum].TypeGet();
 }
 
-/*****************************************************************************/
-inline void         Compiler::lvaAdjustRefCnts() {}
-
-
 /*
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX

--- a/src/jit/compphases.h
+++ b/src/jit/compphases.h
@@ -70,8 +70,6 @@ CompPhaseNameMacro(PHASE_LCLVARLIVENESS_INIT,    "Local var liveness init",     
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS_PERBLOCK,"Per block local var liveness",   "LIV-BLK",  false, PHASE_LCLVARLIVENESS)
 CompPhaseNameMacro(PHASE_LCLVARLIVENESS_INTERBLOCK,  "Global local var liveness",  "LIV-GLBL", false, PHASE_LCLVARLIVENESS)
 
-CompPhaseNameMacro(PHASE_LVA_ADJUST_REF_COUNTS,  "LVA adjust ref counts",          "REF-CNT",  false, -1)
-
 #ifdef LEGACY_BACKEND
 CompPhaseNameMacro(PHASE_RA_ASSIGN_VARS,         "RA assign vars",                 "REGALLOC", false, -1)
 #endif // LEGACY_BACKEND

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7967,9 +7967,7 @@ void                Compiler::fgAddInternal()
         {
             lvaTable[genReturnLocal].lvType = TYP_STRUCT;
             lvaSetStruct(genReturnLocal, info.compMethodInfo->args.retTypeClass, true);
-#if FEATURE_MULTIREG_ARGS_OR_RET
             lvaTable[genReturnLocal].lvIsMultiRegArgOrRet = true;
-#endif
         }
         else
         {

--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -484,9 +484,7 @@ void Compiler::gsParamsToShadows()
             dst = gtNewOperNode(GT_ADDR, TYP_BYREF, dst);
 
             opAssign = gtNewCpObjNode(dst, src, clsHnd, false);
-#if FEATURE_MULTIREG_ARGS_OR_RET
             lvaTable[shadowVar].lvIsMultiRegArgOrRet = lvaTable[lclNum].lvIsMultiRegArgOrRet;
-#endif // FEATURE_MULTIREG_ARGS_OR_RET
         }
         else
         {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7140,12 +7140,10 @@ GenTreePtr          Compiler::impFixupStructReturnType(GenTreePtr op, CORINFO_CL
     {
         if (op->gtOper == GT_LCL_VAR)
         {
-#if FEATURE_MULTIREG_RET
             // This LCL_VAR is an HFA return value, it stays as a TYP_STRUCT
             unsigned lclNum = op->gtLclVarCommon.gtLclNum;
             // Make sure this struct type stays as struct so that we can return it as an HFA
             lvaTable[lclNum].lvIsMultiRegArgOrRet = true;
-#endif // FEATURE_MULTIREG_RET
             return op;
         }
          


### PR DESCRIPTION
We will now unconditionally define this bit field in the LclVar table
At runtime this will be false, unless the architecture supports the passing args in multiple registers
or returning values in multiple registers.

@dotnet/jit-contrib PTAL