### PR TITLE
Fix ReadMemory AV.

### DIFF
--- a/src/pal/src/thread/context.cpp
+++ b/src/pal/src/thread/context.cpp
@@ -655,7 +655,7 @@ DWORD CONTEXTGetExceptionCodeForSignal(const siginfo_t *siginfo,
                             return exceptionCode;
                         }
                     }
-                    // fall through
+                    return EXCEPTION_ACCESS_VIOLATION;
                 }
 #endif
                 default:


### PR DESCRIPTION
Use simple probing to validate read/write memory with a try/catch and explicit h/w exception holder.

Put probing in separate noinline and optnone function for optimized builds.

Fix assert in exception code mapping in context.cpp by handling SIGSEGV subcode SI_KERNEL.