### PR TITLE
Set DebugType to PdbOnly for rel-mode IL tests

### DIFF
--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_b.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_b.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_b.il" />

--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_i4.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_i4.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_i4.il" />

--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_objref.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_objref.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_objref.il" />

--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_r4.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_r4.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_r4.il" />

--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_r8.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_r8.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_r8.il" />

--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_struct.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_struct.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_struct.il" />

--- a/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_u8.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/huge/_il_relhuge_u8.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_u8.il" />

--- a/tests/src/JIT/Methodical/Arrays/lcs/_il_rellcs_ldlen.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/lcs/_il_rellcs_ldlen.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs_ldlen.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_reladdress.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_reladdress.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="address.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_relarrres.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_relarrres.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arrres.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_relgcarr.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_relgcarr.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcarr.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_relinitializearray_enum.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_relinitializearray_enum.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="initializearray_enum.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_relldelem_get.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_relldelem_get.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldelem_get.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_rellength0.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_rellength0.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="length0.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_rellengthm2.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_rellengthm2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lengthm2.il" />

--- a/tests/src/JIT/Methodical/Arrays/misc/_il_relselfref.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/misc/_il_relselfref.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="selfref.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relfloat64_range1.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relfloat64_range1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="float64_range1.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relfloat64_range2.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relfloat64_range2.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="float64_range2.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_0.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_0.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_0.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_0_5a.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_0_5a.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_0_5a.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_0_5b.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_0_5b.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_0_5b.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_1.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_1.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_m1.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_m1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_m1.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_neg_range.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_neg_range.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_neg_range.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_range1.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_range1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_range1.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relint32_range2.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relint32_range2.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="int32_range2.il" />

--- a/tests/src/JIT/Methodical/Arrays/range/_il_relnegIndexRngChkElim.ilproj
+++ b/tests/src/JIT/Methodical/Arrays/range/_il_relnegIndexRngChkElim.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="negIndexRngChkElim.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relarray.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relarray.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="array.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relchain.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relchain.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="chain.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relfinally.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relfinally.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="finally.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relhuge_filter.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relhuge_filter.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_filter.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_reljump.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_reljump.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jump.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_rellocal.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_rellocal.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="local.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_rellocalloc.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_rellocalloc.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="localloc.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relsimple.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_relsimple.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="simple.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_reltailcall.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_reltailcall.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="tailcall.il" />

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/_il_reltry.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/_il_reltry.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="try.il" />

--- a/tests/src/JIT/Methodical/Boxing/callconv/_relinstance_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/callconv/_relinstance_il.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="instance.il" />

--- a/tests/src/JIT/Methodical/Boxing/functional/_relfibo_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/functional/_relfibo_il.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="fibo.il" />

--- a/tests/src/JIT/Methodical/Boxing/functional/_relsin_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/functional/_relsin_il.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sin.il" />

--- a/tests/src/JIT/Methodical/Boxing/misc/_relconcurgc_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_relconcurgc_il.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="concurgc.il" />

--- a/tests/src/JIT/Methodical/Boxing/misc/_relenum_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_relenum_il.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="enum.il" />

--- a/tests/src/JIT/Methodical/Boxing/misc/_relnestval_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_relnestval_il.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="nestval.il" />

--- a/tests/src/JIT/Methodical/Boxing/misc/_reltailjump_il.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_reltailjump_il.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="tailjump.il" />

