### PR TITLE
[Linux/ARM32/64] Unifying the redundant usages of cross-toolchain

### DIFF
--- a/cross/arm64/toolchain.cmake
+++ b/cross/arm64/toolchain.cmake
@@ -4,12 +4,22 @@ set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
 set(CMAKE_SYSTEM_PROCESSOR aarch64)
 
-add_compile_options(-target aarch64-linux-gnu)
+## Specify the toolchain
+set(TOOLCHAIN "aarch64-linux-gnu")
+set(TOOLCHAIN_PREFIX ${TOOLCHAIN}-)
+#set(CMAKE_C_COMPILER ${TOOLCHAIN_PREFIX}gcc)
+#set(CMAKE_CXX_COMPILER ${TOOLCHAIN_PREFIX}g++)
+#set(CMAKE_ASM_COMPILER ${TOOLCHAIN_PREFIX}as)
+#set(CMAKE_AR ${TOOLCHAIN_PREFIX}ar)
+#set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
+#set(CMAKE_OBJDUMP ${TOOLCHAIN_PREFIX}objdump)
+
+add_compile_options(-target ${TOOLCHAIN})
 add_compile_options(--sysroot=${CROSS_ROOTFS})
 
-set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target aarch64-linux-gnu")
-set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/aarch64-linux-gnu")
-set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/lib/aarch64-linux-gnu")
+set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
+set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")
+set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -L${CROSS_ROOTFS}/lib/${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} --sysroot=${CROSS_ROOTFS}")
 
 set(CMAKE_EXE_LINKER_FLAGS    "${CMAKE_EXE_LINKER_FLAGS}    ${CROSS_LINK_FLAGS}" CACHE STRING "" FORCE)


### PR DESCRIPTION
The name of toolchain name has been increasing gradually.
Let's unify the toolchain name of Linux/ARM{32|64} to prevent the
increase of the fragmentation, and to the manatainability.

Signed-off-by: Geunsik Lim geunsik.lim@samsung.com
Signed-off-by: MyungJoo Ham myungjoo.ham@samsung.com
Signed-off-by: Prajwal A N an.prajwal@samsung.com