### PR TITLE
Fix sos loading on xplat

### DIFF
--- a/src/ToolBox/SOS/lldbplugin/soscommand.cpp
+++ b/src/ToolBox/SOS/lldbplugin/soscommand.cpp
@@ -92,6 +92,10 @@ public:
 
             if (g_coreclrDirectory != NULL)
             {
+                // Load the DAC module first explicitly because SOS and DBI
+                // have implicit references to the DAC's PAL.
+                LoadModule(services, MAKEDLLNAME_A("mscordaccore"));
+
                 m_sosHandle = LoadModule(services, MAKEDLLNAME_A("sos"));
             }
         }


### PR DESCRIPTION
Explicitly loading mscordaccore so libsos will properly load when installed at a different location than it was built.