### PR TITLE
Fix Internal builds where ToolsDir doesn't exist

### DIFF
--- a/src/mscorlib/mscorlib.csproj
+++ b/src/mscorlib/mscorlib.csproj
@@ -182,7 +182,7 @@
 
   <Import Project="$(MSBuildThisFileDirectory)Tools\Versioning\GenerateVersionInfo.targets"/>
   <!-- Override versioning targets -->
-  <Import Project="$(ToolsDir)versioning.targets" />
+  <Import Condition="Exists('$(ToolsDir)versioning.targets')" Project="$(ToolsDir)versioning.targets" />
   <Import Project="GenerateSplitStringResources.targets"/>
   <Import Project="GenerateCompilerResponseFile.targets"/>
   <Import Project="$(PostProcessingToolsPath)" />


### PR DESCRIPTION
I forgot to add this condition in my previous PR, so adding it now so that internal builds won't fail.

cc: @weshaggard @gkhanna79