### PR TITLE
ARM64: Update email notification

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -269,9 +269,12 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                         break
                     case 'arm':
                         Utilities.addGithubPushTrigger(job)
+                        break
                     case 'arm64':
                         Utilities.addGithubPushTrigger(job)
-                        addEmailPublisher(job, 'cc:dotnetonarm64@microsoft.com')
+                        if (os == 'Windows_NT') {
+                            addEmailPublisher(job, 'cc:dotnetonarm64@microsoft.com')
+                        }
                         break
                     default:
                         println("Unknown architecture: ${architecture}");
@@ -772,7 +775,6 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
 					        }
                             Utilities.addPrivateGithubPRTriggerForBranch(job, branch, contextString,
                             "(?i).*test\\W+${os}\\W+${architecture}\\W+${configuration}.*", null, ['erozenfeld', 'kyulee1', 'pgavlin', 'russellhadley', 'swaroop-sridhar', 'JosephTremoulet', 'jashook', 'RussKeldorph', 'gkhanna79', 'briansull', 'cmckinsey', 'jkotas', 'ramarag', 'markwilkie', 'rahku', 'tzwlai', 'weshaggard', 'LLITCHEV'])
-					        addEmailPublisher(job, 'cc:dotnetonarm64@microsoft.com')
                             break
 					}
 				    break


### PR DESCRIPTION
Only sending email for Windows run when push occurs.
Skip sending email for private run (PR).