### PR TITLE
Add new configuration mechanism for CoreCLR [RC2]

### DIFF
--- a/src/inc/clrconfig.h
+++ b/src/inc/clrconfig.h
@@ -171,7 +171,10 @@ public:
 
     // Look up a DWORD config value.
     static DWORD GetConfigValue(const ConfigDWORDInfo & info);
-    
+
+    // Look up a DWORD config value.
+    static DWORD GetConfigValue(const ConfigDWORDInfo & info, bool acceptExplicitDefaultFromRegutil, /* [Out] */ bool *isDefault);
+
     // Look up a string config value.
     // You own the string that's returned.
     static LPWSTR GetConfigValue(const ConfigStringInfo & info);

--- a/src/inc/clrconfigvalues.h
+++ b/src/inc/clrconfigvalues.h
@@ -309,6 +309,7 @@ CONFIG_DWORD_INFO(INTERNAL_FastGCCheckStack, W("FastGCCheckStack"), 0, "")
 CONFIG_DWORD_INFO_DIRECT_ACCESS(INTERNAL_FastGCStress, W("FastGCStress"), "reduce the number of GCs done by enabling GCStress")
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCBreakOnOOM, W("GCBreakOnOOM"), "Does a DebugBreak at the soonest time we detect an OOM")
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_gcConcurrent, W("gcConcurrent"), (DWORD)-1, "Enables/Disables concurrent GC")
+
 #ifdef FEATURE_CONSERVATIVE_GC
 RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_gcConservative, W("gcConservative"), 0, "Enables/Disables conservative GC")
 #endif
@@ -335,7 +336,7 @@ RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCCompactRatio, W("GCCompactRatio"), 0, "Sp
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(EXTERNAL_GCPollType, W("GCPollType"), "")
 RETAIL_CONFIG_STRING_INFO_EX(EXTERNAL_NewGCCalc, W("NewGCCalc"), "", CLRConfig::REGUTIL_default)
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCprnLvl, W("GCprnLvl"), "Specifies the maximum level of GC logging")
-RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCRetainVM, W("GCRetainVM"), "When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way)")
+RETAIL_CONFIG_DWORD_INFO(UNSUPPORTED_GCRetainVM, W("GCRetainVM"), 0, "When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way)")
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCSegmentSize, W("GCSegmentSize"), "Specifies the managed heap segment size")
 RETAIL_CONFIG_DWORD_INFO_DIRECT_ACCESS(UNSUPPORTED_GCLOHCompact, W("GCLOHCompact"), "Specifies the LOH compaction mode")
 RETAIL_CONFIG_DWORD_INFO(EXTERNAL_gcAllowVeryLargeObjects, W("gcAllowVeryLargeObjects"), 0, "allow allocation of 2GB+ objects on GC heap")

--- a/src/inc/configuration.h
+++ b/src/inc/configuration.h
@@ -1,0 +1,57 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// 
+// --------------------------------------------------------------------------------------------------
+// configuration.h
+// 
+// 
+// Access and update configuration values, falling back on legacy CLRConfig methods where necessary.
+// 
+// --------------------------------------------------------------------------------------------------
+
+#include "clrconfig.h"
+
+#ifndef __configuration_h__
+#define __configuration_h__
+
+class Configuration
+{
+public:
+    static void InitializeConfigurationKnobs(int numberOfConfigs, LPCWSTR *configNames, LPCWSTR *configValues);
+
+    // Returns (in priority order):
+    //    - The value of the ConfigDWORDInfo if it's set
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcstoul).
+    //    - The default set in the ConfigDWORDInfo
+    static DWORD GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
+
+    // Returns (in priority order):
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcstoul)
+    //    - The default value passed in
+    static DWORD GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue);
+
+    // Returns (in priority order):
+    //    - The value of the ConfigStringInfo if it's set
+    //    - The value of the ConfigurationKnob (searched by name) if it's set
+    //    - nullptr
+    static LPCWSTR GetKnobStringValue(LPCWSTR name, const CLRConfig::ConfigStringInfo& stringInfo);
+
+    // Returns (in priority order):
+    //    - The value of the ConfigurationKnob (searched by name) if it's set
+    //    - nullptr
+    static LPCWSTR GetKnobStringValue(LPCWSTR name);
+
+    // Returns (in priority order):
+    //    - The value of the ConfigDWORDInfo if it's set (1 is true, anything else is false)
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcscmp with "true").
+    //    - The default set in the ConfigDWORDInfo (1 is true, anything else is false)
+    static bool GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo);
+
+    // Returns (in priority order):
+    //    - The value of the ConfigurationKnob (searched by name) if it's set (performs a wcscmp with "true").
+    //    - The default value passed in
+    static bool GetKnobBooleanValue(LPCWSTR name, bool defaultValue);
+};
+
+#endif // __configuration_h__

