### PR TITLE
Improve description of build type spelling for consistency

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ usage()
 {
     echo "Usage: $0 [BuildArch] [BuildType] [clean] [verbose] [coverage] [cross] [clangx.y] [ninja] [configureonly] [skipconfigure] [skipnative] [skipmscorlib] [skiptests] [cmakeargs]"
     echo "BuildArch can be: x64, x86, arm, arm64"
-    echo "BuildType can be: Debug, Checked, Release"
+    echo "BuildType can be: debug, checked, release"
     echo "clean - optional argument to force a clean build."
     echo "verbose - optional argument to enable verbose build output."
     echo "coverage - optional argument to enable code coverage build (currently supported only for Linux and OSX)."


### PR DESCRIPTION
This is trivial patch.
Let's display a help manual with lower case for consistency when the developers run "./build.sh --help" command.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>