### PR TITLE
Fix LPSTR test failure due to incorrect implementation of strncpy_s.

### DIFF
--- a/tests/src/Interop/common/xplatform.h
+++ b/tests/src/Interop/common/xplatform.h
@@ -115,7 +115,9 @@ public:
 // function implementation
 size_t strncpy_s(char* strDest, size_t numberOfElements, const char *strSource, size_t count)
 {
-	return snprintf(strDest, count, "%s", strSource);
+    // NOTE: Need to pass count + 1 since strncpy_s does not count null,
+    // while snprintf does. 
+	return snprintf(strDest, count + 1, "%s", strSource);
 }
 
 size_t strcpy_s(char *dest, size_t n, char const *src)

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -168,7 +168,6 @@ JIT/Methodical/Boxing/xlang/_orelsin_cs_il/_orelsin_cs_il.sh
 JIT/Methodical/Boxing/xlang/_relsin_cs_il/_relsin_cs_il.sh
 JIT/Methodical/localloc/call/call01_small/call01_small.sh
 JIT/Regression/Dev11/External/dev11_145295/CSharpPart/CSharpPart.sh
-Interop/StringMarshalling/LPSTR/LPSTRTest/LPSTRTest.sh
 Interop/StringMarshalling/LPTSTR/LPTSTRTest/LPTSTRTest.sh
 GC/LargeMemory/Allocation/finalizertest/finalizertest.sh
 GC/LargeMemory/API/gc/reregisterforfinalize/reregisterforfinalize.sh


### PR DESCRIPTION
It was implemented using snprintf and didn't account for the null terminator behavioral difference. Test is now passing after the fix. We should see if we can always use xplat helpers in all platforms for easier debugging.

Fix #3572