### PR TITLE
Disable ForeignThreadExceptions test on ARM64

### DIFF
--- a/tests/src/Exceptions/ForeignThread/CMakeLists.txt
+++ b/tests/src/Exceptions/ForeignThread/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required (VERSION 2.6)
 
+if(NOT (CLR_CMAKE_TARGET_ARCH STREQUAL arm64))
+
 project (ForeignThreadExceptionsNative)
 
 include_directories(${INC_PLATFORM_DIR})
@@ -12,4 +14,4 @@ add_library (ForeignThreadExceptionsNative SHARED ${SOURCES})
 # add the install targets
 install (TARGETS ForeignThreadExceptionsNative DESTINATION bin)
 
-
+endif()

--- a/tests/src/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
+++ b/tests/src/Exceptions/ForeignThread/ForeignThreadExceptions.csproj
@@ -13,7 +13,7 @@
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-
+    <DisableProjectBuild Condition=" '$(Platform)' == 'arm64' ">true</DisableProjectBuild> 
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
     <DefineConstants>$(DefineConstants);STATIC</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
#4007 passed all CI checks, but the native portion of the test fails to build on ARM64.

cc:@kyulee1