### PR TITLE
Make sure 4 outgoing arg slots are generated for methods that call

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -1465,15 +1465,17 @@ void                Compiler::compInit(ArenaAllocator * pAlloc, InlineInfo * inl
     SIMDLongHandle       = nullptr;
     SIMDUIntHandle       = nullptr;
     SIMDULongHandle      = nullptr;
-    SIMDVector2Handle   = nullptr;
-    SIMDVector3Handle   = nullptr;
-    SIMDVector4Handle   = nullptr;
+    SIMDVector2Handle    = nullptr;
+    SIMDVector3Handle    = nullptr;
+    SIMDVector4Handle    = nullptr;
     SIMDVectorHandle     = nullptr;
 #endif
 
 #ifdef DEBUG
     inlRNG = nullptr;
 #endif
+
+    compUsesThrowHelper = false;
 }
 
 /*****************************************************************************

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7333,6 +7333,8 @@ public :
 #endif // !LEGACY_BACKEND
     bool                compRationalIRForm;
 
+    bool                compUsesThrowHelper;            // There is a call to a THOROW_HELPER for the compiled method.
+
     bool                compGeneratingProlog;
     bool                compGeneratingEpilog;
     bool                compNeedsGSSecurityCookie;      // There is an unsafe buffer (or localloc) on the stack.

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -17353,10 +17353,17 @@ BasicBlock*         Compiler::fgAddCodeRef(BasicBlock*      srcBlk,
                                            SpecialCodeKind  kind,
                                            unsigned         stkDepth)
 {
-    /* For debuggable code, genJumpToThrowHlpBlk() will generate the 'throw'
-       code inline. It has to be kept consistent with fgAddCodeRef() */
+    // Record that the code will call a THROW_HELPER
+    // so on Windows Amd64 we can allocate the 4 outgoing
+    // arg slots on the stack frame if there are no other calls.
+    compUsesThrowHelper = true;
+
+    // For debuggable code, genJumpToThrowHlpBlk() will generate the 'throw'
+    // code inline. It has to be kept consistent with fgAddCodeRef()
     if (opts.compDbgCode)
-        return NULL;
+    {
+        return nullptr;
+    }
 
     const static
     BBjumpKinds jumpKinds[] =

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -463,6 +463,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 #endif // LEGACY_BACKEND
 
   #define REGSIZE_BYTES            4       // number of bytes in one register
+  #define MIN_ARG_AREA_FOR_CALL    0       // Minimum required outgoing argument space for a call.
 
   #define CODE_ALIGN               1       // code alignment requirement
   #define STACK_ALIGN              4       // stack alignment requirement
@@ -767,12 +768,16 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
 #endif // !ETW_EBP_FRAMED
 
 #ifdef UNIX_AMD64_ABI
+  #define MIN_ARG_AREA_FOR_CALL   0       // Minimum required outgoing argument space for a call.
+
   #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ETW_FRAMED_EBP|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
   #define RBM_INT_CALLEE_TRASH    (RBM_EAX|RBM_RDI|RBM_RSI|RBM_EDX|RBM_ECX|RBM_R8|RBM_R9|RBM_R10|RBM_R11)
   #define RBM_FLT_CALLEE_SAVED    (0)
   #define RBM_FLT_CALLEE_TRASH    (RBM_XMM0|RBM_XMM1|RBM_XMM2|RBM_XMM3|RBM_XMM4|RBM_XMM5|RBM_XMM6|RBM_XMM7| \
                                    RBM_XMM8|RBM_XMM9|RBM_XMM10|RBM_XMM11|RBM_XMM12|RBM_XMM13|RBM_XMM14|RBM_XMM15)
 #else // !UNIX_AMD64_ABI
+#define MIN_ARG_AREA_FOR_CALL     (4 * REGSIZE_BYTES)       // Minimum required outgoing argument space for a call.
+
   #define RBM_INT_CALLEE_SAVED    (RBM_EBX|RBM_ESI|RBM_EDI|RBM_ETW_FRAMED_EBP|RBM_R12|RBM_R13|RBM_R14|RBM_R15)
   #define RBM_INT_CALLEE_TRASH    (RBM_EAX|RBM_ECX|RBM_EDX|RBM_R8|RBM_R9|RBM_R10|RBM_R11)
   #define RBM_FLT_CALLEE_SAVED    (RBM_XMM6|RBM_XMM7|RBM_XMM8|RBM_XMM9|RBM_XMM10|RBM_XMM11|RBM_XMM12|RBM_XMM13|RBM_XMM14|RBM_XMM15)
@@ -1156,6 +1161,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define TINY_REGNUM_BITS         4       // number of bits we will use for a tiny instr desc (may not use float)
   #define REGMASK_BITS             64      // number of bits in a REGNUM_MASK
   #define REGSIZE_BYTES            4       // number of bytes in one register
+  #define MIN_ARG_AREA_FOR_CALL    0       // Minimum required outgoing argument space for a call.
 
   #define CODE_ALIGN               2       // code alignment requirement
   #define STACK_ALIGN              8       // stack alignment requirement
@@ -1471,6 +1477,8 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define REGSIZE_BYTES            8       // number of bytes in one general purpose register
   #define FP_REGSIZE_BYTES         16      // number of bytes in one FP/SIMD register
   #define FPSAVE_REGSIZE_BYTES     8       // number of bytes in one FP/SIMD register that are saved/restored, for callee-saved registers
+
+  #define MIN_ARG_AREA_FOR_CALL    0       // Minimum required outgoing argument space for a call.
 
   #define CODE_ALIGN               4       // code alignment requirement
   #define STACK_ALIGN              16      // stack alignment requirement


### PR DESCRIPTION
THROW_HELPERS for Windows x64.

This is a long standing bug in RyuJit.
When compiling a method for debug mode if there is a call to THROW_HELPER
(and it is the only call) the frame for the method that calls the
THROW_HELPER is not properly set - it is missing the 4 ougoing arg slots.

This was discovered by R2R codegen. In normal jitting of such method in
debug mode the jit always adds a call to CORINFO_HELP_DBG_IS_JUST_MY_CODE
early enough, so the frame size will be properly calculated. This call is
not generated for R2R.

If the method being generated for R2R has only a call to a throw helper
and it is compiled for debug mode, the call is not generated in the IR.
The CodeGen generates the call directly instead. The call is generated
after the stack frame is calculated. This leads to improperly generated
stack frame that doen't have the 4 outgoing arg slots that the Windows x64
ABI requires.

Compiling such method for release mode is never a problem since in
FlowGraph we always generate IR for a block that contains the
THROW_HELPER. This happens before the stack frame is calculated, so the 4
outgoing stack slots are always calculated.

Fixes issue 3604.