### PR TITLE
ARM64: Launch test build and run in parallel

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1064,11 +1064,15 @@ combinedScenarios.each { scenario ->
 
                                     // Up the timeout for arm64 jobs.
                                     Utilities.setJobTimeout(newJob, 240);
-                                    buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} /toolset_dir C:\\ats"
 
-                                    // Debug runs take too long to run.
-                                    if (lowerConfiguration != "debug") {
-                                       buildCommands += "Z:\\arm64\\common\\scripts\\arm64PostBuild.cmd %WORKSPACE% ${architecture} ${lowerConfiguration}"
+                                    // Debug runs take too long to run. So build job only.
+                                    if (lowerConfiguration == "debug") {
+                                       buildCommands += "set __TestIntermediateDir=int&&build.cmd ${lowerConfiguration} ${architecture} /toolset_dir C:\\ats"
+                                    }
+                                    else {
+                                       buildCommands += "set __TestIntermediateDir=int&&build.cmd skiptests ${lowerConfiguration} ${architecture} /toolset_dir C:\\ats"
+                                       // Test build and run are launched together.
+                                       buildCommands += "Z:\\arm64\\common\\scripts\\arm64PostLauncher.cmd %WORKSPACE% ${architecture} ${lowerConfiguration}"
                                        Utilities.addXUnitDotNETResults(newJob, 'bin/tests/testResults.xml')
                                     }
                                     

--- a/tests/buildtest.cmd
+++ b/tests/buildtest.cmd
@@ -68,6 +68,10 @@ if /i "%1" == "gcstresslevel"       (set __GCStressLevel=%2&shift&shift&goto Arg
 
 if /i "%1" == "verbose"             (set __verbosity=detailed&shift&goto Arg_Loop)
 
+@REM It was initially /toolset_dir. Not sure why, since it doesn't match the other usage.
+if /i "%1" == "/toolset_dir"        (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
+if /i "%1" == "toolset_dir"         (set __ToolsetDir=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
+
 if /i not "%1" == "msbuildargs" goto SkipMsbuildArgs
 :: All the rest of the args will be collected and passed directly to msbuild.
 :CollectMsbuildArgs
@@ -81,6 +85,10 @@ echo Invalid command-line argument: %1
 goto Usage
 
 :ArgsDone
+
+rem arm64 builds currently use private toolset which has not been released yet
+REM TODO, remove once the toolset is open.
+if /i "%__BuildArch%" == "arm64" call :PrivateToolSet
 
 if %__verbosity%==detailed (
     echo Enabling verbose file logging
@@ -372,3 +380,23 @@ echo Visual Studio 2013 Express does not include the DIA SDK. ^
 You need Visual Studio 2013+ (Community is free).
 echo See: https://github.com/dotnet/coreclr/blob/master/Documentation/project-docs/developer-guide.md#prerequisites
 exit /b 1
+
+
+:PrivateToolSet
+
+echo %__MsgPrefix% Setting Up the usage of __ToolsetDir:%__ToolsetDir%
+
+if /i "%__ToolsetDir%" == "" (
+    echo %__MsgPrefix%Error: A toolset directory is required for the Arm64 Windows build. Use the toolset_dir argument.
+    exit /b 1
+)
+
+set PATH=%__ToolsetDir%\cpp\bin;%PATH%
+set LIB=%__ToolsetDir%\cpp\libWin9CoreSystem;%__ToolsetDir%\OS\lib;%__ToolsetDir%\cpp\lib
+set INCLUDE=^
+%__ToolsetDir%\cpp\inc;^
+%__ToolsetDir%\OS\inc\Windows;^
+%__ToolsetDir%\OS\inc\Windows\crt;^
+%__ToolsetDir%\cpp\inc\vc;^
+%__ToolsetDir%\OS\inc\win8
+exit /b 0


### PR DESCRIPTION
This change allows to buildtest.cmd for arm64 in separate.
Currently we build coreclr and tests for arm64 and then run tests in
sequence even though we run the pre-built test suite.
This change pushes down the test built part into the lab post script that
launches buildtests.cmd and arm64postbuild.cmd concurrently. The latter
part is mostly waiting for the results from arm64 box. So we can almost
hide the test build time which is around 30 min.