### PR TITLE
Refactor Unix structDesc of GenTreeCall node into MultiRegReturnTypeDesc

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -11276,6 +11276,26 @@ bool Compiler::IsRegisterPassable(GenTreePtr tree)
 {
     return IsRegisterPassable(gtGetStructHandleIfPresent(tree));
 }
+
+//-----------------------------------------------------------------------------------
+// IsMultiRegReturnedType: Returns true if the type is returned in multiple registers
+// 
+// Arguments:
+//     hClass   -  type handle
+//
+// Return Value:
+//     true if type is returned in multiple registers, false otherwise.
+bool Compiler::IsMultiRegReturnedType(CORINFO_CLASS_HANDLE hClass)
+{
+    if (hClass == NO_CLASS_HANDLE)
+    {
+        return false;
+    }
+
+    SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
+    eeGetSystemVAmd64PassStructInRegisterDescriptor(hClass, &structDesc);
+    return structDesc.passedInRegisters && (structDesc.eightByteCount > 1);
+}
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
 #ifdef _TARGET_ARM_

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5728,14 +5728,10 @@ void CodeGen::genCallInstruction(GenTreePtr node)
     emitAttr secondRetSize = EA_UNKNOWN;
     if (varTypeIsStruct(call->gtType))
     {
-        // Make sure it is a multi-register returned struct,  
-        // otherwise, for a struct passed in a single register   
-        // the call would have a normalized type that is not a struct type.  
-        assert(call->structDesc.passedInRegisters &&
-               (call->structDesc.eightByteCount == CLR_SYSTEMV_MAX_EIGHTBYTES_COUNT_TO_RETURN_IN_REGISTERS));
-
-        retSize = emitTypeSize(compiler->getEightByteType(call->structDesc, 0));
-        secondRetSize = emitTypeSize(compiler->getEightByteType(call->structDesc, 1));
+        assert(call->HasMultiRegRetVal());
+        ReturnTypeDesc* retTypeDesc = &(call->gtReturnTypeDesc);
+        retSize = emitTypeSize(retTypeDesc->GetReturnRegType(1));
+        secondRetSize = emitTypeSize(retTypeDesc->GetReturnRegType(2));
     }
     else
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING  

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1393,6 +1393,7 @@ public:
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
     bool                            IsRegisterPassable(CORINFO_CLASS_HANDLE hClass);
     bool                            IsRegisterPassable(GenTreePtr tree);
+    bool                            IsMultiRegReturnedType(CORINFO_CLASS_HANDLE hClass);
 #endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
 
     //-------------------------------------------------------------------------
@@ -2672,10 +2673,11 @@ protected :
 
     bool                impMethodInfo_hasRetBuffArg(CORINFO_METHOD_INFO * methInfo);
 
-    GenTreePtr          impFixupStructReturn(GenTreePtr           call,
-                                             CORINFO_CLASS_HANDLE retClsHnd);
+    GenTreePtr          impFixupCallStructReturn(GenTreePtr           call,
+                                                 CORINFO_CLASS_HANDLE retClsHnd);
+
     GenTreePtr          impFixupStructReturnType(GenTreePtr       op,
-                                             CORINFO_CLASS_HANDLE retClsHnd);
+                                                 CORINFO_CLASS_HANDLE retClsHnd);
 
 #ifdef DEBUG
     var_types           impImportJitTestLabelMark(int numArgs);
@@ -8808,7 +8810,7 @@ public:
 
 #if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
     static var_types GetTypeFromClassificationAndSizes(SystemVClassificationType classType, int size);
-    var_types getEightByteType(const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR& structDesc, unsigned slotNum);
+    static var_types getEightByteType(const SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR& structDesc, unsigned slotNum);
     void fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgument);
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -6308,9 +6308,9 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
         }
         copy->gtCall.gtRetClsHnd = tree->gtCall.gtRetClsHnd;
 
-#if defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
-        copy->gtCall.structDesc.CopyFrom(tree->gtCall.structDesc);
-#endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)  
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+        copy->gtCall.gtReturnTypeDesc = tree->gtCall.gtReturnTypeDesc;
+#endif
 
 #ifdef FEATURE_READYTORUN_COMPILER
         copy->gtCall.gtEntryPoint = tree->gtCall.gtEntryPoint;