--- a/tests/src/JIT/Methodical/Boxing/misc/_reltypedref.ilproj
+++ b/tests/src/JIT/Methodical/Boxing/misc/_reltypedref.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="typedref.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconv_i8_i.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconv_i8_i.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="conv_i8_i.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconv_i8_u.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconv_i8_u.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="conv_i8_u.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconvovf_i8_i.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconvovf_i8_i.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="convovf_i8_i.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconvovf_i8_u.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relconvovf_i8_u.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="convovf_i8_u-ia64.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Condition="'$(Platform)' ==   'x64'" Include="i_array_merge-ia64.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_box.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_box.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_box.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_conv.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_conv.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_conv.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_fld.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_fld.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_fld.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_flood.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_flood.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_flood.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_flow.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_flow.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_flow.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_prop.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_prop.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_prop.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_qsort1.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_qsort1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_qsort1.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_qsort2.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_qsort2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_qsort2.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_ref.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_ref.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_ref.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_seq.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_seq.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_seq.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_vfld.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_vfld.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i_vfld.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relptr.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relptr.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ptr.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relqperm.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relqperm.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="qperm.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Condition="'$(Platform)' ==   'x64'" Include="u_array_merge-ia64.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_box.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_box.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_box.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_conv.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_conv.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_conv.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_fld.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_fld.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_fld.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_flood.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_flood.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_flood.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_flow.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_flow.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_flow.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_prop.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_prop.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_prop.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_qsort1.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_qsort1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_qsort1.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_qsort2.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_qsort2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_qsort2.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_ref.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_ref.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_ref.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_seq.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_seq.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_seq.il" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_vfld.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_vfld.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_vfld.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfault.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfault.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfault.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfault_jmp.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfault_jmp.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfault_jmp.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfault_tail.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfault_tail.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfault_tail.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_ind.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_ind.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfinally_ind.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_jmp.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_jmp.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfinally_jmp.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_jmpind.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_jmpind.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfinally_jmpind.il" />

--- a/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_tail.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/SEH/_il_relcatchfinally_tail.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="catchfinally_tail.il" />

--- a/tests/src/JIT/Methodical/Invoke/callvirt/_il_reltest1.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/callvirt/_il_reltest1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test1.il" />

--- a/tests/src/JIT/Methodical/Invoke/callvirt/_il_reltest2.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/callvirt/_il_reltest2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test2.il" />

--- a/tests/src/JIT/Methodical/Invoke/callvirt/_il_reltest3.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/callvirt/_il_reltest3.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test3.il" />

--- a/tests/src/JIT/Methodical/Invoke/ctor/_il_relval_cctor.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/ctor/_il_relval_cctor.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="val_cctor.il" />

--- a/tests/src/JIT/Methodical/Invoke/ctor/_il_relval_ctor_newobj.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/ctor/_il_relval_ctor_newobj.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="val_ctor_newobj.il" />

--- a/tests/src/JIT/Methodical/Invoke/deep/_il_reldeep1.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/deep/_il_reldeep1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep1.il" />

--- a/tests/src/JIT/Methodical/Invoke/deep/_il_reldeep2.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/deep/_il_reldeep2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep2.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relftn_t.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relftn_t.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ftn_t.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relinstftn.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relinstftn.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="instftn.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relinstftn_t.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relinstftn_t.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="instftn_t.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_calli.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_calli.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_calli.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_jmp.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_jmp.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_jmp.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_jmpi.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_jmpi.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_jmpi.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_tail_call.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_tail_call.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_tail_call.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_tail_calli.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relrecurse_tail_calli.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_tail_calli.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relvalftn.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relvalftn.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="valftn.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relvalftn_t.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relvalftn_t.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="valftn_t.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relvirtftn.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relvirtftn.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="virtftn.il" />

--- a/tests/src/JIT/Methodical/Invoke/fptr/_il_relvirtftn_t.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/fptr/_il_relvirtftn_t.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="virtftn_t.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_relfr4.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_relfr4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="fr4.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_relfr8.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_relfr8.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="fr8.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4i1.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4i1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i4i1.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4i2.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4i2.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i4i2.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4u1.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4u1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i4u1.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4u2.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4u2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i4u2.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4u4.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reli4u4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i4u4.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reli8u8.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reli8u8.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="i8u8.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_relii1.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_relii1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ii1.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_relii2.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_relii2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ii2.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_relii4.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_relii4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ii4.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reliu1.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reliu1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="iu1.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reliu2.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reliu2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="iu2.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_reliu4.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_reliu4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="iu4.il" />

