### PR TITLE
Remove non-portable dependencies from SimplerHashTable.

### DIFF
--- a/src/inc/gcinfoencoder.h
+++ b/src/inc/gcinfoencoder.h
@@ -308,10 +308,13 @@ enum GENERIC_CONTEXTPARAM_TYPE
 class GcInfoEncoder
 {
 public:
+    typedef void (*NoMemoryFunction)(void);
+
     GcInfoEncoder(
             ICorJitInfo*                pCorJitInfo,
             CORINFO_METHOD_INFO*        pMethodInfo,
-            IAllocator*                 pJitAllocator
+            IAllocator*                 pJitAllocator,
+            NoMemoryFunction            pNoMem = ThrowOutOfMemory
             );
 
     struct LifetimeTransition
@@ -476,6 +479,7 @@ private:
     ICorJitInfo*                m_pCorJitInfo;
     CORINFO_METHOD_INFO*        m_pMethodInfo;
     IAllocator*                 m_pAllocator;
+    NoMemoryFunction            m_pNoMem;
 
 #ifdef _DEBUG
     const char *m_MethodName, *m_ModuleName;

--- a/src/inc/simplerhash.h
+++ b/src/inc/simplerhash.h
@@ -2,22 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-// ==++==
-// 
-
-//
-
-// 
-// ==--==
-
-
 #ifndef _SIMPLERHASHTABLE_H_
 #define _SIMPLERHASHTABLE_H_
 
-// #include "utilcode.h" // for string hash functions
-// #include "clrtypes.h"
-// #include "check.h"
-// #include "iterator.h"
 #include "iallocator.h"
 
 // SimplerHashTable implements a mapping from a Key type to a Value type,
@@ -43,11 +30,6 @@
 // 
 // The "Behavior" argument provides the following static members:
 //
-// static const bool s_NoThrow                  true if GetKey, Equals, and hash are NOTHROW functions.  
-//                                              Affects the THROWS clauses of several SHash functions.
-//                                              (Note that the Null- and Deleted-related functions below 
-//                                              are not affected by this and must always be NOTHROW.)
-//
 // s_growth_factor_numerator
 // s_growth_factor_denominator                  Factor to grow allocation (numerator/denominator).  
 //                                              Typically inherited from default traits (3/2)
@@ -60,12 +42,14 @@
 //                                              probably preferable to call Reallocate on initialization rather
 //                                              than override his from the default traits. (7)
 //
+// NoMemory()                                   Called when the has table is unable to grow due to potential
+//                                              overflow or the lack of a sufficiently large prime.
 
-
+void DECLSPEC_NORETURN ThrowOutOfMemory();
 
 class DefaultSimplerHashBehavior
 {
-  public:
+public:
     static const unsigned s_growth_factor_numerator = 3;
     static const unsigned s_growth_factor_denominator = 2;
 
@@ -74,13 +58,14 @@ class DefaultSimplerHashBehavior
 
     static const unsigned s_minimum_allocation = 7;
 
-    static const bool s_NoThrow = true;
+    inline static void DECLSPEC_NORETURN NoMemory()
+    {
+        ::ThrowOutOfMemory();
+    }
 };
 
-
-// stores info about primes, including the magic number and shift amount needed
+// Stores info about primes, including the magic number and shift amount needed
 // to implement a divide without using the divide instruction
-
 class PrimeInfo
 {
 public:
@@ -97,8 +82,7 @@ public:
 template <typename Key, typename KeyFuncs, typename Value, typename Behavior>
 class SimplerHashTable
 {
-  public:
-
+public:
     // Forward declaration.
     class KeyIterator;
 
@@ -109,56 +93,6 @@ class SimplerHashTable
 
     SimplerHashTable(IAllocator* alloc);
     ~SimplerHashTable();
-
-    // We wish to provide overloaded operator new/deletes that take an
-    // "IAllocator", so that an shash may be dynamically allocated
-    // using a non-standard allocator.  If we do so, and in some
-    // contexts still want to use the default operator new, C++ also requires us
-    // to declare overloads for the standard new and delete operators.
-
-    void * operator new(size_t sz)
-    {
-        CONTRACTL
-        {
-            THROWS;
-            GC_NOTRIGGER;
-        }
-        CONTRACTL_END;
-        return ::operator new(sz);
-    }
-
-    void * operator new(size_t sz, const NoThrow& tothrow)
-    {
-        CONTRACTL
-        {
-            if (nothrow.x== tothrow.x)NOTHROW; else THROWS;
-            GC_NOTRIGGER;
-        }
-        CONTRACTL_END;
-        return ::operator new(sz, tothrow);
-    }
-
-    void   operator delete(void* p)
-    {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-        }
-        CONTRACTL_END;
-        ::operator delete(p);
-    }
-
-    void   operator delete[](void* p)
-    {
-        CONTRACTL
-        {
-            NOTHROW;
-            GC_NOTRIGGER;
-        }
-        CONTRACTL_END;
-        ::operator delete[](p);
-    }
 
     // operators new/delete when an IAllocator is to be used.
     void * operator new(size_t sz, IAllocator * alloc);
@@ -173,8 +107,6 @@ class SimplerHashTable
 
     Value *LookupPointer(Key k) const;
 
-    unsigned GetIndexForKey(Key k) const;
-
     // Causes the table to map "key" to "val".  Returns "true" if
     // "key" had already been mapped by the table, "false" otherwise.
     bool Set(Key k, Value val);
@@ -182,10 +114,6 @@ class SimplerHashTable
     // Ensures that "key" is not mapped to a value by the "table."
     // Returns "true" iff it had been mapped.
     bool Remove(Key k);
-
-    // Remove the mapping to which the current iterator "points"
-    // (i.e., will yield).
-    void Remove(KeyIterator& i);
 
     // Remove all mappings in the table.
     void RemoveAll();
@@ -197,10 +125,11 @@ class SimplerHashTable
     // Return the number of elements currently stored in the table
     unsigned GetCount() const; 
 
-  private:
-
+private:
     // Forward declaration of the linked-list node class.
     struct Node;
+
+    unsigned GetIndexForKey(Key k) const;
 
     // If the table has a mapping for "k", return the node containing
     // that mapping, else "NULL".
@@ -214,8 +143,7 @@ class SimplerHashTable
     // the hash table.
     void CheckGrowth();
 
-  public:
-
+public:
     // Reallocates a hash table to a specific size.  The size must be big enough
     // to hold all elements in the table appropriately.  
     //
@@ -234,10 +162,9 @@ class SimplerHashTable
     // }
     // iter.Get() will yield (a reference to) the
     // current key.  It will assert the equivalent of "iter != end."
-    //
-
     class KeyIterator
     {
+    private:
         friend class SimplerHashTable;
 
         // The method implementations have to be here for portability.
@@ -248,15 +175,13 @@ class SimplerHashTable
         unsigned    m_tableSize;
         unsigned    m_index;
 
-      public:
-
+    public:
         KeyIterator(const SimplerHashTable *hash, BOOL begin)
         : m_table(hash->m_table),
           m_node(NULL),
           m_tableSize(hash->m_tableSizeInfo.prime),
           m_index(begin ? 0 : m_tableSize)
         {
-            LIMITED_METHOD_CONTRACT;
             if (begin && hash->m_tableCount > 0)
             {
                 assert(m_table != NULL);
@@ -277,8 +202,6 @@ class SimplerHashTable
 
         const Key& Get() const
         {
-            LIMITED_METHOD_CONTRACT;
-
             assert(m_node != NULL);
 
             return m_node->m_key;
@@ -286,8 +209,6 @@ class SimplerHashTable
 
         const Value& GetValue() const
         {
-            LIMITED_METHOD_CONTRACT;
-
             assert(m_node != NULL);
 
             return m_node->m_val;
@@ -295,8 +216,6 @@ class SimplerHashTable
 
         void SetValue(const Value & value) const
         {
-            LIMITED_METHOD_CONTRACT;
-
             assert(m_node != NULL);
 
             m_node->m_val = value;
@@ -304,8 +223,6 @@ class SimplerHashTable
 
         void Next()
         {
-            LIMITED_METHOD_CONTRACT;
-
             if (m_node != NULL)
             {
                 m_node = m_node->m_next;
@@ -334,18 +251,13 @@ class SimplerHashTable
 
         bool Equal(const KeyIterator &i) const
         { 
-            LIMITED_METHOD_CONTRACT;
             return i.m_node == m_node; 
-        }
-
-        CHECK DoCheck() const
-        {
-            CHECK_OK;
         }
 
         void operator++() {
             Next();
         }
+
         void operator++(int) {
             Next();
         }
@@ -392,13 +304,10 @@ class SimplerHashTable
     }
 
   private:
-
     // Find the next prime number >= the given value.  
-
     static PrimeInfo NextPrime(unsigned number);
 
     // Instance members
-
     IAllocator*   m_alloc;                // IAllocator to use in this
                                           // table.
     // The node type.
@@ -450,8 +359,6 @@ public:
         return static_cast<unsigned>(reinterpret_cast<uintptr_t>(ptr));
     }
 };
-
-
 
 template<typename T> // Must be coercable to "unsigned" with no loss of information.
 struct SmallPrimitiveKeyFuncs: public KeyFuncsDefEquals<T>

--- a/src/inc/simplerhash.h
+++ b/src/inc/simplerhash.h
@@ -42,7 +42,7 @@
 //                                              probably preferable to call Reallocate on initialization rather
 //                                              than override his from the default traits. (7)
 //
-// NoMemory()                                   Called when the has table is unable to grow due to potential
+// NoMemory()                                   Called when the hash table is unable to grow due to potential
 //                                              overflow or the lack of a sufficiently large prime.
 
 void DECLSPEC_NORETURN ThrowOutOfMemory();

--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -1009,13 +1009,13 @@ public:
 };
 
 // A set of blocks.
-typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, bool, DefaultSimplerHashBehavior> BlkSet;
+typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, bool, JitSimplerHashBehavior> BlkSet;
 
 // A map of block -> set of blocks, can be used as sparse block trees.
-typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, BlkSet*, DefaultSimplerHashBehavior> BlkToBlkSetMap;
+typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, BlkSet*, JitSimplerHashBehavior> BlkToBlkSetMap;
 
 // Map from Block to Block.  Used for a variety of purposes.
-typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, BasicBlock*, DefaultSimplerHashBehavior> BlockToBlockMap;
+typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, BasicBlock*, JitSimplerHashBehavior> BlockToBlockMap;
 
 // In compiler terminology the control flow between two BasicBlocks
 // is typically referred to as an "edge".  Most well known are the

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -2090,7 +2090,7 @@ CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigne
 void                CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
-    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc);
+    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder);
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -6708,7 +6708,7 @@ void
 CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
-    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc);
+    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder != nullptr);
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -20969,7 +20969,7 @@ void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologS
 void                CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
-    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc);
+    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder);
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -8498,7 +8498,7 @@ void
 CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
