### PR TITLE
Safe refactoring changes and code cleanup items

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -426,14 +426,15 @@ var_types    Compiler::getJitGCType(BYTE gcType)
 }
 
 #if FEATURE_MULTIREG_ARGS
-//------------------------------------------------------------------------
-// getStructGcPtrsFromOp: Given a GenTree node of TYP_STRUCT that represents a pass by value argument
-//                        return the gcPtr layout for the pointers sized fields //
+//---------------------------------------------------------------------------
+// getStructGcPtrsFromOp: Given a GenTree node of TYP_STRUCT that represents
+//                        a pass by value argument, return the gcPtr layout 
+//                        for the pointers sized fields 
 // Arguments:
 //    op         - the operand of TYP_STRUCT that is passed by value
 //    gcPtrsOut  - an array of BYTES that are written by this method
 //                 they will contain the VM's CorInfoGCType values 
-//                 for each pointer sized field//
+//                 for each pointer sized field
 // Return Value:
 //     Two [or more] values are written into the gcPtrs array
 //

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2030,6 +2030,7 @@ public:
     void                    gtGetLateArgMsg (GenTreePtr             call,
                                              GenTreePtr             arg,
                                              int                    argNum,
+                                             int                    listCount,
                                              char*                  bufp,
                                              unsigned               bufLength);
     void                    gtDispArgList   (GenTreePtr              tree, 

--- a/src/jit/error.h
+++ b/src/jit/error.h
@@ -92,7 +92,7 @@ extern void notYetImplemented(const char * msg, const char * file, unsigned line
 
 #ifdef _TARGET_AMD64_
 
-#define NYI_AMD64(msg)    notYetImplemented("NYI: " # msg, __FILE__, __LINE__)
+#define NYI_AMD64(msg)    notYetImplemented("NYI_AMD64: " # msg, __FILE__, __LINE__)
 #define NYI_X86(msg)      do { } while (0)
 #define NYI_ARM(msg)      do { } while (0)
 #define NYI_ARM64(msg)    do { } while (0)
@@ -100,7 +100,7 @@ extern void notYetImplemented(const char * msg, const char * file, unsigned line
 #elif defined(_TARGET_X86_)
 
 #define NYI_AMD64(msg)    do { } while (0)
-#define NYI_X86(msg)      notYetImplemented("NYI: " # msg, __FILE__, __LINE__)
+#define NYI_X86(msg)      notYetImplemented("NYI_X86: " # msg, __FILE__, __LINE__)
 #define NYI_ARM(msg)      do { } while (0)
 #define NYI_ARM64(msg)    do { } while (0)
 
@@ -108,7 +108,7 @@ extern void notYetImplemented(const char * msg, const char * file, unsigned line
 
 #define NYI_AMD64(msg)    do { } while (0)
 #define NYI_X86(msg)      do { } while (0)
-#define NYI_ARM(msg)      notYetImplemented("NYI: " # msg, __FILE__, __LINE__)
+#define NYI_ARM(msg)      notYetImplemented("NYI_ARM: " # msg, __FILE__, __LINE__)
 #define NYI_ARM64(msg)    do { } while (0)
 
 #elif defined(_TARGET_ARM64_)
@@ -116,7 +116,7 @@ extern void notYetImplemented(const char * msg, const char * file, unsigned line
 #define NYI_AMD64(msg)    do { } while (0)
 #define NYI_X86(msg)      do { } while (0)
 #define NYI_ARM(msg)      do { } while (0)
-#define NYI_ARM64(msg)    notYetImplemented("NYI: " # msg, __FILE__, __LINE__)
+#define NYI_ARM64(msg)    notYetImplemented("NYI_ARM64: " # msg, __FILE__, __LINE__)
 
 #else
 

--- a/src/jit/host.h
+++ b/src/jit/host.h
@@ -51,13 +51,7 @@ extern  "C"
 void    __cdecl     assertAbort(const char *why, const char *file, unsigned line);
 
 #undef  assert
-// TODO-ARM64-NYI: Temporarily make all asserts in the JIT use the NYI code path
-#ifdef _TARGET_ARM64_
-extern void notYetImplemented(const char * msg, const char * file, unsigned line);
-#define assert(p)   (void)((p) || (notYetImplemented("assert: " #p, __FILE__, __LINE__),0))
-#else
 #define assert(p)   (void)((p) || (assertAbort(#p, __FILE__, __LINE__),0))
-#endif
 
 #else // DEBUG
 

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1819,7 +1819,7 @@ unsigned   Compiler::lvaGetFieldLocal(LclVarDsc *  varDsc, unsigned int fldOffse
         }
     }
 
-    noway_assert(!"Cannot find field local.");
+    // This is the not-found error return path, the caller should check for BAD_VAR_NUM
     return BAD_VAR_NUM;
 }
 
@@ -2770,9 +2770,9 @@ void                LclVarDsc::lvaDisqualifyVar()
 #endif // ASSERTION_PROP
 
 #ifndef LEGACY_BACKEND
-/********************************************************************************** 
- * Get type of a variable when passed as an argument.
- */
+/**********************************************************************************
+* Get type of a variable when passed as an argument.
+*/
 var_types           LclVarDsc::lvaArgType()
 {
     var_types type = TypeGet();
@@ -2782,29 +2782,33 @@ var_types           LclVarDsc::lvaArgType()
     {
         switch (lvExactSize)
         {
-           case 1: type = TYP_BYTE;  break;
-           case 2: type = TYP_SHORT; break;
-           case 4: type = TYP_INT;   break;
-           case 8:
-              switch (*lvGcLayout)
-              {
-                 case TYPE_GC_NONE:
-                    type = TYP_I_IMPL;
-                    break;
-                 case TYPE_GC_REF:
-                    type = TYP_REF;
-                    break;
-                 case TYPE_GC_BYREF:
-                    type = TYP_BYREF;
-                    break;
-                 default:
-                    unreached();
-              }
-              break;
+        case 1: type = TYP_BYTE;  break;
+        case 2: type = TYP_SHORT; break;
+        case 4: type = TYP_INT;   break;
+        case 8:
+            switch (*lvGcLayout)
+            {
+            case TYPE_GC_NONE:
+                type = TYP_I_IMPL;
+                break;
 
-           default:
-               type = TYP_BYREF;
-               break;
+            case TYPE_GC_REF:
+                type = TYP_REF;
+                break;
+
+            case TYPE_GC_BYREF:
+                type = TYP_BYREF;
+                break;
+
+            default:
+                unreached();
+            }
+            break;
+
+        default:
+            type = TYP_BYREF;
+            break;
+
         }
     }
 #else

--- a/src/jit/lower.h
+++ b/src/jit/lower.h
@@ -77,7 +77,7 @@ private:
     GenTree* LowerVirtualVtableCall   (GenTreeCall* call);
     GenTree* LowerVirtualStubCall     (GenTreeCall* call);
     void     LowerArgsForCall         (GenTreeCall* call);
-    GenTree* NewPutArg                (GenTreeCall* call, GenTreePtr arg, fgArgTabEntryPtr fp, var_types type);
+    GenTree* NewPutArg                (GenTreeCall* call, GenTreePtr arg, fgArgTabEntryPtr info, var_types type);
     void     LowerArg                 (GenTreeCall* call, GenTreePtr *ppTree);
     void     InsertPInvokeCallProlog  (GenTreeCall* call);
     void     InsertPInvokeCallEpilog  (GenTreeCall* call);

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2932,7 +2932,6 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
         unsigned argAlign = 1;
 
 #ifdef _TARGET_ARM_
-
         var_types hfaType = GetHfaType(argx);
         bool isHfaArg = varTypeIsFloating(hfaType);
 #endif // _TARGET_ARM_
@@ -4067,7 +4066,7 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
                     arg->gtOp.gtOp1->AsLclVarCommon() : arg->AsLclVarCommon();
                 if (fgEntryPtr->structDesc.passedInRegisters)
                 {
-                    if (fgEntryPtr->structDesc.eightByteCount == 1) 
+                    if (fgEntryPtr->structDesc.eightByteCount == 1)
                     {
                         // Change the type and below the code will change the LclVar to a LCL_FLD
                         type = GetTypeFromClassificationAndSizes(fgEntryPtr->structDesc.eightByteClassifications[0], fgEntryPtr->structDesc.eightByteSizes[0]);
@@ -4084,6 +4083,7 @@ void Compiler::fgMorphSystemVStructArgs(GenTreeCall* call, bool hasStructArgumen
                                 fgEntryPtr->structDesc.eightByteSizes[1]),
                             lclCommon->gtLclNum,
                             fgEntryPtr->structDesc.eightByteOffsets[1]);
+                        // Note this should actually be: secondNode = gtNewArgList(newLclField)
                         GenTreeArgList* secondNode = gtNewListNode(newLclField, nullptr);
                         secondNode->gtType = originalType; // Preserve the type. It is a special case.
                         newLclField->gtFieldSeq = FieldSeqStore::NotAField();
@@ -11054,7 +11054,7 @@ CM_ADD_OP:
                 }
 
                 // We will turn a GT_LCL_VAR into a GT_LCL_FLD with an gtLclOffs of 'ival'
-                // ot if we already have a GT_LCL_FLD we will adjust the gtLclOffs by adding 'ival'
+                // or if we already have a GT_LCL_FLD we will adjust the gtLclOffs by adding 'ival'
                 // Then we change the type of the GT_LCL_FLD to match the orginal GT_IND type.
                 //
                 if (temp->OperGet() == GT_LCL_FLD)
@@ -15255,7 +15255,7 @@ void                Compiler::fgPromoteStructs()
                 {
                     if (structPromotionInfo.fieldCnt != 1)
                     {
-                        JITDUMP("Not promoting promotable struct local V%02u, because lvIsParam are true and #fields = %d.\n",
+                        JITDUMP("Not promoting promotable struct local V%02u, because lvIsParam is true and #fields = %d.\n",
                                 lclNum, structPromotionInfo.fieldCnt);
                         continue;
                     }
@@ -15333,6 +15333,7 @@ Compiler::fgWalkResult      Compiler::fgMorphStructField(GenTreePtr tree, fgWalk
                         // Promoted struct
                         unsigned fldOffset     = tree->gtField.gtFldOffset;
                         unsigned fieldLclIndex = lvaGetFieldLocal(varDsc, fldOffset);
+                        noway_assert(fieldLclIndex != BAD_VAR_NUM);
 
                         tree->SetOper(GT_LCL_VAR);
                         tree->gtLclVarCommon.SetLclNum(fieldLclIndex);
@@ -15434,6 +15435,7 @@ Compiler::fgWalkResult      Compiler::fgMorphLocalField(GenTreePtr tree, fgWalkD
         if (fldOffset != BAD_VAR_NUM)
         {
             fieldLclIndex = lvaGetFieldLocal(varDsc, fldOffset);
+            noway_assert(fieldLclIndex != BAD_VAR_NUM);
             fldVarDsc = &lvaTable[fieldLclIndex];
         }
 


### PR DESCRIPTION
Fixed the dumper so that GT_LCL_VAR and GT_LCL_FLD use a common code path
and we now  display (last use) correctly
Moved the checking for invalid GT_LISTs with an op1 arg of a GT_LIST from gtNewArgList to the constructor and called IsListForMultiRegArg in the new assert
Renamed IsListofLclFlds to IsListForMultiRegArgs and added ARM64 support
Modifed the dump to display the GTF_MORPHED flag using a '+' when we don't have a GTF_ORDER_SIDEEFF flag
Fix dumper's gtGetLateArgMsg to display each register for a multireg struct passed using a GT_LIST
Modified the NYI_<target> macros to include the target in their message
Fixed the gtCosts for GT_LIST, GT_OBJ, GT_MKREFANY and GT_BOX nodes
When we construct a new GT_LCL_FLD, initialize the gtFieldSeq to NotAField rather than nullptr
Fix comment header for getStructGcPtrsFromOp
Removed the define on ARM64 that changed the asserts(p) macro to notYetImplemented
In NewPutArg renamed the "fp" argument to be called "info" instead