### PR TITLE
Disabling the object as variant in struct marshalling scenario

### DIFF
--- a/tests/src/Interop/MarshalAPI/OffsetOf/OffsetOf.cs
+++ b/tests/src/Interop/MarshalAPI/OffsetOf/OffsetOf.cs
@@ -315,19 +315,21 @@ public class OffsetTest
             Assert.Fail(string.Format("Unexpected value '{0}' for IntPtr.Size", IntPtr.Size));
         }
     }
-    
-      public static int Main(String[] args) { 
-          TestFieldAlignment_Variant();
-          TestFieldAlignment_Guid();
-          TestFieldAlignment_Decimal();  
-          TestFieldAlignment();   
-          TestExplicitLayout(); 
-          ClassSequentialField();  
-          NullParameter(); 
-          NonExistField();
-          NoLayoutClass(); 
-          StructField();
-          ClassExplicitField(); 
-          return 100;         
-      }
+
+    public static int Main(String[] args)
+    {
+        //https://github.com/dotnet/coreclr/issues/2075  
+        //TestFieldAlignment_Variant();
+        TestFieldAlignment_Guid();
+        TestFieldAlignment_Decimal();
+        TestFieldAlignment();
+        TestExplicitLayout();
+        ClassSequentialField();
+        NullParameter();
+        NonExistField();
+        NoLayoutClass();
+        StructField();
+        ClassExplicitField();
+        return 100;
+    }
 }

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -173,7 +173,6 @@ JIT/Regression/Dev11/External/dev11_145295/CSharpPart/CSharpPart.sh
 Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest/MarshalArrayByValTest.sh
 Interop/StringMarshalling/LPSTR/LPSTRTest/LPSTRTest.sh
 Interop/StringMarshalling/LPTSTR/LPTSTRTest/LPTSTRTest.sh
-Interop/MarshalAPI/OffsetOf/OffsetOf/OffsetOf.sh
 Interop/MarshalAPI/Miscellaneous/MarshalClassTests/MarshalClassTests.sh
 GC/API/WeakReference/Finalize2/Finalize2.sh
 GC/API/WeakReference/NullHandle/NullHandle.sh


### PR DESCRIPTION
Disabled by https://github.com/dotnet/coreclr/issues/2075