--- a/tests/src/JIT/Methodical/Invoke/implicit/_il_relobjref.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/implicit/_il_relobjref.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="objref.il" />

--- a/tests/src/JIT/Methodical/Invoke/thiscall/_relthisnull.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/thiscall/_relthisnull.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="thisnull.il" />

--- a/tests/src/JIT/Methodical/Invoke/thiscall/_speed_relthisnull.ilproj
+++ b/tests/src/JIT/Methodical/Invoke/thiscall/_speed_relthisnull.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="thisnull.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_relaa.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_relaa.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="aa.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_relcalli.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_relcalli.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="calli.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reldd.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reldd.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="dd.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_relee.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_relee.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ee.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumper1.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumper1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumper1.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumper2.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumper2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumper2.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumper3.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumper3.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumper3.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumper4.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumper4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumper4.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumper5.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumper5.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumper5.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumps1.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumps1.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumps1.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumps2.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumps2.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumps2.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumps3.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumps3.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumps3.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumps4.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumps4.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumps4.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_reljumps5.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_reljumps5.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="jumps5.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_relvtret.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_relvtret.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="vtret.il" />

--- a/tests/src/JIT/Methodical/VT/callconv/_il_relvtret2.ilproj
+++ b/tests/src/JIT/Methodical/VT/callconv/_il_relvtret2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="vtret2.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relhan3.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relhan3.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="han3.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relhan3_ctor.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relhan3_ctor.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="han3_ctor.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relhan3_ref.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relhan3_ref.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="han3_ref.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relhanoi.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relhanoi.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hanoi.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relhanoi2.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relhanoi2.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hanoi2.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relknight.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relknight.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="knight.il" />

--- a/tests/src/JIT/Methodical/VT/etc/_il_relnested.ilproj
+++ b/tests/src/JIT/Methodical/VT/etc/_il_relnested.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="nested.il" />

--- a/tests/src/JIT/Methodical/VT/identity/_il_relaccum.ilproj
+++ b/tests/src/JIT/Methodical/VT/identity/_il_relaccum.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="accum.il" />

--- a/tests/src/JIT/Methodical/VT/identity/_il_rellivecall.ilproj
+++ b/tests/src/JIT/Methodical/VT/identity/_il_rellivecall.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="livecall.il" />

--- a/tests/src/JIT/Methodical/VT/identity/_il_relvolatile.ilproj
+++ b/tests/src/JIT/Methodical/VT/identity/_il_relvolatile.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="volatile.il" />

--- a/tests/src/JIT/Methodical/VT/port/_il_relhuge_gcref.ilproj
+++ b/tests/src/JIT/Methodical/VT/port/_il_relhuge_gcref.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="huge_gcref.il" />

--- a/tests/src/JIT/Methodical/casts/SEH/_il_relcastclass_catch.ilproj
+++ b/tests/src/JIT/Methodical/casts/SEH/_il_relcastclass_catch.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_catch.il" />

--- a/tests/src/JIT/Methodical/casts/SEH/_il_relcastclass_catch_neg.ilproj
+++ b/tests/src/JIT/Methodical/casts/SEH/_il_relcastclass_catch_neg.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_catch_neg.il" />

--- a/tests/src/JIT/Methodical/casts/SEH/_il_relfilter.ilproj
+++ b/tests/src/JIT/Methodical/casts/SEH/_il_relfilter.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="filter.il" />

--- a/tests/src/JIT/Methodical/casts/SEH/_il_relisinst_catch.ilproj
+++ b/tests/src/JIT/Methodical/casts/SEH/_il_relisinst_catch.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_catch.il" />

--- a/tests/src/JIT/Methodical/casts/SEH/_il_relisinst_catch_neg.ilproj
+++ b/tests/src/JIT/Methodical/casts/SEH/_il_relisinst_catch_neg.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_catch_neg.il" />

--- a/tests/src/JIT/Methodical/casts/array/_il_relarrays.ilproj
+++ b/tests/src/JIT/Methodical/casts/array/_il_relarrays.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="arrays.il" />

