### PR TITLE
Fix bracket expression matches a character at gawk

### DIFF
--- a/generateversionscript.awk
+++ b/generateversionscript.awk
@@ -8,7 +8,7 @@ BEGIN {
 	gsub(/\r/,"", $0);
 	
 	# Skip empty lines and comment lines starting with semicolon
-	if (NF && !match($0, /^[:space:]*;/))
+	if (NF && !match($0, /^[[:space:]]*;/))
 	{
 		print "        "  $0 ";";
 	}


### PR DESCRIPTION
This is a trivial patch. However, It's must be modified by gawk implementation that check it exactly as a plain character (e.g., space, alnum) within the bracket expression at ./coreclr/generateversionscript.awk

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>