### PR TITLE
Generate map files for symbol resolution for Linux native images on PerfView

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -115,6 +115,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     peimage.cpp
     peimagelayout.cpp
     perfmap.cpp
+    perfinfo.cpp
     precode.cpp
     prestub.cpp
     rejit.cpp

--- a/src/vm/crossgen/CMakeLists.txt
+++ b/src/vm/crossgen/CMakeLists.txt
@@ -150,6 +150,7 @@ endif (WIN32)
 if (CLR_CMAKE_PLATFORM_LINUX)
   list(APPEND VM_CROSSGEN_SOURCES
     ../perfmap.cpp
+    ../perfinfo.cpp
   )
 endif (CLR_CMAKE_PLATFORM_LINUX)
 

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -1310,11 +1310,6 @@ void DomainFile::FinishLoad()
         // Inform metadata that it has been loaded from a native image
         // (and so there was an opportunity to check for or fix inconsistencies in the original IL metadata)
         m_pFile->GetMDImport()->SetVerifiedByTrustedSource(TRUE);
-
-#ifdef FEATURE_PERFMAP
-        // Notify the perfmap of the native image load.
-        PerfMap::LogNativeImageLoad(m_pFile);
-#endif
     }
 
     // Are we absolutely required to use a native image?
@@ -1382,6 +1377,11 @@ void DomainFile::FinishLoad()
     // Set a bit to indicate that the module has been loaded in some domain, and therefore
     // typeloads can involve types from this module. (Used for candidate instantiations.)
     GetModule()->SetIsReadyForTypeLoad();
+
+#ifdef FEATURE_PERFMAP
+    // Notify the perfmap of the IL image load.
+    PerfMap::LogImageLoad(m_pFile);
+#endif
 }
 
 void DomainFile::VerifyExecution()

--- a/src/vm/perfinfo.cpp
+++ b/src/vm/perfinfo.cpp
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ===========================================================================
+// File: perfinfo.cpp
+//
+
+#include "common.h"
+
+#if defined(FEATURE_PERFMAP) && !defined(DACCESS_COMPILE)
+#include "perfinfo.h"
+#include "pal.h"
+
+PerfInfo::PerfInfo(int pid)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    SString tempPath;
+    if (!WszGetTempPath(tempPath))
+    {
+        return;
+    }
+
+    SString path;
+    path.Printf("%Sperfinfo-%d.map", tempPath.GetUnicode(), pid);
+    OpenFile(path);
+}
+
+// Logs image loads into the process' perfinfo-%d.map file
+void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+        PRECONDITION(pFile != NULL);
+        PRECONDITION(guid != NULL);
+    } CONTRACTL_END;
+
+    SString value;
+    const SString& path = pFile->GetPath();
+    value.Printf("%S%c%S", path.GetUnicode(), sDelimiter, guid);
+
+    SString command;
+    command.Printf("%s", "ImageLoad");
+    WriteLine(command, value);
+
+}
+
+// Writes a command line, with "type" being the type of command, with "value" as the command's corresponding instructions/values. This is to be used to log specific information, e.g. LogImage
+void PerfInfo::WriteLine(SString& type, SString& value)
+{
+
+    CONTRACTL    
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+    } CONTRACTL_END;
+
+    if (m_Stream == NULL)
+    {
+        return;
+    }
+
+    SString line;
+    line.Printf("%S%c%S%c\n",
+            type.GetUnicode(), sDelimiter, value.GetUnicode(), sDelimiter);
+
+    EX_TRY
+    {
+        StackScratchBuffer scratch;
+        const char* strLine = line.GetANSI(scratch);
+        ULONG inCount = line.GetCount();
+        ULONG outCount;
+
+        m_Stream->Write(strLine, inCount, &outCount);
+
+        if (inCount != outCount)
+        {
+            // error encountered
+        }
+    }
+    EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
+}
+
+// Opens a file ready to be written in.
+void PerfInfo::OpenFile(SString& path)
+{
+    STANDARD_VM_CONTRACT;
+
+    m_Stream = new (nothrow) CFileStream();
+
+    if (m_Stream != NULL)
+    {
+        HRESULT hr = m_Stream->OpenForWrite(path.GetUnicode());
+        if (FAILED(hr))
+        {
+            delete m_Stream;
+            m_Stream = NULL;
+        }
+    }
+}
+
+PerfInfo::~PerfInfo()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    delete m_Stream;
+    m_Stream = NULL;
+}
+
+
+#endif
+
+
+
+
+
+
+
+
+
+

--- a/src/vm/perfinfo.h
+++ b/src/vm/perfinfo.h
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ===========================================================================
+// File: perfinfo.h
+//
+
+#ifndef PERFINFO_H
+#define PERFINFO_H
+
+
+#include "sstring.h"
+#include "fstream.h"
+
+/*
+   A perfinfo-%d.map is created for every process that is created with manage code, the %d
+   being repaced with the process ID.
+   Every line in the perfinfo-%d.map is a type and value, separated by sDelimiter character: type;value
+   type represents what the user might want to do with its given value. value has a format chosen by
+   the user for parsing later on.
+*/
+class PerfInfo {
+public:
+    PerfInfo(int pid);
+    ~PerfInfo();
+    void LogImage(PEFile* pFile, WCHAR* guid); 
+
+private:
+    CFileStream* m_Stream;
+
+    const char sDelimiter = ';';
+
+    void OpenFile(SString& path);
+
+    void WriteLine(SString& type, SString& value);
+
+};
+
+
+#endif

--- a/src/vm/perfmap.h
+++ b/src/vm/perfmap.h
@@ -10,6 +10,8 @@
 #include "sstring.h"
 #include "fstream.h"
 
+class PerfInfo;
+
 // Generates a perfmap file.
 class PerfMap
 {
@@ -19,6 +21,9 @@ private:
 
     // The file stream to write the map to.
     CFileStream * m_FileStream;
+
+    // The perfinfo file to log images to.
+    PerfInfo* m_PerfInfo;
 
     // Set to true if an error is encountered when writing to the file.
     bool m_ErrorEncountered;
@@ -43,10 +48,10 @@ protected:
     // Does the actual work to log a method to the map.
     void LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize);
 
-    // Does the actual work to log a native image load to the map.
-    void LogNativeImage(PEFile * pFile);
+    // Does the actual work to log an image
+    void LogImage(PEFile * pFile);
 
-    // Get the native image signature and store it as a string.
+    // Get the image signature and store it as a string.
     static void GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned int nSigSize);
 
 public:
@@ -54,7 +59,7 @@ public:
     static void Initialize();
 
     // Log a native image load to the map.
-    static void LogNativeImageLoad(PEFile * pFile);
+    static void LogImageLoad(PEFile * pFile);
 
     // Log a JIT compiled method to the map.
     static void LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize);


### PR DESCRIPTION
We are trying to enable performance investigations for Linux on Windows through PerfView.

Part of this plan requires the ability to map unknown symbols to their resolved symbols from the running program's native images. We do this by having the CoreCLR generate perfinfo-%d.map files (where %d is the running process' ID). perfinfo-%.map files that contain all the dlls loaded for the specific process and this helps us generate map files with symbol mappings for all managed code dlls.