### PR TITLE
Fixed issue #3987 "Debugger fails to stop on entry due to stack walk failure"

### DIFF
--- a/src/debug/daccess/dacdbiimpl.cpp
+++ b/src/debug/daccess/dacdbiimpl.cpp
@@ -5081,6 +5081,9 @@ void DacDbiInterfaceImpl::Hijack(
     // (The hijack function already has the context)
     _ASSERTE((pOriginalContext == NULL) == (cbSizeContext == 0));
     _ASSERTE(EHijackReason::IsValid(reason));
+#ifdef PLATFORM_UNIX
+    _ASSERTE(!"Not supported on this platform");
+#endif
 
     //
     // If we hijack a thread which might not be managed we can set vmThread = NULL

--- a/src/debug/ee/debugger.cpp
+++ b/src/debug/ee/debugger.cpp
@@ -983,6 +983,7 @@ Debugger::Debugger()
 
     m_fShutdownMode = false;
     m_fDisabled = false;
+    m_rgHijackFunction = NULL;
 
 #ifdef _DEBUG
     InitDebugEventCounting();
@@ -17006,6 +17007,7 @@ Debugger::EnumMemoryRegions(CLRDataEnumMemoryFlags flags)
 {
     DAC_ENUM_VTHIS();
     SUPPORTS_DAC;
+    _ASSERTE(m_rgHijackFunction != NULL);
 
     if ( flags != CLRDATA_ENUM_MEM_TRIAGE)
     {


### PR DESCRIPTION
By initializing m_rgHijackFunction to NULL.