### PR TITLE
Remove unused CultureInfo from GetResourceString

### DIFF
--- a/src/mscorlib/src/System/Environment.cs
+++ b/src/mscorlib/src/System/Environment.cs
@@ -78,30 +78,19 @@ namespace System {
             {
                 public ResourceHelper m_resourceHelper;
                 public String m_key;
-                public CultureInfo m_culture;
                 public String m_retVal;
                 public bool m_lockWasTaken;
 
-                public GetResourceStringUserData(ResourceHelper resourceHelper, String key, CultureInfo culture)
+                public GetResourceStringUserData(ResourceHelper resourceHelper, String key)
                 {
                     m_resourceHelper = resourceHelper;
                     m_key = key;
-                    m_culture = culture;
                 }
             }
             
-            [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-            internal String GetResourceString(String key) {
-                if (key == null || key.Length == 0) {
-                    Contract.Assert(false, "Environment::GetResourceString with null or empty key.  Bug in caller, or weird recursive loading problem?");
-                    return "[Resource lookup failed - null or empty resource name]";
-                }
-                return GetResourceString(key, null);
-            }
-
             [System.Security.SecuritySafeCritical]  // auto-generated
             [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
-            internal String GetResourceString(String key, CultureInfo culture)  {
+            internal String GetResourceString(String key)  {
                 if (key == null || key.Length == 0) {
                     Contract.Assert(false, "Environment::GetResourceString with null or empty key.  Bug in caller, or weird recursive loading problem?");
                     return "[Resource lookup failed - null or empty resource name]";
@@ -126,7 +115,7 @@ namespace System {
                 // returning, we're going into an infinite loop and we should 
                 // return a bogus string.  
 
-                GetResourceStringUserData userData = new GetResourceStringUserData(this, key, culture);
+                GetResourceStringUserData userData = new GetResourceStringUserData(this, key);
 
                 RuntimeHelpers.TryCode tryCode = new RuntimeHelpers.TryCode(GetResourceStringCode);
                 RuntimeHelpers.CleanupCode cleanupCode = new RuntimeHelpers.CleanupCode(GetResourceStringBackoutCode);
@@ -145,7 +134,6 @@ namespace System {
                 GetResourceStringUserData userData = (GetResourceStringUserData) userDataIn;
                 ResourceHelper rh = userData.m_resourceHelper;
                 String key = userData.m_key;
-                CultureInfo culture = userData.m_culture;
 
                 Monitor.Enter(rh, ref userData.m_lockWasTaken);
 


### PR DESCRIPTION
In `System.Environment.ResourceHelper`:

* The `culture` local variable in `GetResourceStringCode()` was unused, so I removed it.
* This means that the `m_culture` field in `GetResourceStringUserData` is now never read, so I removed it.
* This means that the `culture` parameter of `GetResourceString()` is now never read, so I removed the overload.
* The overload doesn't seem to be called from anywhere, so that's it.

This is possibly related to #3979.