### PR TITLE
Adding Common versioning to managed and Native components of coreclr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -698,6 +698,7 @@ set(CMAKE_CXX_STANDARD_LIBRARIES "") # do not link against standard win32 libs i
 
 # Include the basic prebuilt headers - required for getting fileversion resource details.
 include_directories("src/pal/prebuilt/inc")
+include_directories("bin/obj")
 
 if (CLR_CMAKE_PLATFORM_UNIX)
   include_directories("src/pal/inc")

--- a/build.cmd
+++ b/build.cmd
@@ -268,6 +268,9 @@ REM === Start the build steps
 REM ===
 REM =========================================================================================
 
+:: Generate _version.h
+if exist "%__RootBinDir%\obj\_version.h" del "%__RootBinDir%\obj\_version.h"
+%_msbuildexe% "%__ProjectFilesDir%\build.proj" /t:GenerateVersionHeader /p:NativeVersionHeaderFile="%__RootBinDir%\obj\_version.h" /p:GenerateVersionHeader=true
 if defined __MscorlibOnly goto PerformMScorlibBuild
 
 if defined __SkipNativeBuild (

--- a/dir.props
+++ b/dir.props
@@ -76,11 +76,13 @@
 
   <!-- Output paths -->
   <PropertyGroup>
-    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)obj</BaseIntermediateOutputPath>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)' == ''">$(RootBinDir)obj/</BaseIntermediateOutputPath>
     <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(BuildType)</IntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)' == ''">$(BaseIntermediateOutputPath)\$(BuildOS).$(BuildArch).$(BuildType)</OutputPath>
     <FinalOutputPath Condition="'$(FinalOutputPath)' == ''">$(BinDir)</FinalOutputPath>
   </PropertyGroup>
+
+  <Import Condition="Exists('$(ToolsDir)BuildVersion.targets')" Project="$(ToolsDir)BuildVersion.targets" />
   
   <!-- Import Build tools common props file where repo-independent properties are found -->  
   <Import Condition="Exists('$(ToolsDir)Build.Common.props')" Project="$(ToolsDir)Build.Common.props" />  

--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -181,6 +181,8 @@
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)Tools\Versioning\GenerateVersionInfo.targets"/>
+  <!-- Override versioning targets -->
+  <Import Project="$(ToolsDir)versioning.targets" />
   <Import Project="GenerateSplitStringResources.targets"/>
   <Import Project="GenerateCompilerResponseFile.targets"/>
   <Import Project="$(PostProcessingToolsPath)" />

--- a/src/pal/prebuilt/inc/fxver.rc
+++ b/src/pal/prebuilt/inc/fxver.rc
@@ -31,6 +31,10 @@
 /*                                                               */
 /*---------------------------------------------------------------*/
 
+#ifdef _WIN32
+#include <_version.h>
+#endif //_WIN32
+
 #ifdef RC_INVOKED
 
 VS_VERSION_INFO VERSIONINFO


### PR DESCRIPTION
Adding the new common versioning to the managed and Native(*Windows only*) components of coreclr. This will enable same versioning as internal builds use today, when building in the open.

CC: @weshaggard @gkhanna79