### PR TITLE
Remove mscorlib 1.x strong references from tests

### DIFF
--- a/tests/src/JIT/Directed/shift/int8.il
+++ b/tests/src/JIT/Directed/shift/int8.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly int8test
 {

--- a/tests/src/JIT/Directed/shift/nativeint.il
+++ b/tests/src/JIT/Directed/shift/nativeint.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly nativeinttest
 {

--- a/tests/src/JIT/Directed/shift/nativeuint.il
+++ b/tests/src/JIT/Directed/shift/nativeuint.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly nativeuinttest
 {

--- a/tests/src/JIT/Methodical/cctor/simple/prefldinit1.il
+++ b/tests/src/JIT/Methodical/cctor/simple/prefldinit1.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly precise1
 {

--- a/tests/src/JIT/Methodical/cctor/simple/prefldinit2.il
+++ b/tests/src/JIT/Methodical/cctor/simple/prefldinit2.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly precise2
 {

--- a/tests/src/JIT/Methodical/cctor/simple/prefldinit4.il
+++ b/tests/src/JIT/Methodical/cctor/simple/prefldinit4.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly precise4
 {

--- a/tests/src/JIT/Methodical/eh/deadcode/deadEHregionacrossBB.il
+++ b/tests/src/JIT/Methodical/eh/deadcode/deadEHregionacrossBB.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:1:3300:0
 }
 .assembly extern common {}
 .assembly test

--- a/tests/src/JIT/Methodical/eh/deadcode/deadcodeincatch.il
+++ b/tests/src/JIT/Methodical/eh/deadcode/deadcodeincatch.il
@@ -3,8 +3,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:3300:0
 }
 .assembly extern System.Console
 {

--- a/tests/src/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet.il
+++ b/tests/src/JIT/Methodical/eh/deadcode/deadoponerrorinfunclet.il
@@ -8,8 +8,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3300:0
 }
 .assembly extern common{}
 .assembly oponerror

--- a/tests/src/JIT/Methodical/eh/deadcode/endfinallyinloop.il
+++ b/tests/src/JIT/Methodical/eh/deadcode/endfinallyinloop.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3300:0
 }
 .assembly extern common{}
 

--- a/tests/src/JIT/Methodical/eh/finallyexec/catchrettoinnertry.il
+++ b/tests/src/JIT/Methodical/eh/finallyexec/catchrettoinnertry.il
@@ -8,8 +8,6 @@
 }
  .assembly extern mscorlib
  {
-   .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-   .ver 1:0:3300:0
  }
  .assembly extern common{}
  .assembly catchrettoinnertry

--- a/tests/src/JIT/Methodical/eh/leaves/2branchesoutoftry.il
+++ b/tests/src/JIT/Methodical/eh/leaves/2branchesoutoftry.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly testit{

--- a/tests/src/JIT/Methodical/eh/leaves/backwardleaveincatch.il
+++ b/tests/src/JIT/Methodical/eh/leaves/backwardleaveincatch.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly branchbackwardswithfinally

--- a/tests/src/JIT/Methodical/eh/leaves/branchbackwardswithcatch.il
+++ b/tests/src/JIT/Methodical/eh/leaves/branchbackwardswithcatch.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly branchbackwardswithfinally

--- a/tests/src/JIT/Methodical/eh/leaves/branchbackwardswithfinally.il
+++ b/tests/src/JIT/Methodical/eh/leaves/branchbackwardswithfinally.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly branchbackwardswithfinally

--- a/tests/src/JIT/Methodical/eh/leaves/branchoutofnestedtryfinally.il
+++ b/tests/src/JIT/Methodical/eh/leaves/branchoutofnestedtryfinally.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly testit

--- a/tests/src/JIT/Methodical/eh/leaves/branchoutoftryfinally.il
+++ b/tests/src/JIT/Methodical/eh/leaves/branchoutoftryfinally.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly testit

--- a/tests/src/JIT/Methodical/eh/leaves/forwardleaveincatch.il
+++ b/tests/src/JIT/Methodical/eh/leaves/forwardleaveincatch.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3102:0
 }
 .assembly extern common{}
 .assembly branchbackwardswithfinally

--- a/tests/src/JIT/Methodical/eh/leaves/labelbeforefinally.il
+++ b/tests/src/JIT/Methodical/eh/leaves/labelbeforefinally.il
@@ -8,8 +8,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern common{}
 .assembly b30630

--- a/tests/src/JIT/Methodical/eh/leaves/labelbeginningfinally.il
+++ b/tests/src/JIT/Methodical/eh/leaves/labelbeginningfinally.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern common{}
 .assembly b30630

--- a/tests/src/JIT/Methodical/eh/leaves/leaveinsameregion.il
+++ b/tests/src/JIT/Methodical/eh/leaves/leaveinsameregion.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:1:3300:0
 }
 .assembly extern common{}
 .assembly trycatch

--- a/tests/src/JIT/Methodical/eh/leaves/leaveintotrybody.il
+++ b/tests/src/JIT/Methodical/eh/leaves/leaveintotrybody.il
@@ -9,8 +9,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern common{}
 .assembly trycatch

--- a/tests/src/JIT/Methodical/eh/leaves/tryfinallyintrycatchwithleaveintotry.il
+++ b/tests/src/JIT/Methodical/eh/leaves/tryfinallyintrycatchwithleaveintotry.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern common{}
 .assembly trycatch

--- a/tests/src/JIT/Methodical/eh/mixedhandler/catchfiltercatch.il
+++ b/tests/src/JIT/Methodical/eh/mixedhandler/catchfiltercatch.il
@@ -12,8 +12,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern common{}
 .assembly testmultihandler

--- a/tests/src/JIT/Methodical/eh/mixedhandler/filterfiltercatchcatch.il
+++ b/tests/src/JIT/Methodical/eh/mixedhandler/filterfiltercatchcatch.il
@@ -12,8 +12,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern common{}
 .assembly testmultihandler

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b102637/gbug.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b102637/gbug.il
@@ -6,8 +6,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:3300:0
 }
 .assembly gbug
 {

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b147924/bigdat.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1.2-Beta1/b147924/bigdat.il
@@ -10,8 +10,6 @@
 .assembly BIGDAT {}
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89)                         // ".z\V.4.."
-  .ver 1:0:5000:0
 }
 .module BIGDAT
 .class public 'BIGDAT'

