### PR TITLE
Fix a bug in the code for inserting a tree in the linear order.

### DIFF
--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -18625,6 +18625,13 @@ void Compiler::fgInsertTreeInListBefore(GenTree* tree, GenTree* insertionPoint, 
     if (beforeTree != nullptr)
     {
         beforeTree->gtNext = first;
+
+        // If the insertionPoint is the gtStatementList,
+        // update the gtStatemenList to include the newly inserted tree.
+        if (stmt->gtStmtList == insertionPoint)
+        {
+            stmt->gtStmtList = first;
+        }
     }
     else
     {

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -324,13 +324,13 @@ Compiler::fgSpliceTreeBefore(BasicBlock* block, GenTreeStmt* insertionPoint, Gen
 }
 
 //------------------------------------------------------------------------------
-// fgMakeEmbeddedStmt: insert the given subtree as an embedded statement 
+// fgMakeEmbeddedStmt: insert the given subtree as an embedded statement
 //
 // Arguments:
 //    block - The block containing the parentStmt, into which the new embedded
 //            statement will go
 //    tree  - The tree that will be the gtStmtExpr of the new embedded statement
-//    parentStmt - The top-level statement that 'tree' is embedded in
+//    parentStmt - A statement (top-level or embedded) that 'tree' is fully contained in
 //
 // Return Value:
 //    A pointer to the new statement.


### PR DESCRIPTION
Fix a bug in the code for inserting a tree in the linear order.

A long standing issue in the Compiler::fgInsertTreeInListBefore method was
found where the gtStmtList of a statement was not updated when a tree is
inserted before the first statement in the list (stmt->gtStmtList ==
insertionPoint). In such case the gtStmtList is not updated to include the
new tree(s) inserted.

After talking to few people offline to understand where this fix should be made
and realizing that the comment on Compiler::fgMakeEmbeddedStmt is
incorrect, I made the necessary fix in Compiler::fgInsertTreeInListBefore
so the newly inserted tree(s) in included in the gtStmtList of the updated
stmt.

Fixes 3618.