### PR TITLE
Don't add nop padding for rejitting a funclet prolog.

### DIFF
--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -7619,7 +7619,22 @@ void CodeGen::genPrologPadForReJit()
 
 #ifdef _TARGET_XARCH_
     if (!(compiler->opts.eeFlags & CORJIT_FLG_PROF_REJIT_NOPS))
+    {
         return;
+    }
+
+#if FEATURE_EH_FUNCLETS
+
+    // No need to generate pad (nops) for funclets.
+    // When compiling the main function (and not a funclet)
+    // the value of funCurrentFunc->funKind is equal to FUNC_ROOT.
+    if (compiler->funCurrentFunc()->funKind != FUNC_ROOT)
+    {
+        return;
+    }
+
+#endif // FEATURE_EH_FUNCLETS
+
     unsigned size = getEmitter()->emitGetPrologOffsetEstimate();
     if (size < 5)
     {


### PR DESCRIPTION
This is along standing issue in RyuJit. When ngenning the crossgen tool
passes CORJIT_FLG_PROF_REJIT_NOPS flag. The padding for rejitting should
be added only for the main function and not the funclets when compiling a
method. Trying to generate a rejit padding for a funclet in debug and
checked build results in a failing assertion.

Fixes issue 3601.