@@ -13415,4 +13415,46 @@ bool GenTree::isCommutativeSIMDIntrinsic()
         return false;
     }
 }
+#endif //FEATURE_SIMD
+
+//-------------------------------------------------------------------------
+// Initialize: Multi-reg Return Type Descriptor given type handle.
+// 
+// Arguments
+//    comp        -  Compiler Instance
+//    retClsHnd   -  VM handle to the type returned
+//
+// Return Value
+//    None
+//
+// Note:
+//    Right now it is implemented only for x64 unix.
+void ReturnTypeDesc::Initialize(Compiler* comp, CORINFO_CLASS_HANDLE retClsHnd)
+{
+    assert(!m_inited);
+    assert(retClsHnd != NO_CLASS_HANDLE);
+
+#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
+    SYSTEMV_AMD64_CORINFO_STRUCT_REG_PASSING_DESCRIPTOR structDesc;
+    comp->eeGetSystemVAmd64PassStructInRegisterDescriptor(retClsHnd, &structDesc);
+
+    if (structDesc.passedInRegisters)
+    {
+        if (structDesc.eightByteCount == 1)
+        {
+            m_regType0 = comp->getEightByteType(structDesc, 0);
+        }
+        else
+        {
+            assert(structDesc.eightByteCount == 2);
+            m_regType0 = comp->getEightByteType(structDesc, 0);
+            m_regType1 = comp->getEightByteType(structDesc, 1);
+        }
+    }
+
+#ifdef DEBUG
+    m_inited = true;
 #endif
+
+#endif // FEATURE_UNIX_AMD64_STRUCT_PASSING
+}


### PR DESCRIPTION
Code changes in this PR corresponds to first two sub-work items in multi-reg call/return work #3941 , namely

1. Refactor code to abstract structDesc field of GenTreeCall node
 ReturnTypeDesc would abstract away existing structDesc (x64 unix) and implement
 an API and replace all uses of structDesc of call node with the API.  This would be
 a pure code refactoring with the addition of ReturnTypeDesc on a GenTreeCall node.

2. Get rid of structDesc and make ReturnTypeDesc platform agnostic.
 Note that on x64 Unix, we still query structDesc from VM and use it to initialize ReturnTypeDesc.

Summary of code changes:
gentree.h/gentree.cpp - structDesc field of GenTreeCall is replaced by RegReturnTypeDesc. For now this is implemented for x64 unix.  As multi-reg support for arm64/32 is implemented, this type will be updated.

During importation of a call node, importer (in impFixupCallStructReturn()) will initialize RegReturnTypeDesc if the call is returning a struct type. 

codegencommon.cpp - Added a convenience routine IsMultiRegReturedType() to abstract the details of structDesc and associated VM call.

Importer.cpp:
 - impFixupStructReturn() - renamed this as impFixupCallStructReturn() to be indicative of its purpose.  This routine is called by impImportCall() to fix struct type return value of a call.  This routine will initialize ReturnTypeDesc on a call node and also normalizes call return type to an 8-byte type if the struct is returned in a single register.

Deleted a stray call to getClassSize(), the return value of which is not used in impFixupCallStructReturn().

 - impFixupStructReturnType() - this method is called to fix up return type of operand of a GT_RETURN node that is returning a struct type.

Updated this method to use IsMultiRegReturnedType() API added in codegencommon.cpp. In case of unix, it could be a struct returned in 2 registers or 1 register or via retbuf arg.  In case of a struct returned in 2 registers, we would force IR to be GT_RETURN(lclvar) or GT_RETURN(call).  The other cases are handled just as in x64 Windows.

This routine has some unnecessary code to query structDesc of retClsHnd.  It is not required, since compRetNativeType would be a normalized type that could be used.


impReturnInstruction() - The big comment block above where the code was changed applies to even x64 unix.  There is no special handling required.  This code goes away to be in sync with the code changes made in impFixupStructReturnType().

morph.cpp:
 - impFixupStructReturn() -  When this method is hit, call node return type could be still TYP_STRUCT that is returned in a single register.  For the reason please see the big comment block in impReturnInstruction.  But such a call node will have its actual return type stored in gtReturnType.  There is no need to query VM for a struct desc as we can use gtReturnType, which is already set by importer in impFixupCallStructReturn() based on return type structDesc.

Desktop DDR is green with zero asm diffs.

