### PR TITLE
Fix error return in getPath

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -4296,7 +4296,7 @@ getPath(
     {
         if (access (lpFileName, F_OK) == 0)
         {
-            if (lpPathFileName.Set(lpFileNameString))
+            if (!lpPathFileName.Set(lpFileNameString))
             {
                 TRACE("Set of StackString failed!\n");
                 return FALSE;


### PR DESCRIPTION
The call to PathCharString.Set returns true on succes, so this code path
was returning false if it succeeded in setting lpPathFileName to
lpFileNameString. It looks like this is just a holdover from the way
this code used to be written.