--- a/src/utilcode/CMakeLists.txt
+++ b/src/utilcode/CMakeLists.txt
@@ -16,6 +16,7 @@ set(UTILCODE_COMMON_SOURCES
   makepath.cpp
   splitpath.cpp
   clrconfig.cpp
+  configuration.cpp
   collections.cpp
   posterror.cpp
   fstream.cpp

--- a/src/utilcode/UtilCode.vcproj
+++ b/src/utilcode/UtilCode.vcproj
@@ -375,6 +375,9 @@
 		<File
 			RelativePath=".\CLRConfig.cpp"
 			>
+		<File
+			RelativePath=".\configuration.cpp"
+			>
 		</File>
 		<File
 			RelativePath=".\clrhost.cpp"

--- a/src/utilcode/UtilCode.vcxproj
+++ b/src/utilcode/UtilCode.vcxproj
@@ -382,6 +382,7 @@
     <ClCompile Include="check.cpp" />
     <ClCompile Include="circularlog.cpp" />
     <ClCompile Include="CLRConfig.cpp" />
+    <ClCompile Include="configuration.cpp" />
     <ClCompile Include="clrhost.cpp" />
     <ClCompile Include="COMEx.cpp" />
     <ClCompile Include="corimage.cpp" />

--- a/src/utilcode/configuration.cpp
+++ b/src/utilcode/configuration.cpp
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+//
+// --------------------------------------------------------------------------------------------------
+// configuration.cpp
+// 
+//
+// Access and update configuration values, falling back on legacy CLRConfig methods where necessary.
+// 
+// --------------------------------------------------------------------------------------------------
+
+#include "stdafx.h"
+
+#include "clrconfig.h"
+#include "configuration.h"
+
+LPCWSTR *knobNames = nullptr;
+LPCWSTR *knobValues = nullptr;
+int numberOfKnobs = 0;
+
+void Configuration::InitializeConfigurationKnobs(int numberOfConfigs, LPCWSTR *names, LPCWSTR *values)
+{
+    numberOfKnobs = numberOfConfigs;
+
+    // Neither should be null, or both should be null
+    _ASSERT(!((names == nullptr) ^ (values == nullptr)));
+
+    knobNames = names;
+    knobValues = values;
+}
+
+static LPCWSTR GetConfigurationValue(LPCWSTR name)
+{
+    _ASSERT(name != nullptr);
+    if (name == nullptr || knobNames == nullptr || knobValues == nullptr)
+    {
+        return nullptr;
+    }
+
+    for (int i = 0; i < numberOfKnobs; ++i)
+    {
+        _ASSERT(knobNames[i] != nullptr);
+        if (wcscmp(name, knobNames[i]) == 0)
+        {
+            return knobValues[i];
+        }
+    }
+
+    return nullptr;
+}
+
+DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo)
+{
+    bool returnedDefaultValue;
+    DWORD legacyValue = CLRConfig::GetConfigValue(dwordInfo, true /* acceptExplicitDefaultFromRegutil */, &returnedDefaultValue);
+    if (!returnedDefaultValue)
+    {
+        return legacyValue;
+    }
+
+    LPCWSTR knobValue = GetConfigurationValue(name);
+    if (knobValue != nullptr)
+    {
+        return wcstoul(knobValue, nullptr, 0);
+    }
+
+    return legacyValue;
+}
+
+DWORD Configuration::GetKnobDWORDValue(LPCWSTR name, DWORD defaultValue)
+{
+    LPCWSTR knobValue = GetConfigurationValue(name);
+    if (knobValue != nullptr)
+    {
+        return wcstoul(knobValue, nullptr, 0);
+    }
+
+    return defaultValue;
+}
+
+LPCWSTR Configuration::GetKnobStringValue(LPCWSTR name, const CLRConfig::ConfigStringInfo& stringInfo)
+{
+    LPCWSTR value = CLRConfig::GetConfigValue(stringInfo);
+    if (value == nullptr)
+    {
+        value = GetConfigurationValue(name);
+    }
+
+    return value;
+}
+
+LPCWSTR Configuration::GetKnobStringValue(LPCWSTR name)
+{
+    return GetConfigurationValue(name);
+}
+
+bool Configuration::GetKnobBooleanValue(LPCWSTR name, const CLRConfig::ConfigDWORDInfo& dwordInfo)
+{
+    bool returnedDefaultValue;
+    DWORD legacyValue = CLRConfig::GetConfigValue(dwordInfo, true /* acceptExplicitDefaultFromRegutil */, &returnedDefaultValue);
+    if (!returnedDefaultValue)
+    {
+        return (legacyValue != 0);
+    }
+
+    LPCWSTR knobValue = GetConfigurationValue(name);
+    if (knobValue != nullptr)
+    {
+        return (wcscmp(knobValue, W("true")) == 0);
+    }
+
+    return (legacyValue != 0);
+}
+
+bool Configuration::GetKnobBooleanValue(LPCWSTR name, bool defaultValue)
+{
+    LPCWSTR knobValue = GetConfigurationValue(name);
+    if (knobValue != nullptr)
+    {
+        return (wcscmp(knobValue, W("true")) == 0);
+    }
+
+    return defaultValue;
+}

