### PR TITLE
Safe Refactor - Remove conditional definition and references to lvIsMultiRegArgOrRet

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -275,9 +275,8 @@ public:
     unsigned char       lvOverlappingFields :1;  // True when we have a struct with possibly overlapping fields
     unsigned char       lvContainsHoles     :1;  // True when we have a promoted struct that contains holes
     unsigned char       lvCustomLayout      :1;  // True when this struct has "CustomLayout"
-#if FEATURE_MULTIREG_ARGS_OR_RET
-    unsigned char       lvIsMultiRegArgOrRet:1; // Is this argument variable holding a value passed or returned in multiple registers?
-#endif
+    unsigned char       lvIsMultiRegArgOrRet:1; // Is this a struct that would be passed or returned in multiple registers?
+
 #ifdef _TARGET_ARM_
     // TODO-Cleanup: Can this be subsumed by the above?
     unsigned char       lvIsHfaRegArg:1;        // Is this argument variable holding a HFA register argument.
@@ -8812,6 +8811,7 @@ public:
     var_types getEightByteType(const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR& structDesc, unsigned slotNum);
     void fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgument);
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
+
 }; // end of class Compiler
 
 // Inline methods of CompAllocator.

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -7970,9 +7970,7 @@ void                Compiler::fgAddInternal()
         {
             lvaTable[genReturnLocal].lvType = TYP_STRUCT;
             lvaSetStruct(genReturnLocal, info.compMethodInfo->args.retTypeClass, true);
-#if FEATURE_MULTIREG_ARGS_OR_RET
             lvaTable[genReturnLocal].lvIsMultiRegArgOrRet = true;
-#endif
         }
         else
         {

--- a/src/jit/gschecks.cpp
+++ b/src/jit/gschecks.cpp
@@ -484,9 +484,7 @@ void Compiler::gsParamsToShadows()
             dst = gtNewOperNode(GT_ADDR, TYP_BYREF, dst);
 
             opAssign = gtNewCpObjNode(dst, src, clsHnd, false);
-#if FEATURE_MULTIREG_ARGS_OR_RET
             lvaTable[shadowVar].lvIsMultiRegArgOrRet = lvaTable[lclNum].lvIsMultiRegArgOrRet;
-#endif // FEATURE_MULTIREG_ARGS_OR_RET
         }
         else
         {

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -7141,12 +7141,10 @@ GenTreePtr          Compiler::impFixupStructReturnType(GenTreePtr op, CORINFO_CL
     {
         if (op->gtOper == GT_LCL_VAR)
         {
-#if FEATURE_MULTIREG_RET
             // This LCL_VAR is an HFA return value, it stays as a TYP_STRUCT
             unsigned lclNum = op->gtLclVarCommon.gtLclNum;
             // Make sure this struct type stays as struct so that we can return it as an HFA
             lvaTable[lclNum].lvIsMultiRegArgOrRet = true;
-#endif // FEATURE_MULTIREG_RET
             return op;
         }
          


### PR DESCRIPTION
We will now unconditionally define this bit field in the LclVar table
 At runtime this will be false, unless the architecture supports the passing args in multiple registers
 or returning values in multiple registers.

@dotnet/jit-contrib PTAL
