### PR TITLE
Handle 'mscorwks_unixexports.src' with better regexp operator for compatibility

### DIFF
--- a/generateversionscript.awk
+++ b/generateversionscript.awk
@@ -8,7 +8,7 @@ BEGIN {
 	gsub(/\r/,"", $0);
 	
 	# Skip empty lines and comment lines starting with semicolon
-	if (NF && !match($0, /^[:space:]*;/))
+	if (NF && !match($0, /^[ \t]*;/))
 	{
 		print "        "  $0 ";";
 	}


### PR DESCRIPTION
ver3:
According to the gawk manual, The '\S' operator (as shorthand for '[^[:space:]]')
matches any character that is not whitespace. However, '[ \t]' is better than
'\S' for Mac OSX.
(source - https://www.gnu.org/software/gawk/manual/html_node/GNU-Regexp-Operators.html )

ver2:
With ver1, the build-break is caused by different awk versions (by @jkotas).
(Revert PR - https://github.com/dotnet/coreclr/pull/4005)
To resolve the limitation of the ver1, @janvorli proposed that the
\S expression is better than [:space:] for the most compatible solution.

There are a lot of different AWK software (e.g. awk, gawk, mawk, nawk, etc)
and versions among the popular Linux distributions. This patch is a simply
way to handle 'mscorwks_unixexports.src' file with \S operator for more
compatibility amon the different awk versions.

ver1:
It's must be modified by gawk implementation that check it exactly
as a plain character (e.g., space, alnum) within the bracket expression
at ./coreclr/generateversionscript.awk. The [[:space:]] is more appropriate than
the [:space:]]. (PR - https://github.com/dotnet/coreclr/pull/3943)

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>
Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>
Signed-off-by: Prajwal A N <an.prajwal@samsung.com>