### PR TITLE
Avoid array allocation in "new MemoryStream()"

### DIFF
--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -65,7 +65,7 @@ namespace System.IO {
             }
             Contract.EndContractBlock();
 
-            _buffer = new byte[capacity];
+            _buffer = capacity != 0 ? new byte[capacity] : EmptyArray<byte>.Value;
             _capacity = capacity;
             _expandable = true;
             _writable = true;


### PR DESCRIPTION
The default MemoryStream ctor is unnecessarily allocating a 0-length array.  This change special-cases 0 in the ctor(int), covering both the ctor() and ctor(int) cases.

cc: @jkotas, @bartonjs 