### PR TITLE
Remove Marshal.Read/Write (AsAny object) overload from CoreCLR.

### DIFF
--- a/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
+++ b/src/mscorlib/src/System/Runtime/InteropServices/Marshal.cs
@@ -402,10 +402,17 @@ namespace System.Runtime.InteropServices
         //====================================================================
         // Read from memory
         //====================================================================
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_RU1")]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern byte ReadByte([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs);    
+#else
+        public static byte ReadByte([MarshalAs(UnmanagedType.AsAny), In] Object ptr, int ofs)
+        {
+            throw new PlatformNotSupportedException();
+        }    
+#endif // !FEATURE_CORECLR
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public static unsafe byte ReadByte(IntPtr ptr, int ofs)
@@ -428,11 +435,18 @@ namespace System.Runtime.InteropServices
             return ReadByte(ptr,0);
         }
         
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_RI2")]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern short ReadInt16([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs);    
-
+#else
+        public static short ReadInt16([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs)
+        {
+            throw new PlatformNotSupportedException();
+        }    
+#endif // !FEATURE_CORECLR
+ 
         [System.Security.SecurityCritical]  // auto-generated_required
         public static unsafe short ReadInt16(IntPtr ptr, int ofs)
         {
@@ -467,11 +481,18 @@ namespace System.Runtime.InteropServices
             return ReadInt16(ptr, 0);
         }
     
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_RI4"), ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern int ReadInt32([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs);    
-
+#else
+        public static int ReadInt32([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#endif // !FEATURE_CORECLR
+ 
         [System.Security.SecurityCritical]  // auto-generated_required
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public static unsafe int ReadInt32(IntPtr ptr, int ofs)
@@ -509,7 +530,7 @@ namespace System.Runtime.InteropServices
         {
             return ReadInt32(ptr,0);
         }
-        
+       
         [System.Security.SecurityCritical]  // auto-generated_required
         [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         public static IntPtr ReadIntPtr([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs)
@@ -543,10 +564,17 @@ namespace System.Runtime.InteropServices
             #endif
         }
 
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_RI8"), ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern long ReadInt64([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs);    
+#else
+        public static long ReadInt64([MarshalAs(UnmanagedType.AsAny),In] Object ptr, int ofs)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#endif // !FEATURE_CORECLR
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public static unsafe long ReadInt64(IntPtr ptr, int ofs)
@@ -608,10 +636,17 @@ namespace System.Runtime.InteropServices
             }
         }
 
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_WU1")]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern void WriteByte([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, byte val);    
+#else
+        public static void WriteByte([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, byte val)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#endif // !FEATURE_CORECLR
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteByte(IntPtr ptr, byte val)
@@ -645,11 +680,18 @@ namespace System.Runtime.InteropServices
             }
         }
     
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_WI2")]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern void WriteInt16([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, short val);
-        
+#else
+        public static void WriteInt16([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, short val)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#endif // !FEATURE_CORECLR
+                
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteInt16(IntPtr ptr, short val)
         {
@@ -702,11 +744,18 @@ namespace System.Runtime.InteropServices
             }
         }
         
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_WI4")]
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern void WriteInt32([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, int val);
-        
+#else
+        public static void WriteInt32([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, int val)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#endif // !FEATURE_CORECLR
+
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteInt32(IntPtr ptr, int val)
         {
@@ -775,11 +824,18 @@ namespace System.Runtime.InteropServices
             }
         }
     
+        [System.Security.SecurityCritical]  // auto-generated
+#if !FEATURE_CORECLR
         [DllImport(Win32Native.SHIM, EntryPoint="ND_WI8")]        
         [SuppressUnmanagedCodeSecurity]
-        [System.Security.SecurityCritical]  // auto-generated
         public static extern void WriteInt64([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, long val);
-    
+#else
+        public static void WriteInt64([MarshalAs(UnmanagedType.AsAny),In,Out] Object ptr, int ofs, long val)
+        {
+            throw new PlatformNotSupportedException();
+        }
+#endif // !FEATURE_CORECLR
+
         [System.Security.SecurityCritical]  // auto-generated_required
         public static void WriteInt64(IntPtr ptr, long val)
         {


### PR DESCRIPTION
I don't expect anyone to use these overloads and it doesn't make sense to keep them. Their semantics are rather convoluted and most likely not what one might expect.

@jkotas @tijoytom PTLA.