--- a/tests/src/JIT/Methodical/casts/array/_il_relcastclass_ldlen.ilproj
+++ b/tests/src/JIT/Methodical/casts/array/_il_relcastclass_ldlen.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_ldlen.il" />

--- a/tests/src/JIT/Methodical/casts/array/_il_relisinst_ldlen.ilproj
+++ b/tests/src/JIT/Methodical/casts/array/_il_relisinst_ldlen.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_ldlen.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_call.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_call.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_call.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_calli.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_calli.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_calli.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_ldarg.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_ldarg.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_ldarg.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_ldloc.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relcastclass_ldloc.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="castclass_ldloc.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_call.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_call.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_call.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_calli.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_calli.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_calli.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_ldarg.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_ldarg.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_ldarg.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_ldloc.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relisinst_ldloc.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="isinst_ldloc.il" />

--- a/tests/src/JIT/Methodical/casts/coverage/_il_relldnull.ilproj
+++ b/tests/src/JIT/Methodical/casts/coverage/_il_relldnull.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldnull.il" />

--- a/tests/src/JIT/Methodical/casts/iface/_il_reliface2.ilproj
+++ b/tests/src/JIT/Methodical/casts/iface/_il_reliface2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="iface2.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_c.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_c.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_c.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_f4.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_f4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_f4.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_f8.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_f8.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_f8.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_i1.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_i1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_i1.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_i2.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_i2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_i2.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_i4.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_i4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_i4.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_o.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_o.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_o.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_s.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefarg_s.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_s.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_c.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_c.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_c.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_i1.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_i1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_i1.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_i2.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_i2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_i2.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_i4.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_i4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_i4.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_o.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_o.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_o.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_o2.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_o2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_o2.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_r4.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_r4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_r4.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_r8.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_r8.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_r8.il" />

--- a/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_u2.ilproj
+++ b/tests/src/JIT/Methodical/explicit/basic/_il_relrefloc_u2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refloc_u2.il" />

--- a/tests/src/JIT/Methodical/explicit/misc/_il_relrefarg_box_f8.ilproj
+++ b/tests/src/JIT/Methodical/explicit/misc/_il_relrefarg_box_f8.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_box_f8.il" />

--- a/tests/src/JIT/Methodical/explicit/misc/_il_relrefarg_box_val.ilproj
+++ b/tests/src/JIT/Methodical/explicit/misc/_il_relrefarg_box_val.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refarg_box_val.il" />

--- a/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_double.ilproj
+++ b/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_double.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="rotarg_double.il" />

--- a/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_float.ilproj
+++ b/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_float.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="rotarg_float.il" />

--- a/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_objref.ilproj
+++ b/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_objref.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="rotarg_objref.il" />

--- a/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_valref.ilproj
+++ b/tests/src/JIT/Methodical/explicit/rotate/_il_relrotarg_valref.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="rotarg_valref.il" />

--- a/tests/src/JIT/Methodical/explicit/rotate/_il_relrotate_i4.ilproj
+++ b/tests/src/JIT/Methodical/explicit/rotate/_il_relrotate_i4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="rotate_i4.il" />

--- a/tests/src/JIT/Methodical/explicit/rotate/_il_relrotate_u2.ilproj
+++ b/tests/src/JIT/Methodical/explicit/rotate/_il_relrotate_u2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="rotate_u2.il" />

--- a/tests/src/JIT/Methodical/int64/arrays/_il_relhugedim.ilproj
+++ b/tests/src/JIT/Methodical/int64/arrays/_il_relhugedim.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="hugedim.il" />

--- a/tests/src/JIT/Methodical/int64/arrays/_il_rellcs_long.ilproj
+++ b/tests/src/JIT/Methodical/int64/arrays/_il_rellcs_long.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs_long.il" />

--- a/tests/src/JIT/Methodical/int64/arrays/_il_rellcs_ulong.ilproj
+++ b/tests/src/JIT/Methodical/int64/arrays/_il_rellcs_ulong.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs_ulong.il" />

