### PR TITLE
Improve performance of parsing integers with default options

### DIFF
--- a/src/mscorlib/src/System/Number.cs
+++ b/src/mscorlib/src/System/Number.cs
@@ -685,6 +685,14 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static Int32 ParseInt32(String s, NumberStyles style, NumberFormatInfo info) {
+            if (style == NumberStyles.Integer && info == NumberFormatInfo.InvariantInfo) {
+                long resultLong;
+                NumberTryParseResult result = TryParseSignedInvariantInteger(s, int.MinValue, int.MaxValue, out resultLong);
+                if (result != NumberTryParseResult.Succeeded) {
+                    throw GetException(result, "Overflow_Int32");
+                }
+                return (int)resultLong;
+            }
 
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
@@ -707,6 +715,15 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static Int64 ParseInt64(String value, NumberStyles options, NumberFormatInfo numfmt) {
+            if (options == NumberStyles.Integer && numfmt == NumberFormatInfo.InvariantInfo) {
+                long resultLong;
+                NumberTryParseResult result = TryParseSignedInvariantInteger(value, long.MinValue, long.MaxValue, out resultLong);
+                if (result != NumberTryParseResult.Succeeded) {
+                    throw GetException(result, "Overflow_Int64");
+                }
+                return resultLong;
+            }
+
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
             Int64 i = 0;
@@ -969,6 +986,16 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static UInt32 ParseUInt32(String value, NumberStyles options, NumberFormatInfo numfmt) {
+            if (options == NumberStyles.Integer && numfmt == NumberFormatInfo.InvariantInfo)
+            {
+                ulong resultLong;
+                NumberTryParseResult result = TryParseUnsignedInvariantInteger(value, uint.MinValue, uint.MaxValue, out resultLong);
+                if (result != NumberTryParseResult.Succeeded)
+                {
+                    throw GetException(result, "Overflow_UInt32");
+                }
+                return (uint)resultLong;
+            }
 
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
@@ -992,6 +1019,17 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static UInt64 ParseUInt64(String value, NumberStyles options, NumberFormatInfo numfmt) {
+            if (options == NumberStyles.Integer && numfmt == NumberFormatInfo.InvariantInfo)
+            {
+                ulong resultLong;
+                NumberTryParseResult result = TryParseUnsignedInvariantInteger(value, ulong.MinValue, ulong.MaxValue, out resultLong);
+                if (result != NumberTryParseResult.Succeeded)
+                {
+                    throw GetException(result, "Overflow_UInt64");
+                }
+                return resultLong;
+            }
+
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
             UInt64 i = 0;
@@ -1072,6 +1110,13 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static Boolean TryParseInt32(String s, NumberStyles style, NumberFormatInfo info, out Int32 result) {
+            if (style == NumberStyles.Integer && info == NumberFormatInfo.InvariantInfo) {
+                long resultLong;
+                NumberTryParseResult tryParseResult = TryParseSignedInvariantInteger(s, int.MinValue, int.MaxValue, out resultLong);
+                // ResultLong is guaranteed to be within bounds for Int32, so this cast is safe
+                result = (int)resultLong;
+                return tryParseResult == NumberTryParseResult.Succeeded;
+            }
 
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
@@ -1096,6 +1141,9 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static Boolean TryParseInt64(String s, NumberStyles style, NumberFormatInfo info, out Int64 result) {
+            if (style == NumberStyles.Integer && info == NumberFormatInfo.InvariantInfo) {
+                return TryParseSignedInvariantInteger(s, long.MinValue, long.MaxValue, out result) == NumberTryParseResult.Succeeded;
+            }
 
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
@@ -1142,6 +1190,13 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static Boolean TryParseUInt32(String s, NumberStyles style, NumberFormatInfo info, out UInt32 result) {
+            if (style == NumberStyles.Integer && info == NumberFormatInfo.InvariantInfo) {
+                ulong resultLong;
+                NumberTryParseResult tryParseResult = TryParseUnsignedInvariantInteger(s, uint.MinValue, uint.MaxValue, out resultLong);
+                // ResultLong is guaranteed to be within bounds for UInt32, so this cast is safe
+                result = (uint)resultLong;
+                return tryParseResult == NumberTryParseResult.Succeeded;
+            }
 
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
@@ -1166,6 +1221,9 @@ namespace System {
 
         [System.Security.SecuritySafeCritical]  // auto-generated
         internal unsafe static Boolean TryParseUInt64(String s, NumberStyles style, NumberFormatInfo info, out UInt64 result) {
+            if (style == NumberStyles.Integer && info == NumberFormatInfo.InvariantInfo) {
+                return TryParseUnsignedInvariantInteger(s, ulong.MinValue, ulong.MaxValue, out result) == NumberTryParseResult.Succeeded;
+            }
 
             Byte * numberBufferBytes = stackalloc Byte[NumberBuffer.NumberBufferBytes];
             NumberBuffer number = new NumberBuffer(numberBufferBytes);
@@ -1210,6 +1268,146 @@ namespace System {
             }
 
             return true;
+        }
+
+        private unsafe static NumberTryParseResult TryParseUnsignedInvariantInteger(string str, ulong minValue, ulong maxValue, out ulong result) {
+            result = 0;
+            if (str == null) {
+                return NumberTryParseResult.NullString;
+            }
+
+            ulong actualResult = 0;
+            fixed (char* strPointer = str) {
+                // Consume any leading or trailing whitespace
+                int start = 0;
+                int end = str.Length;
+                while (start < end && IsWhite(strPointer[start]))
+                    start++;
+                while (end > start && IsWhite(strPointer[end - 1]))
+                    end--;
+
+                char firstChar = strPointer[start];
+                if (strPointer[start] == '-') {
+                    // Can't have a negative unsigned integer
+                    return NumberTryParseResult.Overflow;
+                }
+                else if (strPointer[start] == '+') {
+                    start++;
+                }
+
+                if (start == end) {
+                    // Nothing to parse
+                    return NumberTryParseResult.InvalidFormat;
+                }
+
+                for (int i = start; i < end; i++)
+                {
+                    int digitValue = 0;
+                    char c = strPointer[i];
+                    if (c >= '0' && c <= '9') {
+                        digitValue = c - '0';
+                    }
+                    else {
+                        // Non-digit char
+                        return NumberTryParseResult.InvalidFormat;
+                    }
+
+                    ulong previousResult = actualResult;
+                    actualResult = (actualResult * 10) + (ulong)digitValue;
+                    if (actualResult < previousResult) {
+                        // Overflow occured
+                        return NumberTryParseResult.Overflow;
+                    }
+                }
+                if (actualResult < minValue || actualResult > maxValue) {
+                    return NumberTryParseResult.Overflow;
+                }
+                result = actualResult;
+                return NumberTryParseResult.Succeeded;
+            }
+        }
+
+        private unsafe static NumberTryParseResult TryParseSignedInvariantInteger(String str, long minValue, long maxValue, out long result) {
+            result = 0;
+            if (str == null) {
+                return NumberTryParseResult.NullString;
+            }
+
+            long actualResult = 0;
+            fixed (char* strPointer = str) {
+                // Consume any leading or trailing whitespace
+                int start = 0;
+                int end = str.Length;
+                while (start < end && IsWhite(strPointer[start]))
+                    start++;
+                while (end > start && IsWhite(strPointer[end - 1]))
+                    end--;
+
+                char firstChar = strPointer[start];
+                bool negative = firstChar == '-';
+                if (negative || firstChar == '+') {
+                    start++;
+                }
+
+                if (start == end) {
+                    // Nothing to parse
+                    return NumberTryParseResult.InvalidFormat;
+                }
+
+                for (int i = start; i < end; i++) {
+                    int digitValue = 0;
+                    char c = strPointer[i];
+                    if (c >= '0' && c <= '9') {
+                        digitValue = c - '0';
+                    }
+                    else {
+                        // Non-digit char
+                        return NumberTryParseResult.InvalidFormat;
+                    }
+
+                    long previousResult = actualResult;
+                    actualResult = (actualResult * 10) + digitValue;
+                    if (actualResult < previousResult) {
+                        // Overflow occured
+                        return NumberTryParseResult.Overflow;
+                    }
+                }
+                if (negative) {
+                    actualResult = -actualResult;
+                    if (result > 0) {
+                        // Overflow occured
+                        return NumberTryParseResult.Overflow;
+                    }
+                }
+                if (actualResult < minValue || actualResult > maxValue) {
+                    return NumberTryParseResult.Overflow;
+                }
+                result = actualResult;
+                return NumberTryParseResult.Succeeded;
+            }
+        }
+
+        private static Exception GetException(NumberTryParseResult result, string overflowExceptionReource)
+        {
+            switch (result)
+            {
+                case NumberTryParseResult.NullString:
+                    return new ArgumentNullException("String");
+                case NumberTryParseResult.Overflow:
+                    return new OverflowException(Environment.GetResourceString("Format_InvalidString"));
+                case NumberTryParseResult.InvalidFormat:
+                    return new FormatException(Environment.GetResourceString(overflowExceptionReource));
+                default:
+                    return null;
+            }
+        }
+
+        private enum NumberTryParseResult
+        {
+            Succeeded,
+            NullString,
+            InvalidFormat,
+            Overflow
         }
     }
 }


### PR DESCRIPTION
Fastpath the case of NumberStyles.Integer (and
NumberFormatInfo.InvariantInfo) to provide up to 3x performance boost.

## Benchmarks
- Times are in millseconds, averaged over 25 instances of 5000000 iterations
- Please ignore the changes for HexNumber, those are just a glimpse of what's next if this is merged
![benchmark](https://cloud.githubusercontent.com/assets/1275900/14153965/18abcfa4-f6b2-11e5-9236-c2ec7e040c67.png)

## Benchmark code
<details>
  <summary>Click here</summary>
```
        public static void TimeAction(string prefix, Action action)
        {
            // Warm up and clean up
            action();
            GC.Collect();
            GC.WaitForPendingFinalizers();
            GC.Collect();

            // Profile
            long[] results = new long[25];
            for (int i = 0; i < results.Length; i++)
            {
                Stopwatch stopwatch = new Stopwatch();
                stopwatch.Start();

                for (int j = 0; j < 5000000; j++)
                {
                    action();
                }
                stopwatch.Stop();
                results[i] = stopwatch.ElapsedMilliseconds;
            }

            Console.WriteLine(prefix + results.Average());
        }

        static void Main(string[] args)
        {
            Console.WriteLine("******** NUMBERSTYLES.INTEGER ********");
            Console.WriteLine("**** Measure UInt64 ****");
            TimeAction("Old: ", () => ulong.Parse("18446744073709551615", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseUInt64("18446744073709551615", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("**** Measure UInt32 ****");
            TimeAction("Old: ", () => uint.Parse("4294967295", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseUInt32("4294967295", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("**** Measure Int64 ****");
            TimeAction("Old: ", () => long.Parse("9223372036854775807", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseInt64("9223372036854775807", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("**** Measure Int32 ****");
            TimeAction("Old: ", () => int.Parse("-2147483647", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseInt32("-2147483648", NumberStyles.Integer, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("******** NUMBERSTYLES.HEXNUMBER ********");
            Console.WriteLine("**** Measure UInt64 ****");
            TimeAction("Old: ", () => ulong.Parse("abcdef123456789", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseUInt64("abcdef123456789", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("**** Measure UInt32 ****");
            TimeAction("Old: ", () => uint.Parse("abcdef", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseUInt32("abcdef", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("**** Measure Int64 ****");
            TimeAction("Old: ", () => long.Parse("abcdef123456789", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseInt64("abcdef123456789", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));

            Console.WriteLine("**** Measure Int32 ****");
            TimeAction("Old: ", () => int.Parse("abcdef", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));
            TimeAction("New: ", () => Number.ParseInt32("abcdef", NumberStyles.HexNumber, NumberFormatInfo.InvariantInfo));

            Console.ReadLine();
        }
```
</details>

## Reviewer notes
- There's quite a lot of code duplication - if you think up some ways this can be avoided, let me know
- Do we need to check for InvariantInfo - can any NumberFormatInfo work in these fast pathed cases

/cc @stephentoub