### PR TITLE
Add getReadyToRunDelegateHelper to JitInterface

### DIFF
--- a/src/inc/corinfo.h
+++ b/src/inc/corinfo.h
@@ -2390,6 +2390,14 @@ public:
             CORINFO_CONST_LOOKUP *   pLookup
             ) = 0;
 
+#if COR_JIT_EE_VERSION > 460
+    virtual void getReadyToRunDelegateHelper(
+            CORINFO_RESOLVED_TOKEN * pResolvedToken,
+            CORINFO_CLASS_HANDLE     cls,
+            CORINFO_CONST_LOOKUP *   pLookup
+            ) = 0;
+#endif
+
     virtual const char* getHelperName(
             CorInfoHelpFunc
             ) = 0;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -6924,7 +6924,12 @@ GenTreePtr    Compiler::fgOptimizeDelegateConstructor(GenTreePtr call, CORINFO_C
                 helperArgs->gtOp.gtOp2 = gtNewArgList(call->gtCall.gtCallArgs->gtOp.gtOp1);
 
                 call = gtNewHelperCallNode(CORINFO_HELP_READYTORUN_DELEGATE_CTOR, TYP_VOID, GTF_EXCEPT, helperArgs);
-                call->gtCall.gtEntryPoint = targetMethod->gtFptrVal.gtDelegateCtor;
+#if COR_JIT_EE_VERSION > 460
+                info.compCompHnd->getReadyToRunDelegateHelper(targetMethod->gtFptrVal.gtLdftnResolvedToken, clsHnd, &call->gtCall.gtEntryPoint);
+#else
+                info.compCompHnd->getReadyToRunHelper(targetMethod->gtFptrVal.gtLdftnResolvedToken,
+                    CORINFO_HELP_READYTORUN_DELEGATE_CTOR, &call->gtCall.gtEntryPoint);
+#endif
             }
         }
         else

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5954,7 +5954,8 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
 
 #ifdef FEATURE_READYTORUN_COMPILER
             copy->gtFptrVal.gtEntryPoint = tree->gtFptrVal.gtEntryPoint;
-            copy->gtFptrVal.gtDelegateCtor = tree->gtFptrVal.gtDelegateCtor;
+            copy->gtFptrVal.gtLdftnResolvedToken = new (this, CMK_Unknown) CORINFO_RESOLVED_TOKEN;
+            memcpy(copy->gtFptrVal.gtLdftnResolvedToken, tree->gtFptrVal.gtLdftnResolvedToken, sizeof(CORINFO_RESOLVED_TOKEN));
 #endif
             goto DONE;
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2547,7 +2547,7 @@ struct GenTreeFptrVal: public GenTree
 
 #ifdef FEATURE_READYTORUN_COMPILER
     CORINFO_CONST_LOOKUP gtEntryPoint;
-    CORINFO_CONST_LOOKUP gtDelegateCtor;
+    CORINFO_RESOLVED_TOKEN* gtLdftnResolvedToken;
 #endif
 
     GenTreeFptrVal(var_types type, CORINFO_METHOD_HANDLE meth) : 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1663,10 +1663,8 @@ GenTreePtr Compiler::impMethodPointer(CORINFO_RESOLVED_TOKEN * pResolvedToken, C
         if (opts.IsReadyToRun())
         {
             op1->gtFptrVal.gtEntryPoint = pCallInfo->codePointerLookup.constLookup;
-
-            // In almost all cases, we are going to create the delegate out of the function pointer. While we are here,
-            // get the pointer to the optimized delegate helper. Only one of the two is going to be embedded into the code.
-            info.compCompHnd->getReadyToRunHelper(pResolvedToken, CORINFO_HELP_READYTORUN_DELEGATE_CTOR, &op1->gtFptrVal.gtDelegateCtor);
+            op1->gtFptrVal.gtLdftnResolvedToken = new(this, CMK_Unknown) CORINFO_RESOLVED_TOKEN;
+            memcpy(op1->gtFptrVal.gtLdftnResolvedToken, pResolvedToken, sizeof(CORINFO_RESOLVED_TOKEN));
         }
         else
             op1->gtFptrVal.gtEntryPoint.addr = nullptr;

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -6092,6 +6092,17 @@ void CEEInfo::getReadyToRunHelper(
 }
 
 /***********************************************************************/
+void CEEInfo::getReadyToRunDelegateHelper(
+        CORINFO_RESOLVED_TOKEN * pResolvedToken,
+        CORINFO_CLASS_HANDLE     cls,
+        CORINFO_CONST_LOOKUP *   pLookup
+        )
+{
+    LIMITED_METHOD_CONTRACT;
+    UNREACHABLE();      // only called during NGen
+}
+
+/***********************************************************************/
 // see code:Nullable#NullableVerification
 
 CORINFO_CLASS_HANDLE  CEEInfo::getTypeForBox(CORINFO_CLASS_HANDLE  cls)

--- a/src/vm/jitinterface.h
+++ b/src/vm/jitinterface.h
@@ -538,6 +538,12 @@ public:
             CORINFO_CONST_LOOKUP *   pLookup
             );
 