--- a/tests/src/JIT/Methodical/int64/misc/_il_relbinop.ilproj
+++ b/tests/src/JIT/Methodical/int64/misc/_il_relbinop.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="binop.il" />

--- a/tests/src/JIT/Methodical/int64/misc/_il_relbox.ilproj
+++ b/tests/src/JIT/Methodical/int64/misc/_il_relbox.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="box.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_addsub.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_addsub.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_addsub.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldc_div.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldc_div.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldc_div.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldc_mul.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldc_mul.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldc_mul.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldc_mulovf.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldc_mulovf.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldc_mulovf.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldfld_mul.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldfld_mul.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldfld_mul.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldfld_mulovf.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldfld_mulovf.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldfld_mulovf.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldsfld_mul.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldsfld_mul.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldsfld_mul.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_ldsfld_mulovf.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_ldsfld_mulovf.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_ldsfld_mulovf.il" />

--- a/tests/src/JIT/Methodical/int64/signed/_il_rels_muldiv.ilproj
+++ b/tests/src/JIT/Methodical/int64/signed/_il_rels_muldiv.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="s_muldiv.il" />

--- a/tests/src/JIT/Methodical/int64/superlong/_il_relsuperlong.ilproj
+++ b/tests/src/JIT/Methodical/int64/superlong/_il_relsuperlong.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="superlong.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_reladdsub.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_reladdsub.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="addsub.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relldc_mul.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relldc_mul.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldc_mul.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relldc_mulovf.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relldc_mulovf.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldc_mulovf.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relldfld_mul.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relldfld_mul.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldfld_mul.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relldfld_mulovf.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relldfld_mulovf.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldfld_mulovf.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relldsfld_mul.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relldsfld_mul.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldsfld_mul.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relldsfld_mulovf.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relldsfld_mulovf.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldsfld_mulovf.il" />

--- a/tests/src/JIT/Methodical/int64/unsigned/_il_relmuldiv.ilproj
+++ b/tests/src/JIT/Methodical/int64/unsigned/_il_relmuldiv.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="muldiv.il" />

--- a/tests/src/JIT/Methodical/ldtoken/_il_relldtoken.ilproj
+++ b/tests/src/JIT/Methodical/ldtoken/_il_relldtoken.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldtoken.il" />

--- a/tests/src/JIT/Methodical/ldtoken/_il_relldtokena.ilproj
+++ b/tests/src/JIT/Methodical/ldtoken/_il_relldtokena.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldtokena.il" />

--- a/tests/src/JIT/Methodical/ldtoken/_il_relptr_types.ilproj
+++ b/tests/src/JIT/Methodical/ldtoken/_il_relptr_types.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ptr_types.il" />

--- a/tests/src/JIT/Methodical/ldtoken/_il_reltypes.ilproj
+++ b/tests/src/JIT/Methodical/ldtoken/_il_reltypes.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="types.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relarray1.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relarray1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="array1.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relarray2.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relarray2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="array2.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relarray3.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relarray3.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="array3.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relformat.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relformat.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="format.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relindcall.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relindcall.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="indcall.il" />

--- a/tests/src/JIT/Methodical/refany/_il_rellcs.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_rellcs.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="lcs.il" />

--- a/tests/src/JIT/Methodical/refany/_il_rellongsig.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_rellongsig.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="longsig.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relnative.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relnative.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="native.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relseq.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relseq.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="seq.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relshortsig.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relshortsig.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="shortsig.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relstress2.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relstress2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="stress2.il" />

