### PR TITLE
Fix some of the tests failing on x86

### DIFF
--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
@@ -30,7 +30,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x86'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(Platform)' ==   'arm'" Include="i_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
@@ -29,7 +29,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="sizeof-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
@@ -30,7 +30,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x86'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(Platform)' ==   'arm'" Include="u_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
@@ -30,7 +30,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x86'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(Platform)' ==   'arm'" Include="i_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
@@ -30,7 +30,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(Platform)' ==   'x86'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(Platform)' ==   'arm'" Include="u_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge-i386.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge-i386.il
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib
+{ }
+.assembly 'test'
+{ }
+.class private auto ansi Test extends [mscorlib]System.Object
+{
+.method private hidebysig static int32 Main() il managed
+{
+	.entrypoint
+	.maxstack  8
+	.locals (int32[0...], native int[0...], native int, native int)
+	ldc.i4 16
+	newobj instance void native int[0...]::.ctor(int32)
+	stloc.0
+	ldc.i4 16
+	newobj instance void int32[0...]::.ctor(int32)
+	stloc.1
+
+	ldc.i4 0x12345678
+	stloc.2
+
+	ldc.i4.1
+	stloc.3
+loop_begin:
+	//
+	//	This switch determines type of array (int32 or native int)
+	ldloc.3
+	switch (err1,a1,a1,a1,a1,a2,a2,a2,a2)
+err1:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+a1:
+	ldloc.0
+	ldstr "branch1.1"
+	br.s end_a
+a2:
+	ldloc.1
+	ldstr "branch1.2"
+end_a:
+	call void [System.Console]System.Console::WriteLine(string)
+	dup
+	//	This switch determines opcode stelem.i or stelem.i4
+	ldloc.3
+	dup
+	dup
+	switch (err2,b1,b2,b1,b2,b1,b2,b1,b2)
+err2:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+b1:
+	stelem.i
+	ldstr "branch2.1"
+	br end_b
+b2:
+	stelem.i4
+	ldstr "branch2.2"
+end_b:
+	call void [System.Console]System.Console::WriteLine(string)
+
+	dup
+	call void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+	ldloc.3
+	
+	dup
+	switch (err3,c1,c1,c2,c2,c1,c1,c2,c2)
+err3:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+err4:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+c1:
+	ldelem.i
+	ldstr "branch3.1"
+	br end_c
+c2:
+	ldelem.i4
+	ldstr "branch3.2"
+end_c:
+	call void [System.Console]System.Console::WriteLine(string)
+	ldloc.3
+	ceq
+	brfalse err4
+
+	ldloc.3
+	ldc.i4.1
+	add
+	dup
+	stloc.3
+	ldc.i4 9
+	ceq
+	brfalse loop_begin
+	
+	ldc.i4 0x64
+	ret
+} // end of method 'Test::Main'
+
+.method public hidebysig specialname rtspecialname 
+        instance void .ctor() il managed
+{
+  .maxstack  8
+  IL_0000:  ldarg.0
+  IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+  IL_0006:  ret
+} // end of method 'Test::.ctor'
+
+} // end of class 'Test'

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/sizeof-i386.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/sizeof-i386.il
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+
+
+
+
+
+.assembly extern mscorlib { }
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+.assembly 'avg'// as "avg"
+{
+}
+.module 'avg.exe'
+// MVID: {BCA6096F-DF11-4FA3-BF16-EEDA01729535}
+.namespace AvgTest
+{
+  .class private auto ansi Test
+         extends [mscorlib]System.Object
+  {
+    .method private hidebysig static int32 Main() il managed
+    {
+		.entrypoint
+		// Code size       48 (0x30)
+		.maxstack  5
+		ldc.i4.4
+		dup 
+		dup
+		dup
+		sizeof native int
+		ceq
+		brfalse pop3
+		sizeof native unsigned int
+		ceq
+		brfalse pop2
+		sizeof [mscorlib]System.IntPtr
+		ceq
+		brfalse pop1
+		sizeof [mscorlib]System.UIntPtr
+		ceq
+		brfalse pop0
+		ldc.i4 0x64
+		br.s return
+	pop3:
+		pop
+	pop2:
+		pop
+	pop1:
+		pop
+	pop0:
+		ldc.i4.1
+	return:		
+		ret
+    } // end of method 'Test::Main'
+
+    .method public hidebysig specialname rtspecialname 
+            instance void .ctor() il managed
+    {
+      // Code size       7 (0x7)
+      .maxstack  8
+      IL_0000:  ldarg.0
+      IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+      IL_0006:  ret
+    } // end of method 'Test::.ctor'
+
+  } // end of class 'Test'
+
+} // end of namespace 'AvgTest'
+
+//*********** DISASSEMBLY COMPLETE ***********************

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge-i386.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge-i386.il
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib
+{ }
+.assembly 'test'
+{ }
+.class private auto ansi Test extends [mscorlib]System.Object
+{
+.method private hidebysig static int32 Main() il managed
+{
+	.entrypoint
+	.maxstack  8
+	.locals (unsigned int32[0...], native unsigned int[0...], native unsigned int, native unsigned int)
+	ldc.i4 16
+	newobj instance void native unsigned int[0...]::.ctor(int32)
+	stloc.0
+	ldc.i4 16
+	newobj instance void unsigned int32[0...]::.ctor(int32)
+	stloc.1
+
+	ldc.i4 0x12345678
+	stloc.2
+
+	ldc.i4.1
+	stloc.3
+loop_begin:
+	//
+	//	This switch determines type of array (int32 or native int)
+	ldloc.3
+	switch (err1,a1,a1,a1,a1,a2,a2,a2,a2)
+err1:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+a1:
+	ldloc.0
+	ldstr "branch1.1"
+	br.s end_a
+a2:
+	ldloc.1
+	ldstr "branch1.2"
+end_a:
+	call void [System.Console]System.Console::WriteLine(string)
+	dup
+	//	This switch determines opcode stelem.i or stelem.i4
+	ldloc.3
+	dup
+	dup
+	switch (err2,b1,b2,b1,b2,b1,b2,b1,b2)
+err2:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+b1:
+	stelem.i
+	ldstr "branch2.1"
+	br end_b
+b2:
+	stelem.i4
+	ldstr "branch2.2"
+end_b:
+	call void [System.Console]System.Console::WriteLine(string)
+
+	dup
+	call void [System.Console]System.Console::WriteLine(class [mscorlib]System.Object)
+	ldloc.3
+	
+	dup
+	switch (err3,c1,c1,c2,c2,c1,c1,c2,c2)
+err3:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+err4:
+	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	throw
+c1:
+	ldelem.i
+	ldstr "branch3.1"
+	br end_c
+c2:
+	ldelem.i4
+	ldstr "branch3.2"
+end_c:
+	call void [System.Console]System.Console::WriteLine(string)
+	ldloc.3
+	ceq
+	brfalse err4
+
+	ldloc.3
+	ldc.i4.1
+	add
+	dup
+	stloc.3
+	ldc.i4 9
+	ceq
+	brfalse loop_begin
+	
+	ldc.i4 0x64
+	ret
+} // end of method 'Test::Main'
+
+.method public hidebysig specialname rtspecialname 
+        instance void .ctor() il managed
+{
+  .maxstack  8
+  IL_0000:  ldarg.0
+  IL_0001:  call       instance void [mscorlib]System.Object::.ctor()
+  IL_0006:  ret
+} // end of method 'Test::.ctor'
+
+} // end of class 'Test'

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_d.csproj
@@ -33,6 +33,16 @@
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_do.csproj
@@ -33,6 +33,16 @@
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_r.csproj
@@ -33,6 +33,16 @@
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
+++ b/tests/src/JIT/Methodical/doublearray/dblarray4_cs_ro.csproj
@@ -33,6 +33,16 @@
   <ItemGroup>
     <Compile Include="dblarray4.cs" />
   </ItemGroup>