-    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc);
+    GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);
     assert(gcInfoEncoder);
 
     // Follow the code pattern of the x86 gc info encoder (genCreateAndStoreGCInfoJIT32).

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1234,7 +1234,7 @@ struct TestLabelAndNum
     TestLabelAndNum() : m_tl(TestLabel(0)), m_num(0) {}
 };
 
-typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, TestLabelAndNum, DefaultSimplerHashBehavior> NodeToTestDataMap;
+typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, TestLabelAndNum, JitSimplerHashBehavior> NodeToTestDataMap;
 
 
 //XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -1598,7 +1598,7 @@ public:
     flowList*           BlockPredsWithEH(BasicBlock* blk);
 
     // This table is useful for memoization of the method above.
-    typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, flowList*, DefaultSimplerHashBehavior> BlockToFlowListMap;
+    typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, flowList*, JitSimplerHashBehavior> BlockToFlowListMap;
     BlockToFlowListMap* m_blockToEHPreds;
     BlockToFlowListMap* GetBlockToEHPreds()
     {
@@ -3553,7 +3553,7 @@ public :
     // "x", and a def of a new SSA name for "x".  The tree only has one local variable for "x", so it has to choose whether
     // to treat that as the use or def.  It chooses the "use", and thus the old SSA name.  This map allows us to record/recover
     // the "def" SSA number, given the lcl var node for "x" in such a tree.
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, unsigned, DefaultSimplerHashBehavior> NodeToUnsignedMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, unsigned, JitSimplerHashBehavior> NodeToUnsignedMap;
     NodeToUnsignedMap*  m_opAsgnVarDefSsaNums;
     NodeToUnsignedMap*  GetOpAsgnVarDefSsaNums()
     {
@@ -3615,7 +3615,7 @@ public :
         {}
 
     };
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, IndirectAssignmentAnnotation*, DefaultSimplerHashBehavior> NodeToIndirAssignMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, IndirectAssignmentAnnotation*, JitSimplerHashBehavior> NodeToIndirAssignMap;
     NodeToIndirAssignMap* m_indirAssignMap;
     NodeToIndirAssignMap* GetIndirAssignMap()
     {
@@ -3939,7 +3939,7 @@ public:
         void UpdateTarget(IAllocator* alloc, BasicBlock* switchBlk, BasicBlock* from, BasicBlock* to);
     };
 
-    typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, SwitchUniqueSuccSet, DefaultSimplerHashBehavior> BlockToSwitchDescMap;
+    typedef SimplerHashTable<BasicBlock*, PtrKeyFuncs<BasicBlock>, SwitchUniqueSuccSet, JitSimplerHashBehavior> BlockToSwitchDescMap;
 
     private:
     // Maps BasicBlock*'s that end in switch statements to SwitchUniqueSuccSets that allow
@@ -4748,7 +4748,7 @@ protected:
     void                optHoistLoopCode();
 
     // To represent sets of VN's that have already been hoisted in outer loops.
-    typedef SimplerHashTable<ValueNum, SmallPrimitiveKeyFuncs<ValueNum>, bool, DefaultSimplerHashBehavior> VNToBoolMap;
+    typedef SimplerHashTable<ValueNum, SmallPrimitiveKeyFuncs<ValueNum>, bool, JitSimplerHashBehavior> VNToBoolMap;
     typedef VNToBoolMap VNSet;
 
     struct LoopHoistContext
@@ -4967,11 +4967,11 @@ public:
         int                 lpLoopVarFPCount;           // The register count for the FP LclVars that are read/written inside this loop
         int                 lpVarInOutFPCount;          // The register count for the FP LclVars that are alive inside or accross this loop
 
-        typedef SimplerHashTable<CORINFO_FIELD_HANDLE, PtrKeyFuncs<struct CORINFO_FIELD_STRUCT_>, bool, DefaultSimplerHashBehavior> FieldHandleSet;
+        typedef SimplerHashTable<CORINFO_FIELD_HANDLE, PtrKeyFuncs<struct CORINFO_FIELD_STRUCT_>, bool, JitSimplerHashBehavior> FieldHandleSet;
         FieldHandleSet*     lpFieldsModified;           // This has entries (mappings to "true") for all static field and object instance fields modified
                                                         // in the loop.
         
-        typedef SimplerHashTable<CORINFO_CLASS_HANDLE, PtrKeyFuncs<struct CORINFO_CLASS_STRUCT_>, bool, DefaultSimplerHashBehavior> ClassHandleSet;
+        typedef SimplerHashTable<CORINFO_CLASS_HANDLE, PtrKeyFuncs<struct CORINFO_CLASS_STRUCT_>, bool, JitSimplerHashBehavior> ClassHandleSet;
         ClassHandleSet*     lpArrayElemTypesModified;   // Bits set indicate the set of sz array element types such that arrays of that type are modified
                                                         // in the loop.
 
@@ -5406,7 +5406,7 @@ protected :
 public:
     // VN based copy propagation.
     typedef ArrayStack<GenTreePtr> GenTreePtrStack;
-    typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, GenTreePtrStack*, DefaultSimplerHashBehavior> LclNumToGenTreePtrStack;
+    typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, GenTreePtrStack*, JitSimplerHashBehavior> LclNumToGenTreePtrStack;
 
     // Kill set to track variables with intervening definitions.
     VARSET_TP optCopyPropKillSet;
@@ -5737,7 +5737,7 @@ public :
         return optAssertionCount;
     }
     ASSERT_TP* bbJtrueAssertionOut;