--- a/tests/src/JIT/Methodical/refany/_il_relu_native.ilproj
+++ b/tests/src/JIT/Methodical/refany/_il_relu_native.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="u_native.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_enum.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_enum.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_enum.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_i2_bool.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_i2_bool.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_i2_bool.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_i4_i1.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_i4_i1.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_i4_i1.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_i4_u.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_i4_u.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_i4_u.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_i_u2.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_i_u2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_i_u2.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_obj.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_obj.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_obj.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_r4_r8.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_r4_r8.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_r4_r8.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_r4_r8_inl.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_r4_r8_inl.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_r4_r8_inl.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_r8_r4.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_r8_r4.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_r8_r4.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_r8_r4_inl.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_r8_r4_inl.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_r8_r4_inl.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relcompat_v.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relcompat_v.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="compat_v.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reldeep_array.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reldeep_array.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep_array.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reldeep_array_nz.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reldeep_array_nz.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep_array_nz.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reldeep_gc.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reldeep_gc.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep_gc.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reldeep_inst.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reldeep_inst.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep_inst.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reldeep_value.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reldeep_value.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep_value.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reldeep_virt.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reldeep_virt.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="deep_virt.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relgcval.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relgcval.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcval.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relgcval_nested.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relgcval_nested.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcval_nested.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relgcval_sideeffect.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relgcval_sideeffect.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="gcval_sideeffect.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relpointer.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relpointer.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="pointer.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relpointer_i.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relpointer_i.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="pointer_i.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relrecurse_ep.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relrecurse_ep.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_ep.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relrecurse_ep_void.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relrecurse_ep_void.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="recurse_ep_void.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_relreference_i.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_relreference_i.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="reference_i.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_2a.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_2a.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_2a.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_2b.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_2b.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_2b.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_2c.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_2c.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_2c.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_3b.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_3b.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_3b.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_implicit.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_implicit.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_implicit.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_mutual_rec.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_mutual_rec.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_mutual_rec.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_switch.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_switch.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_switch.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_virt.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_virt.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_virt.il" />

--- a/tests/src/JIT/Methodical/tailcall/_il_reltest_void.ilproj
+++ b/tests/src/JIT/Methodical/tailcall/_il_reltest_void.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="test_void.il" />

--- a/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_I.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_I.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldobj_I.il" />

--- a/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_I8.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_I8.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldobj_I8.il" />

--- a/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_R4.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_R4.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldobj_R4.il" />

--- a/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_R8.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_R8.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldobj_R8.il" />

--- a/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_U2.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_U2.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldobj_U2.il" />

--- a/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_V.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/ldobj/_il_relldobj_V.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldobj_V.il" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_il_relconst.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_il_relconst.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="const.il" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_il_relldelema.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_il_relldelema.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ldelema.il" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_il_rellocalloc.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_il_rellocalloc.ilproj
@@ -26,6 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="localloc.il" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_il_relmdarray.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_il_relmdarray.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mdarray.il" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_il_relrefanyval.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_il_relrefanyval.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="refanyval.il" />

--- a/tests/src/JIT/Methodical/xxobj/operand/_il_relunbox.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/operand/_il_relunbox.ilproj
@@ -26,7 +26,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unbox.il" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof.il" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof32.il" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
@@ -27,7 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
-    
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof64.il" />

--- a/tests/src/JIT/Regression/JitBlue/DevDiv_205323/starg0.ilproj
+++ b/tests/src/JIT/Regression/JitBlue/DevDiv_205323/starg0.ilproj
@@ -27,6 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="starg0.il" />

--- a/tests/src/JIT/opt/Inline/regression/mismatch32/mismatch32.ilproj
+++ b/tests/src/JIT/opt/Inline/regression/mismatch32/mismatch32.ilproj
@@ -27,6 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mismatch32.il" />

--- a/tests/src/JIT/opt/Inline/regression/mismatch64/mismatch64.ilproj
+++ b/tests/src/JIT/opt/Inline/regression/mismatch64/mismatch64.ilproj
@@ -27,6 +27,7 @@
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
   <PropertyGroup>
+    <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="mismatch64.il" />


### PR DESCRIPTION
Ensures that execution of these tests always invokes the jit's optimizer,
regardless of the build configuration.

See issue #4124.