### PR TITLE
Enabling execution of Perflab perf tests

### DIFF
--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -393,7 +393,7 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
 {
   "dependencies": {
     "Microsoft.NETCore.Runtime.CoreCLR": "$(CoreclrPackageVersion)",
-    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23816",
+    "Microsoft.NETCore.TestHost": "1.0.0-rc2-23816"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/tests/src/performance/perflab/project.json
+++ b/tests/src/performance/perflab/project.json
@@ -1,9 +1,14 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029",
+    "Microsoft.DotNet.xunit.performance.analysis": "1.0.0-alpha-build0029",		
+    "Microsoft.DotNet.xunit.performance.runner.Windows": "1.0.0-alpha-build0029",
     "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
+    "System.Console": "4.0.0-rc2-23816",
     "System.Reflection": "4.0.10",
     "xunit": "2.1.0",
-    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0029"
+    "xunit.console.netcore": "1.0.2-prerelease-00101",
+    "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
     "dnxcore50": {


### PR DESCRIPTION
Adding project dependencies to perflab so that AssemblyList.txt generated will contain all the dependencies to actually run the tests on the end machine

@lt72 @brianrob