+  <PropertyGroup>
+    <CLRTestBatchPreCommands><![CDATA[
+$(CLRTestBatchPreCommands)
+set COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></CLRTestBatchPreCommands>
+  <BashCLRTestPreCommands><![CDATA[
+$(BashCLRTestPreCommands)
+export COMPlus_DoubleArrayToLargeObjectHeap=0x64
+]]></BashCLRTestPreCommands>
+  </PropertyGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_dbgsizeof.csproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_dbgsizeof.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -26,20 +26,29 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+    <Optimize>False</Optimize>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Include="sizeof.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
   </PropertyGroup> 

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
@@ -30,7 +30,8 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="64sizeof.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof.il" />
+    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
@@ -30,7 +30,8 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="64sizeof32.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof32.il" />
+    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64.ilproj
@@ -30,7 +30,8 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="64sizeof64.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof64.il" />
+    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
@@ -30,7 +30,8 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="64sizeof.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof.il" />
+    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
@@ -30,7 +30,8 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="64sizeof32.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof32.il" />
+    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
@@ -30,7 +30,8 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="64sizeof64.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof64.il" />
+    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_relsizeof.csproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_relsizeof.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -26,20 +26,29 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>None</DebugType>
+    <Optimize>False</Optimize>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Include="sizeof.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
   </PropertyGroup> 

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_speed_dbgsizeof.csproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_speed_dbgsizeof.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -26,20 +26,29 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>Full</DebugType>
+    <Optimize>True</Optimize>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Include="sizeof.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
   </PropertyGroup> 

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_speed_relsizeof.csproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_speed_relsizeof.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
   </PropertyGroup>
@@ -26,20 +26,29 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <!-- Set to 'Full' if the Debug? column is marked in the spreadsheet. Leave blank otherwise. -->
+    <DebugType>None</DebugType>
+    <Optimize>True</Optimize>
+    <NoLogo>True</NoLogo>
+    <NoStandardLib>True</NoStandardLib>
+    <Noconfig>True</Noconfig>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Include="sizeof.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
   </PropertyGroup> 

--- a/tests/src/JIT/Methodical/xxobj/sizeof/sizeof.cs
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/sizeof.cs
@@ -1,0 +1,73 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace JitTest
+{
+	using System;
+
+	struct SimpleStruct
+	{
+		int m_int;
+		uint m_uint;
+		byte m_byte;
+		sbyte m_sbyte;
+		char m_char;
+		short m_short;
+		ushort m_ushort;
+		long m_long;
+		ulong m_ulong;
+	}
+
+	struct ComplexStruct
+	{
+		SimpleStruct ss1;
+		SimpleStruct ss2;
+	}
+	
+	struct ComplexStruct2
+	{
+		ComplexStruct x1;
+		ComplexStruct x2;
+		ComplexStruct x3;
+		ComplexStruct x4;
+		ComplexStruct x5;
+		ComplexStruct x6;
+		ComplexStruct x7;
+		ComplexStruct x8;
+		ComplexStruct x9;
+		ComplexStruct x10;
+		ComplexStruct x11;
+		ComplexStruct x12;
+		ComplexStruct x13;
+		ComplexStruct x14;
+		ComplexStruct x15;
+		ComplexStruct x16;
+		ComplexStruct x17;
+		ComplexStruct x18;
+	}
+
+	struct Test
+	{
+		static unsafe int Main()
+		{
+			if (sizeof(SimpleStruct) != 32)
+			{
+				Console.WriteLine("sizeof(SimpleStruct) failed.");
+				return 101;
+			}
+			if (sizeof(ComplexStruct) != 64)
+			{
+				Console.WriteLine("sizeof(ComplexStruct) failed.");
+				return 102;
+			}
+			if (sizeof(ComplexStruct2) != sizeof(ComplexStruct) * 18)
+			{
+				Console.WriteLine("sizeof(ComplexStruct2) failed.");
+				return 103;
+			}
+			Console.WriteLine("sizeof passed");
+			return 100;
+		}
+	}
+}

--- a/tests/src/JIT/Methodical/xxobj/sizeof/sizeof.il
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/sizeof.il
@@ -1,0 +1,145 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+.assembly extern System.Console
+{
+  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
+  .ver 4:0:0:0
+}
+
+.assembly extern mscorlib { }
+.assembly 'sizeof'
+{
+}
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.namespace JitTest
+{
+  .class private sequential ansi sealed beforefieldinit SimpleStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field private int32 m_int
+    .field private unsigned int32 m_uint
+    .field private unsigned int8 m_byte
+    .field private int8 m_sbyte
+    .field private char m_char
+    .field private int16 m_short
+    .field private unsigned int16 m_ushort
+    .field private int64 m_long
+    .field private unsigned int64 m_ulong
+  }
+  .class private sequential ansi sealed beforefieldinit ComplexStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field private valuetype JitTest.SimpleStruct ss1
+    .field private valuetype JitTest.SimpleStruct ss2
+  }
+  .class private sequential ansi sealed beforefieldinit RefComplexStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field private valuetype JitTest.SimpleStruct ss1
+    .field private valuetype JitTest.SimpleStruct[] ssarr
+    .field private valuetype JitTest.SimpleStruct ss2
+  }
+  .class private sequential ansi sealed beforefieldinit ComplexStruct2
+         extends [mscorlib]System.ValueType
+  {
+    .field private valuetype JitTest.ComplexStruct x1
+    .field private valuetype JitTest.ComplexStruct x2
+    .field private valuetype JitTest.ComplexStruct x3
+    .field private valuetype JitTest.ComplexStruct x4
+    .field private valuetype JitTest.ComplexStruct x5
+    .field private valuetype JitTest.ComplexStruct x6
+    .field private valuetype JitTest.ComplexStruct x7
+    .field private valuetype JitTest.ComplexStruct x8
+    .field private valuetype JitTest.ComplexStruct x9
+    .field private valuetype JitTest.ComplexStruct x10
+    .field private valuetype JitTest.ComplexStruct x11
+    .field private valuetype JitTest.ComplexStruct x12
+    .field private valuetype JitTest.ComplexStruct x13
+    .field private valuetype JitTest.ComplexStruct x14
+    .field private valuetype JitTest.ComplexStruct x15
+    .field private valuetype JitTest.ComplexStruct x16
+    .field private valuetype JitTest.ComplexStruct x17
+    .field private valuetype JitTest.ComplexStruct x18
+  }
+  .class private sequential ansi sealed beforefieldinit RefComplexStruct2
+         extends [mscorlib]System.ValueType
+  {
+    .field private valuetype JitTest.ComplexStruct2 ss1
+    .field private class [mscorlib]System.AppDomain ad
+    .field private valuetype JitTest.ComplexStruct2 ss2
+  }
+  .class private sequential ansi sealed beforefieldinit Test
+         extends [mscorlib]System.ValueType
+  {
+    .pack 1
+    .size 1
+    .method private hidebysig static int32
+            Main() cil managed
+    {
+      .entrypoint
+      .maxstack  3
+      .locals (int32 V_0)
+      IL_0000:  sizeof     JitTest.SimpleStruct
+      IL_0006:  ldc.i4.s   32
+      IL_0008:  beq.s      IL_0019
+      IL_000a:  ldstr      "sizeof(SimpleStruct) failed."
+      IL_000f:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_0014:  ldc.i4.s   101
+      IL_0016:  stloc.0
+      IL_0017:  br       EXIT
+      IL_0019:  sizeof     JitTest.ComplexStruct
+      IL_001f:  ldc.i4.s   64
+      IL_0021:  beq.s      IL_0032
+      IL_0023:  ldstr      "sizeof(ComplexStruct) failed."
+      IL_0028:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_002d:  ldc.i4.s   102
+      IL_002f:  stloc.0
+      IL_0030:  br.s       EXIT
+      IL_0032:  sizeof     JitTest.ComplexStruct2
+      IL_0038:  sizeof     JitTest.ComplexStruct
+      IL_003e:  ldc.i4.s   18
+      IL_0040:  mul
+      IL_0041:  beq.s      NEXT1
+      IL_0043:  ldstr      "sizeof(ComplexStruct2) failed."
+      IL_0048:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_004d:  ldc.i4.s   103
+      IL_004f:  stloc.0
+      IL_0050:  br.s       EXIT
+      			
+      NEXT1:
+      			sizeof     JitTest.RefComplexStruct
+      			ldc.i4.s   68
+      			beq.s  NEXT2
+      			
+      				ldstr      "sizeof(RefComplexStruct) failed."
+      				call       void [System.Console]System.Console::WriteLine(string)
+      				ldc.i4.s   104
+      				stloc.0
+      				br.s       EXIT
+      
+      NEXT2:			
+      			sizeof     JitTest.RefComplexStruct2
+      			sizeof     JitTest.ComplexStruct2
+      			ldc.i4.1
+      			shl
+      			ldc.i4.4
+      			add
+      			beq.s  OK
+      			
+      				ldstr      "sizeof(RefComplexStruct2) failed."
+      				call       void [System.Console]System.Console::WriteLine(string)
+      				ldc.i4.s   105
+      				stloc.0
+      				br.s       EXIT
+      
+      OK:  ldstr      "sizeof passed"
+      IL_0057:  call       void [System.Console]System.Console::WriteLine(string)
+      IL_005c:  ldc.i4 100
+      IL_005d:  stloc.0
+      
+      EXIT: ldloc.0
+      			ret
+    }
+  }
+}