-    typedef SimplerHashTable<ValueNum, SmallPrimitiveKeyFuncs<ValueNum>, ASSERT_TP, DefaultSimplerHashBehavior> ValueNumToAssertsMap;
+    typedef SimplerHashTable<ValueNum, SmallPrimitiveKeyFuncs<ValueNum>, ASSERT_TP, JitSimplerHashBehavior> ValueNumToAssertsMap;
     ValueNumToAssertsMap* optValueNumToAsserts;
 
     static const AssertionIndex NO_ASSERTION_INDEX = 0;
@@ -6573,7 +6573,7 @@ public :
     // whose return type is other than TYP_VOID. 2) GT_CALL node is a frequently used
     // structure and IL offset is needed only when generating debuggable code. Therefore
     // it is desirable to avoid memory size penalty in retail scenarios.
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, IL_OFFSETX, DefaultSimplerHashBehavior> CallSiteILOffsetTable;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, IL_OFFSETX, JitSimplerHashBehavior> CallSiteILOffsetTable;
     CallSiteILOffsetTable *  genCallSite2ILOffsetMap;
 #endif // DEBUGGING_SUPPORT
 
@@ -8147,7 +8147,7 @@ public :
     // Max value of scope count for which we would use linear search; for larger values we would use hashtable lookup.
     static const unsigned MAX_LINEAR_FIND_LCL_SCOPELIST = 32;
 
