### PR TITLE
", >, and < are valid wildcard characters

### DIFF
--- a/src/mscorlib/src/System/IO/Path.cs
+++ b/src/mscorlib/src/System/IO/Path.cs
@@ -65,10 +65,11 @@ namespace System.IO {
         // See the "Naming a File" MSDN conceptual docs for more details on
         // what is valid in a file name (which is slightly different from what
         // is legal in a path name).
+        // Exclude wildcards per FsRtllsNameInExpression: .?*"><
         // Note: This list is duplicated in CheckInvalidPathChars
         [Obsolete("Please use GetInvalidPathChars or GetInvalidFileNameChars instead.")]
 #if !PLATFORM_UNIX
-        public static readonly char[] InvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+        public static readonly char[] InvalidPathChars = { '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
 #else
         public static readonly char[] InvalidPathChars = { '\0' };
 #endif // !PLATFORM_UNIX
@@ -78,7 +79,8 @@ namespace System.IO {
         internal static readonly char[] TrimEndChars = { (char) 0x9, (char) 0xA, (char) 0xB, (char) 0xC, (char) 0xD, (char) 0x20,   (char) 0x85, (char) 0xA0};
         
 #if !PLATFORM_UNIX
-        private static readonly char[] RealInvalidPathChars = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
+        // Exclude wildcards per FsRtllsNameInExpression: .?*"><
+        private static readonly char[] RealInvalidPathChars = { '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31 };
 
         // This is used by HasIllegalCharacters
         private static readonly char[] InvalidPathCharsWithAdditionalChecks = { '\"', '<', '>', '|', '\0', (Char)1, (Char)2, (Char)3, (Char)4, (Char)5, (Char)6, (Char)7, (Char)8, (Char)9, (Char)10, (Char)11, (Char)12, (Char)13, (Char)14, (Char)15, (Char)16, (Char)17, (Char)18, (Char)19, (Char)20, (Char)21, (Char)22, (Char)23, (Char)24, (Char)25, (Char)26, (Char)27, (Char)28, (Char)29, (Char)30, (Char)31, '*', '?' };


### PR DESCRIPTION
FsRtllsNameInExpression offers MS-DOS-compatible wildcard characters: DOS_DOT, DOS_QM, and DOS_STAR, corresponding to ", >, and <, respectively.  System.IO.PatternMatcher attempts to support these, so they should be treated as valid characters.  Otherwise, behavior is inconsistent throughout .NET.  See http://stackoverflow.com/a/17739503/1188377

Note that this pull request lacks a related bug fix that can be found at https://github.com/Microsoft/referencesource/pull/19, as dotnet/coreclr currently lacks PatternMatcher.  For correct functionality of > and <, the typos in PatternMatcher need to be fixed; until then, their functionality is swapped.