### PR TITLE
Fix for bad *nix optimization in CopyObj morphing.

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -8236,12 +8236,7 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
             // Spill the (complex) address to a BYREF temp.
             // Note, at most one address may need to be spilled.
             addrSpillTemp = lvaGrabTemp(true DEBUGARG("BlockOp address local"));
-#ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
-            lvaTable[addrSpillTemp].lvType = TYP_I_IMPL;
 
-            tree = gtNewAssignNode(gtNewLclvNode(addrSpillTemp, TYP_I_IMPL),
-                                   addrSpill);
-#else // !FEATURE_UNIX_AMD64_STRUCT_PASSING
             lvaTable[addrSpillTemp].lvType = TYP_BYREF;
 
             if (addrSpillIsStackDest)
@@ -8251,7 +8246,6 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
 
             tree = gtNewAssignNode(gtNewLclvNode(addrSpillTemp, TYP_BYREF),
                                    addrSpill);
-#endif // !FEATURE_UNIX_AMD64_STRUCT_PASSING
 
 #ifndef LEGACY_BACKEND
             // If we are assigning the address of a LclVar here 


### PR DESCRIPTION
A bad optimization for*nix was introduced some time ago which is
incorrectly setting the type of a temp var created for spilling.
This cahne removes this optimization and uses the same code used for all
other OSs.