-    typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, VarScopeMapInfo*, DefaultSimplerHashBehavior> VarNumToScopeDscMap;
+    typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, VarScopeMapInfo*, JitSimplerHashBehavior> VarNumToScopeDscMap;
 
     // Map to keep variables' scope indexed by varNum containing it's scope dscs at the index.
     VarNumToScopeDscMap*  compVarScopeMap;
@@ -8682,7 +8682,7 @@ public:
         return compRoot->m_nodeTestData;
     }
 
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, int, DefaultSimplerHashBehavior> NodeToIntMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, int, JitSimplerHashBehavior> NodeToIntMap;
     
     // Returns the set (i.e., the domain of the result map) of nodes that are keys in m_nodeTestData, and
     // currently occur in the AST graph.
@@ -8718,7 +8718,7 @@ public:
         return compRoot->m_fieldSeqStore;
     }
 
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, FieldSeqNode*, DefaultSimplerHashBehavior> NodeToFieldSeqMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, FieldSeqNode*, JitSimplerHashBehavior> NodeToFieldSeqMap;
 
     // Some nodes of "TYP_BYREF" or "TYP_I_IMPL" actually represent the address of a field within a struct, but since the offset of
     // the field is zero, there's no "GT_ADD" node.  We normally attach a field sequence to the constant that is