--- a/tests/src/JIT/Regression/CLR-x86-JIT/v2.1/b173313/b173313.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/v2.1/b173313/b173313.il
@@ -8,8 +8,6 @@
 // Metadata version: v2.0.50727
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:1:0:0
 }
 .assembly a
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b106158/branchoutoftry.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b106158/branchoutoftry.il
@@ -14,8 +14,6 @@
 // Metadata version: v1.1.904.chk
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:1:3102:0
 }
 .assembly testit
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b141062/ericswitch.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b141062/ericswitch.il
@@ -13,8 +13,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                           // .z\V.4..
-  .ver 1:1:3300:0
 }
 .assembly ericswitch
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b98431/ConsoleApplication2.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b98431/ConsoleApplication2.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern Microsoft.VisualBasic
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b99403/cbyte7a.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b99403/cbyte7a.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:0:2411:0
 }
 .assembly extern Microsoft.VisualBasic
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b126221/cs_il.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-Beta1/b126221/cs_il.il
@@ -4,10 +4,6 @@
 
 .assembly extern legacy library mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .hash = (CA 05 4F 87 FF A4 18 D8 3E 2E 6B D2 6E 73 FE 65   
-           5F E5 6E 66 )                                     
-  .ver 1:2:3400:0
 }
 .assembly legacy library cs_test_01
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M01/b10841/repro_good.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M01/b10841/repro_good.il
@@ -13,8 +13,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                           // .z\V.4..
-  .ver 1:1:3300:0
 }
 .assembly main
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M01/b10852/test3.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M01/b10852/test3.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                           
-  .ver 1:1:3300:0
 }
 .assembly test3
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M01/b11131/bug2.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M01/b11131/bug2.il
@@ -8,10 +8,6 @@
 // Metadata version: v1.1.1919
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .hash = (77 05 78 E2 0E 97 32 6B 44 09 C8 5F 32 3F 27 30   // w.x...2kD.._2?'0
-           1A 90 4E 64 )                                     // ..Nd
-  .ver 1:1:3300:0
 }
 .assembly 'switch'
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14355/call01.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b14355/call01.il
@@ -10,8 +10,6 @@
 }
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         
-  .ver 1:2:3300:0
 }
 .assembly extern common
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b17023/test1a.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b17023/test1a.il
@@ -14,8 +14,6 @@
 // Metadata version: v1.0.1427
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:2:3300:0
 }
 .assembly test
 {

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b17904/test.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V1.2-M02/b17904/test.il
@@ -14,8 +14,6 @@
 // Metadata version: v1.0.1427
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:2:3300:0
 }
 .assembly test
 {

--- a/tests/src/JIT/jit64/localloc/common/common.il
+++ b/tests/src/JIT/jit64/localloc/common/common.il
@@ -11,8 +11,6 @@
 
 .assembly extern mscorlib
 {
-  .publickeytoken = (B7 7A 5C 56 19 34 E0 89 )                         // .z\V.4..
-  .ver 1:0:5000:0
 }
 .assembly Common
 {


### PR DESCRIPTION
Referencing mscorlib 1.x forces ILASM to emit a reference to the legacy
DebuggableAttribute constructor (the one that takes bools). That
constructor is not in the .NET Core profile and not all core base class
libraries will have it.

See src/ilasm/asmman.cpp#L389.