### PR TITLE
[WIP] Handle different awk name & version among Linux distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,13 +238,64 @@ function(preprocess_def_file inputFilename outputFilename)
                               PROPERTIES GENERATED TRUE)
 endfunction()
 
+
 function(generate_exports_file inputFilename outputFilename)
+
+  # Calculate name and version of awk in Linux distribution
+  # .awk : Oldest version 
+  # .gawk: GNU Awk (Standard for modern Linux distribution)
+  # .mawk: Fast Awk (written by Mike Brennan for Debian, Gentoo)
+  # .nawk: New Awk (A new version of the program)
+  include(FindPackageHandleStandardArgs)
+  if(AWK_BIN)
+     set(AWK_FIND_QUIETLY TRUE)
+  endif(AWK_BIN)
+  set(AWK_NAMES awk gawk mawk nawk)
+  find_program(AWK_BIN NAMES ${AWK_NAMES})
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(AWK DEFAULT_MSG AWK_BIN)
+
+  if(AWK_FOUND)
+    EXECUTE_PROCESS(COMMAND ${AWK_BIN} -Wv
+    RESULT_VARIABLE RET_VALUE
+    OUTPUT_VARIABLE AWK_VERSION
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT${RET_VALUE} EQUAL 0 OR AWK_VERSION STREQUAL "")
+      EXECUTE_PROCESS(COMMAND ${AWK_BIN} --version
+      RESULT_VARIABLE RET_VALUE
+      OUTPUT_VARIABLE AWK_VERSION
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    endif(NOT${RET_VALUE} EQUAL 0 OR AWK_VERSION STREQUAL "")
+
+    if(${RET_VALUE} EQUAL 0)
+      string(REGEX REPLACE "\n.*" "" AWK_VERSION "${AWK_VERSION}")
+      if(NOT AWK_FIND_QUIETLY)
+        message(STATUS "AWK version: ${AWK_VERSION}")
+      endif(NOT AWK_FIND_QUIETLY)
+      string(REGEX REPLACE " " ";" AWK_VERSION "${AWK_VERSION}")
+      list(GET AWK_VERSION 0 FILTERED_AWK_INFO)  
+      list(GET AWK_VERSION 1 FILTERED_AWK_NAME)  
+      list(GET AWK_VERSION 2 FILTERED_AWK_VERSION)  
+    else(${RET_VALUE} EQUAL 0)
+      set(AWK_VERSION)
+    endif(${RET_VALUE} EQUAL 0)
+  else(AWK_FOUND)
+    set(AWK_BIN)
+    set(AWK_VERSION)
+  endif(AWK_FOUND)
 
   if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
     set(AWK_SCRIPT generateexportedsymbols.awk)
+  elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
+     if(FILTERED_AWK_INFO STREQUAL "GNU" AND FILTERED_AWK_NAME STREQUAL "Awk" AND FILTERED_AWK_VERSION VERSION_GREATER 4.0.0)
+        set(AWK_SCRIPT generateversionscript-gawk-400.awk)
+     else(FILTERED_AWK_INFO STREQUAL "GNU" AND FILTERED_AWK_NAME STREQUAL "Awk" AND FILTERED_AWK_VERSION VERSION_GREATER 4.0.0)
+        set(AWK_SCRIPT generateversionscript.awk)
+     endif()
   else()
     set(AWK_SCRIPT generateversionscript.awk)
-  endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  endif()
 
   add_custom_command(
     OUTPUT ${outputFilename}

--- a/generateversionscript-gawk-400.awk
+++ b/generateversionscript-gawk-400.awk
@@ -1,0 +1,19 @@
+BEGIN {
+	print "V1.0 {";
+	print "    global:";
+} 
+{ 
+	# Remove the CR character in case the sources are mapped from
+	# a Windows share and contain CRLF line endings
+	gsub(/\r/,"", $0);
+	
+	# Skip empty lines and comment lines starting with semicolon
+	if (NF && !match($0, /^[[:space:]]*;/))
+	{
+		print "        "  $0 ";";
+	}
+} 
+END {
+	print "    local: *;"
+	print "};";
+}


### PR DESCRIPTION
ver2:
With ver1, the build-break is caused by different awk versions (by @jkotas).
(Revert PR - https://github.com/dotnet/coreclr/pull/4005)
To resolve the limitation of the ver1, @janvorli proposed that the
\S expression is better than [:space:] for the most compatible solution.
There are a lot of different AWK software (e.g. awk, gawk, mawk, nawk, etc)
and versions among the popular Linux distributions. Let's make the infrastructure
to check the different AWK name and version among the popular Linux distributions.

ver1:
It's must be modified by gawk implementation that check it exactly
as a plain character (e.g., space, alnum) within the bracket expression
at ./coreclr/generateversionscript.awk. The [[:space:]] is more appropriate than
the [:space:]]. (PR - https://github.com/dotnet/coreclr/pull/3943)

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
Signed-off-by: Prajwal A N <an.prajwal@samsung.com>