@@ -8751,7 +8751,7 @@ public:
     void fgAddFieldSeqForZeroOffset(GenTreePtr op1, FieldSeqNode* fieldSeq);
 
 
-    typedef SimplerHashTable<const GenTree*, PtrKeyFuncs<GenTree>, ArrayInfo, DefaultSimplerHashBehavior> NodeToArrayInfoMap;
+    typedef SimplerHashTable<const GenTree*, PtrKeyFuncs<GenTree>, ArrayInfo, JitSimplerHashBehavior> NodeToArrayInfoMap;
     NodeToArrayInfoMap* m_arrayInfoMap;
 
     NodeToArrayInfoMap* GetArrayInfoMap()

--- a/src/jit/disasm.h
+++ b/src/jit/disasm.h
@@ -69,8 +69,8 @@ struct SizeTKeyFuncs: SmallPrimitiveKeyFuncs<T>
 };
 #endif // _HOST_64BIT_
 
-typedef SimplerHashTable<size_t, SizeTKeyFuncs<size_t>, CORINFO_METHOD_HANDLE, DefaultSimplerHashBehavior> AddrToMethodHandleMap;
-typedef SimplerHashTable<size_t, SizeTKeyFuncs<size_t>, size_t, DefaultSimplerHashBehavior> AddrToAddrMap;
+typedef SimplerHashTable<size_t, SizeTKeyFuncs<size_t>, CORINFO_METHOD_HANDLE, JitSimplerHashBehavior> AddrToMethodHandleMap;
+typedef SimplerHashTable<size_t, SizeTKeyFuncs<size_t>, size_t, JitSimplerHashBehavior> AddrToAddrMap;
 
 class Compiler;
 

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -3282,8 +3282,8 @@ void                GCInfo::gcFindPtrsInFrame(const void* infoBlock,
 #include "simplerhash.h"
 
 // Do explicit instantiation.
-template class SimplerHashTable<RegSlotIdKey, RegSlotIdKey, GcSlotId, DefaultSimplerHashBehavior>;
-template class SimplerHashTable<StackSlotIdKey, StackSlotIdKey, GcSlotId, DefaultSimplerHashBehavior>;
+template class SimplerHashTable<RegSlotIdKey, RegSlotIdKey, GcSlotId, JitSimplerHashBehavior>;
+template class SimplerHashTable<StackSlotIdKey, StackSlotIdKey, GcSlotId, JitSimplerHashBehavior>;
 
 #ifdef DEBUG
 

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -184,7 +184,7 @@ struct FieldSeqNode
 // This class canonicalizes field sequences.
 class FieldSeqStore
 {
-    typedef SimplerHashTable<FieldSeqNode, /*KeyFuncs*/FieldSeqNode, FieldSeqNode*, DefaultSimplerHashBehavior> FieldSeqNodeCanonMap;
+    typedef SimplerHashTable<FieldSeqNode, /*KeyFuncs*/FieldSeqNode, FieldSeqNode*, JitSimplerHashBehavior> FieldSeqNodeCanonMap;
 
     IAllocator*           m_alloc;
     FieldSeqNodeCanonMap* m_canonMap;

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -60,11 +60,11 @@ struct StackSlotIdKey
     }
 };
 