--- a/tests/src/JIT/Methodical/xxobj/sizeof/sizeof32.il
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/sizeof32.il
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// sizeof32.il
+.assembly extern mscorlib { }
+.assembly sizeof32 { }
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.namespace JitTest
+{
+  .class private sequential ansi sealed beforefieldinit SimpleStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 m_int
+    .field public unsigned int32 m_uint
+    .field public unsigned int8 m_byte
+    .field public int8 m_sbyte
+    .field public char m_char
+    .field public int16 m_short
+    .field public unsigned int16 m_ushort
+    .field public int64 m_long
+    .field public unsigned int64 m_ulong
+  }
+  .class private sequential ansi sealed beforefieldinit RefComplexStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field public valuetype JitTest.SimpleStruct ss1
+    .field public valuetype JitTest.SimpleStruct[0...] ss_array
+    .field public valuetype JitTest.SimpleStruct ss2
+  }
+  .class private sequential ansi sealed beforefieldinit Test
+         extends [mscorlib]System.ValueType
+  {
+    .pack 1
+    .size 1
+    .method private hidebysig static int32
+            Main() cil managed
+    {
+      .entrypoint
+      .maxstack  4
+      .locals (int32 V_0,
+               int32 V_1,
+               valuetype JitTest.RefComplexStruct V_2,
+               valuetype JitTest.SimpleStruct V_3)
+      IL_0000:  sizeof     JitTest.RefComplexStruct
+      IL_0006:  conv.i1
+      IL_0007:  conv.i4
+      IL_0008:  stloc.0
+      IL_0009:  ldloc.0
+      IL_000a:  sizeof     JitTest.RefComplexStruct
+      IL_0010:  ldloca.s   V_2
+      IL_0012:  initobj    JitTest.RefComplexStruct
+      IL_0018:  ldloc.2
+      IL_0019:  stloc.2
+      IL_001a:  ldloca.s   V_2
+      IL_001c:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss1
+      IL_0021:  stloc.3
+      IL_0022:  ldloca.s   V_3
+      IL_0024:  ldfld      int8 JitTest.SimpleStruct::m_sbyte
+      IL_0029:  conv.i4
+      IL_002a:  add
+      IL_002b:  add
+      IL_002c:  stloc.0
+      IL_002d:  ldloc.0
+      IL_002e:  ldc.i4     0x80
+      IL_0033:  ldloca.s   V_2
+      IL_0035:  initobj    JitTest.RefComplexStruct
+      IL_003b:  ldloc.2
+      IL_003c:  stloc.2
+      IL_003d:  ldloca.s   V_2
+      IL_003f:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss2
+      IL_0044:  stloc.3
+      IL_0045:  ldloca.s   V_3
+      IL_0047:  ldfld      unsigned int16 JitTest.SimpleStruct::m_ushort
+      IL_004c:  conv.i4
+      IL_004d:  sub
+      IL_004e:  sizeof     JitTest.RefComplexStruct
+      IL_0054:  sub
+      IL_0055:  sub
+      IL_0056:  stloc.0
+      IL_0057:  ldloc.0
+      IL_0058:  sizeof     JitTest.RefComplexStruct
+      IL_005e:  ldloca.s   V_2
+      IL_0060:  initobj    JitTest.RefComplexStruct
+      IL_0066:  ldloc.2
+      IL_0067:  stloc.2
+      IL_0068:  ldloca.s   V_2
+      IL_006a:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss1
+      IL_006f:  stloc.3
+      IL_0070:  ldloca.s   V_3
+      IL_0072:  ldfld      unsigned int32 JitTest.SimpleStruct::m_uint
+      IL_0077:  ldc.i4.1
+      IL_0078:  add
+      IL_0079:  mul
+      IL_007a:  mul
+      IL_007b:  stloc.0
+      IL_007c:  ldloc.0
+      IL_007d:  sizeof     JitTest.RefComplexStruct
+      IL_0083:  ldloca.s   V_2
+      IL_0085:  initobj    JitTest.RefComplexStruct
+      IL_008b:  ldloc.2
+      IL_008c:  stloc.2
+      IL_008d:  ldloca.s   V_2
+      IL_008f:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss2
+      IL_0094:  stloc.3
+      IL_0095:  ldloca.s   V_3
+      IL_0097:  ldfld      unsigned int64 JitTest.SimpleStruct::m_ulong
+      IL_009c:  ldc.i4.1
+      IL_009d:  conv.i8
+      IL_009e:  add
+      IL_009f:  conv.i4
+      IL_00a0:  div
+      IL_00a1:  div
+      IL_00a2:  stloc.0
+      IL_00a3:  sizeof     JitTest.RefComplexStruct
+      IL_00a9:  ldc.i4.s   64
+      IL_00ab:  xor
+      IL_00ac:  ldloc.0
+      IL_00ad:  or
+      IL_00ae:  stloc.0
+      IL_00af:  sizeof     JitTest.RefComplexStruct
+      IL_00b5:  ldc.i4.s   -65
+      IL_00b7:  xor
+      IL_00b8:  ldloc.0
+      IL_00b9:  and
+      IL_00ba:  stloc.0
+      IL_00bb:  ldloc.0
+      IL_00bc:  ldc.i4.s   28
+      IL_00be:  add
+      IL_00bf:  stloc.1
+      IL_00c0:  br.s       IL_00c2
+      IL_00c2:  ldloc.1
+      IL_00c3:  ret
+    }
+  }
+}