--- a/src/utilcode/utilcode.settings.targets
+++ b/src/utilcode/utilcode.settings.targets
@@ -45,6 +45,7 @@
         <CppCompile Include="$(UtilCodeSrcDir)\SplitPath.cpp" />
         
         <CppCompile Include="$(UtilCodeSrcDir)\ClrConfig.cpp" />
+        <CppCompile Include="$(UtilCodeSrcDir)\configuration.cpp" />
         <CppCompile Include="$(UtilCodeSrcDir)\RegUtil.cpp" />
         <CppCompile Include="$(UtilCodeSrcDir)\RegistryWrapper.cpp" />
         

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -3006,7 +3006,7 @@ static BOOL CacheCommandLine(__in LPWSTR pCmdLine, __in_opt LPWSTR* ArgvW)
 }
 
 //*****************************************************************************
-// This entry point is called from the native entry piont of the loaded
+// This entry point is called from the native entry point of the loaded
 // executable image.  The command line arguments and other entry point data
 // will be gathered here.  The entry point for the user image will be found
 // and handled accordingly.

--- a/src/vm/corhost.cpp
+++ b/src/vm/corhost.cpp
@@ -2004,11 +2004,6 @@ HRESULT CorHost2::SetStartupFlags(STARTUP_FLAGS flag)
         return HOST_E_INVALIDOPERATION;
     }
 
-    if (CLRConfig::GetConfigValue(CLRConfig::UNSUPPORTED_gcServer) != 0)
-    {
-        flag = (STARTUP_FLAGS)(flag | STARTUP_SERVER_GC);
-    }
-    
     m_dwStartupFlags = flag;
 
     return S_OK;


### PR DESCRIPTION
Like PR #3896, but for RC2.

This change allows hosts using `coreclr_initialize` to specify configuration properties via key-value strings. The values of these properties can be retrieved at run time using a new mechanism that allows falling back on CLRConfig settings if desired.

Addresses #3884 for RC2.