-typedef SimplerHashTable<RegSlotIdKey, RegSlotIdKey, GcSlotId, DefaultSimplerHashBehavior>     RegSlotMap;
-typedef SimplerHashTable<StackSlotIdKey, StackSlotIdKey, GcSlotId, DefaultSimplerHashBehavior> StackSlotMap;
+typedef SimplerHashTable<RegSlotIdKey, RegSlotIdKey, GcSlotId, JitSimplerHashBehavior>     RegSlotMap;
+typedef SimplerHashTable<StackSlotIdKey, StackSlotIdKey, GcSlotId, JitSimplerHashBehavior> StackSlotMap;
 #endif
 
-typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, VARSET_TP*, DefaultSimplerHashBehavior> NodeToVarsetPtrMap;
+typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, VARSET_TP*, JitSimplerHashBehavior> NodeToVarsetPtrMap;
 
 class GCInfo
 {

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -779,7 +779,7 @@ private:
         unsigned                fromBBNum;
         unsigned                toBBNum;
     };
-    typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, SplitEdgeInfo, DefaultSimplerHashBehavior>
+    typedef SimplerHashTable<unsigned, SmallPrimitiveKeyFuncs<unsigned>, SplitEdgeInfo, JitSimplerHashBehavior>
                                 SplitBBNumToTargetBBNumMap;
     SplitBBNumToTargetBBNumMap* splitBBNumToTargetBBNumMap;
     SplitBBNumToTargetBBNumMap* getSplitBBNumToTargetBBNumMap()

--- a/src/jit/rangecheck.h
+++ b/src/jit/rangecheck.h
@@ -480,11 +480,11 @@ public:
         Location();
     };   
 
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, bool, DefaultSimplerHashBehavior> OverflowMap;
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, Range*, DefaultSimplerHashBehavior> RangeMap;
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, BasicBlock*, DefaultSimplerHashBehavior> SearchPath;
-    typedef SimplerHashTable<INT64, LargePrimitiveKeyFuncs<INT64>, Location*, DefaultSimplerHashBehavior> VarToLocMap;
-    typedef SimplerHashTable<INT64, LargePrimitiveKeyFuncs<INT64>, ExpandArrayStack<Location*>*, DefaultSimplerHashBehavior> VarToLocArrayMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, bool, JitSimplerHashBehavior> OverflowMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, Range*, JitSimplerHashBehavior> RangeMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, BasicBlock*, JitSimplerHashBehavior> SearchPath;
+    typedef SimplerHashTable<INT64, LargePrimitiveKeyFuncs<INT64>, Location*, JitSimplerHashBehavior> VarToLocMap;
+    typedef SimplerHashTable<INT64, LargePrimitiveKeyFuncs<INT64>, ExpandArrayStack<Location*>*, JitSimplerHashBehavior> VarToLocArrayMap;
 
     // Generate a hashcode unique for this ssa var.
     UINT64 HashCode(unsigned lclNum, unsigned ssaNum);

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -1718,8 +1718,8 @@ void Compiler::JitTestCheckSSA()
         }
     };
 
-    typedef SimplerHashTable<ssize_t, SmallPrimitiveKeyFuncs<ssize_t>, SSAName, DefaultSimplerHashBehavior> LabelToSSANameMap;
-    typedef SimplerHashTable<SSAName, SSAName, ssize_t, DefaultSimplerHashBehavior> SSANameToLabelMap;
+    typedef SimplerHashTable<ssize_t, SmallPrimitiveKeyFuncs<ssize_t>, SSAName, JitSimplerHashBehavior> LabelToSSANameMap;
+    typedef SimplerHashTable<SSAName, SSAName, ssize_t, JitSimplerHashBehavior> SSANameToLabelMap;
 
     // If we have no test data, early out.
     if (m_nodeTestData == NULL) return;

