### PR TITLE
Don't use --only-keep-debug option flag to create executable file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,7 +302,7 @@ function(strip_symbols targetName outputFilename)
           TARGET ${targetName}
           POST_BUILD
           VERBATIM 
-          COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
+          COMMAND ${OBJCOPY} ${strip_source_file} ${strip_destination_file}
           COMMAND ${OBJCOPY} --strip-unneeded ${strip_source_file}
           COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
           COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}


### PR DESCRIPTION
The "foo.dbg" file pointed to by the --add-gnu-debuglink, can be
the dbg executable. Note that it does not have to be a file created
by the --only-keep-debug switch. Let's use objcopy command without
--only-keep-debug option to create two executable files.

step 1. Run objcopy foo foo.dbg
step 2. Run objcopy --strip-unneeded foo
step 3. Run objcopy --add-gnu-debuglink=foo.dbg foo

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
Signed-off-by: Prajwal A N <an.prajwal@samsung.com>