+    void getReadyToRunDelegateHelper(
+            CORINFO_RESOLVED_TOKEN * pResolvedToken,
+            CORINFO_CLASS_HANDLE     cls,
+            CORINFO_CONST_LOOKUP *   pLookup
+            );
+
     CorInfoInitClassResult initClass(
             CORINFO_FIELD_HANDLE    field,
             CORINFO_METHOD_HANDLE   method,

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2667,7 +2667,7 @@ CORINFO_METHOD_HANDLE ZapInfo::GetDelegateCtor(CORINFO_METHOD_HANDLE   methHnd,
                                                CORINFO_METHOD_HANDLE   targetMethodHnd,
                                                DelegateCtorArgs *      pCtorData)
 {
-    // For ReadyToRun, this optimization is done via ZapInfo::getReadyToRunHelper
+    // For ReadyToRun, this optimization is done via ZapInfo::getReadyToRunDelegateHelper
     if (IsReadyToRunCompilation())
         return methHnd;
 
@@ -3422,6 +3422,21 @@ void ZapInfo::getReadyToRunHelper(
 
     pLookup->accessType = IAT_PVALUE;
     pLookup->addr = pImport;
+#endif
+}
+
+void ZapInfo::getReadyToRunDelegateHelper(
+        CORINFO_RESOLVED_TOKEN * pResolvedToken,
+        CORINFO_CLASS_HANDLE     cls,
+        CORINFO_CONST_LOOKUP *   pLookup
+        )
+{
+#ifdef FEATURE_READYTORUN_COMPILER
+    _ASSERTE(IsReadyToRunCompilation());
+
+    pLookup->accessType = IAT_PVALUE;
+    pLookup->addr = m_pImage->GetImportTable()->GetDynamicHelperCell(
+            (CORCOMPILE_FIXUP_BLOB_KIND)(ENCODE_DELEGATE_CTOR), pResolvedToken->hMethod, pResolvedToken);
 #endif
 }
 

--- a/src/zap/zapinfo.h
+++ b/src/zap/zapinfo.h
@@ -550,6 +550,12 @@ public:
             CORINFO_CONST_LOOKUP *   pLookup
             );
 
+    void getReadyToRunDelegateHelper(
+            CORINFO_RESOLVED_TOKEN * pResolvedToken,
+            CORINFO_CLASS_HANDLE     cls,
+            CORINFO_CONST_LOOKUP *   pLookup
+            );
+
     CorInfoInitClassResult initClass(
             CORINFO_FIELD_HANDLE    field,
             CORINFO_METHOD_HANDLE   method,


### PR DESCRIPTION
The existing approach to constructing delegates with the general purpose
getReadyToRunHelper has limitations for fully static construction of the
delegate. In particular, EE needs to know the delegate type along with
the method that the delegate is getting created for so that it can
distinguish between open/closed delegates at compile time.

This adds a new method to JIT-EE interface to allow that. The EE
implementation on the CoreCLR side doesn't use the new parameter right
now, but it might in the future.

It also has the nice property of not asking for a R2R helper unless
really needed.