--- a/src/jit/utils.h
+++ b/src/jit/utils.h
@@ -65,6 +65,23 @@ template <typename T> int signum(T val)
         return 0;
 }
 
+class JitSimplerHashBehavior
+{
+public:
+    static const unsigned s_growth_factor_numerator = 3;
+    static const unsigned s_growth_factor_denominator = 2;
+
+    static const unsigned s_density_factor_numerator = 3;
+    static const unsigned s_density_factor_denominator = 4;
+
+    static const unsigned s_minimum_allocation = 7;
+
+    inline static void DECLSPEC_NORETURN NoMemory()
+    {
+        NOMEM();
+    }
+};
+
 #ifdef DEBUG
 /**************************************************************************/
 

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -6917,8 +6917,8 @@ bool Compiler::fgValueNumberHelperCall(GenTreeCall* call)
 // TODO-Cleanup: new JitTestLabels for lib vs cons vs both VN classes?
 void Compiler::JitTestCheckVN()
 {
-    typedef SimplerHashTable<ssize_t, SmallPrimitiveKeyFuncs<ssize_t>, ValueNum, DefaultSimplerHashBehavior> LabelToVNMap;
-    typedef SimplerHashTable<ValueNum, SmallPrimitiveKeyFuncs<ValueNum>, ssize_t, DefaultSimplerHashBehavior> VNToLabelMap;
+    typedef SimplerHashTable<ssize_t, SmallPrimitiveKeyFuncs<ssize_t>, ValueNum, JitSimplerHashBehavior> LabelToVNMap;
+    typedef SimplerHashTable<ValueNum, SmallPrimitiveKeyFuncs<ValueNum>, ssize_t, JitSimplerHashBehavior> VNToLabelMap;
 
     // If we have no test data, early out.
     if (m_nodeTestData == NULL) return;
@@ -6926,7 +6926,7 @@ void Compiler::JitTestCheckVN()
     NodeToTestDataMap* testData = GetNodeTestData();
 
     // First we have to know which nodes in the tree are reachable.
-    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, int, DefaultSimplerHashBehavior> NodeToIntMap;
+    typedef SimplerHashTable<GenTreePtr, PtrKeyFuncs<GenTree>, int, JitSimplerHashBehavior> NodeToIntMap;
     NodeToIntMap* reachable = FindReachableNodesInNodeTestData();
 
     LabelToVNMap* labelToVN = new (getAllocatorDebugOnly()) LabelToVNMap(getAllocatorDebugOnly());

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -92,10 +92,10 @@ public:
     //         This class has two purposes - to abstract the implementation and to validate the ValueNums
     //         being stored or retrieved.
     template <class fromType, class keyfuncs=LargePrimitiveKeyFuncs<fromType>> 
-        class VNMap : public SimplerHashTable<fromType, keyfuncs, ValueNum, DefaultSimplerHashBehavior>
+        class VNMap : public SimplerHashTable<fromType, keyfuncs, ValueNum, JitSimplerHashBehavior>
     {
     public:
-        VNMap(IAllocator* alloc) : SimplerHashTable<fromType, keyfuncs, ValueNum, DefaultSimplerHashBehavior>(alloc) {}
+        VNMap(IAllocator* alloc) : SimplerHashTable<fromType, keyfuncs, ValueNum, JitSimplerHashBehavior>(alloc) {}
         ~VNMap()
         {
             ~VNMap<fromType, keyfuncs>::SimplerHashTable();
@@ -104,11 +104,11 @@ public:
         bool Set(fromType k, ValueNum val)
         {
             assert(val != RecursiveVN);
-            return SimplerHashTable<fromType, keyfuncs, ValueNum, DefaultSimplerHashBehavior>::Set(k, val);
+            return SimplerHashTable<fromType, keyfuncs, ValueNum, JitSimplerHashBehavior>::Set(k, val);
         }
         bool Lookup(fromType k, ValueNum* pVal = NULL) const
         {
-            bool result = SimplerHashTable<fromType, keyfuncs, ValueNum, DefaultSimplerHashBehavior>::Lookup(k, pVal);
+            bool result = SimplerHashTable<fromType, keyfuncs, ValueNum, JitSimplerHashBehavior>::Lookup(k, pVal);
             assert(!result || *pVal != RecursiveVN);
             return result;
         }

--- a/src/vm/interpreter.cpp
+++ b/src/vm/interpreter.cpp
@@ -23,7 +23,6 @@
 #include "runtimehandles.h"
 #include "vars.hpp"
 #include "cycletimer.h"
-#include "defaultallocator.h"
 #ifdef FEATURE_REMOTING
 #include "remoting.h"
 #endif
@@ -10838,7 +10837,7 @@ Interpreter::AddrToMDMap* Interpreter::GetAddrToMdMap()
 
     if (s_addrToMDMap == NULL)
     {
-        s_addrToMDMap = new AddrToMDMap(DefaultAllocator::Singleton());
+        s_addrToMDMap = new AddrToMDMap();
     }
     return s_addrToMDMap;
 }
@@ -10860,7 +10859,7 @@ void Interpreter::RecordInterpreterStubForMethodDesc(CORINFO_METHOD_HANDLE md, v
     CORINFO_METHOD_HANDLE dummy;
     assert(!map->Lookup(addr, &dummy));
 #endif // DEBUG
-    map->Set(addr, md);
+    map->AddOrReplace(KeyValuePair<void*,CORINFO_METHOD_HANDLE>(addr, md));
 }
 
 MethodDesc* Interpreter::InterpretationStubToMethodInfo(PCODE addr)
@@ -10900,7 +10899,7 @@ Interpreter::MethodHandleToInterpMethInfoPtrMap* Interpreter::GetMethodHandleToI
 
     if (s_methodHandleToInterpMethInfoPtrMap == NULL)
     {
-        s_methodHandleToInterpMethInfoPtrMap = new MethodHandleToInterpMethInfoPtrMap(DefaultAllocator::Singleton());
+        s_methodHandleToInterpMethInfoPtrMap = new MethodHandleToInterpMethInfoPtrMap();
     }
     return s_methodHandleToInterpMethInfoPtrMap;
 }
@@ -10936,8 +10935,8 @@ InterpreterMethodInfo* Interpreter::RecordInterpreterMethodInfoForMethodHandle(C
     mi.m_thread = GetThread();
 #endif
 
-    bool b = map->Set(md, mi);
-    _ASSERTE_MSG(!b, "Multiple InterpMethInfos for method desc.");
+    _ASSERTE_MSG(map->LookupPtr(md) == NULL, "Multiple InterpMethInfos for method desc.");
+    map->Add(md, mi);
     return methInfo;
 }
 

--- a/src/vm/interpreter.h
+++ b/src/vm/interpreter.h
@@ -10,7 +10,6 @@
 #include "corinfo.h"
 #include "codeman.h"
 #include "jitinterface.h"
-#include "simplerhash.h"
 #include "stack.h"
 #include "crst.h"
 #include "callhelpers.h"
@@ -1017,7 +1016,7 @@ private:
 #endif
     };
 
