### PR TITLE
Fix COMPlus_JitHalt on Unix by not calling _DbgBreakCheck()

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4646,7 +4646,7 @@ void Compiler::compCompileFinish()
     {
         if (compJitHaltMethod())
         {
-#ifndef _TARGET_ARM64_
+#if !defined(_TARGET_ARM64_) && !defined(PLATFORM_UNIX)
             // TODO-ARM64-NYI: re-enable this when we have an OS that supports a pop-up dialog
 
             // Don't do an assert, but just put up the dialog box so we get just-in-time debugger


### PR DESCRIPTION
Without this, we end up calling TerminateProcess instead of just breaking at the injected 'int 3' when in a debugger.

@briansull @dotnet/jit-contrib PTAL