### PR TITLE
ARM64: Fix conversion double to unsigned int

### DIFF
--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -1596,14 +1596,21 @@ unsigned __int64 FloatingPointUtils::convertDoubleToUInt64(double d) {
         return u64;
     }
 
-    // This double cast to account for an ECMA spec hole.
-    // When converting from a double to an unsigned the ECMA
-    // spec states that a conforming implementation should 
-    // "truncate to zero." However that doesn't make much sense
-    // when the double in question is negative and the target
-    // is unsigned. gcc converts a negative double to zero when
-    // cast to an unsigned. To make gcc conform to MSVC behavior
-    // this cast is necessary.
-    u64 = UINT64(INT64(d));     
+#ifdef _TARGET_XARCH_
+
+    // While the Ecma spec does not specifically call this out,
+    // the case of conversion from negative double to unsigned integer is
+    // effectively an overflow and therefore the result is unspecified.
+    // With MSVC for x86/x64, such a conversion results in the bit-equivalent
+    // unsigned value of the conversion to integer. Other compilers convert
+    // negative doubles to zero when the target is unsigned.
+    // To make the behavior consistent across OS's on TARGET_XARCH,
+    // this double cast is needed to conform MSVC behavior.
+
+    u64 = UINT64(INT64(d));
+#else
+    u64 = UINT64(d);
+#endif // _TARGET_XARCH_
+
     return u64;
 }

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -24301,14 +24301,14 @@ RelativePath=JIT\Methodical\FPtrunc\convx_il_d\convx_il_d.exe
 WorkingDir=JIT\Methodical\FPtrunc\convx_il_d
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEED_UPDATE_TEST
 HostStyle=Any
 [convx_il_r.exe_3530]
 RelativePath=JIT\Methodical\FPtrunc\convx_il_r\convx_il_r.exe
 WorkingDir=JIT\Methodical\FPtrunc\convx_il_r
 Expected=100
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;NEED_UPDATE_TEST
 HostStyle=Any
 [test.exe_3531]
 RelativePath=JIT\Methodical\inlining\bug505642\test\test.exe

--- a/tests/src/JIT/Methodical/FPtrunc/convX.il
+++ b/tests/src/JIT/Methodical/FPtrunc/convX.il
@@ -182,20 +182,8 @@ IL_CASE15:  ldc.r8     65535
     dup
     call       void [System.Console]System.Console::WriteLine(unsigned int32)
     ldc.i4	65535
-    beq.s      IL_CASE16
-    ldstr "CASE15 FAILED"
-	call       void [System.Console]System.Console::WriteLine(string)
-	ldc.i4.1
-    br       IL_0041
-
-	// r8 - conv.u8 - truncate to zero
-IL_CASE16:  ldc.r8     18446744073709551615
-    conv.u8
-    dup
-    call       void [System.Console]System.Console::WriteLine(unsigned int64)
-    ldc.i8	18446744073709551615
     beq.s      IL_CASE17
-    ldstr "CASE16 FAILED"
+    ldstr "CASE15 FAILED"
 	call       void [System.Console]System.Console::WriteLine(string)
 	ldc.i4.1
     br       IL_0041


### PR DESCRIPTION
For ARM/ARM64, converting negative double to unsigned int is 0, which aligns with all native compilers.
I also removed the part of test that depends on architecture specific values.
Since ARM64 tests were prepopulated, I just updated the tag so that we can update the tests later.