-    typedef SimplerHashTable<void*, PtrKeyFuncs<void>, CORINFO_METHOD_HANDLE, DefaultSimplerHashBehavior> AddrToMDMap;
+    typedef MapSHash<void*, CORINFO_METHOD_HANDLE> AddrToMDMap;
     static AddrToMDMap* s_addrToMDMap;
     static AddrToMDMap* GetAddrToMdMap();
 
@@ -1030,7 +1029,7 @@ private:
         Thread* m_thread;
 #endif // _DEBUG
     };
-    typedef SimplerHashTable<CORINFO_METHOD_HANDLE, PtrKeyFuncs<CORINFO_METHOD_STRUCT_>, MethInfo, DefaultSimplerHashBehavior> MethodHandleToInterpMethInfoPtrMap;
+    typedef MapSHash<CORINFO_METHOD_HANDLE, MethInfo> MethodHandleToInterpMethInfoPtrMap;
     static MethodHandleToInterpMethInfoPtrMap* s_methodHandleToInterpMethInfoPtrMap;
     static MethodHandleToInterpMethInfoPtrMap* GetMethodHandleToInterpMethInfoPtrMap();
 


### PR DESCRIPTION
- Remove contracts. Pre- and post-conditions have been replaced
  with asserts.
- Hang the "no memory" callback off of Behavior instead of
  calling ThrowOutOfMemory directly
- Remove operator new overloads that defer to the global
  operator new.

This is part of an alternative to #3998.