### PR TITLE
Delete junk attributes in tests

### DIFF
--- a/tests/src/JIT/Directed/coverage/importer/Desktop/badendfinally.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/badendfinally.il
@@ -1,5 +1,5 @@
 .assembly extern mscorlib {}
-.assembly badendfinally {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly badendfinally { }
 .method public static int32 f() noinlining
 {
 endfinally

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/badldsfld.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/badldsfld.il
@@ -1,6 +1,6 @@
 
 .assembly extern mscorlib {}
-.assembly badldslfd {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly badldslfd { }
 .class Test extends [mscorlib]System.Object
 {
 .field int32 i

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/badtailcall.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/badtailcall.il
@@ -1,5 +1,5 @@
 .assembly extern mscorlib {}
-.assembly badtailcall {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly badtailcall { }
 .method public static int32 f()
 {
 ldc.i4 100

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/bleref.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/bleref.il
@@ -5,7 +5,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly bleref {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly bleref { }
 .method public static int32 f()
 {
 ldnull

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/byrefsubbyref1.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/byrefsubbyref1.il
@@ -9,7 +9,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly byrefsubbyref1 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly byrefsubbyref1 { }
 .class a extends [mscorlib]System.Object
 {
 .field static class ctest S_1

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/calli2.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/calli2.il
@@ -1,5 +1,5 @@
 .assembly extern legacy library mscorlib {}
-.assembly legacy library calli2 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library calli2 { }
 .class private auto ansi beforefieldinit calli2
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ceeillegal.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ceeillegal.il
@@ -6,7 +6,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly ceeillegal {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly ceeillegal { }
 .method public static void f()
 {
 .emitbyte 0xee

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ldelemnullarr1.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ldelemnullarr1.il
@@ -7,7 +7,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly legacy library ldelemnullarr1 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library ldelemnullarr1 { }
 .class private auto ansi beforefieldinit ldelemnullarr1
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ldelemnullarr2.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ldelemnullarr2.il
@@ -7,7 +7,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly legacy library ldelemnullarr2 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library ldelemnullarr2 { }
 .class private auto ansi beforefieldinit ldelemnullarr2
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ldfldr4.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ldfldr4.il
@@ -6,7 +6,7 @@
 }
 .assembly extern legacy library mscorlib {}
 
-.assembly legacy library ldfldr4 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library ldfldr4 { }
 .class sealed private auto ansi beforefieldinit Test
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ldfldstatic1.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ldfldstatic1.il
@@ -9,7 +9,7 @@
 }
 
 .assembly extern legacy library mscorlib {}
-.assembly legacy library ldfldstatic1 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library ldfldstatic1 { }
 .class private auto ansi beforefieldinit ldfldstatic1
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ldfldunboxedvt.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ldfldunboxedvt.il
@@ -5,7 +5,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly legacy library ldfldunboxedvt {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library ldfldunboxedvt { }
 .class public sequential ansi sealed beforefieldinit VT
        extends [mscorlib]System.ValueType
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/ldvirtftnsideeffect.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/ldvirtftnsideeffect.il
@@ -1,5 +1,5 @@
 .assembly extern mscorlib {}
-.assembly ldvirtftnsideeffect {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly ldvirtftnsideeffect { }
 .method public static class MyTest f(class MyTest)
 {
 ldarg.0

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/nonrefsdarr.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/nonrefsdarr.il
@@ -6,7 +6,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly legacy library arrlen {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library arrlen { }
 .class private auto ansi beforefieldinit nonrefsdarr
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/nullsdarr.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/nullsdarr.il
@@ -6,7 +6,7 @@
   .ver 4:0:0:0
 }
 .assembly extern legacy library mscorlib {}
-.assembly legacy library arrlen {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library arrlen { }
 .class private auto ansi beforefieldinit nullsdarr
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/refanytype1.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/refanytype1.il
@@ -1,6 +1,6 @@
 
 .assembly extern legacy library mscorlib {}
-.assembly refanytype1 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly refanytype1 { }
 .method public static int32 f()
 {
 ldc.i4 100

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/stfldstatic1.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/stfldstatic1.il
@@ -10,7 +10,7 @@
 }
 
 .assembly extern legacy library mscorlib {}
-.assembly legacy library stfldstatic1 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly legacy library stfldstatic1 { }
 .class private auto ansi beforefieldinit stfldstatic1
        extends [mscorlib]System.Object
 {

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/subovfun1.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/subovfun1.il
@@ -3,7 +3,7 @@
 
 
 .assembly extern legacy library mscorlib {}
-.assembly subovfun1 {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly subovfun1 { }
 .method public static uint32 f(uint32 arg)
 {
 ldarg.0

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/volatilldind.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/volatilldind.il
@@ -1,5 +1,5 @@
 .assembly extern mscorlib {}
-.assembly volatilldind {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly volatilldind { }
 .method public static void f()
 {
 .locals init (int32* V_0)

--- a/tests/src/JIT/Directed/coverage/importer/Desktop/volatilstind.il
+++ b/tests/src/JIT/Directed/coverage/importer/Desktop/volatilstind.il
@@ -1,5 +1,5 @@
 .assembly extern mscorlib {}
-.assembly volatilstind {.custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) }
+.assembly volatilstind { }
 .method public static void f()
 {
 .locals init (int32* V_0)

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32879/b32879.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b32879/b32879.il
@@ -8,7 +8,6 @@
 .assembly 'bug' { }
 .class public auto ansi HiDad extends [mscorlib]System.Object
 {
-  .custom instance void [mscorlib]Microsoft.VisualBasic.Globals.StandardModuleAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static void main() il managed forwardref
   {
     .maxstack  8

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b46292/b46292.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M11-Beta1/b46292/b46292.il
@@ -22,7 +22,6 @@
 .class private auto ansi Mod1
        extends [mscorlib]System.Object
 {
-  .custom instance void ['mscorlib']Microsoft.VisualBasic.Globals$StandardModuleAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static void Main() il managed
   {
     // Code size       26 (0x1a)
@@ -76,7 +75,6 @@
 .class private auto ansi _vbProject
        extends [mscorlib]System.Object
 {
-  .custom instance void ['mscorlib']Microsoft.VisualBasic.Globals$StandardModuleAttribute::.ctor() = ( 01 00 00 00 ) 
   .method public static int32  _main(class [mscorlib]System.String[] _s) il managed
   {
     .entrypoint

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b423755/b423755.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V2.0-Beta2/b423755/b423755.il
@@ -7,7 +7,7 @@
 .assembly extern mscorlib {}
 
 .assembly 'test' {
-  .custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 02 00 00 )  .custom instance void [mscorlib]System.Security.SecurityTransparentAttribute::.ctor() = ( 01 00 00 00 )
+.custom instance void [mscorlib]System.Security.SecurityTransparentAttribute::.ctor() = ( 01 00 00 00 )
 }
 
 .method public static int32 Main()

--- a/tests/src/JIT/jit64/localloc/verify/verify01_dynamic.il
+++ b/tests/src/JIT/jit64/localloc/verify/verify01_dynamic.il
@@ -8,7 +8,6 @@
 .assembly extern mscorlib{}
 .assembly eh01
 {
-  .custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) 
 }
 
 .class private auto ansi beforefieldinit LocallocTest

--- a/tests/src/JIT/jit64/localloc/verify/verify01_large.il
+++ b/tests/src/JIT/jit64/localloc/verify/verify01_large.il
@@ -8,7 +8,6 @@
 .assembly extern mscorlib{}
 .assembly eh01
 {
-  .custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) 
 }
 
 .class private auto ansi beforefieldinit LocallocTest

--- a/tests/src/JIT/jit64/localloc/verify/verify01_small.il
+++ b/tests/src/JIT/jit64/localloc/verify/verify01_small.il
@@ -8,7 +8,6 @@
 .assembly extern mscorlib{}
 .assembly eh01
 {
-  .custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) 
 }
 
 .class private auto ansi beforefieldinit LocallocTest

--- a/tests/src/JIT/jit64/regress/ndpw/21220/21220.il
+++ b/tests/src/JIT/jit64/regress/ndpw/21220/21220.il
@@ -20,7 +20,6 @@
 
 .assembly b21220
 {
-  .custom instance void [mscorlib]System.Security.SecurityRulesAttribute::.ctor(valuetype [mscorlib]System.Security.SecurityRuleSet) = ( 01 00 01 00 00 ) 
   .hash algorithm 0x00008004
   .ver 0:0:0:0
 }


### PR DESCRIPTION
There is no such thing as
`Microsoft.VisualBasic.Globals$StandardModuleAttribute` and
`System.Security.SecurityRulesAttribute` in mscorlib. Presence of these
unresolvable references just trips up static compilers.