### PR TITLE
Replace uses of _WIN64 with _HOST_64BIT_.

### DIFF
--- a/src/jit/_typeinfo.h
+++ b/src/jit/_typeinfo.h
@@ -312,6 +312,17 @@ private:
         CORINFO_METHOD_HANDLE m_method;
     };
 
+    template<typename T>
+    static bool isInvalidHandle(const T handle)
+    {
+        static_assert(std::is_same<T, CORINFO_CLASS_HANDLE>::value || std::is_same<T, CORINFO_METHOD_HANDLE>::value, "");
+#ifdef _HOST_64BIT_
+        return handle == reinterpret_cast<T>(0xcccccccccccccccc);
+#else
+        return handle == reinterpret_cast<T>(0xcccccccc);
+#endif
+    }
+
 public:
     typeInfo():m_flags(TI_ERROR) 
     {
@@ -345,7 +356,7 @@ public:
     typeInfo(ti_types tiType, CORINFO_CLASS_HANDLE cls, bool typeVar = false) 
     {
         assert(tiType == TI_STRUCT || tiType == TI_REF);
-        assert(cls != 0 && cls != CORINFO_CLASS_HANDLE(NOT_WIN64(0xcccccccc) WIN64_ONLY(0xcccccccccccccccc)));
+        assert(cls != 0 && !isInvalidHandle(cls));
         m_flags = tiType;
         if (typeVar) 
             m_flags |= TI_FLAG_GENERIC_TYPE_VAR;
@@ -354,8 +365,7 @@ public:
 
     typeInfo(CORINFO_METHOD_HANDLE method)
     {
-        assert(method != 0 && method != CORINFO_METHOD_HANDLE(NOT_WIN64(0xcccccccc)
-                                                              WIN64_ONLY(0xcccccccccccccccc)));
+        assert(method != 0 && !isInvalidHandle(method));
         m_flags = TI_METHOD;
         m_method = method;
     }

--- a/src/jit/bitsetasshortlong.h
+++ b/src/jit/bitsetasshortlong.h
@@ -432,7 +432,7 @@ public:
             {
                 DWORD nextBit;
                 BOOL hasBit;
-#ifdef _WIN64
+#ifdef _HOST_64BIT_
                 static_assert_no_msg(sizeof(size_t) == 8);
                 hasBit = BitScanForward64(&nextBit, m_bits);
 #else

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -4799,7 +4799,7 @@ void            CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg,
 
 
             noway_assert(varDsc->lvIsParam && varDsc->lvIsRegArg);
-#ifndef _WIN64
+#ifndef _TARGET_64BIT_
             //Right now we think that incoming arguments are not pointer sized.  When we eventually
             //understand the calling convention... this still won't be true.  But maybe we'll have a better
             //idea of how to ignore it.
@@ -4807,7 +4807,7 @@ void            CodeGen::genFnPrologCalleeRegArgs(regNumber xtraReg,
             // On Arm, a long can be passed in register
             noway_assert(genTypeSize(genActualType(varDsc->TypeGet())) == sizeof(void *));
 #endif
-#endif //_WIN64
+#endif //_TARGET_64BIT_
 
             noway_assert(varDsc->lvIsInReg() && !regArgTab[argNum].circular);
 

--- a/src/jit/disasm.cpp
+++ b/src/jit/disasm.cpp
@@ -1314,7 +1314,9 @@ void DisAssembler::DisasmBuffer(FILE*         pfile,
         return;
     }
 
-    WIN64_ONLY(pdis->SetAddr64(true));
+#ifdef _TARGET_64BIT_
+    pdis->SetAddr64(true);
+#endif
 
     // Store a pointer to the DisAssembler so that the callback functions
     // can get to it.

--- a/src/jit/disasm.h
+++ b/src/jit/disasm.h
@@ -57,17 +57,17 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 /*****************************************************************************/
 
-#ifdef _WIN64
+#ifdef _HOST_64BIT_
 template<typename T>
 struct SizeTKeyFuncs: LargePrimitiveKeyFuncs<T>
 {
 };
-#else // !_WIN64
+#else // !_HOST_64BIT_
 template<typename T>
 struct SizeTKeyFuncs: SmallPrimitiveKeyFuncs<T>
 {
 };
-#endif // !_WIN64
+#endif // _HOST_64BIT_
 
 typedef SimplerHashTable<size_t, SizeTKeyFuncs<size_t>, CORINFO_METHOD_HANDLE, DefaultSimplerHashBehavior> AddrToMethodHandleMap;
 typedef SimplerHashTable<size_t, SizeTKeyFuncs<size_t>, size_t, DefaultSimplerHashBehavior> AddrToAddrMap;

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -247,7 +247,7 @@ struct GenTreeArgList;
 
 /*****************************************************************************/
 
-#ifndef _WIN64
+#ifndef _HOST_64BIT_
 #include <pshpack4.h>
 #endif
 
@@ -3748,7 +3748,7 @@ inline var_types& GenTree::CastToType()  { return this->gtCast.gtCastType; }
 
 /*****************************************************************************/
 
-#ifndef _WIN64
+#ifndef _HOST_64BIT_
 #include <poppack.h>
 #endif
 

--- a/src/jit/instr.h
+++ b/src/jit/instr.h
@@ -246,8 +246,12 @@ DECLARE_TYPED_ENUM(emitAttr,unsigned)
                 EA_32BYTE        = 0x020,
                 EA_SIZE_MASK     = 0x03F,
 
-                EA_PTRSIZE       = NOT_WIN64(EA_4BYTE)
-                                   WIN64_ONLY(EA_8BYTE),
+#ifdef _TARGET_64BIT_
+                EA_PTRSIZE       = EA_8BYTE,
+#else
+                EA_PTRSIZE       = EA_4BYTE,
+#endif
+
                 EA_OFFSET_FLG    = 0x040,
                 EA_OFFSET        = EA_OFFSET_FLG | EA_PTRSIZE,       /* size ==  0 */
                 EA_GCREF_FLG     = 0x080,

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -90,6 +90,10 @@
   #error Unsupported or unset host architecture
 #endif
 
+#if defined(_HOST_AMD64_) || defined(_HOST_ARM64_)
+  #define _HOST_64BIT_
+#endif
+
 #if defined(_TARGET_X86_)
   #if defined(_TARGET_ARM_)
     #error Cannot define both _TARGET_X86_ and _TARGET_ARM_
@@ -786,8 +790,11 @@ extern  int                     jitNativeCode(CORINFO_METHOD_HANDLE methodHnd,
                                               void *            inlineInfoPtr
                                               );
 
-const size_t DEAD_BEEF =    NOT_WIN64(0xDEADBEEF)
-                            WIN64_ONLY(0xDEADBEEFDEADBEEF);
+#ifdef _HOST_64BIT_
+const size_t INVALID_POINTER_VALUE = 0xFEEDFACEABADF00D;
+#else
+const size_t INVALID_POINTER_VALUE = 0xFEEDFACE;
+#endif
 
 // Constants for making sure size_t fit into smaller types.
 const size_t MAX_USHORT_SIZE_T = static_cast<size_t>(static_cast<unsigned short>(-1));

--- a/src/jit/jiteh.cpp
+++ b/src/jit/jiteh.cpp
@@ -1323,7 +1323,7 @@ void                Compiler::fgRemoveEHTableEntry(unsigned XTnum)
     if (compHndBBtabCount == 0)
     {
         // No more entries remaining.
-        INDEBUG(compHndBBtab = (EHblkDsc *)DEAD_BEEF;)
+        INDEBUG(compHndBBtab = (EHblkDsc *)INVALID_POINTER_VALUE;)
     }
     else
     {

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -13912,7 +13912,7 @@ void                Compiler::fgMorphStmts(BasicBlock * block,
 #endif
 
 #ifdef DEBUG
-    compCurBB = (BasicBlock*)DEAD_BEEF;
+    compCurBB = (BasicBlock*)INVALID_POINTER_VALUE;
 #endif
 
     // Reset this back so that it doesn't leak out impacting other blocks

--- a/src/jit/typeinfo.cpp
+++ b/src/jit/typeinfo.cpp
@@ -217,7 +217,7 @@ BOOL         typeInfo::tiCompatibleWith          (COMP_HANDLE CompHnd,
         return tiCompatibleWithByRef(CompHnd, child, parent);
     }
 #ifdef _TARGET_64BIT_
-    // In WIN64 we have precise representation for native int, so these rules
+    // On 64-bit targets we have precise representation for native int, so these rules
     // represent the fact that the ECMA spec permits the implicit conversion 
     // between an int32 and a native int.
     else if (parent.IsType(TI_INT) && typeInfo::AreEquivalent(nativeInt(), child))
@@ -348,7 +348,7 @@ BOOL         typeInfo::tiMergeToCommonParent     (COMP_HANDLE CompHnd, typeInfo 
         return tiCompatibleWithByRef(CompHnd, *pSrc, *pDest);
     }
 #ifdef _TARGET_64BIT_
-    // In WIN64 we have precise representation for native int, so these rules
+    // On 64-bit targets we have precise representation for native int, so these rules
     // represent the fact that the ECMA spec permits the implicit conversion 
     // between an int32 and a native int.
     else if (typeInfo::AreEquivalent(*pDest, typeInfo::nativeInt()) && pSrc->IsType(TI_INT))

--- a/src/jit/vartype.h
+++ b/src/jit/vartype.h
@@ -37,7 +37,7 @@ END_DECLARE_TYPED_ENUM(var_types,BYTE)
  * platform
  */
 
-#ifdef _WIN64
+#ifdef _TARGET_64BIT_
 #define TYP_I_IMPL          TYP_LONG
 #define TYP_U_IMPL          TYP_ULONG
 #define TYPE_REF_IIM        TYPE_REF_LNG


### PR DESCRIPTION
This terminology is more accurate. This change also corrects
a few bits of code that were making target-related decisions
based on the host's bitness.