--- a/tests/src/JIT/Methodical/xxobj/sizeof/sizeof64.il
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/sizeof64.il
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+// sizeof64.il
+.assembly extern mscorlib { }
+.assembly sizeof64 { }
+.custom instance void [mscorlib]System.Security.UnverifiableCodeAttribute::.ctor() = ( 01 00 00 00 ) 
+.namespace JitTest
+{
+  .class private sequential ansi sealed beforefieldinit SimpleStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field public int32 m_int
+    .field public unsigned int32 m_uint
+    .field public unsigned int8 m_byte
+    .field public int8 m_sbyte
+    .field public char m_char
+    .field public int16 m_short
+    .field public unsigned int16 m_ushort
+    .field public int64 m_long
+    .field public unsigned int64 m_ulong
+    .field public valuetype JitTest.SimpleStruct[0...] ss_array
+  }
+  .class private sequential ansi sealed beforefieldinit RefComplexStruct
+         extends [mscorlib]System.ValueType
+  {
+    .field public valuetype JitTest.SimpleStruct ss1
+    .field public valuetype JitTest.SimpleStruct[0...] ss_array
+    .field public valuetype JitTest.SimpleStruct ss2
+  }
+  .class private sequential ansi sealed beforefieldinit Test
+         extends [mscorlib]System.ValueType
+  {
+    .pack 1
+    .size 1
+    .method private hidebysig static int32
+            Main() cil managed
+    {
+      .entrypoint
+      .maxstack  4
+      .locals (int64 V_0,
+               int32 V_1,
+               valuetype JitTest.RefComplexStruct V_2,
+               valuetype JitTest.SimpleStruct V_3)
+      IL_0000:  sizeof     JitTest.RefComplexStruct
+      IL_0006:  conv.i1
+      IL_0007:  conv.i8
+      IL_0008:  stloc.0
+      IL_0009:  ldloc.0
+      IL_000a:  sizeof     JitTest.RefComplexStruct
+      IL_0010:  ldloca.s   V_2
+      IL_0012:  initobj    JitTest.RefComplexStruct
+      IL_0018:  ldloc.2
+      IL_0019:  stloc.2
+      IL_001a:  ldloca.s   V_2
+      IL_001c:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss1
+      IL_0021:  stloc.3
+      IL_0022:  ldloca.s   V_3
+      IL_0024:  ldfld      int8 JitTest.SimpleStruct::m_sbyte
+      IL_0029:  conv.i4
+      IL_002a:  add
+      IL_002b:  conv.i8
+      IL_002c:  add
+      IL_002d:  stloc.0
+      IL_002e:  ldloc.0
+      IL_002f:  ldc.i4     0x80
+      IL_0034:  conv.i8
+      IL_0035:  ldloca.s   V_2
+      IL_0037:  initobj    JitTest.RefComplexStruct
+      IL_003d:  ldloc.2
+      IL_003e:  stloc.2
+      IL_003f:  ldloca.s   V_2
+      IL_0041:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss2
+      IL_0046:  stloc.3
+      IL_0047:  ldloca.s   V_3
+      IL_0049:  ldfld      unsigned int16 JitTest.SimpleStruct::m_ushort
+      IL_004e:  conv.u8
+      IL_004f:  sub
+      IL_0050:  sizeof     JitTest.RefComplexStruct
+      IL_0056:  conv.i8
+      IL_0057:  sub
+      IL_0058:  sub
+      IL_0059:  stloc.0
+      IL_005a:  ldloc.0
+      IL_005b:  sizeof     JitTest.RefComplexStruct
+      IL_0061:  conv.i8
+      IL_0062:  ldloca.s   V_2
+      IL_0064:  initobj    JitTest.RefComplexStruct
+      IL_006a:  ldloc.2
+      IL_006b:  stloc.2
+      IL_006c:  ldloca.s   V_2
+      IL_006e:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss1
+      IL_0073:  stloc.3
+      IL_0074:  ldloca.s   V_3
+      IL_0076:  ldfld      unsigned int32 JitTest.SimpleStruct::m_uint
+      IL_007b:  ldc.i4.1
+      IL_007c:  add
+      IL_007d:  conv.u8
+      IL_007e:  mul
+      IL_007f:  mul
+      IL_0080:  stloc.0
+      IL_0081:  ldloc.0
+      IL_0082:  sizeof     JitTest.RefComplexStruct
+      IL_0088:  ldloca.s   V_2
+      IL_008a:  initobj    JitTest.RefComplexStruct
+      IL_0090:  ldloc.2
+      IL_0091:  stloc.2
+      IL_0092:  ldloca.s   V_2
+      IL_0094:  ldfld      valuetype JitTest.SimpleStruct JitTest.RefComplexStruct::ss2
+      IL_0099:  stloc.3
+      IL_009a:  ldloca.s   V_3
+      IL_009c:  ldfld      unsigned int64 JitTest.SimpleStruct::m_ulong
+      IL_00a1:  ldc.i4.1
+      IL_00a2:  conv.i8
+      IL_00a3:  add
+      IL_00a4:  conv.i4
+      IL_00a5:  div
+      IL_00a6:  conv.i8
+      IL_00a7:  div
+      IL_00a8:  stloc.0
+      IL_00a9:  sizeof     JitTest.RefComplexStruct
+      IL_00af:  ldc.i4.s   64
+      IL_00b1:  xor
+      IL_00b2:  conv.i8
+      IL_00b3:  ldloc.0
+      IL_00b4:  or
+      IL_00b5:  stloc.0
+      IL_00b6:  sizeof     JitTest.RefComplexStruct
+      IL_00bc:  ldc.i4.s   -65
+      IL_00be:  xor
+      IL_00bf:  conv.i8
+      IL_00c0:  ldloc.0
+      IL_00c1:  and
+      IL_00c2:  stloc.0
+      IL_00c3:  ldloc.0
+      IL_00c4:  ldc.i4.s   4
+      IL_00c6:  conv.i8
+      IL_00c7:  add
+      IL_00c8:  conv.i4
+      IL_00c9:  stloc.1
+      IL_00ca:  br.s       IL_00cc
+      IL_00cc:  ldloc.1
+      IL_00cd:  ret
+    }
+  }
+}

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -22,9 +22,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_rellocalloc\_il_rellocalloc.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_dbgsizeof64\_il_dbgsizeof64.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\global_il_d\global_il_d.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -61,9 +58,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads3_il_d\threads3_il_d.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_ro\dblarray4_cs_ro.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_cs_il\_dbgsin_cs_il.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -92,9 +86,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\Interop\ArrayMarshalling\BoolArray\MarshalBoolArrayTest\MarshalBoolArrayTest.cmd Timed Out">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_array_merge\_il_reli_array_merge.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\switch\switch11\switch11.cmd">
@@ -130,9 +121,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\badldsfld_il_r\badldsfld_il_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relsizeof\_il_relsizeof.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relpointer_i\_il_relpointer_i.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -157,12 +145,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b03689\b03689\b03689.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_dbgsizeof32\_il_dbgsizeof32.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_relsizeof\_il_relsizeof.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tls\mutualrecurthd-tls\mutualrecurthd-tls.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -176,9 +158,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b101136\b101136\b101136.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgsizeof\_il_dbgsizeof.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic3\rva_rvastatic3.cmd Timed Out">
@@ -223,9 +202,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\Threading\ThreadStatics\ThreadStatic06\ThreadStatic06.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_relsizeof32\_il_relsizeof32.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Serialization\Serialize\Serialize.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -245,9 +221,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_r\bleref_il_r.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_array_merge\_il_dbgu_array_merge.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgpointer_i\_il_dbgpointer_i.cmd">
@@ -289,9 +262,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u8div_cs_do\u8div_cs_do.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_do\dblarray4_cs_do.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_il_il\_odbgsin_il_il.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -308,9 +278,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_implicit\_il_reltest_implicit.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_r\dblarray4_cs_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15307\b15307\b15307.cmd">
@@ -364,12 +331,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\prefix\volatile\1\arglist\arglist.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_array_merge\_il_dbgi_array_merge.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_dbgsizeof\_il_dbgsizeof.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_il_il\_orelsin_il_il.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -386,9 +347,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\rva_rvastatic4\rva_rvastatic4.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_relsizeof64\_il_relsizeof64.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Tailcall\TailcallVerifyWithPrefix\TailcallVerifyWithPrefix.cmd">
@@ -409,9 +367,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_r\CircleInConvex_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_array_merge\_il_relu_array_merge.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_void\_il_dbgtest_void.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -428,9 +383,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_cs_il\_odbgsin_cs_il.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_d\dblarray4_cs_d.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102754\test2\test2.cmd">


### PR DESCRIPTION
Some tests were ported exclusively for x64 but originally had non-x64
variants, so I'm just completing the porting of those for x86.  For
dblarray4, it is supposed to run with an env var set.  The way this is
done is pretty ugly ("precommands"), and if we require more of this, we
should add a better way to do it to the test harness.

Fixes #3972 
Fixes part of #2877