### PR TITLE
Leave Function Name Symbols in Release Binaries For Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ function(strip_symbols targetName outputFilename)
           POST_BUILD
           VERBATIM 
           COMMAND ${OBJCOPY} --only-keep-debug ${strip_source_file} ${strip_destination_file}
-          COMMAND ${OBJCOPY} --strip-unneeded ${strip_source_file}
+          COMMAND ${OBJCOPY} --strip-debug ${strip_source_file}
           COMMAND ${OBJCOPY} --add-gnu-debuglink=${strip_destination_file} ${strip_source_file}
           COMMENT Stripping symbols from ${strip_source_file} into file ${strip_destination_file}
         )


### PR DESCRIPTION
This change causes function name symbols to remain in release binaries when debug information is stripped on Linux.  This is a temporary change until symbol download work has been completed.

Symbols work is tracked by https://github.com/dotnet/coreclr/issues/4090 and https://github.com/dotnet/coreclr/issues/4091.