### PR TITLE
Remove usage of ApplicationException in tests

### DIFF
--- a/tests/src/JIT/Directed/ExcepFilters/mixed3/mixed3.il
+++ b/tests/src/JIT/Directed/ExcepFilters/mixed3/mixed3.il
@@ -65,7 +65,7 @@ filter_begin:
                int32 V_2,
                int32 V_3,
                class [mscorlib]System.DivideByZeroException V_4,
-               class [mscorlib]System.ApplicationException V_5)
+               class [mscorlib]System.ArgumentException V_5)
 
       IL_0000:  ldc.i4.0
       IL_0001:  stloc.0
@@ -104,7 +104,7 @@ filter_begin:
       IL_002d:  mul
       IL_002e:  stloc.3
       IL_002f:  ldstr      "Something wrong."
-      IL_0034:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_0034:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string)
       IL_0039:  throw
 
       IL_003a:  leave.s    IL_0074
@@ -139,7 +139,7 @@ filter_begin:
       IL_007b:  ldloc.0
       IL_007c:  ret
       .try IL_0002 to IL_003c catch [mscorlib]System.DivideByZeroException handler IL_003c to IL_0056
-      .try IL_0002 to IL_003c catch [mscorlib]System.ApplicationException handler IL_0056 to IL_0074
+      .try IL_0002 to IL_003c catch [mscorlib]System.ArgumentException handler IL_0056 to IL_0074
       .try IL_0002 to IL_0076 finally handler IL_0076 to IL_007b
     } // end of method 'ZZ::Filter'
 

--- a/tests/src/JIT/Directed/RVAInit/extended.il
+++ b/tests/src/JIT/Directed/RVAInit/extended.il
@@ -51,7 +51,7 @@
       IL_000b:  ldc.i4.s   123
       IL_000d:  beq.s      IL_0015
 
-      IL_000f:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_000f:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0014:  throw
 
       IL_0015:  ldc.i4.0
@@ -100,7 +100,7 @@
       IL_000c:  conv.u1
       IL_000d:  beq.s      IL_0015
 
-      IL_000f:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_000f:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0014:  throw
 
       IL_0015:  ldloc.1
@@ -127,7 +127,7 @@
       IL_0005:  ldc.i4.s   11
       IL_0007:  beq.s      IL_000f
 
-      IL_0009:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0009:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_000e:  throw
 
       IL_000f:  ldsflda    unsigned int8 JitTest.Test::buffer

--- a/tests/src/JIT/Directed/RVAInit/gcref1.il
+++ b/tests/src/JIT/Directed/RVAInit/gcref1.il
@@ -282,7 +282,7 @@
     IL_00f7:  ldc.i4     0xc822
     IL_00fc:  beq.s      IL_0104
 
-    IL_00fe:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+    IL_00fe:  newobj     instance void [mscorlib]System.Exception::.ctor()
     IL_0103:  throw
 
     IL_0104:  ret

--- a/tests/src/JIT/Directed/RVAInit/gcref2.il
+++ b/tests/src/JIT/Directed/RVAInit/gcref2.il
@@ -282,7 +282,7 @@
     IL_00f7:  ldc.i4     0xc822
     IL_00fc:  beq.s      IL_0104
 
-    IL_00fe:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+    IL_00fe:  newobj     instance void [mscorlib]System.Exception::.ctor()
     IL_0103:  throw
 
     IL_0104:  ret

--- a/tests/src/JIT/Directed/RVAInit/nested.il
+++ b/tests/src/JIT/Directed/RVAInit/nested.il
@@ -221,7 +221,7 @@
     IL_00f7:  ldc.i4     0xc822
     IL_00fc:  beq.s      IL_0104
 
-    IL_00fe:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+    IL_00fe:  newobj     instance void [mscorlib]System.Exception::.ctor()
     IL_0103:  throw
 
     IL_0104:  ret

--- a/tests/src/JIT/Directed/RVAInit/overlap.il
+++ b/tests/src/JIT/Directed/RVAInit/overlap.il
@@ -215,7 +215,7 @@
     IL_007c:  ldc.r8     80.001999999999995
     IL_0085:  beq.s      IL_008d
 
-    IL_0087:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+    IL_0087:  newobj     instance void [mscorlib]System.Exception::.ctor()
     IL_008c:  throw
 
     IL_008d:  ret

--- a/tests/src/JIT/Directed/RVAInit/simple.il
+++ b/tests/src/JIT/Directed/RVAInit/simple.il
@@ -206,7 +206,7 @@
     IL_007c:  ldc.r8     80.001999999999995
     IL_0085:  beq.s      IL_008d
 
-    IL_0087:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+    IL_0087:  newobj     instance void [mscorlib]System.Exception::.ctor()
     IL_008c:  throw
 
     IL_008d:  ret

--- a/tests/src/JIT/Directed/pinvoke/tail.il
+++ b/tests/src/JIT/Directed/pinvoke/tail.il
@@ -132,7 +132,7 @@
                                                            string)
         IL_0030:  brtrue.s   IL_0038
 
-        IL_0032:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+        IL_0032:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_0037:  throw
 
         IL_0038:  ldloc.1
@@ -164,7 +164,7 @@
                                                                unsigned int32)
         IL_0064:  brtrue.s   IL_006c
 
-        IL_0066:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+        IL_0066:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_006b:  throw
 
         IL_006c:  ldloc.2
@@ -175,7 +175,7 @@
                                                                          string)
         IL_007e:  brfalse.s  IL_0086
 
-        IL_0080:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+        IL_0080:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_0085:  throw
 
         IL_0086:  ldloc.1
@@ -195,7 +195,7 @@
         IL_0092:  call       bool JitTest.Test::__DestroyMenu(native uint)
         IL_0097:  brtrue.s   IL_009f
 
-        IL_0099:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+        IL_0099:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_009e:  throw
 
         IL_009f:  endfinally

--- a/tests/src/JIT/Directed/rvastatics/rvastatic1.il
+++ b/tests/src/JIT/Directed/rvastatics/rvastatic1.il
@@ -27,769 +27,769 @@
   ldsfld int16 [rvastatic1]A::a0100
   ldc.i4 0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld float32 [rvastatic1]A::a0101
   ldc.r4 1.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld float32 [rvastatic1]A::a0102
   ldc.r4 2.0
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int8 [rvastatic1]A::a0103
   ldc.i4 3
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int16 [rvastatic1]A::a0104
   ldc.i4 4
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int8 [rvastatic1]A::a0105
   ldc.i4 5
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld int8 [rvastatic1]A::a0106
   ldc.i4 6
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld float32 [rvastatic1]A::a0107
   ldc.r4 7.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld float32 [rvastatic1]A::a0108
   ldc.r4 8.0
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int64 [rvastatic1]A::a0109
   ldc.i8 9
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int8 [rvastatic1]A::a01010
   ldc.i4 10
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int8 [rvastatic1]A::a01011
   ldc.i4 11
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int16 [rvastatic1]A::a01012
   ldc.i4 12
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld int32 [rvastatic1]A::a01013
   ldc.i4 13
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int32 [rvastatic1]A::a01014
   ldc.i4 14
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int16 [rvastatic1]A::a01015
   ldc.i4 15
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld int16 [rvastatic1]A::a01016
   ldc.i4 16
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int16 [rvastatic1]A::a01017
   ldc.i4 17
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int32 [rvastatic1]A::a01018
   ldc.i4 18
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int16 [rvastatic1]A::a01019
   ldc.i4 19
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int16 [rvastatic1]A::a01020
   ldc.i4 20
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int64 [rvastatic1]A::a01021
   ldc.i8 21
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int64 [rvastatic1]A::a01022
   ldc.i8 22
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int32 [rvastatic1]A::a01023
   ldc.i4 23
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int8 [rvastatic1]A::a01024
   ldc.i4 24
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int64 [rvastatic1]A::a01025
   ldc.i8 25
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int8 [rvastatic1]A::a01026
   ldc.i4 26
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int16 [rvastatic1]A::a01027
   ldc.i4 27
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int32 [rvastatic1]A::a01028
   ldc.i4 28
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld float32 [rvastatic1]A::a01029
   ldc.r4 29.0
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int16 [rvastatic1]A::a01030
   ldc.i4 30
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int8 [rvastatic1]A::a01031
   ldc.i4 31
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld float32 [rvastatic1]A::a01032
   ldc.r4 32.0
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int32 [rvastatic1]A::a01033
   ldc.i4 33
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int64 [rvastatic1]A::a01034
   ldc.i8 34
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int16 [rvastatic1]A::a01035
   ldc.i4 35
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int8 [rvastatic1]A::a01036
   ldc.i4 36
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int8 [rvastatic1]A::a01037
   ldc.i4 37
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int32 [rvastatic1]A::a01038
   ldc.i4 38
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int16 [rvastatic1]A::a01039
   ldc.i4 39
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int16 [rvastatic1]A::a01040
   ldc.i4 40
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int64 [rvastatic1]A::a01041
   ldc.i8 41
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int8 [rvastatic1]A::a01042
   ldc.i4 42
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld float32 [rvastatic1]A::a01043
   ldc.r4 43.0
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int8 [rvastatic1]A::a01044
   ldc.i4 44
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int16 [rvastatic1]A::a01045
   ldc.i4 45
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int64 [rvastatic1]A::a01046
   ldc.i8 46
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int64 [rvastatic1]A::a01047
   ldc.i8 47
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int16 [rvastatic1]A::a01048
   ldc.i4 48
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int64 [rvastatic1]A::a01049
   ldc.i8 49
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld float32 [rvastatic1]A::a01050
   ldc.r4 50.0
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int32 [rvastatic1]A::a01051
   ldc.i4 51
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int16 [rvastatic1]A::a01052
   ldc.i4 52
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int16 [rvastatic1]A::a01053
   ldc.i4 53
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld float32 [rvastatic1]A::a01054
   ldc.r4 54.0
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int64 [rvastatic1]A::a01055
   ldc.i8 55
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld int16 [rvastatic1]A::a01056
   ldc.i4 56
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int32 [rvastatic1]A::a01057
   ldc.i4 57
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int8 [rvastatic1]A::a01058
   ldc.i4 58
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int64 [rvastatic1]A::a01059
   ldc.i8 59
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld float32 [rvastatic1]A::a01060
   ldc.r4 60.0
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int64 [rvastatic1]A::a01061
   ldc.i8 61
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int32 [rvastatic1]A::a01062
   ldc.i4 62
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int8 [rvastatic1]A::a01063
   ldc.i4 63
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int16 [rvastatic1]A::a01064
   ldc.i4 64
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int8 [rvastatic1]A::a01065
   ldc.i4 65
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int16 [rvastatic1]A::a01066
   ldc.i4 66
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int64 [rvastatic1]A::a01067
   ldc.i8 67
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int64 [rvastatic1]A::a01068
   ldc.i8 68
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int8 [rvastatic1]A::a01069
   ldc.i4 69
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int16 [rvastatic1]A::a01070
   ldc.i4 70
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int16 [rvastatic1]A::a01071
   ldc.i4 71
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld float32 [rvastatic1]A::a01072
   ldc.r4 72.0
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int8 [rvastatic1]A::a01073
   ldc.i4 73
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int8 [rvastatic1]A::a01074
   ldc.i4 74
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int64 [rvastatic1]A::a01075
   ldc.i8 75
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int32 [rvastatic1]A::a01076
   ldc.i4 76
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int64 [rvastatic1]A::a01077
   ldc.i8 77
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int32 [rvastatic1]A::a01078
   ldc.i4 78
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld int64 [rvastatic1]A::a01079
   ldc.i8 79
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld float32 [rvastatic1]A::a01080
   ldc.r4 80.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld int16 [rvastatic1]A::a01081
   ldc.i4 81
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld float32 [rvastatic1]A::a01082
   ldc.r4 82.0
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int64 [rvastatic1]A::a01083
   ldc.i8 83
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int8 [rvastatic1]A::a01084
   ldc.i4 84
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld float32 [rvastatic1]A::a01085
   ldc.r4 85.0
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld float32 [rvastatic1]A::a01086
   ldc.r4 86.0
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int64 [rvastatic1]A::a01087
   ldc.i8 87
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int32 [rvastatic1]A::a01088
   ldc.i4 88
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int8 [rvastatic1]A::a01089
   ldc.i4 89
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int8 [rvastatic1]A::a01090
   ldc.i4 90
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int32 [rvastatic1]A::a01091
   ldc.i4 91
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int8 [rvastatic1]A::a01092
   ldc.i4 92
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld float32 [rvastatic1]A::a01093
   ldc.r4 93.0
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int16 [rvastatic1]A::a01094
   ldc.i4 94
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int32 [rvastatic1]A::a01095
   ldc.i4 95
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int16 [rvastatic1]A::a01096
   ldc.i4 96
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int8 [rvastatic1]A::a01097
   ldc.i4 97
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int64 [rvastatic1]A::a01098
   ldc.i8 98
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int8 [rvastatic1]A::a01099
   ldc.i4 99
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int8 [rvastatic1]A::a010100
   ldc.i4 100
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int8 [rvastatic1]A::a010101
   ldc.i4 101
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int8 [rvastatic1]A::a010102
   ldc.i4 102
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int8 [rvastatic1]A::a010103
   ldc.i4 103
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int16 [rvastatic1]A::a010104
   ldc.i4 104
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int64 [rvastatic1]A::a010105
   ldc.i8 105
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld int32 [rvastatic1]A::a010106
   ldc.i4 106
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int8 [rvastatic1]A::a010107
   ldc.i4 107
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int8 [rvastatic1]A::a010108
   ldc.i4 108
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int16 [rvastatic1]A::a010109
   ldc.i4 109
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int16 [rvastatic1]A::a010110
   ldc.i4 110
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int32 [rvastatic1]A::a010111
   ldc.i4 111
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld float32 [rvastatic1]A::a010112
   ldc.r4 112.0
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int16 [rvastatic1]A::a010113
   ldc.i4 113
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int64 [rvastatic1]A::a010114
   ldc.i8 114
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int64 [rvastatic1]A::a010115
   ldc.i8 115
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int64 [rvastatic1]A::a010116
   ldc.i8 116
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int64 [rvastatic1]A::a010117
   ldc.i8 117
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld float32 [rvastatic1]A::a010118
   ldc.r4 118.0
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int16 [rvastatic1]A::a010119
   ldc.i4 119
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int16 [rvastatic1]A::a010120
   ldc.i4 120
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int64 [rvastatic1]A::a010121
   ldc.i8 121
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int16 [rvastatic1]A::a010122
   ldc.i4 122
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int64 [rvastatic1]A::a010123
   ldc.i8 123
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int8 [rvastatic1]A::a010124
   ldc.i4 4
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int64 [rvastatic1]A::a010125
   ldc.i8 125
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int8 [rvastatic1]A::a010126
   ldc.i4 6
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ldsfld int8 [rvastatic1]A::a010127
   ldc.i4 7
   beq a010128
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010128:
  ret}
@@ -798,896 +798,896 @@ a010128:
   ldind.i2
   ldc.i4 0
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsflda float32 [rvastatic1]A::a0101
   ldind.r4
   ldc.r4 1.0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsflda float32 [rvastatic1]A::a0102
   ldind.r4
   ldc.r4 2.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsflda int8 [rvastatic1]A::a0103
   ldind.i1
   ldc.i4 3
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsflda int16 [rvastatic1]A::a0104
   ldind.i2
   ldc.i4 4
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsflda int8 [rvastatic1]A::a0105
   ldind.i1
   ldc.i4 5
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsflda int8 [rvastatic1]A::a0106
   ldind.i1
   ldc.i4 6
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsflda float32 [rvastatic1]A::a0107
   ldind.r4
   ldc.r4 7.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsflda float32 [rvastatic1]A::a0108
   ldind.r4
   ldc.r4 8.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsflda int64 [rvastatic1]A::a0109
   ldind.i8
   ldc.i8 9
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsflda int8 [rvastatic1]A::a01010
   ldind.i1
   ldc.i4 10
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsflda int8 [rvastatic1]A::a01011
   ldind.i1
   ldc.i4 11
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsflda int16 [rvastatic1]A::a01012
   ldind.i2
   ldc.i4 12
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsflda int32 [rvastatic1]A::a01013
   ldind.i4
   ldc.i4 13
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsflda int32 [rvastatic1]A::a01014
   ldind.i4
   ldc.i4 14
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsflda int16 [rvastatic1]A::a01015
   ldind.i2
   ldc.i4 15
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsflda int16 [rvastatic1]A::a01016
   ldind.i2
   ldc.i4 16
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsflda int16 [rvastatic1]A::a01017
   ldind.i2
   ldc.i4 17
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsflda int32 [rvastatic1]A::a01018
   ldind.i4
   ldc.i4 18
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsflda int16 [rvastatic1]A::a01019
   ldind.i2
   ldc.i4 19
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsflda int16 [rvastatic1]A::a01020
   ldind.i2
   ldc.i4 20
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsflda int64 [rvastatic1]A::a01021
   ldind.i8
   ldc.i8 21
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsflda int64 [rvastatic1]A::a01022
   ldind.i8
   ldc.i8 22
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsflda int32 [rvastatic1]A::a01023
   ldind.i4
   ldc.i4 23
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsflda int8 [rvastatic1]A::a01024
   ldind.i1
   ldc.i4 24
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsflda int64 [rvastatic1]A::a01025
   ldind.i8
   ldc.i8 25
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsflda int8 [rvastatic1]A::a01026
   ldind.i1
   ldc.i4 26
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsflda int16 [rvastatic1]A::a01027
   ldind.i2
   ldc.i4 27
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsflda int32 [rvastatic1]A::a01028
   ldind.i4
   ldc.i4 28
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsflda float32 [rvastatic1]A::a01029
   ldind.r4
   ldc.r4 29.0
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsflda int16 [rvastatic1]A::a01030
   ldind.i2
   ldc.i4 30
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsflda int8 [rvastatic1]A::a01031
   ldind.i1
   ldc.i4 31
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsflda float32 [rvastatic1]A::a01032
   ldind.r4
   ldc.r4 32.0
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsflda int32 [rvastatic1]A::a01033
   ldind.i4
   ldc.i4 33
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsflda int64 [rvastatic1]A::a01034
   ldind.i8
   ldc.i8 34
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsflda int16 [rvastatic1]A::a01035
   ldind.i2
   ldc.i4 35
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsflda int8 [rvastatic1]A::a01036
   ldind.i1
   ldc.i4 36
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsflda int8 [rvastatic1]A::a01037
   ldind.i1
   ldc.i4 37
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsflda int32 [rvastatic1]A::a01038
   ldind.i4
   ldc.i4 38
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsflda int16 [rvastatic1]A::a01039
   ldind.i2
   ldc.i4 39
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsflda int16 [rvastatic1]A::a01040
   ldind.i2
   ldc.i4 40
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsflda int64 [rvastatic1]A::a01041
   ldind.i8
   ldc.i8 41
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsflda int8 [rvastatic1]A::a01042
   ldind.i1
   ldc.i4 42
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsflda float32 [rvastatic1]A::a01043
   ldind.r4
   ldc.r4 43.0
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsflda int8 [rvastatic1]A::a01044
   ldind.i1
   ldc.i4 44
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsflda int16 [rvastatic1]A::a01045
   ldind.i2
   ldc.i4 45
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsflda int64 [rvastatic1]A::a01046
   ldind.i8
   ldc.i8 46
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsflda int64 [rvastatic1]A::a01047
   ldind.i8
   ldc.i8 47
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsflda int16 [rvastatic1]A::a01048
   ldind.i2
   ldc.i4 48
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsflda int64 [rvastatic1]A::a01049
   ldind.i8
   ldc.i8 49
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsflda float32 [rvastatic1]A::a01050
   ldind.r4
   ldc.r4 50.0
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsflda int32 [rvastatic1]A::a01051
   ldind.i4
   ldc.i4 51
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsflda int16 [rvastatic1]A::a01052
   ldind.i2
   ldc.i4 52
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsflda int16 [rvastatic1]A::a01053
   ldind.i2
   ldc.i4 53
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsflda float32 [rvastatic1]A::a01054
   ldind.r4
   ldc.r4 54.0
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsflda int64 [rvastatic1]A::a01055
   ldind.i8
   ldc.i8 55
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsflda int16 [rvastatic1]A::a01056
   ldind.i2
   ldc.i4 56
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsflda int32 [rvastatic1]A::a01057
   ldind.i4
   ldc.i4 57
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsflda int8 [rvastatic1]A::a01058
   ldind.i1
   ldc.i4 58
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsflda int64 [rvastatic1]A::a01059
   ldind.i8
   ldc.i8 59
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsflda float32 [rvastatic1]A::a01060
   ldind.r4
   ldc.r4 60.0
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsflda int64 [rvastatic1]A::a01061
   ldind.i8
   ldc.i8 61
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsflda int32 [rvastatic1]A::a01062
   ldind.i4
   ldc.i4 62
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsflda int8 [rvastatic1]A::a01063
   ldind.i1
   ldc.i4 63
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsflda int16 [rvastatic1]A::a01064
   ldind.i2
   ldc.i4 64
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsflda int8 [rvastatic1]A::a01065
   ldind.i1
   ldc.i4 65
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsflda int16 [rvastatic1]A::a01066
   ldind.i2
   ldc.i4 66
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsflda int64 [rvastatic1]A::a01067
   ldind.i8
   ldc.i8 67
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsflda int64 [rvastatic1]A::a01068
   ldind.i8
   ldc.i8 68
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsflda int8 [rvastatic1]A::a01069
   ldind.i1
   ldc.i4 69
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsflda int16 [rvastatic1]A::a01070
   ldind.i2
   ldc.i4 70
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsflda int16 [rvastatic1]A::a01071
   ldind.i2
   ldc.i4 71
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsflda float32 [rvastatic1]A::a01072
   ldind.r4
   ldc.r4 72.0
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsflda int8 [rvastatic1]A::a01073
   ldind.i1
   ldc.i4 73
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsflda int8 [rvastatic1]A::a01074
   ldind.i1
   ldc.i4 74
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsflda int64 [rvastatic1]A::a01075
   ldind.i8
   ldc.i8 75
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsflda int32 [rvastatic1]A::a01076
   ldind.i4
   ldc.i4 76
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsflda int64 [rvastatic1]A::a01077
   ldind.i8
   ldc.i8 77
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsflda int32 [rvastatic1]A::a01078
   ldind.i4
   ldc.i4 78
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsflda int64 [rvastatic1]A::a01079
   ldind.i8
   ldc.i8 79
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsflda float32 [rvastatic1]A::a01080
   ldind.r4
   ldc.r4 80.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsflda int16 [rvastatic1]A::a01081
   ldind.i2
   ldc.i4 81
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsflda float32 [rvastatic1]A::a01082
   ldind.r4
   ldc.r4 82.0
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsflda int64 [rvastatic1]A::a01083
   ldind.i8
   ldc.i8 83
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsflda int8 [rvastatic1]A::a01084
   ldind.i1
   ldc.i4 84
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsflda float32 [rvastatic1]A::a01085
   ldind.r4
   ldc.r4 85.0
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsflda float32 [rvastatic1]A::a01086
   ldind.r4
   ldc.r4 86.0
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsflda int64 [rvastatic1]A::a01087
   ldind.i8
   ldc.i8 87
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsflda int32 [rvastatic1]A::a01088
   ldind.i4
   ldc.i4 88
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsflda int8 [rvastatic1]A::a01089
   ldind.i1
   ldc.i4 89
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsflda int8 [rvastatic1]A::a01090
   ldind.i1
   ldc.i4 90
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsflda int32 [rvastatic1]A::a01091
   ldind.i4
   ldc.i4 91
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsflda int8 [rvastatic1]A::a01092
   ldind.i1
   ldc.i4 92
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsflda float32 [rvastatic1]A::a01093
   ldind.r4
   ldc.r4 93.0
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsflda int16 [rvastatic1]A::a01094
   ldind.i2
   ldc.i4 94
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsflda int32 [rvastatic1]A::a01095
   ldind.i4
   ldc.i4 95
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsflda int16 [rvastatic1]A::a01096
   ldind.i2
   ldc.i4 96
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsflda int8 [rvastatic1]A::a01097
   ldind.i1
   ldc.i4 97
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsflda int64 [rvastatic1]A::a01098
   ldind.i8
   ldc.i8 98
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsflda int8 [rvastatic1]A::a01099
   ldind.i1
   ldc.i4 99
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsflda int8 [rvastatic1]A::a010100
   ldind.i1
   ldc.i4 100
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsflda int8 [rvastatic1]A::a010101
   ldind.i1
   ldc.i4 101
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsflda int8 [rvastatic1]A::a010102
   ldind.i1
   ldc.i4 102
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsflda int8 [rvastatic1]A::a010103
   ldind.i1
   ldc.i4 103
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsflda int16 [rvastatic1]A::a010104
   ldind.i2
   ldc.i4 104
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsflda int64 [rvastatic1]A::a010105
   ldind.i8
   ldc.i8 105
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsflda int32 [rvastatic1]A::a010106
   ldind.i4
   ldc.i4 106
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsflda int8 [rvastatic1]A::a010107
   ldind.i1
   ldc.i4 107
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsflda int8 [rvastatic1]A::a010108
   ldind.i1
   ldc.i4 108
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsflda int16 [rvastatic1]A::a010109
   ldind.i2
   ldc.i4 109
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsflda int16 [rvastatic1]A::a010110
   ldind.i2
   ldc.i4 110
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsflda int32 [rvastatic1]A::a010111
   ldind.i4
   ldc.i4 111
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsflda float32 [rvastatic1]A::a010112
   ldind.r4
   ldc.r4 112.0
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsflda int16 [rvastatic1]A::a010113
   ldind.i2
   ldc.i4 113
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsflda int64 [rvastatic1]A::a010114
   ldind.i8
   ldc.i8 114
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsflda int64 [rvastatic1]A::a010115
   ldind.i8
   ldc.i8 115
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsflda int64 [rvastatic1]A::a010116
   ldind.i8
   ldc.i8 116
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsflda int64 [rvastatic1]A::a010117
   ldind.i8
   ldc.i8 117
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsflda float32 [rvastatic1]A::a010118
   ldind.r4
   ldc.r4 118.0
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsflda int16 [rvastatic1]A::a010119
   ldind.i2
   ldc.i4 119
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsflda int16 [rvastatic1]A::a010120
   ldind.i2
   ldc.i4 120
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsflda int64 [rvastatic1]A::a010121
   ldind.i8
   ldc.i8 121
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsflda int16 [rvastatic1]A::a010122
   ldind.i2
   ldc.i4 122
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsflda int64 [rvastatic1]A::a010123
   ldind.i8
   ldc.i8 123
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsflda int8 [rvastatic1]A::a010124
   ldind.i1
   ldc.i4 4
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsflda int64 [rvastatic1]A::a010125
   ldind.i8
   ldc.i8 125
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsflda int8 [rvastatic1]A::a010126
   ldind.i1
   ldc.i4 6
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsflda int8 [rvastatic1]A::a010127
   ldind.i1
   ldc.i4 7
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
  ret}
@@ -1695,769 +1695,769 @@ a010127:
   ldsfld float32 [rvastatic1]A::a01050
   ldc.r4 50.0
   beq a010129
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010129:
   ldsfld int32 [rvastatic1]A::a01038
   ldc.i4 38
   beq a010130
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010130:
   ldsfld int32 [rvastatic1]A::a01018
   ldc.i4 18
   beq a010131
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010131:
   ldsfld int64 [rvastatic1]A::a01055
   ldc.i8 55
   beq a010132
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010132:
   ldsfld int32 [rvastatic1]A::a01078
   ldc.i4 78
   beq a010133
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010133:
   ldsfld float32 [rvastatic1]A::a010118
   ldc.r4 118.0
   beq a010134
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010134:
   ldsfld int8 [rvastatic1]A::a01044
   ldc.i4 44
   beq a010135
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010135:
   ldsfld int8 [rvastatic1]A::a010108
   ldc.i4 108
   beq a010136
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010136:
   ldsfld float32 [rvastatic1]A::a01060
   ldc.r4 60.0
   beq a010137
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010137:
   ldsfld int64 [rvastatic1]A::a01047
   ldc.i8 47
   beq a010138
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010138:
   ldsfld float32 [rvastatic1]A::a01050
   ldc.r4 50.0
   beq a010139
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010139:
   ldsfld int64 [rvastatic1]A::a01079
   ldc.i8 79
   beq a010140
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010140:
   ldsfld int16 [rvastatic1]A::a01071
   ldc.i4 71
   beq a010141
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010141:
   ldsfld int16 [rvastatic1]A::a01016
   ldc.i4 16
   beq a010142
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010142:
   ldsfld int8 [rvastatic1]A::a010102
   ldc.i4 102
   beq a010143
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010143:
   ldsfld int8 [rvastatic1]A::a01065
   ldc.i4 65
   beq a010144
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010144:
   ldsfld float32 [rvastatic1]A::a01080
   ldc.r4 80.0
   beq a010145
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010145:
   ldsfld int8 [rvastatic1]A::a01097
   ldc.i4 97
   beq a010146
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010146:
   ldsfld int16 [rvastatic1]A::a01020
   ldc.i4 20
   beq a010147
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010147:
   ldsfld int64 [rvastatic1]A::a01098
   ldc.i8 98
   beq a010148
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010148:
   ldsfld int8 [rvastatic1]A::a01092
   ldc.i4 92
   beq a010149
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010149:
   ldsfld int64 [rvastatic1]A::a01067
   ldc.i8 67
   beq a010150
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010150:
   ldsfld int64 [rvastatic1]A::a01021
   ldc.i8 21
   beq a010151
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010151:
   ldsfld int8 [rvastatic1]A::a01044
   ldc.i4 44
   beq a010152
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010152:
   ldsfld int8 [rvastatic1]A::a010107
   ldc.i4 107
   beq a010153
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010153:
   ldsfld int16 [rvastatic1]A::a01052
   ldc.i4 52
   beq a010154
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010154:
   ldsfld int8 [rvastatic1]A::a010100
   ldc.i4 100
   beq a010155
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010155:
   ldsfld int16 [rvastatic1]A::a01035
   ldc.i4 35
   beq a010156
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010156:
   ldsfld int16 [rvastatic1]A::a0104
   ldc.i4 4
   beq a010157
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010157:
   ldsfld int8 [rvastatic1]A::a01065
   ldc.i4 65
   beq a010158
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010158:
   ldsfld int64 [rvastatic1]A::a01067
   ldc.i8 67
   beq a010159
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010159:
   ldsfld int8 [rvastatic1]A::a01065
   ldc.i4 65
   beq a010160
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010160:
   ldsfld float32 [rvastatic1]A::a01054
   ldc.r4 54.0
   beq a010161
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010161:
   ldsfld float32 [rvastatic1]A::a01043
   ldc.r4 43.0
   beq a010162
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010162:
   ldsfld int64 [rvastatic1]A::a010123
   ldc.i8 123
   beq a010163
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010163:
   ldsfld float32 [rvastatic1]A::a010118
   ldc.r4 118.0
   beq a010164
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010164:
   ldsfld int32 [rvastatic1]A::a01051
   ldc.i4 51
   beq a010165
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010165:
   ldsfld int16 [rvastatic1]A::a01066
   ldc.i4 66
   beq a010166
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010166:
   ldsfld int8 [rvastatic1]A::a01092
   ldc.i4 92
   beq a010167
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010167:
   ldsfld int16 [rvastatic1]A::a01096
   ldc.i4 96
   beq a010168
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010168:
   ldsfld int32 [rvastatic1]A::a01033
   ldc.i4 33
   beq a010169
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010169:
   ldsfld int64 [rvastatic1]A::a010115
   ldc.i8 115
   beq a010170
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010170:
   ldsfld int16 [rvastatic1]A::a01027
   ldc.i4 27
   beq a010171
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010171:
   ldsfld int64 [rvastatic1]A::a01079
   ldc.i8 79
   beq a010172
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010172:
   ldsfld int32 [rvastatic1]A::a010111
   ldc.i4 111
   beq a010173
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010173:
   ldsfld int8 [rvastatic1]A::a01074
   ldc.i4 74
   beq a010174
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010174:
   ldsfld int32 [rvastatic1]A::a01013
   ldc.i4 13
   beq a010175
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010175:
   ldsfld int16 [rvastatic1]A::a01015
   ldc.i4 15
   beq a010176
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010176:
   ldsfld int16 [rvastatic1]A::a010120
   ldc.i4 120
   beq a010177
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010177:
   ldsfld int32 [rvastatic1]A::a01076
   ldc.i4 76
   beq a010178
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010178:
   ldsfld int16 [rvastatic1]A::a01020
   ldc.i4 20
   beq a010179
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010179:
   ldsfld int16 [rvastatic1]A::a01048
   ldc.i4 48
   beq a010180
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010180:
   ldsfld float32 [rvastatic1]A::a010112
   ldc.r4 112.0
   beq a010181
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010181:
   ldsfld int8 [rvastatic1]A::a010127
   ldc.i4 7
   beq a010182
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010182:
   ldsfld int8 [rvastatic1]A::a010124
   ldc.i4 4
   beq a010183
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010183:
   ldsfld int32 [rvastatic1]A::a010111
   ldc.i4 111
   beq a010184
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010184:
   ldsfld int16 [rvastatic1]A::a01016
   ldc.i4 16
   beq a010185
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010185:
   ldsfld int8 [rvastatic1]A::a010102
   ldc.i4 102
   beq a010186
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010186:
   ldsfld int32 [rvastatic1]A::a01076
   ldc.i4 76
   beq a010187
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010187:
   ldsfld int64 [rvastatic1]A::a01025
   ldc.i8 25
   beq a010188
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010188:
   ldsfld int16 [rvastatic1]A::a01017
   ldc.i4 17
   beq a010189
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010189:
   ldsfld float32 [rvastatic1]A::a0108
   ldc.r4 8.0
   beq a010190
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010190:
   ldsfld int8 [rvastatic1]A::a010103
   ldc.i4 103
   beq a010191
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010191:
   ldsfld int64 [rvastatic1]A::a010123
   ldc.i8 123
   beq a010192
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010192:
   ldsfld int8 [rvastatic1]A::a010107
   ldc.i4 107
   beq a010193
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010193:
   ldsfld int16 [rvastatic1]A::a010113
   ldc.i4 113
   beq a010194
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010194:
   ldsfld int8 [rvastatic1]A::a01024
   ldc.i4 24
   beq a010195
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010195:
   ldsfld int32 [rvastatic1]A::a01028
   ldc.i4 28
   beq a010196
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010196:
   ldsfld int16 [rvastatic1]A::a01020
   ldc.i4 20
   beq a010197
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010197:
   ldsfld float32 [rvastatic1]A::a010112
   ldc.r4 112.0
   beq a010198
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010198:
   ldsfld int32 [rvastatic1]A::a01013
   ldc.i4 13
   beq a010199
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010199:
   ldsfld int32 [rvastatic1]A::a01013
   ldc.i4 13
   beq a010200
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010200:
   ldsfld int16 [rvastatic1]A::a0104
   ldc.i4 4
   beq a010201
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010201:
   ldsfld int32 [rvastatic1]A::a01051
   ldc.i4 51
   beq a010202
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010202:
   ldsfld int16 [rvastatic1]A::a01064
   ldc.i4 64
   beq a010203
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010203:
   ldsfld int64 [rvastatic1]A::a010105
   ldc.i8 105
   beq a010204
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010204:
   ldsfld int16 [rvastatic1]A::a01040
   ldc.i4 40
   beq a010205
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010205:
   ldsfld int8 [rvastatic1]A::a01069
   ldc.i4 69
   beq a010206
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010206:
   ldsfld float32 [rvastatic1]A::a01060
   ldc.r4 60.0
   beq a010207
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010207:
   ldsfld float32 [rvastatic1]A::a01032
   ldc.r4 32.0
   beq a010208
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010208:
   ldsfld int16 [rvastatic1]A::a01039
   ldc.i4 39
   beq a010209
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010209:
   ldsfld int8 [rvastatic1]A::a01084
   ldc.i4 84
   beq a010210
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010210:
   ldsfld float32 [rvastatic1]A::a01043
   ldc.r4 43.0
   beq a010211
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010211:
   ldsfld int64 [rvastatic1]A::a01055
   ldc.i8 55
   beq a010212
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010212:
   ldsfld int8 [rvastatic1]A::a01044
   ldc.i4 44
   beq a010213
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010213:
   ldsfld int16 [rvastatic1]A::a01019
   ldc.i4 19
   beq a010214
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010214:
   ldsfld float32 [rvastatic1]A::a01080
   ldc.r4 80.0
   beq a010215
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010215:
   ldsfld float32 [rvastatic1]A::a01054
   ldc.r4 54.0
   beq a010216
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010216:
   ldsfld int64 [rvastatic1]A::a01046
   ldc.i8 46
   beq a010217
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010217:
   ldsfld int16 [rvastatic1]A::a01012
   ldc.i4 12
   beq a010218
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010218:
   ldsfld int8 [rvastatic1]A::a010101
   ldc.i4 101
   beq a010219
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010219:
   ldsfld int32 [rvastatic1]A::a01076
   ldc.i4 76
   beq a010220
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010220:
   ldsfld float32 [rvastatic1]A::a010118
   ldc.r4 118.0
   beq a010221
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010221:
   ldsfld int16 [rvastatic1]A::a01066
   ldc.i4 66
   beq a010222
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010222:
   ldsfld int32 [rvastatic1]A::a01078
   ldc.i4 78
   beq a010223
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010223:
   ldsfld int8 [rvastatic1]A::a01024
   ldc.i4 24
   beq a010224
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010224:
   ldsfld int16 [rvastatic1]A::a01012
   ldc.i4 12
   beq a010225
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010225:
   ldsfld int8 [rvastatic1]A::a01031
   ldc.i4 31
   beq a010226
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010226:
   ldsfld int8 [rvastatic1]A::a01099
   ldc.i4 99
   beq a010227
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010227:
   ldsfld int8 [rvastatic1]A::a010126
   ldc.i4 6
   beq a010228
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010228:
   ldsfld int64 [rvastatic1]A::a01049
   ldc.i8 49
   beq a010229
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010229:
   ldsfld int16 [rvastatic1]A::a010113
   ldc.i4 113
   beq a010230
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010230:
   ldsfld int64 [rvastatic1]A::a010123
   ldc.i8 123
   beq a010231
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010231:
   ldsfld float32 [rvastatic1]A::a0108
   ldc.r4 8.0
   beq a010232
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010232:
   ldsfld int8 [rvastatic1]A::a01063
   ldc.i4 63
   beq a010233
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010233:
   ldsfld float32 [rvastatic1]A::a0107
   ldc.r4 7.0
   beq a010234
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010234:
   ldsfld float32 [rvastatic1]A::a01043
   ldc.r4 43.0
   beq a010235
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010235:
   ldsfld int64 [rvastatic1]A::a01061
   ldc.i8 61
   beq a010236
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010236:
   ldsfld int8 [rvastatic1]A::a01063
   ldc.i4 63
   beq a010237
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010237:
   ldsfld int16 [rvastatic1]A::a01019
   ldc.i4 19
   beq a010238
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010238:
   ldsfld int16 [rvastatic1]A::a01071
   ldc.i4 71
   beq a010239
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010239:
   ldsfld int8 [rvastatic1]A::a01074
   ldc.i4 74
   beq a010240
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010240:
   ldsfld int8 [rvastatic1]A::a01042
   ldc.i4 42
   beq a010241
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010241:
   ldsfld float32 [rvastatic1]A::a01043
   ldc.r4 43.0
   beq a010242
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010242:
   ldsfld int64 [rvastatic1]A::a010114
   ldc.i8 114
   beq a010243
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010243:
   ldsfld int64 [rvastatic1]A::a01061
   ldc.i8 61
   beq a010244
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010244:
   ldsfld float32 [rvastatic1]A::a01093
   ldc.r4 93.0
   beq a010245
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010245:
   ldsfld int64 [rvastatic1]A::a01047
   ldc.i8 47
   beq a010246
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010246:
   ldsfld int64 [rvastatic1]A::a01079
   ldc.i8 79
   beq a010247
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010247:
   ldsfld int32 [rvastatic1]A::a01088
   ldc.i4 88
   beq a010248
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010248:
   ldsfld float32 [rvastatic1]A::a01032
   ldc.r4 32.0
   beq a010249
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010249:
   ldsfld int64 [rvastatic1]A::a01098
   ldc.i8 98
   beq a010250
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010250:
   ldsfld int16 [rvastatic1]A::a010110
   ldc.i4 110
   beq a010251
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010251:
   ldsfld float32 [rvastatic1]A::a0107
   ldc.r4 7.0
   beq a010252
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010252:
   ldsfld int8 [rvastatic1]A::a01010
   ldc.i4 10
   beq a010253
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010253:
   ldsfld int16 [rvastatic1]A::a01064
   ldc.i4 64
   beq a010254
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010254:
   ldsfld int32 [rvastatic1]A::a01023
   ldc.i4 23
   beq a010255
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010255:
   ldsfld int16 [rvastatic1]A::a01066
   ldc.i4 66
   beq a010256
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010256:
  ret}
@@ -2478,7 +2478,7 @@ a010256:
   ldc.i4 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda float32 [rvastatic1]A::a0101
@@ -2493,7 +2493,7 @@ a0100:
   ldc.r4 1.0
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda float32 [rvastatic1]A::a0102
@@ -2512,7 +2512,7 @@ a0101:
   ldc.r4 2.0
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int8 [rvastatic1]A::a0103
@@ -2531,7 +2531,7 @@ a0102:
   ldc.i4 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int16 [rvastatic1]A::a0104
@@ -2547,7 +2547,7 @@ a0103:
   ldc.i4 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int8 [rvastatic1]A::a0105
@@ -2566,7 +2566,7 @@ a0104:
   ldc.i4 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int8 [rvastatic1]A::a0106
@@ -2581,7 +2581,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda float32 [rvastatic1]A::a0107
@@ -2595,7 +2595,7 @@ a0106:
   ldc.r4 7.0
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda float32 [rvastatic1]A::a0108
@@ -2610,7 +2610,7 @@ a0107:
   ldc.r4 8.0
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int64 [rvastatic1]A::a0109
@@ -2625,7 +2625,7 @@ a0108:
   ldc.i8 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int8 [rvastatic1]A::a01010
@@ -2640,7 +2640,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int8 [rvastatic1]A::a01011
@@ -2654,7 +2654,7 @@ a01010:
   ldc.i4 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int16 [rvastatic1]A::a01012
@@ -2668,7 +2668,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda int32 [rvastatic1]A::a01013
@@ -2687,7 +2687,7 @@ a01012:
   ldc.i4 13
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda int32 [rvastatic1]A::a01014
@@ -2702,7 +2702,7 @@ a01013:
   ldc.i4 14
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int16 [rvastatic1]A::a01015
@@ -2721,7 +2721,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda int16 [rvastatic1]A::a01016
@@ -2735,7 +2735,7 @@ a01015:
   ldc.i4 16
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda int16 [rvastatic1]A::a01017
@@ -2749,7 +2749,7 @@ a01016:
   ldc.i4 17
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int32 [rvastatic1]A::a01018
@@ -2764,7 +2764,7 @@ a01017:
   ldc.i4 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int16 [rvastatic1]A::a01019
@@ -2779,7 +2779,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int16 [rvastatic1]A::a01020
@@ -2794,7 +2794,7 @@ a01019:
   ldc.i4 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda int64 [rvastatic1]A::a01021
@@ -2809,7 +2809,7 @@ a01020:
   ldc.i8 21
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int64 [rvastatic1]A::a01022
@@ -2824,7 +2824,7 @@ a01021:
   ldc.i8 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int32 [rvastatic1]A::a01023
@@ -2840,7 +2840,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int8 [rvastatic1]A::a01024
@@ -2859,7 +2859,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int64 [rvastatic1]A::a01025
@@ -2875,7 +2875,7 @@ a01024:
   ldc.i8 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int8 [rvastatic1]A::a01026
@@ -2891,7 +2891,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int16 [rvastatic1]A::a01027
@@ -2905,7 +2905,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int32 [rvastatic1]A::a01028
@@ -2919,7 +2919,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda float32 [rvastatic1]A::a01029
@@ -2935,7 +2935,7 @@ a01028:
   ldc.r4 29.0
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int16 [rvastatic1]A::a01030
@@ -2949,7 +2949,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int8 [rvastatic1]A::a01031
@@ -2968,7 +2968,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda float32 [rvastatic1]A::a01032
@@ -2982,7 +2982,7 @@ a01031:
   ldc.r4 32.0
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda int32 [rvastatic1]A::a01033
@@ -2997,7 +2997,7 @@ a01032:
   ldc.i4 33
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int64 [rvastatic1]A::a01034
@@ -3016,7 +3016,7 @@ a01033:
   ldc.i8 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int16 [rvastatic1]A::a01035
@@ -3035,7 +3035,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int8 [rvastatic1]A::a01036
@@ -3054,7 +3054,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int8 [rvastatic1]A::a01037
@@ -3073,7 +3073,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int32 [rvastatic1]A::a01038
@@ -3092,7 +3092,7 @@ a01037:
   ldc.i4 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int16 [rvastatic1]A::a01039
@@ -3107,7 +3107,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int16 [rvastatic1]A::a01040
@@ -3121,7 +3121,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int64 [rvastatic1]A::a01041
@@ -3136,7 +3136,7 @@ a01040:
   ldc.i8 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int8 [rvastatic1]A::a01042
@@ -3155,7 +3155,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda float32 [rvastatic1]A::a01043
@@ -3174,7 +3174,7 @@ a01042:
   ldc.r4 43.0
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int8 [rvastatic1]A::a01044
@@ -3188,7 +3188,7 @@ a01043:
   ldc.i4 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int16 [rvastatic1]A::a01045
@@ -3207,7 +3207,7 @@ a01044:
   ldc.i4 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int64 [rvastatic1]A::a01046
@@ -3222,7 +3222,7 @@ a01045:
   ldc.i8 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int64 [rvastatic1]A::a01047
@@ -3238,7 +3238,7 @@ a01046:
   ldc.i8 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda int16 [rvastatic1]A::a01048
@@ -3252,7 +3252,7 @@ a01047:
   ldc.i4 48
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int64 [rvastatic1]A::a01049
@@ -3267,7 +3267,7 @@ a01048:
   ldc.i8 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda float32 [rvastatic1]A::a01050
@@ -3286,7 +3286,7 @@ a01049:
   ldc.r4 50.0
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int32 [rvastatic1]A::a01051
@@ -3301,7 +3301,7 @@ a01050:
   ldc.i4 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int16 [rvastatic1]A::a01052
@@ -3316,7 +3316,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int16 [rvastatic1]A::a01053
@@ -3331,7 +3331,7 @@ a01052:
   ldc.i4 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda float32 [rvastatic1]A::a01054
@@ -3346,7 +3346,7 @@ a01053:
   ldc.r4 54.0
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int64 [rvastatic1]A::a01055
@@ -3361,7 +3361,7 @@ a01054:
   ldc.i8 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda int16 [rvastatic1]A::a01056
@@ -3375,7 +3375,7 @@ a01055:
   ldc.i4 56
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int32 [rvastatic1]A::a01057
@@ -3389,7 +3389,7 @@ a01056:
   ldc.i4 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int8 [rvastatic1]A::a01058
@@ -3403,7 +3403,7 @@ a01057:
   ldc.i4 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int64 [rvastatic1]A::a01059
@@ -3418,7 +3418,7 @@ a01058:
   ldc.i8 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda float32 [rvastatic1]A::a01060
@@ -3434,7 +3434,7 @@ a01059:
   ldc.r4 60.0
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int64 [rvastatic1]A::a01061
@@ -3449,7 +3449,7 @@ a01060:
   ldc.i8 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int32 [rvastatic1]A::a01062
@@ -3468,7 +3468,7 @@ a01061:
   ldc.i4 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda int8 [rvastatic1]A::a01063
@@ -3482,7 +3482,7 @@ a01062:
   ldc.i4 63
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int16 [rvastatic1]A::a01064
@@ -3498,7 +3498,7 @@ a01063:
   ldc.i4 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int8 [rvastatic1]A::a01065
@@ -3512,7 +3512,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int16 [rvastatic1]A::a01066
@@ -3527,7 +3527,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int64 [rvastatic1]A::a01067
@@ -3546,7 +3546,7 @@ a01066:
   ldc.i8 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int64 [rvastatic1]A::a01068
@@ -3561,7 +3561,7 @@ a01067:
   ldc.i8 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int8 [rvastatic1]A::a01069
@@ -3575,7 +3575,7 @@ a01068:
   ldc.i4 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda int16 [rvastatic1]A::a01070
@@ -3590,7 +3590,7 @@ a01069:
   ldc.i4 70
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int16 [rvastatic1]A::a01071
@@ -3609,7 +3609,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda float32 [rvastatic1]A::a01072
@@ -3628,7 +3628,7 @@ a01071:
   ldc.r4 72.0
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int8 [rvastatic1]A::a01073
@@ -3643,7 +3643,7 @@ a01072:
   ldc.i4 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda int8 [rvastatic1]A::a01074
@@ -3658,7 +3658,7 @@ a01073:
   ldc.i4 74
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int64 [rvastatic1]A::a01075
@@ -3677,7 +3677,7 @@ a01074:
   ldc.i8 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int32 [rvastatic1]A::a01076
@@ -3692,7 +3692,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int64 [rvastatic1]A::a01077
@@ -3711,7 +3711,7 @@ a01076:
   ldc.i8 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int32 [rvastatic1]A::a01078
@@ -3730,7 +3730,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda int64 [rvastatic1]A::a01079
@@ -3745,7 +3745,7 @@ a01078:
   ldc.i8 79
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda float32 [rvastatic1]A::a01080
@@ -3760,7 +3760,7 @@ a01079:
   ldc.r4 80.0
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda int16 [rvastatic1]A::a01081
@@ -3779,7 +3779,7 @@ a01080:
   ldc.i4 81
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda float32 [rvastatic1]A::a01082
@@ -3793,7 +3793,7 @@ a01081:
   ldc.r4 82.0
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int64 [rvastatic1]A::a01083
@@ -3807,7 +3807,7 @@ a01082:
   ldc.i8 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int8 [rvastatic1]A::a01084
@@ -3826,7 +3826,7 @@ a01083:
   ldc.i4 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda float32 [rvastatic1]A::a01085
@@ -3842,7 +3842,7 @@ a01084:
   ldc.r4 85.0
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda float32 [rvastatic1]A::a01086
@@ -3858,7 +3858,7 @@ a01085:
   ldc.r4 86.0
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int64 [rvastatic1]A::a01087
@@ -3874,7 +3874,7 @@ a01086:
   ldc.i8 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int32 [rvastatic1]A::a01088
@@ -3888,7 +3888,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int8 [rvastatic1]A::a01089
@@ -3907,7 +3907,7 @@ a01088:
   ldc.i4 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int8 [rvastatic1]A::a01090
@@ -3926,7 +3926,7 @@ a01089:
   ldc.i4 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int32 [rvastatic1]A::a01091
@@ -3945,7 +3945,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int8 [rvastatic1]A::a01092
@@ -3959,7 +3959,7 @@ a01091:
   ldc.i4 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda float32 [rvastatic1]A::a01093
@@ -3974,7 +3974,7 @@ a01092:
   ldc.r4 93.0
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int16 [rvastatic1]A::a01094
@@ -3988,7 +3988,7 @@ a01093:
   ldc.i4 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int32 [rvastatic1]A::a01095
@@ -4004,7 +4004,7 @@ a01094:
   ldc.i4 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda int16 [rvastatic1]A::a01096
@@ -4020,7 +4020,7 @@ a01095:
   ldc.i4 96
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int8 [rvastatic1]A::a01097
@@ -4039,7 +4039,7 @@ a01096:
   ldc.i4 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda int64 [rvastatic1]A::a01098
@@ -4053,7 +4053,7 @@ a01097:
   ldc.i8 98
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int8 [rvastatic1]A::a01099
@@ -4067,7 +4067,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int8 [rvastatic1]A::a010100
@@ -4082,7 +4082,7 @@ a01099:
   ldc.i4 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int8 [rvastatic1]A::a010101
@@ -4101,7 +4101,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda int8 [rvastatic1]A::a010102
@@ -4115,7 +4115,7 @@ a010101:
   ldc.i4 102
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int8 [rvastatic1]A::a010103
@@ -4130,7 +4130,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int16 [rvastatic1]A::a010104
@@ -4149,7 +4149,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int64 [rvastatic1]A::a010105
@@ -4164,7 +4164,7 @@ a010104:
   ldc.i8 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda int32 [rvastatic1]A::a010106
@@ -4179,7 +4179,7 @@ a010105:
   ldc.i4 106
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda int8 [rvastatic1]A::a010107
@@ -4194,7 +4194,7 @@ a010106:
   ldc.i4 107
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int8 [rvastatic1]A::a010108
@@ -4208,7 +4208,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int16 [rvastatic1]A::a010109
@@ -4223,7 +4223,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int16 [rvastatic1]A::a010110
@@ -4237,7 +4237,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int32 [rvastatic1]A::a010111
@@ -4251,7 +4251,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda float32 [rvastatic1]A::a010112
@@ -4266,7 +4266,7 @@ a010111:
   ldc.r4 112.0
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int16 [rvastatic1]A::a010113
@@ -4281,7 +4281,7 @@ a010112:
   ldc.i4 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int64 [rvastatic1]A::a010114
@@ -4296,7 +4296,7 @@ a010113:
   ldc.i8 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int64 [rvastatic1]A::a010115
@@ -4312,7 +4312,7 @@ a010114:
   ldc.i8 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int64 [rvastatic1]A::a010116
@@ -4331,7 +4331,7 @@ a010115:
   ldc.i8 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int64 [rvastatic1]A::a010117
@@ -4346,7 +4346,7 @@ a010116:
   ldc.i8 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda float32 [rvastatic1]A::a010118
@@ -4362,7 +4362,7 @@ a010117:
   ldc.r4 118.0
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int16 [rvastatic1]A::a010119
@@ -4377,7 +4377,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int16 [rvastatic1]A::a010120
@@ -4396,7 +4396,7 @@ a010119:
   ldc.i4 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int64 [rvastatic1]A::a010121
@@ -4412,7 +4412,7 @@ a010120:
   ldc.i8 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int16 [rvastatic1]A::a010122
@@ -4427,7 +4427,7 @@ a010121:
   ldc.i4 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int64 [rvastatic1]A::a010123
@@ -4443,7 +4443,7 @@ a010122:
   ldc.i8 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int8 [rvastatic1]A::a010124
@@ -4457,7 +4457,7 @@ a010123:
   ldc.i4 4
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int64 [rvastatic1]A::a010125
@@ -4476,7 +4476,7 @@ a010124:
   ldc.i8 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int8 [rvastatic1]A::a010126
@@ -4491,7 +4491,7 @@ a010125:
   ldc.i4 6
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int8 [rvastatic1]A::a010127
@@ -4505,7 +4505,7 @@ a010126:
   ldc.i4 7
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -4517,7 +4517,7 @@ a010127:
   ldc.i4 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda float32 [rvastatic1]A::a0101
@@ -4527,7 +4527,7 @@ a0100:
   ldc.r4 1.0
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda float32 [rvastatic1]A::a0102
@@ -4537,7 +4537,7 @@ a0101:
   ldc.r4 2.0
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int8 [rvastatic1]A::a0103
@@ -4547,7 +4547,7 @@ a0102:
   ldc.i4 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int16 [rvastatic1]A::a0104
@@ -4557,7 +4557,7 @@ a0103:
   ldc.i4 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int8 [rvastatic1]A::a0105
@@ -4567,7 +4567,7 @@ a0104:
   ldc.i4 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int8 [rvastatic1]A::a0106
@@ -4577,7 +4577,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda float32 [rvastatic1]A::a0107
@@ -4587,7 +4587,7 @@ a0106:
   ldc.r4 7.0
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda float32 [rvastatic1]A::a0108
@@ -4597,7 +4597,7 @@ a0107:
   ldc.r4 8.0
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int64 [rvastatic1]A::a0109
@@ -4607,7 +4607,7 @@ a0108:
   ldc.i8 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int8 [rvastatic1]A::a01010
@@ -4617,7 +4617,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int8 [rvastatic1]A::a01011
@@ -4627,7 +4627,7 @@ a01010:
   ldc.i4 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int16 [rvastatic1]A::a01012
@@ -4637,7 +4637,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda int32 [rvastatic1]A::a01013
@@ -4647,7 +4647,7 @@ a01012:
   ldc.i4 13
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda int32 [rvastatic1]A::a01014
@@ -4657,7 +4657,7 @@ a01013:
   ldc.i4 14
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int16 [rvastatic1]A::a01015
@@ -4667,7 +4667,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda int16 [rvastatic1]A::a01016
@@ -4677,7 +4677,7 @@ a01015:
   ldc.i4 16
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda int16 [rvastatic1]A::a01017
@@ -4687,7 +4687,7 @@ a01016:
   ldc.i4 17
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int32 [rvastatic1]A::a01018
@@ -4697,7 +4697,7 @@ a01017:
   ldc.i4 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int16 [rvastatic1]A::a01019
@@ -4707,7 +4707,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int16 [rvastatic1]A::a01020
@@ -4717,7 +4717,7 @@ a01019:
   ldc.i4 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda int64 [rvastatic1]A::a01021
@@ -4727,7 +4727,7 @@ a01020:
   ldc.i8 21
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int64 [rvastatic1]A::a01022
@@ -4737,7 +4737,7 @@ a01021:
   ldc.i8 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int32 [rvastatic1]A::a01023
@@ -4747,7 +4747,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int8 [rvastatic1]A::a01024
@@ -4757,7 +4757,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int64 [rvastatic1]A::a01025
@@ -4767,7 +4767,7 @@ a01024:
   ldc.i8 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int8 [rvastatic1]A::a01026
@@ -4777,7 +4777,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int16 [rvastatic1]A::a01027
@@ -4787,7 +4787,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int32 [rvastatic1]A::a01028
@@ -4797,7 +4797,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda float32 [rvastatic1]A::a01029
@@ -4807,7 +4807,7 @@ a01028:
   ldc.r4 29.0
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int16 [rvastatic1]A::a01030
@@ -4817,7 +4817,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int8 [rvastatic1]A::a01031
@@ -4827,7 +4827,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda float32 [rvastatic1]A::a01032
@@ -4837,7 +4837,7 @@ a01031:
   ldc.r4 32.0
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda int32 [rvastatic1]A::a01033
@@ -4847,7 +4847,7 @@ a01032:
   ldc.i4 33
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int64 [rvastatic1]A::a01034
@@ -4857,7 +4857,7 @@ a01033:
   ldc.i8 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int16 [rvastatic1]A::a01035
@@ -4867,7 +4867,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int8 [rvastatic1]A::a01036
@@ -4877,7 +4877,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int8 [rvastatic1]A::a01037
@@ -4887,7 +4887,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int32 [rvastatic1]A::a01038
@@ -4897,7 +4897,7 @@ a01037:
   ldc.i4 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int16 [rvastatic1]A::a01039
@@ -4907,7 +4907,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int16 [rvastatic1]A::a01040
@@ -4917,7 +4917,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int64 [rvastatic1]A::a01041
@@ -4927,7 +4927,7 @@ a01040:
   ldc.i8 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int8 [rvastatic1]A::a01042
@@ -4937,7 +4937,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda float32 [rvastatic1]A::a01043
@@ -4947,7 +4947,7 @@ a01042:
   ldc.r4 43.0
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int8 [rvastatic1]A::a01044
@@ -4957,7 +4957,7 @@ a01043:
   ldc.i4 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int16 [rvastatic1]A::a01045
@@ -4967,7 +4967,7 @@ a01044:
   ldc.i4 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int64 [rvastatic1]A::a01046
@@ -4977,7 +4977,7 @@ a01045:
   ldc.i8 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int64 [rvastatic1]A::a01047
@@ -4987,7 +4987,7 @@ a01046:
   ldc.i8 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda int16 [rvastatic1]A::a01048
@@ -4997,7 +4997,7 @@ a01047:
   ldc.i4 48
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int64 [rvastatic1]A::a01049
@@ -5007,7 +5007,7 @@ a01048:
   ldc.i8 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda float32 [rvastatic1]A::a01050
@@ -5017,7 +5017,7 @@ a01049:
   ldc.r4 50.0
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int32 [rvastatic1]A::a01051
@@ -5027,7 +5027,7 @@ a01050:
   ldc.i4 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int16 [rvastatic1]A::a01052
@@ -5037,7 +5037,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int16 [rvastatic1]A::a01053
@@ -5047,7 +5047,7 @@ a01052:
   ldc.i4 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda float32 [rvastatic1]A::a01054
@@ -5057,7 +5057,7 @@ a01053:
   ldc.r4 54.0
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int64 [rvastatic1]A::a01055
@@ -5067,7 +5067,7 @@ a01054:
   ldc.i8 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda int16 [rvastatic1]A::a01056
@@ -5077,7 +5077,7 @@ a01055:
   ldc.i4 56
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int32 [rvastatic1]A::a01057
@@ -5087,7 +5087,7 @@ a01056:
   ldc.i4 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int8 [rvastatic1]A::a01058
@@ -5097,7 +5097,7 @@ a01057:
   ldc.i4 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int64 [rvastatic1]A::a01059
@@ -5107,7 +5107,7 @@ a01058:
   ldc.i8 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda float32 [rvastatic1]A::a01060
@@ -5117,7 +5117,7 @@ a01059:
   ldc.r4 60.0
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int64 [rvastatic1]A::a01061
@@ -5127,7 +5127,7 @@ a01060:
   ldc.i8 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int32 [rvastatic1]A::a01062
@@ -5137,7 +5137,7 @@ a01061:
   ldc.i4 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda int8 [rvastatic1]A::a01063
@@ -5147,7 +5147,7 @@ a01062:
   ldc.i4 63
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int16 [rvastatic1]A::a01064
@@ -5157,7 +5157,7 @@ a01063:
   ldc.i4 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int8 [rvastatic1]A::a01065
@@ -5167,7 +5167,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int16 [rvastatic1]A::a01066
@@ -5177,7 +5177,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int64 [rvastatic1]A::a01067
@@ -5187,7 +5187,7 @@ a01066:
   ldc.i8 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int64 [rvastatic1]A::a01068
@@ -5197,7 +5197,7 @@ a01067:
   ldc.i8 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int8 [rvastatic1]A::a01069
@@ -5207,7 +5207,7 @@ a01068:
   ldc.i4 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda int16 [rvastatic1]A::a01070
@@ -5217,7 +5217,7 @@ a01069:
   ldc.i4 70
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int16 [rvastatic1]A::a01071
@@ -5227,7 +5227,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda float32 [rvastatic1]A::a01072
@@ -5237,7 +5237,7 @@ a01071:
   ldc.r4 72.0
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int8 [rvastatic1]A::a01073
@@ -5247,7 +5247,7 @@ a01072:
   ldc.i4 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda int8 [rvastatic1]A::a01074
@@ -5257,7 +5257,7 @@ a01073:
   ldc.i4 74
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int64 [rvastatic1]A::a01075
@@ -5267,7 +5267,7 @@ a01074:
   ldc.i8 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int32 [rvastatic1]A::a01076
@@ -5277,7 +5277,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int64 [rvastatic1]A::a01077
@@ -5287,7 +5287,7 @@ a01076:
   ldc.i8 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int32 [rvastatic1]A::a01078
@@ -5297,7 +5297,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda int64 [rvastatic1]A::a01079
@@ -5307,7 +5307,7 @@ a01078:
   ldc.i8 79
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda float32 [rvastatic1]A::a01080
@@ -5317,7 +5317,7 @@ a01079:
   ldc.r4 80.0
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda int16 [rvastatic1]A::a01081
@@ -5327,7 +5327,7 @@ a01080:
   ldc.i4 81
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda float32 [rvastatic1]A::a01082
@@ -5337,7 +5337,7 @@ a01081:
   ldc.r4 82.0
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int64 [rvastatic1]A::a01083
@@ -5347,7 +5347,7 @@ a01082:
   ldc.i8 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int8 [rvastatic1]A::a01084
@@ -5357,7 +5357,7 @@ a01083:
   ldc.i4 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda float32 [rvastatic1]A::a01085
@@ -5367,7 +5367,7 @@ a01084:
   ldc.r4 85.0
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda float32 [rvastatic1]A::a01086
@@ -5377,7 +5377,7 @@ a01085:
   ldc.r4 86.0
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int64 [rvastatic1]A::a01087
@@ -5387,7 +5387,7 @@ a01086:
   ldc.i8 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int32 [rvastatic1]A::a01088
@@ -5397,7 +5397,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int8 [rvastatic1]A::a01089
@@ -5407,7 +5407,7 @@ a01088:
   ldc.i4 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int8 [rvastatic1]A::a01090
@@ -5417,7 +5417,7 @@ a01089:
   ldc.i4 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int32 [rvastatic1]A::a01091
@@ -5427,7 +5427,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int8 [rvastatic1]A::a01092
@@ -5437,7 +5437,7 @@ a01091:
   ldc.i4 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda float32 [rvastatic1]A::a01093
@@ -5447,7 +5447,7 @@ a01092:
   ldc.r4 93.0
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int16 [rvastatic1]A::a01094
@@ -5457,7 +5457,7 @@ a01093:
   ldc.i4 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int32 [rvastatic1]A::a01095
@@ -5467,7 +5467,7 @@ a01094:
   ldc.i4 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda int16 [rvastatic1]A::a01096
@@ -5477,7 +5477,7 @@ a01095:
   ldc.i4 96
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int8 [rvastatic1]A::a01097
@@ -5487,7 +5487,7 @@ a01096:
   ldc.i4 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda int64 [rvastatic1]A::a01098
@@ -5497,7 +5497,7 @@ a01097:
   ldc.i8 98
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int8 [rvastatic1]A::a01099
@@ -5507,7 +5507,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int8 [rvastatic1]A::a010100
@@ -5517,7 +5517,7 @@ a01099:
   ldc.i4 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int8 [rvastatic1]A::a010101
@@ -5527,7 +5527,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda int8 [rvastatic1]A::a010102
@@ -5537,7 +5537,7 @@ a010101:
   ldc.i4 102
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int8 [rvastatic1]A::a010103
@@ -5547,7 +5547,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int16 [rvastatic1]A::a010104
@@ -5557,7 +5557,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int64 [rvastatic1]A::a010105
@@ -5567,7 +5567,7 @@ a010104:
   ldc.i8 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda int32 [rvastatic1]A::a010106
@@ -5577,7 +5577,7 @@ a010105:
   ldc.i4 106
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda int8 [rvastatic1]A::a010107
@@ -5587,7 +5587,7 @@ a010106:
   ldc.i4 107
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int8 [rvastatic1]A::a010108
@@ -5597,7 +5597,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int16 [rvastatic1]A::a010109
@@ -5607,7 +5607,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int16 [rvastatic1]A::a010110
@@ -5617,7 +5617,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int32 [rvastatic1]A::a010111
@@ -5627,7 +5627,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda float32 [rvastatic1]A::a010112
@@ -5637,7 +5637,7 @@ a010111:
   ldc.r4 112.0
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int16 [rvastatic1]A::a010113
@@ -5647,7 +5647,7 @@ a010112:
   ldc.i4 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int64 [rvastatic1]A::a010114
@@ -5657,7 +5657,7 @@ a010113:
   ldc.i8 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int64 [rvastatic1]A::a010115
@@ -5667,7 +5667,7 @@ a010114:
   ldc.i8 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int64 [rvastatic1]A::a010116
@@ -5677,7 +5677,7 @@ a010115:
   ldc.i8 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int64 [rvastatic1]A::a010117
@@ -5687,7 +5687,7 @@ a010116:
   ldc.i8 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda float32 [rvastatic1]A::a010118
@@ -5697,7 +5697,7 @@ a010117:
   ldc.r4 118.0
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int16 [rvastatic1]A::a010119
@@ -5707,7 +5707,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int16 [rvastatic1]A::a010120
@@ -5717,7 +5717,7 @@ a010119:
   ldc.i4 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int64 [rvastatic1]A::a010121
@@ -5727,7 +5727,7 @@ a010120:
   ldc.i8 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int16 [rvastatic1]A::a010122
@@ -5737,7 +5737,7 @@ a010121:
   ldc.i4 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int64 [rvastatic1]A::a010123
@@ -5747,7 +5747,7 @@ a010122:
   ldc.i8 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int8 [rvastatic1]A::a010124
@@ -5757,7 +5757,7 @@ a010123:
   ldc.i4 4
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int64 [rvastatic1]A::a010125
@@ -5767,7 +5767,7 @@ a010124:
   ldc.i8 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int8 [rvastatic1]A::a010126
@@ -5777,7 +5777,7 @@ a010125:
   ldc.i4 6
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int8 [rvastatic1]A::a010127
@@ -5787,7 +5787,7 @@ a010126:
   ldc.i4 7
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -5799,7 +5799,7 @@ a010127:
   ldsfld int16 [rvastatic1]A::a0100
   ldc.i4 1
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsfld float32 [rvastatic1]A::a0101
@@ -5809,7 +5809,7 @@ a0100:
   ldsfld float32 [rvastatic1]A::a0101
   ldc.r4 2.0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld float32 [rvastatic1]A::a0102
@@ -5819,7 +5819,7 @@ a0101:
   ldsfld float32 [rvastatic1]A::a0102
   ldc.r4 3.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int8 [rvastatic1]A::a0103
@@ -5829,7 +5829,7 @@ a0102:
   ldsfld int8 [rvastatic1]A::a0103
   ldc.i4 4
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int16 [rvastatic1]A::a0104
@@ -5839,7 +5839,7 @@ a0103:
   ldsfld int16 [rvastatic1]A::a0104
   ldc.i4 5
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int8 [rvastatic1]A::a0105
@@ -5849,7 +5849,7 @@ a0104:
   ldsfld int8 [rvastatic1]A::a0105
   ldc.i4 6
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int8 [rvastatic1]A::a0106
@@ -5859,7 +5859,7 @@ a0105:
   ldsfld int8 [rvastatic1]A::a0106
   ldc.i4 7
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld float32 [rvastatic1]A::a0107
@@ -5869,7 +5869,7 @@ a0106:
   ldsfld float32 [rvastatic1]A::a0107
   ldc.r4 8.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld float32 [rvastatic1]A::a0108
@@ -5879,7 +5879,7 @@ a0107:
   ldsfld float32 [rvastatic1]A::a0108
   ldc.r4 9.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int64 [rvastatic1]A::a0109
@@ -5889,7 +5889,7 @@ a0108:
   ldsfld int64 [rvastatic1]A::a0109
   ldc.i8 10
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int8 [rvastatic1]A::a01010
@@ -5899,7 +5899,7 @@ a0109:
   ldsfld int8 [rvastatic1]A::a01010
   ldc.i4 11
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int8 [rvastatic1]A::a01011
@@ -5909,7 +5909,7 @@ a01010:
   ldsfld int8 [rvastatic1]A::a01011
   ldc.i4 12
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int16 [rvastatic1]A::a01012
@@ -5919,7 +5919,7 @@ a01011:
   ldsfld int16 [rvastatic1]A::a01012
   ldc.i4 13
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int32 [rvastatic1]A::a01013
@@ -5929,7 +5929,7 @@ a01012:
   ldsfld int32 [rvastatic1]A::a01013
   ldc.i4 14
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld int32 [rvastatic1]A::a01014
@@ -5939,7 +5939,7 @@ a01013:
   ldsfld int32 [rvastatic1]A::a01014
   ldc.i4 15
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int16 [rvastatic1]A::a01015
@@ -5949,7 +5949,7 @@ a01014:
   ldsfld int16 [rvastatic1]A::a01015
   ldc.i4 16
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int16 [rvastatic1]A::a01016
@@ -5959,7 +5959,7 @@ a01015:
   ldsfld int16 [rvastatic1]A::a01016
   ldc.i4 17
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld int16 [rvastatic1]A::a01017
@@ -5969,7 +5969,7 @@ a01016:
   ldsfld int16 [rvastatic1]A::a01017
   ldc.i4 18
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int32 [rvastatic1]A::a01018
@@ -5979,7 +5979,7 @@ a01017:
   ldsfld int32 [rvastatic1]A::a01018
   ldc.i4 19
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int16 [rvastatic1]A::a01019
@@ -5989,7 +5989,7 @@ a01018:
   ldsfld int16 [rvastatic1]A::a01019
   ldc.i4 20
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int16 [rvastatic1]A::a01020
@@ -5999,7 +5999,7 @@ a01019:
   ldsfld int16 [rvastatic1]A::a01020
   ldc.i4 21
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int64 [rvastatic1]A::a01021
@@ -6009,7 +6009,7 @@ a01020:
   ldsfld int64 [rvastatic1]A::a01021
   ldc.i8 22
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int64 [rvastatic1]A::a01022
@@ -6019,7 +6019,7 @@ a01021:
   ldsfld int64 [rvastatic1]A::a01022
   ldc.i8 23
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int32 [rvastatic1]A::a01023
@@ -6029,7 +6029,7 @@ a01022:
   ldsfld int32 [rvastatic1]A::a01023
   ldc.i4 24
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int8 [rvastatic1]A::a01024
@@ -6039,7 +6039,7 @@ a01023:
   ldsfld int8 [rvastatic1]A::a01024
   ldc.i4 25
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int64 [rvastatic1]A::a01025
@@ -6049,7 +6049,7 @@ a01024:
   ldsfld int64 [rvastatic1]A::a01025
   ldc.i8 26
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int8 [rvastatic1]A::a01026
@@ -6059,7 +6059,7 @@ a01025:
   ldsfld int8 [rvastatic1]A::a01026
   ldc.i4 27
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int16 [rvastatic1]A::a01027
@@ -6069,7 +6069,7 @@ a01026:
   ldsfld int16 [rvastatic1]A::a01027
   ldc.i4 28
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int32 [rvastatic1]A::a01028
@@ -6079,7 +6079,7 @@ a01027:
   ldsfld int32 [rvastatic1]A::a01028
   ldc.i4 29
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld float32 [rvastatic1]A::a01029
@@ -6089,7 +6089,7 @@ a01028:
   ldsfld float32 [rvastatic1]A::a01029
   ldc.r4 30.0
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int16 [rvastatic1]A::a01030
@@ -6099,7 +6099,7 @@ a01029:
   ldsfld int16 [rvastatic1]A::a01030
   ldc.i4 31
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int8 [rvastatic1]A::a01031
@@ -6109,7 +6109,7 @@ a01030:
   ldsfld int8 [rvastatic1]A::a01031
   ldc.i4 32
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld float32 [rvastatic1]A::a01032
@@ -6119,7 +6119,7 @@ a01031:
   ldsfld float32 [rvastatic1]A::a01032
   ldc.r4 33.0
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int32 [rvastatic1]A::a01033
@@ -6129,7 +6129,7 @@ a01032:
   ldsfld int32 [rvastatic1]A::a01033
   ldc.i4 34
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int64 [rvastatic1]A::a01034
@@ -6139,7 +6139,7 @@ a01033:
   ldsfld int64 [rvastatic1]A::a01034
   ldc.i8 35
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int16 [rvastatic1]A::a01035
@@ -6149,7 +6149,7 @@ a01034:
   ldsfld int16 [rvastatic1]A::a01035
   ldc.i4 36
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int8 [rvastatic1]A::a01036
@@ -6159,7 +6159,7 @@ a01035:
   ldsfld int8 [rvastatic1]A::a01036
   ldc.i4 37
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int8 [rvastatic1]A::a01037
@@ -6169,7 +6169,7 @@ a01036:
   ldsfld int8 [rvastatic1]A::a01037
   ldc.i4 38
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int32 [rvastatic1]A::a01038
@@ -6179,7 +6179,7 @@ a01037:
   ldsfld int32 [rvastatic1]A::a01038
   ldc.i4 39
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int16 [rvastatic1]A::a01039
@@ -6189,7 +6189,7 @@ a01038:
   ldsfld int16 [rvastatic1]A::a01039
   ldc.i4 40
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int16 [rvastatic1]A::a01040
@@ -6199,7 +6199,7 @@ a01039:
   ldsfld int16 [rvastatic1]A::a01040
   ldc.i4 41
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int64 [rvastatic1]A::a01041
@@ -6209,7 +6209,7 @@ a01040:
   ldsfld int64 [rvastatic1]A::a01041
   ldc.i8 42
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int8 [rvastatic1]A::a01042
@@ -6219,7 +6219,7 @@ a01041:
   ldsfld int8 [rvastatic1]A::a01042
   ldc.i4 43
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld float32 [rvastatic1]A::a01043
@@ -6229,7 +6229,7 @@ a01042:
   ldsfld float32 [rvastatic1]A::a01043
   ldc.r4 44.0
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int8 [rvastatic1]A::a01044
@@ -6239,7 +6239,7 @@ a01043:
   ldsfld int8 [rvastatic1]A::a01044
   ldc.i4 45
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int16 [rvastatic1]A::a01045
@@ -6249,7 +6249,7 @@ a01044:
   ldsfld int16 [rvastatic1]A::a01045
   ldc.i4 46
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int64 [rvastatic1]A::a01046
@@ -6259,7 +6259,7 @@ a01045:
   ldsfld int64 [rvastatic1]A::a01046
   ldc.i8 47
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int64 [rvastatic1]A::a01047
@@ -6269,7 +6269,7 @@ a01046:
   ldsfld int64 [rvastatic1]A::a01047
   ldc.i8 48
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int16 [rvastatic1]A::a01048
@@ -6279,7 +6279,7 @@ a01047:
   ldsfld int16 [rvastatic1]A::a01048
   ldc.i4 49
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int64 [rvastatic1]A::a01049
@@ -6289,7 +6289,7 @@ a01048:
   ldsfld int64 [rvastatic1]A::a01049
   ldc.i8 50
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld float32 [rvastatic1]A::a01050
@@ -6299,7 +6299,7 @@ a01049:
   ldsfld float32 [rvastatic1]A::a01050
   ldc.r4 51.0
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int32 [rvastatic1]A::a01051
@@ -6309,7 +6309,7 @@ a01050:
   ldsfld int32 [rvastatic1]A::a01051
   ldc.i4 52
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int16 [rvastatic1]A::a01052
@@ -6319,7 +6319,7 @@ a01051:
   ldsfld int16 [rvastatic1]A::a01052
   ldc.i4 53
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int16 [rvastatic1]A::a01053
@@ -6329,7 +6329,7 @@ a01052:
   ldsfld int16 [rvastatic1]A::a01053
   ldc.i4 54
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld float32 [rvastatic1]A::a01054
@@ -6339,7 +6339,7 @@ a01053:
   ldsfld float32 [rvastatic1]A::a01054
   ldc.r4 55.0
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int64 [rvastatic1]A::a01055
@@ -6349,7 +6349,7 @@ a01054:
   ldsfld int64 [rvastatic1]A::a01055
   ldc.i8 56
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int16 [rvastatic1]A::a01056
@@ -6359,7 +6359,7 @@ a01055:
   ldsfld int16 [rvastatic1]A::a01056
   ldc.i4 57
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld int32 [rvastatic1]A::a01057
@@ -6369,7 +6369,7 @@ a01056:
   ldsfld int32 [rvastatic1]A::a01057
   ldc.i4 58
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int8 [rvastatic1]A::a01058
@@ -6379,7 +6379,7 @@ a01057:
   ldsfld int8 [rvastatic1]A::a01058
   ldc.i4 59
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int64 [rvastatic1]A::a01059
@@ -6389,7 +6389,7 @@ a01058:
   ldsfld int64 [rvastatic1]A::a01059
   ldc.i8 60
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld float32 [rvastatic1]A::a01060
@@ -6399,7 +6399,7 @@ a01059:
   ldsfld float32 [rvastatic1]A::a01060
   ldc.r4 61.0
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int64 [rvastatic1]A::a01061
@@ -6409,7 +6409,7 @@ a01060:
   ldsfld int64 [rvastatic1]A::a01061
   ldc.i8 62
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int32 [rvastatic1]A::a01062
@@ -6419,7 +6419,7 @@ a01061:
   ldsfld int32 [rvastatic1]A::a01062
   ldc.i4 63
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int8 [rvastatic1]A::a01063
@@ -6429,7 +6429,7 @@ a01062:
   ldsfld int8 [rvastatic1]A::a01063
   ldc.i4 64
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int16 [rvastatic1]A::a01064
@@ -6439,7 +6439,7 @@ a01063:
   ldsfld int16 [rvastatic1]A::a01064
   ldc.i4 65
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int8 [rvastatic1]A::a01065
@@ -6449,7 +6449,7 @@ a01064:
   ldsfld int8 [rvastatic1]A::a01065
   ldc.i4 66
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int16 [rvastatic1]A::a01066
@@ -6459,7 +6459,7 @@ a01065:
   ldsfld int16 [rvastatic1]A::a01066
   ldc.i4 67
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int64 [rvastatic1]A::a01067
@@ -6469,7 +6469,7 @@ a01066:
   ldsfld int64 [rvastatic1]A::a01067
   ldc.i8 68
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int64 [rvastatic1]A::a01068
@@ -6479,7 +6479,7 @@ a01067:
   ldsfld int64 [rvastatic1]A::a01068
   ldc.i8 69
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int8 [rvastatic1]A::a01069
@@ -6489,7 +6489,7 @@ a01068:
   ldsfld int8 [rvastatic1]A::a01069
   ldc.i4 70
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int16 [rvastatic1]A::a01070
@@ -6499,7 +6499,7 @@ a01069:
   ldsfld int16 [rvastatic1]A::a01070
   ldc.i4 71
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int16 [rvastatic1]A::a01071
@@ -6509,7 +6509,7 @@ a01070:
   ldsfld int16 [rvastatic1]A::a01071
   ldc.i4 72
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld float32 [rvastatic1]A::a01072
@@ -6519,7 +6519,7 @@ a01071:
   ldsfld float32 [rvastatic1]A::a01072
   ldc.r4 73.0
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int8 [rvastatic1]A::a01073
@@ -6529,7 +6529,7 @@ a01072:
   ldsfld int8 [rvastatic1]A::a01073
   ldc.i4 74
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int8 [rvastatic1]A::a01074
@@ -6539,7 +6539,7 @@ a01073:
   ldsfld int8 [rvastatic1]A::a01074
   ldc.i4 75
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int64 [rvastatic1]A::a01075
@@ -6549,7 +6549,7 @@ a01074:
   ldsfld int64 [rvastatic1]A::a01075
   ldc.i8 76
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int32 [rvastatic1]A::a01076
@@ -6559,7 +6559,7 @@ a01075:
   ldsfld int32 [rvastatic1]A::a01076
   ldc.i4 77
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int64 [rvastatic1]A::a01077
@@ -6569,7 +6569,7 @@ a01076:
   ldsfld int64 [rvastatic1]A::a01077
   ldc.i8 78
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int32 [rvastatic1]A::a01078
@@ -6579,7 +6579,7 @@ a01077:
   ldsfld int32 [rvastatic1]A::a01078
   ldc.i4 79
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int64 [rvastatic1]A::a01079
@@ -6589,7 +6589,7 @@ a01078:
   ldsfld int64 [rvastatic1]A::a01079
   ldc.i8 80
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld float32 [rvastatic1]A::a01080
@@ -6599,7 +6599,7 @@ a01079:
   ldsfld float32 [rvastatic1]A::a01080
   ldc.r4 81.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld int16 [rvastatic1]A::a01081
@@ -6609,7 +6609,7 @@ a01080:
   ldsfld int16 [rvastatic1]A::a01081
   ldc.i4 82
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld float32 [rvastatic1]A::a01082
@@ -6619,7 +6619,7 @@ a01081:
   ldsfld float32 [rvastatic1]A::a01082
   ldc.r4 83.0
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int64 [rvastatic1]A::a01083
@@ -6629,7 +6629,7 @@ a01082:
   ldsfld int64 [rvastatic1]A::a01083
   ldc.i8 84
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int8 [rvastatic1]A::a01084
@@ -6639,7 +6639,7 @@ a01083:
   ldsfld int8 [rvastatic1]A::a01084
   ldc.i4 85
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld float32 [rvastatic1]A::a01085
@@ -6649,7 +6649,7 @@ a01084:
   ldsfld float32 [rvastatic1]A::a01085
   ldc.r4 86.0
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld float32 [rvastatic1]A::a01086
@@ -6659,7 +6659,7 @@ a01085:
   ldsfld float32 [rvastatic1]A::a01086
   ldc.r4 87.0
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int64 [rvastatic1]A::a01087
@@ -6669,7 +6669,7 @@ a01086:
   ldsfld int64 [rvastatic1]A::a01087
   ldc.i8 88
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int32 [rvastatic1]A::a01088
@@ -6679,7 +6679,7 @@ a01087:
   ldsfld int32 [rvastatic1]A::a01088
   ldc.i4 89
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int8 [rvastatic1]A::a01089
@@ -6689,7 +6689,7 @@ a01088:
   ldsfld int8 [rvastatic1]A::a01089
   ldc.i4 90
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int8 [rvastatic1]A::a01090
@@ -6699,7 +6699,7 @@ a01089:
   ldsfld int8 [rvastatic1]A::a01090
   ldc.i4 91
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int32 [rvastatic1]A::a01091
@@ -6709,7 +6709,7 @@ a01090:
   ldsfld int32 [rvastatic1]A::a01091
   ldc.i4 92
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int8 [rvastatic1]A::a01092
@@ -6719,7 +6719,7 @@ a01091:
   ldsfld int8 [rvastatic1]A::a01092
   ldc.i4 93
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld float32 [rvastatic1]A::a01093
@@ -6729,7 +6729,7 @@ a01092:
   ldsfld float32 [rvastatic1]A::a01093
   ldc.r4 94.0
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int16 [rvastatic1]A::a01094
@@ -6739,7 +6739,7 @@ a01093:
   ldsfld int16 [rvastatic1]A::a01094
   ldc.i4 95
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int32 [rvastatic1]A::a01095
@@ -6749,7 +6749,7 @@ a01094:
   ldsfld int32 [rvastatic1]A::a01095
   ldc.i4 96
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int16 [rvastatic1]A::a01096
@@ -6759,7 +6759,7 @@ a01095:
   ldsfld int16 [rvastatic1]A::a01096
   ldc.i4 97
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int8 [rvastatic1]A::a01097
@@ -6769,7 +6769,7 @@ a01096:
   ldsfld int8 [rvastatic1]A::a01097
   ldc.i4 98
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int64 [rvastatic1]A::a01098
@@ -6779,7 +6779,7 @@ a01097:
   ldsfld int64 [rvastatic1]A::a01098
   ldc.i8 99
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int8 [rvastatic1]A::a01099
@@ -6789,7 +6789,7 @@ a01098:
   ldsfld int8 [rvastatic1]A::a01099
   ldc.i4 100
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int8 [rvastatic1]A::a010100
@@ -6799,7 +6799,7 @@ a01099:
   ldsfld int8 [rvastatic1]A::a010100
   ldc.i4 101
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int8 [rvastatic1]A::a010101
@@ -6809,7 +6809,7 @@ a010100:
   ldsfld int8 [rvastatic1]A::a010101
   ldc.i4 102
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int8 [rvastatic1]A::a010102
@@ -6819,7 +6819,7 @@ a010101:
   ldsfld int8 [rvastatic1]A::a010102
   ldc.i4 103
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int8 [rvastatic1]A::a010103
@@ -6829,7 +6829,7 @@ a010102:
   ldsfld int8 [rvastatic1]A::a010103
   ldc.i4 104
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int16 [rvastatic1]A::a010104
@@ -6839,7 +6839,7 @@ a010103:
   ldsfld int16 [rvastatic1]A::a010104
   ldc.i4 105
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int64 [rvastatic1]A::a010105
@@ -6849,7 +6849,7 @@ a010104:
   ldsfld int64 [rvastatic1]A::a010105
   ldc.i8 106
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int32 [rvastatic1]A::a010106
@@ -6859,7 +6859,7 @@ a010105:
   ldsfld int32 [rvastatic1]A::a010106
   ldc.i4 107
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld int8 [rvastatic1]A::a010107
@@ -6869,7 +6869,7 @@ a010106:
   ldsfld int8 [rvastatic1]A::a010107
   ldc.i4 108
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int8 [rvastatic1]A::a010108
@@ -6879,7 +6879,7 @@ a010107:
   ldsfld int8 [rvastatic1]A::a010108
   ldc.i4 109
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int16 [rvastatic1]A::a010109
@@ -6889,7 +6889,7 @@ a010108:
   ldsfld int16 [rvastatic1]A::a010109
   ldc.i4 110
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int16 [rvastatic1]A::a010110
@@ -6899,7 +6899,7 @@ a010109:
   ldsfld int16 [rvastatic1]A::a010110
   ldc.i4 111
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int32 [rvastatic1]A::a010111
@@ -6909,7 +6909,7 @@ a010110:
   ldsfld int32 [rvastatic1]A::a010111
   ldc.i4 112
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld float32 [rvastatic1]A::a010112
@@ -6919,7 +6919,7 @@ a010111:
   ldsfld float32 [rvastatic1]A::a010112
   ldc.r4 113.0
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int16 [rvastatic1]A::a010113
@@ -6929,7 +6929,7 @@ a010112:
   ldsfld int16 [rvastatic1]A::a010113
   ldc.i4 114
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int64 [rvastatic1]A::a010114
@@ -6939,7 +6939,7 @@ a010113:
   ldsfld int64 [rvastatic1]A::a010114
   ldc.i8 115
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int64 [rvastatic1]A::a010115
@@ -6949,7 +6949,7 @@ a010114:
   ldsfld int64 [rvastatic1]A::a010115
   ldc.i8 116
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int64 [rvastatic1]A::a010116
@@ -6959,7 +6959,7 @@ a010115:
   ldsfld int64 [rvastatic1]A::a010116
   ldc.i8 117
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int64 [rvastatic1]A::a010117
@@ -6969,7 +6969,7 @@ a010116:
   ldsfld int64 [rvastatic1]A::a010117
   ldc.i8 118
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld float32 [rvastatic1]A::a010118
@@ -6979,7 +6979,7 @@ a010117:
   ldsfld float32 [rvastatic1]A::a010118
   ldc.r4 119.0
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int16 [rvastatic1]A::a010119
@@ -6989,7 +6989,7 @@ a010118:
   ldsfld int16 [rvastatic1]A::a010119
   ldc.i4 120
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int16 [rvastatic1]A::a010120
@@ -6999,7 +6999,7 @@ a010119:
   ldsfld int16 [rvastatic1]A::a010120
   ldc.i4 121
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int64 [rvastatic1]A::a010121
@@ -7009,7 +7009,7 @@ a010120:
   ldsfld int64 [rvastatic1]A::a010121
   ldc.i8 122
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int16 [rvastatic1]A::a010122
@@ -7019,7 +7019,7 @@ a010121:
   ldsfld int16 [rvastatic1]A::a010122
   ldc.i4 123
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int64 [rvastatic1]A::a010123
@@ -7029,7 +7029,7 @@ a010122:
   ldsfld int64 [rvastatic1]A::a010123
   ldc.i8 124
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int8 [rvastatic1]A::a010124
@@ -7039,7 +7039,7 @@ a010123:
   ldsfld int8 [rvastatic1]A::a010124
   ldc.i4 5
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int64 [rvastatic1]A::a010125
@@ -7049,7 +7049,7 @@ a010124:
   ldsfld int64 [rvastatic1]A::a010125
   ldc.i8 126
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int8 [rvastatic1]A::a010126
@@ -7059,7 +7059,7 @@ a010125:
   ldsfld int8 [rvastatic1]A::a010126
   ldc.i4 7
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int8 [rvastatic1]A::a010127
@@ -7069,7 +7069,7 @@ a010126:
   ldsfld int8 [rvastatic1]A::a010127
   ldc.i4 8
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ret}

--- a/tests/src/JIT/Directed/rvastatics/rvastatic2.il
+++ b/tests/src/JIT/Directed/rvastatics/rvastatic2.il
@@ -39,769 +39,769 @@
   ldsfld float32 [rvastatic2]A::a0100
   ldc.r4 0.0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld int16 [rvastatic2]A::a0101
   ldc.i4 1
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int64 [rvastatic2]A::a0102
   ldc.i8 2
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int64 [rvastatic2]A::a0103
   ldc.i8 3
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld float32 [rvastatic2]A::a0104
   ldc.r4 4.0
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int64 [rvastatic2]A::a0105
   ldc.i8 5
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld int16 [rvastatic2]A::a0106
   ldc.i4 6
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld float32 [rvastatic2]A::a0107
   ldc.r4 7.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld float32 [rvastatic2]A::a0108
   ldc.r4 8.0
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld float32 [rvastatic2]A::a0109
   ldc.r4 9.0
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int16 [rvastatic2]A::a01010
   ldc.i4 10
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int64 [rvastatic2]A::a01011
   ldc.i8 11
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int8 [rvastatic2]A::a01012
   ldc.i4 12
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld float32 [rvastatic2]A::a01013
   ldc.r4 13.0
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld float32 [rvastatic2]A::a01014
   ldc.r4 14.0
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int16 [rvastatic2]A::a01015
   ldc.i4 15
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld float32 [rvastatic2]A::a01016
   ldc.r4 16.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld float32 [rvastatic2]A::a01017
   ldc.r4 17.0
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int64 [rvastatic2]A::a01018
   ldc.i8 18
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int32 [rvastatic2]A::a01019
   ldc.i4 19
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int64 [rvastatic2]A::a01020
   ldc.i8 20
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int64 [rvastatic2]A::a01021
   ldc.i8 21
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int16 [rvastatic2]A::a01022
   ldc.i4 22
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int32 [rvastatic2]A::a01023
   ldc.i4 23
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int16 [rvastatic2]A::a01024
   ldc.i4 24
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int64 [rvastatic2]A::a01025
   ldc.i8 25
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int64 [rvastatic2]A::a01027
   ldc.i8 27
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int8 [rvastatic2]A::a01028
   ldc.i4 28
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int8 [rvastatic2]A::a01029
   ldc.i4 29
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int8 [rvastatic2]A::a01030
   ldc.i4 30
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld float32 [rvastatic2]A::a01031
   ldc.r4 31.0
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int64 [rvastatic2]A::a01032
   ldc.i8 32
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int32 [rvastatic2]A::a01033
   ldc.i4 33
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld float32 [rvastatic2]A::a01034
   ldc.r4 34.0
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int8 [rvastatic2]A::a01035
   ldc.i4 35
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int32 [rvastatic2]A::a01036
   ldc.i4 36
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int32 [rvastatic2]A::a01037
   ldc.i4 37
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int64 [rvastatic2]A::a01038
   ldc.i8 38
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int16 [rvastatic2]A::a01039
   ldc.i4 39
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int32 [rvastatic2]A::a01040
   ldc.i4 40
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int32 [rvastatic2]A::a01041
   ldc.i4 41
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int32 [rvastatic2]A::a01042
   ldc.i4 42
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int16 [rvastatic2]A::a01043
   ldc.i4 43
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int64 [rvastatic2]A::a01044
   ldc.i8 44
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld float32 [rvastatic2]A::a01045
   ldc.r4 45.0
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int32 [rvastatic2]A::a01046
   ldc.i4 46
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld float32 [rvastatic2]A::a01047
   ldc.r4 47.0
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld float32 [rvastatic2]A::a01048
   ldc.r4 48.0
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int8 [rvastatic2]A::a01049
   ldc.i4 49
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int32 [rvastatic2]A::a01050
   ldc.i4 50
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int64 [rvastatic2]A::a01051
   ldc.i8 51
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int16 [rvastatic2]A::a01052
   ldc.i4 52
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int8 [rvastatic2]A::a01053
   ldc.i4 53
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int16 [rvastatic2]A::a01054
   ldc.i4 54
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int16 [rvastatic2]A::a01055
   ldc.i4 55
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld int8 [rvastatic2]A::a01056
   ldc.i4 56
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int8 [rvastatic2]A::a01057
   ldc.i4 57
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int16 [rvastatic2]A::a01058
   ldc.i4 58
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int16 [rvastatic2]A::a01059
   ldc.i4 59
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int32 [rvastatic2]A::a01060
   ldc.i4 60
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int64 [rvastatic2]A::a01061
   ldc.i8 61
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int64 [rvastatic2]A::a01062
   ldc.i8 62
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int64 [rvastatic2]A::a01063
   ldc.i8 63
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld float32 [rvastatic2]A::a01064
   ldc.r4 64.0
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int32 [rvastatic2]A::a01065
   ldc.i4 65
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld float32 [rvastatic2]A::a01066
   ldc.r4 66.0
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int64 [rvastatic2]A::a01067
   ldc.i8 67
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int8 [rvastatic2]A::a01068
   ldc.i4 68
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int64 [rvastatic2]A::a01069
   ldc.i8 69
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld float32 [rvastatic2]A::a01070
   ldc.r4 70.0
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int16 [rvastatic2]A::a01071
   ldc.i4 71
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int8 [rvastatic2]A::a01072
   ldc.i4 72
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int32 [rvastatic2]A::a01073
   ldc.i4 73
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld float32 [rvastatic2]A::a01074
   ldc.r4 74.0
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int16 [rvastatic2]A::a01075
   ldc.i4 75
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int8 [rvastatic2]A::a01076
   ldc.i4 76
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld float32 [rvastatic2]A::a01077
   ldc.r4 77.0
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld float32 [rvastatic2]A::a01078
   ldc.r4 78.0
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld int16 [rvastatic2]A::a01079
   ldc.i4 79
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld int8 [rvastatic2]A::a01080
   ldc.i4 80
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld int32 [rvastatic2]A::a01081
   ldc.i4 81
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int64 [rvastatic2]A::a01082
   ldc.i8 82
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int8 [rvastatic2]A::a01083
   ldc.i4 83
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int64 [rvastatic2]A::a01084
   ldc.i8 84
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int16 [rvastatic2]A::a01085
   ldc.i4 85
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int32 [rvastatic2]A::a01086
   ldc.i4 86
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int32 [rvastatic2]A::a01087
   ldc.i4 87
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int16 [rvastatic2]A::a01088
   ldc.i4 88
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int32 [rvastatic2]A::a01089
   ldc.i4 89
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int8 [rvastatic2]A::a01090
   ldc.i4 90
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int16 [rvastatic2]A::a01091
   ldc.i4 91
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int8 [rvastatic2]A::a01092
   ldc.i4 92
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int32 [rvastatic2]A::a01093
   ldc.i4 93
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int64 [rvastatic2]A::a01094
   ldc.i8 94
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int64 [rvastatic2]A::a01095
   ldc.i8 95
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int64 [rvastatic2]A::a01096
   ldc.i8 96
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int64 [rvastatic2]A::a01097
   ldc.i8 97
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int32 [rvastatic2]A::a01098
   ldc.i4 98
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int16 [rvastatic2]A::a01099
   ldc.i4 99
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int8 [rvastatic2]A::a010100
   ldc.i4 100
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld float32 [rvastatic2]A::a010101
   ldc.r4 101.0
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld float32 [rvastatic2]A::a010102
   ldc.r4 102.0
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int8 [rvastatic2]A::a010103
   ldc.i4 103
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int16 [rvastatic2]A::a010104
   ldc.i4 104
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int8 [rvastatic2]A::a010105
   ldc.i4 105
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld int32 [rvastatic2]A::a010106
   ldc.i4 106
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld float32 [rvastatic2]A::a010107
   ldc.r4 107.0
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int16 [rvastatic2]A::a010108
   ldc.i4 108
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int8 [rvastatic2]A::a010109
   ldc.i4 109
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int8 [rvastatic2]A::a010110
   ldc.i4 110
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int16 [rvastatic2]A::a010111
   ldc.i4 111
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int16 [rvastatic2]A::a010112
   ldc.i4 112
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld float32 [rvastatic2]A::a010113
   ldc.r4 113.0
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int16 [rvastatic2]A::a010114
   ldc.i4 114
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int8 [rvastatic2]A::a010115
   ldc.i4 115
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int8 [rvastatic2]A::a010116
   ldc.i4 116
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int64 [rvastatic2]A::a010117
   ldc.i8 117
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int8 [rvastatic2]A::a010118
   ldc.i4 118
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int32 [rvastatic2]A::a010119
   ldc.i4 119
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld float32 [rvastatic2]A::a010120
   ldc.r4 120.0
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int16 [rvastatic2]A::a010121
   ldc.i4 121
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int32 [rvastatic2]A::a010122
   ldc.i4 122
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int32 [rvastatic2]A::a010123
   ldc.i4 123
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int64 [rvastatic2]A::a010124
   ldc.i8 124
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int32 [rvastatic2]A::a010125
   ldc.i4 125
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 6
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ldsfld int64 [rvastatic2]A::a010127
   ldc.i8 127
   beq a010128
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010128:
  ret}
@@ -810,896 +810,896 @@ a010128:
   ldind.r4
   ldc.r4 0.0
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsflda int16 [rvastatic2]A::a0101
   ldind.i2
   ldc.i4 1
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsflda int64 [rvastatic2]A::a0102
   ldind.i8
   ldc.i8 2
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsflda int64 [rvastatic2]A::a0103
   ldind.i8
   ldc.i8 3
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsflda float32 [rvastatic2]A::a0104
   ldind.r4
   ldc.r4 4.0
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsflda int64 [rvastatic2]A::a0105
   ldind.i8
   ldc.i8 5
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsflda int16 [rvastatic2]A::a0106
   ldind.i2
   ldc.i4 6
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsflda float32 [rvastatic2]A::a0107
   ldind.r4
   ldc.r4 7.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsflda float32 [rvastatic2]A::a0108
   ldind.r4
   ldc.r4 8.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsflda float32 [rvastatic2]A::a0109
   ldind.r4
   ldc.r4 9.0
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsflda int16 [rvastatic2]A::a01010
   ldind.i2
   ldc.i4 10
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsflda int64 [rvastatic2]A::a01011
   ldind.i8
   ldc.i8 11
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsflda int8 [rvastatic2]A::a01012
   ldind.i1
   ldc.i4 12
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsflda float32 [rvastatic2]A::a01013
   ldind.r4
   ldc.r4 13.0
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsflda float32 [rvastatic2]A::a01014
   ldind.r4
   ldc.r4 14.0
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsflda int16 [rvastatic2]A::a01015
   ldind.i2
   ldc.i4 15
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsflda float32 [rvastatic2]A::a01016
   ldind.r4
   ldc.r4 16.0
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsflda float32 [rvastatic2]A::a01017
   ldind.r4
   ldc.r4 17.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsflda int64 [rvastatic2]A::a01018
   ldind.i8
   ldc.i8 18
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsflda int32 [rvastatic2]A::a01019
   ldind.i4
   ldc.i4 19
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsflda int64 [rvastatic2]A::a01020
   ldind.i8
   ldc.i8 20
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsflda int64 [rvastatic2]A::a01021
   ldind.i8
   ldc.i8 21
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsflda int16 [rvastatic2]A::a01022
   ldind.i2
   ldc.i4 22
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsflda int32 [rvastatic2]A::a01023
   ldind.i4
   ldc.i4 23
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsflda int16 [rvastatic2]A::a01024
   ldind.i2
   ldc.i4 24
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsflda int64 [rvastatic2]A::a01025
   ldind.i8
   ldc.i8 25
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsflda int16 [rvastatic2]A::a01026
   ldind.i2
   ldc.i4 26
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsflda int64 [rvastatic2]A::a01027
   ldind.i8
   ldc.i8 27
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsflda int8 [rvastatic2]A::a01028
   ldind.i1
   ldc.i4 28
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsflda int8 [rvastatic2]A::a01029
   ldind.i1
   ldc.i4 29
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsflda int8 [rvastatic2]A::a01030
   ldind.i1
   ldc.i4 30
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsflda float32 [rvastatic2]A::a01031
   ldind.r4
   ldc.r4 31.0
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsflda int64 [rvastatic2]A::a01032
   ldind.i8
   ldc.i8 32
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsflda int32 [rvastatic2]A::a01033
   ldind.i4
   ldc.i4 33
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsflda float32 [rvastatic2]A::a01034
   ldind.r4
   ldc.r4 34.0
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsflda int8 [rvastatic2]A::a01035
   ldind.i1
   ldc.i4 35
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsflda int32 [rvastatic2]A::a01036
   ldind.i4
   ldc.i4 36
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsflda int32 [rvastatic2]A::a01037
   ldind.i4
   ldc.i4 37
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsflda int64 [rvastatic2]A::a01038
   ldind.i8
   ldc.i8 38
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsflda int16 [rvastatic2]A::a01039
   ldind.i2
   ldc.i4 39
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsflda int32 [rvastatic2]A::a01040
   ldind.i4
   ldc.i4 40
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsflda int32 [rvastatic2]A::a01041
   ldind.i4
   ldc.i4 41
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsflda int32 [rvastatic2]A::a01042
   ldind.i4
   ldc.i4 42
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsflda int16 [rvastatic2]A::a01043
   ldind.i2
   ldc.i4 43
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsflda int64 [rvastatic2]A::a01044
   ldind.i8
   ldc.i8 44
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsflda float32 [rvastatic2]A::a01045
   ldind.r4
   ldc.r4 45.0
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsflda int32 [rvastatic2]A::a01046
   ldind.i4
   ldc.i4 46
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsflda float32 [rvastatic2]A::a01047
   ldind.r4
   ldc.r4 47.0
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsflda float32 [rvastatic2]A::a01048
   ldind.r4
   ldc.r4 48.0
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsflda int8 [rvastatic2]A::a01049
   ldind.i1
   ldc.i4 49
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsflda int32 [rvastatic2]A::a01050
   ldind.i4
   ldc.i4 50
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsflda int64 [rvastatic2]A::a01051
   ldind.i8
   ldc.i8 51
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsflda int16 [rvastatic2]A::a01052
   ldind.i2
   ldc.i4 52
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsflda int8 [rvastatic2]A::a01053
   ldind.i1
   ldc.i4 53
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsflda int16 [rvastatic2]A::a01054
   ldind.i2
   ldc.i4 54
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsflda int16 [rvastatic2]A::a01055
   ldind.i2
   ldc.i4 55
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsflda int8 [rvastatic2]A::a01056
   ldind.i1
   ldc.i4 56
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsflda int8 [rvastatic2]A::a01057
   ldind.i1
   ldc.i4 57
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsflda int16 [rvastatic2]A::a01058
   ldind.i2
   ldc.i4 58
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsflda int16 [rvastatic2]A::a01059
   ldind.i2
   ldc.i4 59
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsflda int32 [rvastatic2]A::a01060
   ldind.i4
   ldc.i4 60
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsflda int64 [rvastatic2]A::a01061
   ldind.i8
   ldc.i8 61
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsflda int64 [rvastatic2]A::a01062
   ldind.i8
   ldc.i8 62
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsflda int64 [rvastatic2]A::a01063
   ldind.i8
   ldc.i8 63
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsflda float32 [rvastatic2]A::a01064
   ldind.r4
   ldc.r4 64.0
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsflda int32 [rvastatic2]A::a01065
   ldind.i4
   ldc.i4 65
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsflda float32 [rvastatic2]A::a01066
   ldind.r4
   ldc.r4 66.0
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsflda int64 [rvastatic2]A::a01067
   ldind.i8
   ldc.i8 67
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsflda int8 [rvastatic2]A::a01068
   ldind.i1
   ldc.i4 68
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsflda int64 [rvastatic2]A::a01069
   ldind.i8
   ldc.i8 69
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsflda float32 [rvastatic2]A::a01070
   ldind.r4
   ldc.r4 70.0
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsflda int16 [rvastatic2]A::a01071
   ldind.i2
   ldc.i4 71
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsflda int8 [rvastatic2]A::a01072
   ldind.i1
   ldc.i4 72
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsflda int32 [rvastatic2]A::a01073
   ldind.i4
   ldc.i4 73
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsflda float32 [rvastatic2]A::a01074
   ldind.r4
   ldc.r4 74.0
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsflda int16 [rvastatic2]A::a01075
   ldind.i2
   ldc.i4 75
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsflda int8 [rvastatic2]A::a01076
   ldind.i1
   ldc.i4 76
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsflda float32 [rvastatic2]A::a01077
   ldind.r4
   ldc.r4 77.0
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsflda float32 [rvastatic2]A::a01078
   ldind.r4
   ldc.r4 78.0
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsflda int16 [rvastatic2]A::a01079
   ldind.i2
   ldc.i4 79
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsflda int8 [rvastatic2]A::a01080
   ldind.i1
   ldc.i4 80
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsflda int32 [rvastatic2]A::a01081
   ldind.i4
   ldc.i4 81
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsflda int64 [rvastatic2]A::a01082
   ldind.i8
   ldc.i8 82
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsflda int8 [rvastatic2]A::a01083
   ldind.i1
   ldc.i4 83
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsflda int64 [rvastatic2]A::a01084
   ldind.i8
   ldc.i8 84
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsflda int16 [rvastatic2]A::a01085
   ldind.i2
   ldc.i4 85
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsflda int32 [rvastatic2]A::a01086
   ldind.i4
   ldc.i4 86
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsflda int32 [rvastatic2]A::a01087
   ldind.i4
   ldc.i4 87
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsflda int16 [rvastatic2]A::a01088
   ldind.i2
   ldc.i4 88
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsflda int32 [rvastatic2]A::a01089
   ldind.i4
   ldc.i4 89
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsflda int8 [rvastatic2]A::a01090
   ldind.i1
   ldc.i4 90
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsflda int16 [rvastatic2]A::a01091
   ldind.i2
   ldc.i4 91
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsflda int8 [rvastatic2]A::a01092
   ldind.i1
   ldc.i4 92
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsflda int32 [rvastatic2]A::a01093
   ldind.i4
   ldc.i4 93
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsflda int64 [rvastatic2]A::a01094
   ldind.i8
   ldc.i8 94
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsflda int64 [rvastatic2]A::a01095
   ldind.i8
   ldc.i8 95
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsflda int64 [rvastatic2]A::a01096
   ldind.i8
   ldc.i8 96
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsflda int64 [rvastatic2]A::a01097
   ldind.i8
   ldc.i8 97
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsflda int32 [rvastatic2]A::a01098
   ldind.i4
   ldc.i4 98
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsflda int16 [rvastatic2]A::a01099
   ldind.i2
   ldc.i4 99
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsflda int8 [rvastatic2]A::a010100
   ldind.i1
   ldc.i4 100
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsflda float32 [rvastatic2]A::a010101
   ldind.r4
   ldc.r4 101.0
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsflda float32 [rvastatic2]A::a010102
   ldind.r4
   ldc.r4 102.0
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsflda int8 [rvastatic2]A::a010103
   ldind.i1
   ldc.i4 103
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsflda int16 [rvastatic2]A::a010104
   ldind.i2
   ldc.i4 104
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsflda int8 [rvastatic2]A::a010105
   ldind.i1
   ldc.i4 105
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsflda int32 [rvastatic2]A::a010106
   ldind.i4
   ldc.i4 106
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsflda float32 [rvastatic2]A::a010107
   ldind.r4
   ldc.r4 107.0
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsflda int16 [rvastatic2]A::a010108
   ldind.i2
   ldc.i4 108
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsflda int8 [rvastatic2]A::a010109
   ldind.i1
   ldc.i4 109
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsflda int8 [rvastatic2]A::a010110
   ldind.i1
   ldc.i4 110
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsflda int16 [rvastatic2]A::a010111
   ldind.i2
   ldc.i4 111
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsflda int16 [rvastatic2]A::a010112
   ldind.i2
   ldc.i4 112
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsflda float32 [rvastatic2]A::a010113
   ldind.r4
   ldc.r4 113.0
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsflda int16 [rvastatic2]A::a010114
   ldind.i2
   ldc.i4 114
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsflda int8 [rvastatic2]A::a010115
   ldind.i1
   ldc.i4 115
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsflda int8 [rvastatic2]A::a010116
   ldind.i1
   ldc.i4 116
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsflda int64 [rvastatic2]A::a010117
   ldind.i8
   ldc.i8 117
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsflda int8 [rvastatic2]A::a010118
   ldind.i1
   ldc.i4 118
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsflda int32 [rvastatic2]A::a010119
   ldind.i4
   ldc.i4 119
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsflda float32 [rvastatic2]A::a010120
   ldind.r4
   ldc.r4 120.0
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsflda int16 [rvastatic2]A::a010121
   ldind.i2
   ldc.i4 121
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsflda int32 [rvastatic2]A::a010122
   ldind.i4
   ldc.i4 122
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsflda int32 [rvastatic2]A::a010123
   ldind.i4
   ldc.i4 123
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsflda int64 [rvastatic2]A::a010124
   ldind.i8
   ldc.i8 124
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsflda int32 [rvastatic2]A::a010125
   ldind.i4
   ldc.i4 125
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsflda int8 [rvastatic2]A::a010126
   ldind.i1
   ldc.i4 6
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsflda int64 [rvastatic2]A::a010127
   ldind.i8
   ldc.i8 127
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
  ret}
@@ -1707,769 +1707,769 @@ a010127:
   ldsfld int64 [rvastatic2]A::a01069
   ldc.i8 69
   beq a010129
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010129:
   ldsfld float32 [rvastatic2]A::a01034
   ldc.r4 34.0
   beq a010130
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010130:
   ldsfld int8 [rvastatic2]A::a01029
   ldc.i4 29
   beq a010131
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010131:
   ldsfld int16 [rvastatic2]A::a01075
   ldc.i4 75
   beq a010132
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010132:
   ldsfld int8 [rvastatic2]A::a01083
   ldc.i4 83
   beq a010133
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010133:
   ldsfld int32 [rvastatic2]A::a01093
   ldc.i4 93
   beq a010134
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010134:
   ldsfld int16 [rvastatic2]A::a01075
   ldc.i4 75
   beq a010135
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010135:
   ldsfld int16 [rvastatic2]A::a010108
   ldc.i4 108
   beq a010136
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010136:
   ldsfld int32 [rvastatic2]A::a01081
   ldc.i4 81
   beq a010137
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010137:
   ldsfld int32 [rvastatic2]A::a01040
   ldc.i4 40
   beq a010138
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010138:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a010139
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010139:
   ldsfld float32 [rvastatic2]A::a01047
   ldc.r4 47.0
   beq a010140
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010140:
   ldsfld int64 [rvastatic2]A::a01094
   ldc.i8 94
   beq a010141
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010141:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 6
   beq a010142
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010142:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a010143
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010143:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a010144
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010144:
   ldsfld int8 [rvastatic2]A::a01092
   ldc.i4 92
   beq a010145
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010145:
   ldsfld int64 [rvastatic2]A::a01094
   ldc.i8 94
   beq a010146
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010146:
   ldsfld int32 [rvastatic2]A::a010125
   ldc.i4 125
   beq a010147
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010147:
   ldsfld float32 [rvastatic2]A::a01078
   ldc.r4 78.0
   beq a010148
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010148:
   ldsfld float32 [rvastatic2]A::a01016
   ldc.r4 16.0
   beq a010149
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010149:
   ldsfld int64 [rvastatic2]A::a01038
   ldc.i8 38
   beq a010150
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010150:
   ldsfld int8 [rvastatic2]A::a010109
   ldc.i4 109
   beq a010151
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010151:
   ldsfld int64 [rvastatic2]A::a01061
   ldc.i8 61
   beq a010152
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010152:
   ldsfld int32 [rvastatic2]A::a01037
   ldc.i4 37
   beq a010153
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010153:
   ldsfld int8 [rvastatic2]A::a01049
   ldc.i4 49
   beq a010154
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010154:
   ldsfld int64 [rvastatic2]A::a01097
   ldc.i8 97
   beq a010155
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010155:
   ldsfld int32 [rvastatic2]A::a010122
   ldc.i4 122
   beq a010156
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010156:
   ldsfld float32 [rvastatic2]A::a010113
   ldc.r4 113.0
   beq a010157
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010157:
   ldsfld float32 [rvastatic2]A::a0109
   ldc.r4 9.0
   beq a010158
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010158:
   ldsfld int64 [rvastatic2]A::a01011
   ldc.i8 11
   beq a010159
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010159:
   ldsfld int16 [rvastatic2]A::a01059
   ldc.i4 59
   beq a010160
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010160:
   ldsfld int8 [rvastatic2]A::a01092
   ldc.i4 92
   beq a010161
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010161:
   ldsfld int32 [rvastatic2]A::a010123
   ldc.i4 123
   beq a010162
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010162:
   ldsfld int16 [rvastatic2]A::a01099
   ldc.i4 99
   beq a010163
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010163:
   ldsfld int8 [rvastatic2]A::a01092
   ldc.i4 92
   beq a010164
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010164:
   ldsfld int64 [rvastatic2]A::a010127
   ldc.i8 127
   beq a010165
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010165:
   ldsfld int16 [rvastatic2]A::a01058
   ldc.i4 58
   beq a010166
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010166:
   ldsfld float32 [rvastatic2]A::a01045
   ldc.r4 45.0
   beq a010167
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010167:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 6
   beq a010168
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010168:
   ldsfld float32 [rvastatic2]A::a01066
   ldc.r4 66.0
   beq a010169
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010169:
   ldsfld int16 [rvastatic2]A::a01075
   ldc.i4 75
   beq a010170
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010170:
   ldsfld float32 [rvastatic2]A::a01045
   ldc.r4 45.0
   beq a010171
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010171:
   ldsfld float32 [rvastatic2]A::a010120
   ldc.r4 120.0
   beq a010172
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010172:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a010173
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010173:
   ldsfld int64 [rvastatic2]A::a01020
   ldc.i8 20
   beq a010174
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010174:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 6
   beq a010175
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010175:
   ldsfld int64 [rvastatic2]A::a01069
   ldc.i8 69
   beq a010176
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010176:
   ldsfld int8 [rvastatic2]A::a010118
   ldc.i4 118
   beq a010177
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010177:
   ldsfld int8 [rvastatic2]A::a01057
   ldc.i4 57
   beq a010178
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010178:
   ldsfld int64 [rvastatic2]A::a0103
   ldc.i8 3
   beq a010179
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010179:
   ldsfld int8 [rvastatic2]A::a01056
   ldc.i4 56
   beq a010180
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010180:
   ldsfld int32 [rvastatic2]A::a01073
   ldc.i4 73
   beq a010181
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010181:
   ldsfld int8 [rvastatic2]A::a010103
   ldc.i4 103
   beq a010182
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010182:
   ldsfld int16 [rvastatic2]A::a01022
   ldc.i4 22
   beq a010183
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010183:
   ldsfld float32 [rvastatic2]A::a01031
   ldc.r4 31.0
   beq a010184
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010184:
   ldsfld int8 [rvastatic2]A::a01053
   ldc.i4 53
   beq a010185
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010185:
   ldsfld int64 [rvastatic2]A::a01095
   ldc.i8 95
   beq a010186
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010186:
   ldsfld int64 [rvastatic2]A::a01038
   ldc.i8 38
   beq a010187
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010187:
   ldsfld float32 [rvastatic2]A::a01034
   ldc.r4 34.0
   beq a010188
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010188:
   ldsfld int64 [rvastatic2]A::a010124
   ldc.i8 124
   beq a010189
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010189:
   ldsfld int32 [rvastatic2]A::a01081
   ldc.i4 81
   beq a010190
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010190:
   ldsfld int32 [rvastatic2]A::a010123
   ldc.i4 123
   beq a010191
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010191:
   ldsfld int8 [rvastatic2]A::a01072
   ldc.i4 72
   beq a010192
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010192:
   ldsfld int8 [rvastatic2]A::a01028
   ldc.i4 28
   beq a010193
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010193:
   ldsfld int64 [rvastatic2]A::a01094
   ldc.i8 94
   beq a010194
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010194:
   ldsfld int8 [rvastatic2]A::a01083
   ldc.i4 83
   beq a010195
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010195:
   ldsfld int32 [rvastatic2]A::a01098
   ldc.i4 98
   beq a010196
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010196:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a010197
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010197:
   ldsfld int64 [rvastatic2]A::a01062
   ldc.i8 62
   beq a010198
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010198:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 26
   beq a010199
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010199:
   ldsfld int32 [rvastatic2]A::a01033
   ldc.i4 33
   beq a010200
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010200:
   ldsfld float32 [rvastatic2]A::a01048
   ldc.r4 48.0
   beq a010201
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010201:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 6
   beq a010202
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010202:
   ldsfld int64 [rvastatic2]A::a01011
   ldc.i8 11
   beq a010203
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010203:
   ldsfld int8 [rvastatic2]A::a01068
   ldc.i4 68
   beq a010204
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010204:
   ldsfld float32 [rvastatic2]A::a010120
   ldc.r4 120.0
   beq a010205
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010205:
   ldsfld int64 [rvastatic2]A::a010117
   ldc.i8 117
   beq a010206
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010206:
   ldsfld float32 [rvastatic2]A::a01034
   ldc.r4 34.0
   beq a010207
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010207:
   ldsfld float32 [rvastatic2]A::a01016
   ldc.r4 16.0
   beq a010208
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010208:
   ldsfld int32 [rvastatic2]A::a01050
   ldc.i4 50
   beq a010209
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010209:
   ldsfld int64 [rvastatic2]A::a01027
   ldc.i8 27
   beq a010210
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010210:
   ldsfld float32 [rvastatic2]A::a0104
   ldc.r4 4.0
   beq a010211
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010211:
   ldsfld int16 [rvastatic2]A::a01055
   ldc.i4 55
   beq a010212
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010212:
   ldsfld int16 [rvastatic2]A::a0106
   ldc.i4 6
   beq a010213
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010213:
   ldsfld int8 [rvastatic2]A::a01083
   ldc.i4 83
   beq a010214
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010214:
   ldsfld int16 [rvastatic2]A::a010114
   ldc.i4 114
   beq a010215
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010215:
   ldsfld int8 [rvastatic2]A::a010116
   ldc.i4 116
   beq a010216
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010216:
   ldsfld int8 [rvastatic2]A::a010100
   ldc.i4 100
   beq a010217
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010217:
   ldsfld int64 [rvastatic2]A::a01067
   ldc.i8 67
   beq a010218
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010218:
   ldsfld int64 [rvastatic2]A::a01038
   ldc.i8 38
   beq a010219
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010219:
   ldsfld float32 [rvastatic2]A::a01031
   ldc.r4 31.0
   beq a010220
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010220:
   ldsfld int64 [rvastatic2]A::a01020
   ldc.i8 20
   beq a010221
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010221:
   ldsfld int64 [rvastatic2]A::a01011
   ldc.i8 11
   beq a010222
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010222:
   ldsfld int16 [rvastatic2]A::a0101
   ldc.i4 1
   beq a010223
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010223:
   ldsfld float32 [rvastatic2]A::a010113
   ldc.r4 113.0
   beq a010224
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010224:
   ldsfld int8 [rvastatic2]A::a01080
   ldc.i4 80
   beq a010225
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010225:
   ldsfld float32 [rvastatic2]A::a010101
   ldc.r4 101.0
   beq a010226
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010226:
   ldsfld int16 [rvastatic2]A::a01091
   ldc.i4 91
   beq a010227
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010227:
   ldsfld int16 [rvastatic2]A::a01059
   ldc.i4 59
   beq a010228
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010228:
   ldsfld int32 [rvastatic2]A::a01065
   ldc.i4 65
   beq a010229
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010229:
   ldsfld int64 [rvastatic2]A::a01027
   ldc.i8 27
   beq a010230
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010230:
   ldsfld int32 [rvastatic2]A::a01042
   ldc.i4 42
   beq a010231
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010231:
   ldsfld int8 [rvastatic2]A::a01056
   ldc.i4 56
   beq a010232
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010232:
   ldsfld int8 [rvastatic2]A::a01030
   ldc.i4 30
   beq a010233
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010233:
   ldsfld int64 [rvastatic2]A::a01097
   ldc.i8 97
   beq a010234
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010234:
   ldsfld float32 [rvastatic2]A::a0107
   ldc.r4 7.0
   beq a010235
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010235:
   ldsfld float32 [rvastatic2]A::a01074
   ldc.r4 74.0
   beq a010236
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010236:
   ldsfld int8 [rvastatic2]A::a01092
   ldc.i4 92
   beq a010237
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010237:
   ldsfld int32 [rvastatic2]A::a01081
   ldc.i4 81
   beq a010238
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010238:
   ldsfld int64 [rvastatic2]A::a01038
   ldc.i8 38
   beq a010239
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010239:
   ldsfld float32 [rvastatic2]A::a01064
   ldc.r4 64.0
   beq a010240
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010240:
   ldsfld int32 [rvastatic2]A::a01060
   ldc.i4 60
   beq a010241
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010241:
   ldsfld int64 [rvastatic2]A::a01021
   ldc.i8 21
   beq a010242
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010242:
   ldsfld int16 [rvastatic2]A::a010111
   ldc.i4 111
   beq a010243
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010243:
   ldsfld int64 [rvastatic2]A::a01096
   ldc.i8 96
   beq a010244
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010244:
   ldsfld int8 [rvastatic2]A::a01076
   ldc.i4 76
   beq a010245
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010245:
   ldsfld int64 [rvastatic2]A::a01067
   ldc.i8 67
   beq a010246
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010246:
   ldsfld float32 [rvastatic2]A::a01066
   ldc.r4 66.0
   beq a010247
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010247:
   ldsfld int32 [rvastatic2]A::a01073
   ldc.i4 73
   beq a010248
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010248:
   ldsfld int16 [rvastatic2]A::a010108
   ldc.i4 108
   beq a010249
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010249:
   ldsfld int64 [rvastatic2]A::a01094
   ldc.i8 94
   beq a010250
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010250:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 6
   beq a010251
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010251:
   ldsfld int32 [rvastatic2]A::a01086
   ldc.i4 86
   beq a010252
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010252:
   ldsfld int32 [rvastatic2]A::a01023
   ldc.i4 23
   beq a010253
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010253:
   ldsfld int32 [rvastatic2]A::a010123
   ldc.i4 123
   beq a010254
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010254:
   ldsfld float32 [rvastatic2]A::a01013
   ldc.r4 13.0
   beq a010255
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010255:
   ldsfld int32 [rvastatic2]A::a01037
   ldc.i4 37
   beq a010256
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010256:
  ret}
@@ -2486,7 +2486,7 @@ a010256:
   ldc.r4 0.0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda int16 [rvastatic2]A::a0101
@@ -2505,7 +2505,7 @@ a0100:
   ldc.i4 1
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda int64 [rvastatic2]A::a0102
@@ -2520,7 +2520,7 @@ a0101:
   ldc.i8 2
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int64 [rvastatic2]A::a0103
@@ -2535,7 +2535,7 @@ a0102:
   ldc.i8 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda float32 [rvastatic2]A::a0104
@@ -2551,7 +2551,7 @@ a0103:
   ldc.r4 4.0
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int64 [rvastatic2]A::a0105
@@ -2565,7 +2565,7 @@ a0104:
   ldc.i8 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int16 [rvastatic2]A::a0106
@@ -2584,7 +2584,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda float32 [rvastatic2]A::a0107
@@ -2598,7 +2598,7 @@ a0106:
   ldc.r4 7.0
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda float32 [rvastatic2]A::a0108
@@ -2612,7 +2612,7 @@ a0107:
   ldc.r4 8.0
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda float32 [rvastatic2]A::a0109
@@ -2628,7 +2628,7 @@ a0108:
   ldc.r4 9.0
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int16 [rvastatic2]A::a01010
@@ -2643,7 +2643,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int64 [rvastatic2]A::a01011
@@ -2662,7 +2662,7 @@ a01010:
   ldc.i8 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int8 [rvastatic2]A::a01012
@@ -2678,7 +2678,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda float32 [rvastatic2]A::a01013
@@ -2692,7 +2692,7 @@ a01012:
   ldc.r4 13.0
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda float32 [rvastatic2]A::a01014
@@ -2707,7 +2707,7 @@ a01013:
   ldc.r4 14.0
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int16 [rvastatic2]A::a01015
@@ -2721,7 +2721,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda float32 [rvastatic2]A::a01016
@@ -2740,7 +2740,7 @@ a01015:
   ldc.r4 16.0
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda float32 [rvastatic2]A::a01017
@@ -2755,7 +2755,7 @@ a01016:
   ldc.r4 17.0
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int64 [rvastatic2]A::a01018
@@ -2774,7 +2774,7 @@ a01017:
   ldc.i8 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int32 [rvastatic2]A::a01019
@@ -2788,7 +2788,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int64 [rvastatic2]A::a01020
@@ -2804,7 +2804,7 @@ a01019:
   ldc.i8 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda int64 [rvastatic2]A::a01021
@@ -2823,7 +2823,7 @@ a01020:
   ldc.i8 21
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int16 [rvastatic2]A::a01022
@@ -2842,7 +2842,7 @@ a01021:
   ldc.i4 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int32 [rvastatic2]A::a01023
@@ -2861,7 +2861,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int16 [rvastatic2]A::a01024
@@ -2880,7 +2880,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int64 [rvastatic2]A::a01025
@@ -2895,7 +2895,7 @@ a01024:
   ldc.i8 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int16 [rvastatic2]A::a01026
@@ -2909,7 +2909,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int64 [rvastatic2]A::a01027
@@ -2928,7 +2928,7 @@ a01026:
   ldc.i8 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int8 [rvastatic2]A::a01028
@@ -2942,7 +2942,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int8 [rvastatic2]A::a01029
@@ -2956,7 +2956,7 @@ a01028:
   ldc.i4 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int8 [rvastatic2]A::a01030
@@ -2970,7 +2970,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda float32 [rvastatic2]A::a01031
@@ -2985,7 +2985,7 @@ a01030:
   ldc.r4 31.0
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int64 [rvastatic2]A::a01032
@@ -3001,7 +3001,7 @@ a01031:
   ldc.i8 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda int32 [rvastatic2]A::a01033
@@ -3015,7 +3015,7 @@ a01032:
   ldc.i4 33
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda float32 [rvastatic2]A::a01034
@@ -3030,7 +3030,7 @@ a01033:
   ldc.r4 34.0
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int8 [rvastatic2]A::a01035
@@ -3049,7 +3049,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int32 [rvastatic2]A::a01036
@@ -3064,7 +3064,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int32 [rvastatic2]A::a01037
@@ -3079,7 +3079,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int64 [rvastatic2]A::a01038
@@ -3093,7 +3093,7 @@ a01037:
   ldc.i8 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int16 [rvastatic2]A::a01039
@@ -3108,7 +3108,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int32 [rvastatic2]A::a01040
@@ -3127,7 +3127,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int32 [rvastatic2]A::a01041
@@ -3142,7 +3142,7 @@ a01040:
   ldc.i4 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int32 [rvastatic2]A::a01042
@@ -3158,7 +3158,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int16 [rvastatic2]A::a01043
@@ -3173,7 +3173,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int64 [rvastatic2]A::a01044
@@ -3192,7 +3192,7 @@ a01043:
   ldc.i8 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda float32 [rvastatic2]A::a01045
@@ -3207,7 +3207,7 @@ a01044:
   ldc.r4 45.0
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int32 [rvastatic2]A::a01046
@@ -3221,7 +3221,7 @@ a01045:
   ldc.i4 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda float32 [rvastatic2]A::a01047
@@ -3237,7 +3237,7 @@ a01046:
   ldc.r4 47.0
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda float32 [rvastatic2]A::a01048
@@ -3256,7 +3256,7 @@ a01047:
   ldc.r4 48.0
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int8 [rvastatic2]A::a01049
@@ -3271,7 +3271,7 @@ a01048:
   ldc.i4 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int32 [rvastatic2]A::a01050
@@ -3286,7 +3286,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int64 [rvastatic2]A::a01051
@@ -3301,7 +3301,7 @@ a01050:
   ldc.i8 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int16 [rvastatic2]A::a01052
@@ -3315,7 +3315,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int8 [rvastatic2]A::a01053
@@ -3330,7 +3330,7 @@ a01052:
   ldc.i4 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda int16 [rvastatic2]A::a01054
@@ -3346,7 +3346,7 @@ a01053:
   ldc.i4 54
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int16 [rvastatic2]A::a01055
@@ -3365,7 +3365,7 @@ a01054:
   ldc.i4 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda int8 [rvastatic2]A::a01056
@@ -3379,7 +3379,7 @@ a01055:
   ldc.i4 56
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int8 [rvastatic2]A::a01057
@@ -3394,7 +3394,7 @@ a01056:
   ldc.i4 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int16 [rvastatic2]A::a01058
@@ -3408,7 +3408,7 @@ a01057:
   ldc.i4 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int16 [rvastatic2]A::a01059
@@ -3423,7 +3423,7 @@ a01058:
   ldc.i4 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int32 [rvastatic2]A::a01060
@@ -3438,7 +3438,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int64 [rvastatic2]A::a01061
@@ -3452,7 +3452,7 @@ a01060:
   ldc.i8 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int64 [rvastatic2]A::a01062
@@ -3471,7 +3471,7 @@ a01061:
   ldc.i8 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda int64 [rvastatic2]A::a01063
@@ -3487,7 +3487,7 @@ a01062:
   ldc.i8 63
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda float32 [rvastatic2]A::a01064
@@ -3501,7 +3501,7 @@ a01063:
   ldc.r4 64.0
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int32 [rvastatic2]A::a01065
@@ -3516,7 +3516,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda float32 [rvastatic2]A::a01066
@@ -3531,7 +3531,7 @@ a01065:
   ldc.r4 66.0
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int64 [rvastatic2]A::a01067
@@ -3550,7 +3550,7 @@ a01066:
   ldc.i8 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int8 [rvastatic2]A::a01068
@@ -3566,7 +3566,7 @@ a01067:
   ldc.i4 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int64 [rvastatic2]A::a01069
@@ -3580,7 +3580,7 @@ a01068:
   ldc.i8 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda float32 [rvastatic2]A::a01070
@@ -3599,7 +3599,7 @@ a01069:
   ldc.r4 70.0
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int16 [rvastatic2]A::a01071
@@ -3615,7 +3615,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda int8 [rvastatic2]A::a01072
@@ -3634,7 +3634,7 @@ a01071:
   ldc.i4 72
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int32 [rvastatic2]A::a01073
@@ -3653,7 +3653,7 @@ a01072:
   ldc.i4 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda float32 [rvastatic2]A::a01074
@@ -3667,7 +3667,7 @@ a01073:
   ldc.r4 74.0
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int16 [rvastatic2]A::a01075
@@ -3683,7 +3683,7 @@ a01074:
   ldc.i4 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int8 [rvastatic2]A::a01076
@@ -3698,7 +3698,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda float32 [rvastatic2]A::a01077
@@ -3717,7 +3717,7 @@ a01076:
   ldc.r4 77.0
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda float32 [rvastatic2]A::a01078
@@ -3733,7 +3733,7 @@ a01077:
   ldc.r4 78.0
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda int16 [rvastatic2]A::a01079
@@ -3747,7 +3747,7 @@ a01078:
   ldc.i4 79
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda int8 [rvastatic2]A::a01080
@@ -3761,7 +3761,7 @@ a01079:
   ldc.i4 80
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda int32 [rvastatic2]A::a01081
@@ -3776,7 +3776,7 @@ a01080:
   ldc.i4 81
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda int64 [rvastatic2]A::a01082
@@ -3791,7 +3791,7 @@ a01081:
   ldc.i8 82
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int8 [rvastatic2]A::a01083
@@ -3806,7 +3806,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int64 [rvastatic2]A::a01084
@@ -3821,7 +3821,7 @@ a01083:
   ldc.i8 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int16 [rvastatic2]A::a01085
@@ -3840,7 +3840,7 @@ a01084:
   ldc.i4 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int32 [rvastatic2]A::a01086
@@ -3856,7 +3856,7 @@ a01085:
   ldc.i4 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int32 [rvastatic2]A::a01087
@@ -3875,7 +3875,7 @@ a01086:
   ldc.i4 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int16 [rvastatic2]A::a01088
@@ -3891,7 +3891,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int32 [rvastatic2]A::a01089
@@ -3910,7 +3910,7 @@ a01088:
   ldc.i4 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int8 [rvastatic2]A::a01090
@@ -3924,7 +3924,7 @@ a01089:
   ldc.i4 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int16 [rvastatic2]A::a01091
@@ -3940,7 +3940,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int8 [rvastatic2]A::a01092
@@ -3959,7 +3959,7 @@ a01091:
   ldc.i4 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int32 [rvastatic2]A::a01093
@@ -3974,7 +3974,7 @@ a01092:
   ldc.i4 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int64 [rvastatic2]A::a01094
@@ -3988,7 +3988,7 @@ a01093:
   ldc.i8 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int64 [rvastatic2]A::a01095
@@ -4002,7 +4002,7 @@ a01094:
   ldc.i8 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda int64 [rvastatic2]A::a01096
@@ -4021,7 +4021,7 @@ a01095:
   ldc.i8 96
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int64 [rvastatic2]A::a01097
@@ -4037,7 +4037,7 @@ a01096:
   ldc.i8 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda int32 [rvastatic2]A::a01098
@@ -4052,7 +4052,7 @@ a01097:
   ldc.i4 98
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int16 [rvastatic2]A::a01099
@@ -4071,7 +4071,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int8 [rvastatic2]A::a010100
@@ -4090,7 +4090,7 @@ a01099:
   ldc.i4 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda float32 [rvastatic2]A::a010101
@@ -4106,7 +4106,7 @@ a010100:
   ldc.r4 101.0
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda float32 [rvastatic2]A::a010102
@@ -4121,7 +4121,7 @@ a010101:
   ldc.r4 102.0
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int8 [rvastatic2]A::a010103
@@ -4135,7 +4135,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int16 [rvastatic2]A::a010104
@@ -4150,7 +4150,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int8 [rvastatic2]A::a010105
@@ -4169,7 +4169,7 @@ a010104:
   ldc.i4 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda int32 [rvastatic2]A::a010106
@@ -4183,7 +4183,7 @@ a010105:
   ldc.i4 106
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda float32 [rvastatic2]A::a010107
@@ -4199,7 +4199,7 @@ a010106:
   ldc.r4 107.0
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int16 [rvastatic2]A::a010108
@@ -4214,7 +4214,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int8 [rvastatic2]A::a010109
@@ -4229,7 +4229,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int8 [rvastatic2]A::a010110
@@ -4248,7 +4248,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int16 [rvastatic2]A::a010111
@@ -4267,7 +4267,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int16 [rvastatic2]A::a010112
@@ -4283,7 +4283,7 @@ a010111:
   ldc.i4 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda float32 [rvastatic2]A::a010113
@@ -4297,7 +4297,7 @@ a010112:
   ldc.r4 113.0
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int16 [rvastatic2]A::a010114
@@ -4316,7 +4316,7 @@ a010113:
   ldc.i4 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int8 [rvastatic2]A::a010115
@@ -4330,7 +4330,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int8 [rvastatic2]A::a010116
@@ -4349,7 +4349,7 @@ a010115:
   ldc.i4 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int64 [rvastatic2]A::a010117
@@ -4365,7 +4365,7 @@ a010116:
   ldc.i8 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int8 [rvastatic2]A::a010118
@@ -4379,7 +4379,7 @@ a010117:
   ldc.i4 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int32 [rvastatic2]A::a010119
@@ -4398,7 +4398,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda float32 [rvastatic2]A::a010120
@@ -4412,7 +4412,7 @@ a010119:
   ldc.r4 120.0
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int16 [rvastatic2]A::a010121
@@ -4431,7 +4431,7 @@ a010120:
   ldc.i4 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int32 [rvastatic2]A::a010122
@@ -4447,7 +4447,7 @@ a010121:
   ldc.i4 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int32 [rvastatic2]A::a010123
@@ -4461,7 +4461,7 @@ a010122:
   ldc.i4 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int64 [rvastatic2]A::a010124
@@ -4475,7 +4475,7 @@ a010123:
   ldc.i8 124
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int32 [rvastatic2]A::a010125
@@ -4489,7 +4489,7 @@ a010124:
   ldc.i4 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int8 [rvastatic2]A::a010126
@@ -4503,7 +4503,7 @@ a010125:
   ldc.i4 6
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int64 [rvastatic2]A::a010127
@@ -4518,7 +4518,7 @@ a010126:
   ldc.i8 127
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -4530,7 +4530,7 @@ a010127:
   ldc.r4 0.0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda int16 [rvastatic2]A::a0101
@@ -4540,7 +4540,7 @@ a0100:
   ldc.i4 1
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda int64 [rvastatic2]A::a0102
@@ -4550,7 +4550,7 @@ a0101:
   ldc.i8 2
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int64 [rvastatic2]A::a0103
@@ -4560,7 +4560,7 @@ a0102:
   ldc.i8 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda float32 [rvastatic2]A::a0104
@@ -4570,7 +4570,7 @@ a0103:
   ldc.r4 4.0
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int64 [rvastatic2]A::a0105
@@ -4580,7 +4580,7 @@ a0104:
   ldc.i8 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int16 [rvastatic2]A::a0106
@@ -4590,7 +4590,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda float32 [rvastatic2]A::a0107
@@ -4600,7 +4600,7 @@ a0106:
   ldc.r4 7.0
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda float32 [rvastatic2]A::a0108
@@ -4610,7 +4610,7 @@ a0107:
   ldc.r4 8.0
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda float32 [rvastatic2]A::a0109
@@ -4620,7 +4620,7 @@ a0108:
   ldc.r4 9.0
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int16 [rvastatic2]A::a01010
@@ -4630,7 +4630,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int64 [rvastatic2]A::a01011
@@ -4640,7 +4640,7 @@ a01010:
   ldc.i8 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int8 [rvastatic2]A::a01012
@@ -4650,7 +4650,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda float32 [rvastatic2]A::a01013
@@ -4660,7 +4660,7 @@ a01012:
   ldc.r4 13.0
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda float32 [rvastatic2]A::a01014
@@ -4670,7 +4670,7 @@ a01013:
   ldc.r4 14.0
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int16 [rvastatic2]A::a01015
@@ -4680,7 +4680,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda float32 [rvastatic2]A::a01016
@@ -4690,7 +4690,7 @@ a01015:
   ldc.r4 16.0
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda float32 [rvastatic2]A::a01017
@@ -4700,7 +4700,7 @@ a01016:
   ldc.r4 17.0
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int64 [rvastatic2]A::a01018
@@ -4710,7 +4710,7 @@ a01017:
   ldc.i8 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int32 [rvastatic2]A::a01019
@@ -4720,7 +4720,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int64 [rvastatic2]A::a01020
@@ -4730,7 +4730,7 @@ a01019:
   ldc.i8 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda int64 [rvastatic2]A::a01021
@@ -4740,7 +4740,7 @@ a01020:
   ldc.i8 21
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int16 [rvastatic2]A::a01022
@@ -4750,7 +4750,7 @@ a01021:
   ldc.i4 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int32 [rvastatic2]A::a01023
@@ -4760,7 +4760,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int16 [rvastatic2]A::a01024
@@ -4770,7 +4770,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int64 [rvastatic2]A::a01025
@@ -4780,7 +4780,7 @@ a01024:
   ldc.i8 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int16 [rvastatic2]A::a01026
@@ -4790,7 +4790,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int64 [rvastatic2]A::a01027
@@ -4800,7 +4800,7 @@ a01026:
   ldc.i8 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int8 [rvastatic2]A::a01028
@@ -4810,7 +4810,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int8 [rvastatic2]A::a01029
@@ -4820,7 +4820,7 @@ a01028:
   ldc.i4 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int8 [rvastatic2]A::a01030
@@ -4830,7 +4830,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda float32 [rvastatic2]A::a01031
@@ -4840,7 +4840,7 @@ a01030:
   ldc.r4 31.0
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int64 [rvastatic2]A::a01032
@@ -4850,7 +4850,7 @@ a01031:
   ldc.i8 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda int32 [rvastatic2]A::a01033
@@ -4860,7 +4860,7 @@ a01032:
   ldc.i4 33
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda float32 [rvastatic2]A::a01034
@@ -4870,7 +4870,7 @@ a01033:
   ldc.r4 34.0
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int8 [rvastatic2]A::a01035
@@ -4880,7 +4880,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int32 [rvastatic2]A::a01036
@@ -4890,7 +4890,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int32 [rvastatic2]A::a01037
@@ -4900,7 +4900,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int64 [rvastatic2]A::a01038
@@ -4910,7 +4910,7 @@ a01037:
   ldc.i8 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int16 [rvastatic2]A::a01039
@@ -4920,7 +4920,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int32 [rvastatic2]A::a01040
@@ -4930,7 +4930,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int32 [rvastatic2]A::a01041
@@ -4940,7 +4940,7 @@ a01040:
   ldc.i4 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int32 [rvastatic2]A::a01042
@@ -4950,7 +4950,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int16 [rvastatic2]A::a01043
@@ -4960,7 +4960,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int64 [rvastatic2]A::a01044
@@ -4970,7 +4970,7 @@ a01043:
   ldc.i8 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda float32 [rvastatic2]A::a01045
@@ -4980,7 +4980,7 @@ a01044:
   ldc.r4 45.0
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int32 [rvastatic2]A::a01046
@@ -4990,7 +4990,7 @@ a01045:
   ldc.i4 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda float32 [rvastatic2]A::a01047
@@ -5000,7 +5000,7 @@ a01046:
   ldc.r4 47.0
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda float32 [rvastatic2]A::a01048
@@ -5010,7 +5010,7 @@ a01047:
   ldc.r4 48.0
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int8 [rvastatic2]A::a01049
@@ -5020,7 +5020,7 @@ a01048:
   ldc.i4 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int32 [rvastatic2]A::a01050
@@ -5030,7 +5030,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int64 [rvastatic2]A::a01051
@@ -5040,7 +5040,7 @@ a01050:
   ldc.i8 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int16 [rvastatic2]A::a01052
@@ -5050,7 +5050,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int8 [rvastatic2]A::a01053
@@ -5060,7 +5060,7 @@ a01052:
   ldc.i4 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda int16 [rvastatic2]A::a01054
@@ -5070,7 +5070,7 @@ a01053:
   ldc.i4 54
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int16 [rvastatic2]A::a01055
@@ -5080,7 +5080,7 @@ a01054:
   ldc.i4 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda int8 [rvastatic2]A::a01056
@@ -5090,7 +5090,7 @@ a01055:
   ldc.i4 56
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int8 [rvastatic2]A::a01057
@@ -5100,7 +5100,7 @@ a01056:
   ldc.i4 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int16 [rvastatic2]A::a01058
@@ -5110,7 +5110,7 @@ a01057:
   ldc.i4 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int16 [rvastatic2]A::a01059
@@ -5120,7 +5120,7 @@ a01058:
   ldc.i4 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int32 [rvastatic2]A::a01060
@@ -5130,7 +5130,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int64 [rvastatic2]A::a01061
@@ -5140,7 +5140,7 @@ a01060:
   ldc.i8 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int64 [rvastatic2]A::a01062
@@ -5150,7 +5150,7 @@ a01061:
   ldc.i8 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda int64 [rvastatic2]A::a01063
@@ -5160,7 +5160,7 @@ a01062:
   ldc.i8 63
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda float32 [rvastatic2]A::a01064
@@ -5170,7 +5170,7 @@ a01063:
   ldc.r4 64.0
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int32 [rvastatic2]A::a01065
@@ -5180,7 +5180,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda float32 [rvastatic2]A::a01066
@@ -5190,7 +5190,7 @@ a01065:
   ldc.r4 66.0
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int64 [rvastatic2]A::a01067
@@ -5200,7 +5200,7 @@ a01066:
   ldc.i8 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int8 [rvastatic2]A::a01068
@@ -5210,7 +5210,7 @@ a01067:
   ldc.i4 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int64 [rvastatic2]A::a01069
@@ -5220,7 +5220,7 @@ a01068:
   ldc.i8 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda float32 [rvastatic2]A::a01070
@@ -5230,7 +5230,7 @@ a01069:
   ldc.r4 70.0
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int16 [rvastatic2]A::a01071
@@ -5240,7 +5240,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda int8 [rvastatic2]A::a01072
@@ -5250,7 +5250,7 @@ a01071:
   ldc.i4 72
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int32 [rvastatic2]A::a01073
@@ -5260,7 +5260,7 @@ a01072:
   ldc.i4 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda float32 [rvastatic2]A::a01074
@@ -5270,7 +5270,7 @@ a01073:
   ldc.r4 74.0
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int16 [rvastatic2]A::a01075
@@ -5280,7 +5280,7 @@ a01074:
   ldc.i4 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int8 [rvastatic2]A::a01076
@@ -5290,7 +5290,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda float32 [rvastatic2]A::a01077
@@ -5300,7 +5300,7 @@ a01076:
   ldc.r4 77.0
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda float32 [rvastatic2]A::a01078
@@ -5310,7 +5310,7 @@ a01077:
   ldc.r4 78.0
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda int16 [rvastatic2]A::a01079
@@ -5320,7 +5320,7 @@ a01078:
   ldc.i4 79
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda int8 [rvastatic2]A::a01080
@@ -5330,7 +5330,7 @@ a01079:
   ldc.i4 80
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda int32 [rvastatic2]A::a01081
@@ -5340,7 +5340,7 @@ a01080:
   ldc.i4 81
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda int64 [rvastatic2]A::a01082
@@ -5350,7 +5350,7 @@ a01081:
   ldc.i8 82
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int8 [rvastatic2]A::a01083
@@ -5360,7 +5360,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int64 [rvastatic2]A::a01084
@@ -5370,7 +5370,7 @@ a01083:
   ldc.i8 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int16 [rvastatic2]A::a01085
@@ -5380,7 +5380,7 @@ a01084:
   ldc.i4 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int32 [rvastatic2]A::a01086
@@ -5390,7 +5390,7 @@ a01085:
   ldc.i4 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int32 [rvastatic2]A::a01087
@@ -5400,7 +5400,7 @@ a01086:
   ldc.i4 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int16 [rvastatic2]A::a01088
@@ -5410,7 +5410,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int32 [rvastatic2]A::a01089
@@ -5420,7 +5420,7 @@ a01088:
   ldc.i4 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int8 [rvastatic2]A::a01090
@@ -5430,7 +5430,7 @@ a01089:
   ldc.i4 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int16 [rvastatic2]A::a01091
@@ -5440,7 +5440,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int8 [rvastatic2]A::a01092
@@ -5450,7 +5450,7 @@ a01091:
   ldc.i4 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int32 [rvastatic2]A::a01093
@@ -5460,7 +5460,7 @@ a01092:
   ldc.i4 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int64 [rvastatic2]A::a01094
@@ -5470,7 +5470,7 @@ a01093:
   ldc.i8 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int64 [rvastatic2]A::a01095
@@ -5480,7 +5480,7 @@ a01094:
   ldc.i8 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda int64 [rvastatic2]A::a01096
@@ -5490,7 +5490,7 @@ a01095:
   ldc.i8 96
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int64 [rvastatic2]A::a01097
@@ -5500,7 +5500,7 @@ a01096:
   ldc.i8 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda int32 [rvastatic2]A::a01098
@@ -5510,7 +5510,7 @@ a01097:
   ldc.i4 98
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int16 [rvastatic2]A::a01099
@@ -5520,7 +5520,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int8 [rvastatic2]A::a010100
@@ -5530,7 +5530,7 @@ a01099:
   ldc.i4 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda float32 [rvastatic2]A::a010101
@@ -5540,7 +5540,7 @@ a010100:
   ldc.r4 101.0
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda float32 [rvastatic2]A::a010102
@@ -5550,7 +5550,7 @@ a010101:
   ldc.r4 102.0
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int8 [rvastatic2]A::a010103
@@ -5560,7 +5560,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int16 [rvastatic2]A::a010104
@@ -5570,7 +5570,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int8 [rvastatic2]A::a010105
@@ -5580,7 +5580,7 @@ a010104:
   ldc.i4 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda int32 [rvastatic2]A::a010106
@@ -5590,7 +5590,7 @@ a010105:
   ldc.i4 106
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda float32 [rvastatic2]A::a010107
@@ -5600,7 +5600,7 @@ a010106:
   ldc.r4 107.0
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int16 [rvastatic2]A::a010108
@@ -5610,7 +5610,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int8 [rvastatic2]A::a010109
@@ -5620,7 +5620,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int8 [rvastatic2]A::a010110
@@ -5630,7 +5630,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int16 [rvastatic2]A::a010111
@@ -5640,7 +5640,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int16 [rvastatic2]A::a010112
@@ -5650,7 +5650,7 @@ a010111:
   ldc.i4 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda float32 [rvastatic2]A::a010113
@@ -5660,7 +5660,7 @@ a010112:
   ldc.r4 113.0
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int16 [rvastatic2]A::a010114
@@ -5670,7 +5670,7 @@ a010113:
   ldc.i4 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int8 [rvastatic2]A::a010115
@@ -5680,7 +5680,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int8 [rvastatic2]A::a010116
@@ -5690,7 +5690,7 @@ a010115:
   ldc.i4 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int64 [rvastatic2]A::a010117
@@ -5700,7 +5700,7 @@ a010116:
   ldc.i8 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int8 [rvastatic2]A::a010118
@@ -5710,7 +5710,7 @@ a010117:
   ldc.i4 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int32 [rvastatic2]A::a010119
@@ -5720,7 +5720,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda float32 [rvastatic2]A::a010120
@@ -5730,7 +5730,7 @@ a010119:
   ldc.r4 120.0
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int16 [rvastatic2]A::a010121
@@ -5740,7 +5740,7 @@ a010120:
   ldc.i4 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int32 [rvastatic2]A::a010122
@@ -5750,7 +5750,7 @@ a010121:
   ldc.i4 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int32 [rvastatic2]A::a010123
@@ -5760,7 +5760,7 @@ a010122:
   ldc.i4 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int64 [rvastatic2]A::a010124
@@ -5770,7 +5770,7 @@ a010123:
   ldc.i8 124
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int32 [rvastatic2]A::a010125
@@ -5780,7 +5780,7 @@ a010124:
   ldc.i4 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int8 [rvastatic2]A::a010126
@@ -5790,7 +5790,7 @@ a010125:
   ldc.i4 6
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int64 [rvastatic2]A::a010127
@@ -5800,7 +5800,7 @@ a010126:
   ldc.i8 127
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -5812,7 +5812,7 @@ a010127:
   ldsfld float32 [rvastatic2]A::a0100
   ldc.r4 1.0
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsfld int16 [rvastatic2]A::a0101
@@ -5822,7 +5822,7 @@ a0100:
   ldsfld int16 [rvastatic2]A::a0101
   ldc.i4 2
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld int64 [rvastatic2]A::a0102
@@ -5832,7 +5832,7 @@ a0101:
   ldsfld int64 [rvastatic2]A::a0102
   ldc.i8 3
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int64 [rvastatic2]A::a0103
@@ -5842,7 +5842,7 @@ a0102:
   ldsfld int64 [rvastatic2]A::a0103
   ldc.i8 4
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld float32 [rvastatic2]A::a0104
@@ -5852,7 +5852,7 @@ a0103:
   ldsfld float32 [rvastatic2]A::a0104
   ldc.r4 5.0
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int64 [rvastatic2]A::a0105
@@ -5862,7 +5862,7 @@ a0104:
   ldsfld int64 [rvastatic2]A::a0105
   ldc.i8 6
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int16 [rvastatic2]A::a0106
@@ -5872,7 +5872,7 @@ a0105:
   ldsfld int16 [rvastatic2]A::a0106
   ldc.i4 7
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld float32 [rvastatic2]A::a0107
@@ -5882,7 +5882,7 @@ a0106:
   ldsfld float32 [rvastatic2]A::a0107
   ldc.r4 8.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld float32 [rvastatic2]A::a0108
@@ -5892,7 +5892,7 @@ a0107:
   ldsfld float32 [rvastatic2]A::a0108
   ldc.r4 9.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld float32 [rvastatic2]A::a0109
@@ -5902,7 +5902,7 @@ a0108:
   ldsfld float32 [rvastatic2]A::a0109
   ldc.r4 10.0
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int16 [rvastatic2]A::a01010
@@ -5912,7 +5912,7 @@ a0109:
   ldsfld int16 [rvastatic2]A::a01010
   ldc.i4 11
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int64 [rvastatic2]A::a01011
@@ -5922,7 +5922,7 @@ a01010:
   ldsfld int64 [rvastatic2]A::a01011
   ldc.i8 12
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int8 [rvastatic2]A::a01012
@@ -5932,7 +5932,7 @@ a01011:
   ldsfld int8 [rvastatic2]A::a01012
   ldc.i4 13
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld float32 [rvastatic2]A::a01013
@@ -5942,7 +5942,7 @@ a01012:
   ldsfld float32 [rvastatic2]A::a01013
   ldc.r4 14.0
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld float32 [rvastatic2]A::a01014
@@ -5952,7 +5952,7 @@ a01013:
   ldsfld float32 [rvastatic2]A::a01014
   ldc.r4 15.0
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int16 [rvastatic2]A::a01015
@@ -5962,7 +5962,7 @@ a01014:
   ldsfld int16 [rvastatic2]A::a01015
   ldc.i4 16
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld float32 [rvastatic2]A::a01016
@@ -5972,7 +5972,7 @@ a01015:
   ldsfld float32 [rvastatic2]A::a01016
   ldc.r4 17.0
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld float32 [rvastatic2]A::a01017
@@ -5982,7 +5982,7 @@ a01016:
   ldsfld float32 [rvastatic2]A::a01017
   ldc.r4 18.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int64 [rvastatic2]A::a01018
@@ -5992,7 +5992,7 @@ a01017:
   ldsfld int64 [rvastatic2]A::a01018
   ldc.i8 19
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int32 [rvastatic2]A::a01019
@@ -6002,7 +6002,7 @@ a01018:
   ldsfld int32 [rvastatic2]A::a01019
   ldc.i4 20
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int64 [rvastatic2]A::a01020
@@ -6012,7 +6012,7 @@ a01019:
   ldsfld int64 [rvastatic2]A::a01020
   ldc.i8 21
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int64 [rvastatic2]A::a01021
@@ -6022,7 +6022,7 @@ a01020:
   ldsfld int64 [rvastatic2]A::a01021
   ldc.i8 22
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int16 [rvastatic2]A::a01022
@@ -6032,7 +6032,7 @@ a01021:
   ldsfld int16 [rvastatic2]A::a01022
   ldc.i4 23
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int32 [rvastatic2]A::a01023
@@ -6042,7 +6042,7 @@ a01022:
   ldsfld int32 [rvastatic2]A::a01023
   ldc.i4 24
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int16 [rvastatic2]A::a01024
@@ -6052,7 +6052,7 @@ a01023:
   ldsfld int16 [rvastatic2]A::a01024
   ldc.i4 25
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int64 [rvastatic2]A::a01025
@@ -6062,7 +6062,7 @@ a01024:
   ldsfld int64 [rvastatic2]A::a01025
   ldc.i8 26
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int16 [rvastatic2]A::a01026
@@ -6072,7 +6072,7 @@ a01025:
   ldsfld int16 [rvastatic2]A::a01026
   ldc.i4 27
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int64 [rvastatic2]A::a01027
@@ -6082,7 +6082,7 @@ a01026:
   ldsfld int64 [rvastatic2]A::a01027
   ldc.i8 28
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int8 [rvastatic2]A::a01028
@@ -6092,7 +6092,7 @@ a01027:
   ldsfld int8 [rvastatic2]A::a01028
   ldc.i4 29
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int8 [rvastatic2]A::a01029
@@ -6102,7 +6102,7 @@ a01028:
   ldsfld int8 [rvastatic2]A::a01029
   ldc.i4 30
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int8 [rvastatic2]A::a01030
@@ -6112,7 +6112,7 @@ a01029:
   ldsfld int8 [rvastatic2]A::a01030
   ldc.i4 31
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld float32 [rvastatic2]A::a01031
@@ -6122,7 +6122,7 @@ a01030:
   ldsfld float32 [rvastatic2]A::a01031
   ldc.r4 32.0
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int64 [rvastatic2]A::a01032
@@ -6132,7 +6132,7 @@ a01031:
   ldsfld int64 [rvastatic2]A::a01032
   ldc.i8 33
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int32 [rvastatic2]A::a01033
@@ -6142,7 +6142,7 @@ a01032:
   ldsfld int32 [rvastatic2]A::a01033
   ldc.i4 34
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld float32 [rvastatic2]A::a01034
@@ -6152,7 +6152,7 @@ a01033:
   ldsfld float32 [rvastatic2]A::a01034
   ldc.r4 35.0
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int8 [rvastatic2]A::a01035
@@ -6162,7 +6162,7 @@ a01034:
   ldsfld int8 [rvastatic2]A::a01035
   ldc.i4 36
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int32 [rvastatic2]A::a01036
@@ -6172,7 +6172,7 @@ a01035:
   ldsfld int32 [rvastatic2]A::a01036
   ldc.i4 37
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int32 [rvastatic2]A::a01037
@@ -6182,7 +6182,7 @@ a01036:
   ldsfld int32 [rvastatic2]A::a01037
   ldc.i4 38
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int64 [rvastatic2]A::a01038
@@ -6192,7 +6192,7 @@ a01037:
   ldsfld int64 [rvastatic2]A::a01038
   ldc.i8 39
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int16 [rvastatic2]A::a01039
@@ -6202,7 +6202,7 @@ a01038:
   ldsfld int16 [rvastatic2]A::a01039
   ldc.i4 40
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int32 [rvastatic2]A::a01040
@@ -6212,7 +6212,7 @@ a01039:
   ldsfld int32 [rvastatic2]A::a01040
   ldc.i4 41
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int32 [rvastatic2]A::a01041
@@ -6222,7 +6222,7 @@ a01040:
   ldsfld int32 [rvastatic2]A::a01041
   ldc.i4 42
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int32 [rvastatic2]A::a01042
@@ -6232,7 +6232,7 @@ a01041:
   ldsfld int32 [rvastatic2]A::a01042
   ldc.i4 43
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int16 [rvastatic2]A::a01043
@@ -6242,7 +6242,7 @@ a01042:
   ldsfld int16 [rvastatic2]A::a01043
   ldc.i4 44
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int64 [rvastatic2]A::a01044
@@ -6252,7 +6252,7 @@ a01043:
   ldsfld int64 [rvastatic2]A::a01044
   ldc.i8 45
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld float32 [rvastatic2]A::a01045
@@ -6262,7 +6262,7 @@ a01044:
   ldsfld float32 [rvastatic2]A::a01045
   ldc.r4 46.0
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int32 [rvastatic2]A::a01046
@@ -6272,7 +6272,7 @@ a01045:
   ldsfld int32 [rvastatic2]A::a01046
   ldc.i4 47
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld float32 [rvastatic2]A::a01047
@@ -6282,7 +6282,7 @@ a01046:
   ldsfld float32 [rvastatic2]A::a01047
   ldc.r4 48.0
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld float32 [rvastatic2]A::a01048
@@ -6292,7 +6292,7 @@ a01047:
   ldsfld float32 [rvastatic2]A::a01048
   ldc.r4 49.0
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int8 [rvastatic2]A::a01049
@@ -6302,7 +6302,7 @@ a01048:
   ldsfld int8 [rvastatic2]A::a01049
   ldc.i4 50
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int32 [rvastatic2]A::a01050
@@ -6312,7 +6312,7 @@ a01049:
   ldsfld int32 [rvastatic2]A::a01050
   ldc.i4 51
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int64 [rvastatic2]A::a01051
@@ -6322,7 +6322,7 @@ a01050:
   ldsfld int64 [rvastatic2]A::a01051
   ldc.i8 52
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int16 [rvastatic2]A::a01052
@@ -6332,7 +6332,7 @@ a01051:
   ldsfld int16 [rvastatic2]A::a01052
   ldc.i4 53
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int8 [rvastatic2]A::a01053
@@ -6342,7 +6342,7 @@ a01052:
   ldsfld int8 [rvastatic2]A::a01053
   ldc.i4 54
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int16 [rvastatic2]A::a01054
@@ -6352,7 +6352,7 @@ a01053:
   ldsfld int16 [rvastatic2]A::a01054
   ldc.i4 55
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int16 [rvastatic2]A::a01055
@@ -6362,7 +6362,7 @@ a01054:
   ldsfld int16 [rvastatic2]A::a01055
   ldc.i4 56
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int8 [rvastatic2]A::a01056
@@ -6372,7 +6372,7 @@ a01055:
   ldsfld int8 [rvastatic2]A::a01056
   ldc.i4 57
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld int8 [rvastatic2]A::a01057
@@ -6382,7 +6382,7 @@ a01056:
   ldsfld int8 [rvastatic2]A::a01057
   ldc.i4 58
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int16 [rvastatic2]A::a01058
@@ -6392,7 +6392,7 @@ a01057:
   ldsfld int16 [rvastatic2]A::a01058
   ldc.i4 59
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int16 [rvastatic2]A::a01059
@@ -6402,7 +6402,7 @@ a01058:
   ldsfld int16 [rvastatic2]A::a01059
   ldc.i4 60
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int32 [rvastatic2]A::a01060
@@ -6412,7 +6412,7 @@ a01059:
   ldsfld int32 [rvastatic2]A::a01060
   ldc.i4 61
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int64 [rvastatic2]A::a01061
@@ -6422,7 +6422,7 @@ a01060:
   ldsfld int64 [rvastatic2]A::a01061
   ldc.i8 62
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int64 [rvastatic2]A::a01062
@@ -6432,7 +6432,7 @@ a01061:
   ldsfld int64 [rvastatic2]A::a01062
   ldc.i8 63
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int64 [rvastatic2]A::a01063
@@ -6442,7 +6442,7 @@ a01062:
   ldsfld int64 [rvastatic2]A::a01063
   ldc.i8 64
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld float32 [rvastatic2]A::a01064
@@ -6452,7 +6452,7 @@ a01063:
   ldsfld float32 [rvastatic2]A::a01064
   ldc.r4 65.0
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int32 [rvastatic2]A::a01065
@@ -6462,7 +6462,7 @@ a01064:
   ldsfld int32 [rvastatic2]A::a01065
   ldc.i4 66
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld float32 [rvastatic2]A::a01066
@@ -6472,7 +6472,7 @@ a01065:
   ldsfld float32 [rvastatic2]A::a01066
   ldc.r4 67.0
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int64 [rvastatic2]A::a01067
@@ -6482,7 +6482,7 @@ a01066:
   ldsfld int64 [rvastatic2]A::a01067
   ldc.i8 68
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int8 [rvastatic2]A::a01068
@@ -6492,7 +6492,7 @@ a01067:
   ldsfld int8 [rvastatic2]A::a01068
   ldc.i4 69
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int64 [rvastatic2]A::a01069
@@ -6502,7 +6502,7 @@ a01068:
   ldsfld int64 [rvastatic2]A::a01069
   ldc.i8 70
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld float32 [rvastatic2]A::a01070
@@ -6512,7 +6512,7 @@ a01069:
   ldsfld float32 [rvastatic2]A::a01070
   ldc.r4 71.0
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int16 [rvastatic2]A::a01071
@@ -6522,7 +6522,7 @@ a01070:
   ldsfld int16 [rvastatic2]A::a01071
   ldc.i4 72
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int8 [rvastatic2]A::a01072
@@ -6532,7 +6532,7 @@ a01071:
   ldsfld int8 [rvastatic2]A::a01072
   ldc.i4 73
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int32 [rvastatic2]A::a01073
@@ -6542,7 +6542,7 @@ a01072:
   ldsfld int32 [rvastatic2]A::a01073
   ldc.i4 74
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld float32 [rvastatic2]A::a01074
@@ -6552,7 +6552,7 @@ a01073:
   ldsfld float32 [rvastatic2]A::a01074
   ldc.r4 75.0
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int16 [rvastatic2]A::a01075
@@ -6562,7 +6562,7 @@ a01074:
   ldsfld int16 [rvastatic2]A::a01075
   ldc.i4 76
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int8 [rvastatic2]A::a01076
@@ -6572,7 +6572,7 @@ a01075:
   ldsfld int8 [rvastatic2]A::a01076
   ldc.i4 77
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld float32 [rvastatic2]A::a01077
@@ -6582,7 +6582,7 @@ a01076:
   ldsfld float32 [rvastatic2]A::a01077
   ldc.r4 78.0
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld float32 [rvastatic2]A::a01078
@@ -6592,7 +6592,7 @@ a01077:
   ldsfld float32 [rvastatic2]A::a01078
   ldc.r4 79.0
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int16 [rvastatic2]A::a01079
@@ -6602,7 +6602,7 @@ a01078:
   ldsfld int16 [rvastatic2]A::a01079
   ldc.i4 80
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld int8 [rvastatic2]A::a01080
@@ -6612,7 +6612,7 @@ a01079:
   ldsfld int8 [rvastatic2]A::a01080
   ldc.i4 81
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld int32 [rvastatic2]A::a01081
@@ -6622,7 +6622,7 @@ a01080:
   ldsfld int32 [rvastatic2]A::a01081
   ldc.i4 82
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld int64 [rvastatic2]A::a01082
@@ -6632,7 +6632,7 @@ a01081:
   ldsfld int64 [rvastatic2]A::a01082
   ldc.i8 83
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int8 [rvastatic2]A::a01083
@@ -6642,7 +6642,7 @@ a01082:
   ldsfld int8 [rvastatic2]A::a01083
   ldc.i4 84
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int64 [rvastatic2]A::a01084
@@ -6652,7 +6652,7 @@ a01083:
   ldsfld int64 [rvastatic2]A::a01084
   ldc.i8 85
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int16 [rvastatic2]A::a01085
@@ -6662,7 +6662,7 @@ a01084:
   ldsfld int16 [rvastatic2]A::a01085
   ldc.i4 86
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int32 [rvastatic2]A::a01086
@@ -6672,7 +6672,7 @@ a01085:
   ldsfld int32 [rvastatic2]A::a01086
   ldc.i4 87
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int32 [rvastatic2]A::a01087
@@ -6682,7 +6682,7 @@ a01086:
   ldsfld int32 [rvastatic2]A::a01087
   ldc.i4 88
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int16 [rvastatic2]A::a01088
@@ -6692,7 +6692,7 @@ a01087:
   ldsfld int16 [rvastatic2]A::a01088
   ldc.i4 89
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int32 [rvastatic2]A::a01089
@@ -6702,7 +6702,7 @@ a01088:
   ldsfld int32 [rvastatic2]A::a01089
   ldc.i4 90
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int8 [rvastatic2]A::a01090
@@ -6712,7 +6712,7 @@ a01089:
   ldsfld int8 [rvastatic2]A::a01090
   ldc.i4 91
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int16 [rvastatic2]A::a01091
@@ -6722,7 +6722,7 @@ a01090:
   ldsfld int16 [rvastatic2]A::a01091
   ldc.i4 92
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int8 [rvastatic2]A::a01092
@@ -6732,7 +6732,7 @@ a01091:
   ldsfld int8 [rvastatic2]A::a01092
   ldc.i4 93
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int32 [rvastatic2]A::a01093
@@ -6742,7 +6742,7 @@ a01092:
   ldsfld int32 [rvastatic2]A::a01093
   ldc.i4 94
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int64 [rvastatic2]A::a01094
@@ -6752,7 +6752,7 @@ a01093:
   ldsfld int64 [rvastatic2]A::a01094
   ldc.i8 95
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int64 [rvastatic2]A::a01095
@@ -6762,7 +6762,7 @@ a01094:
   ldsfld int64 [rvastatic2]A::a01095
   ldc.i8 96
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int64 [rvastatic2]A::a01096
@@ -6772,7 +6772,7 @@ a01095:
   ldsfld int64 [rvastatic2]A::a01096
   ldc.i8 97
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int64 [rvastatic2]A::a01097
@@ -6782,7 +6782,7 @@ a01096:
   ldsfld int64 [rvastatic2]A::a01097
   ldc.i8 98
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int32 [rvastatic2]A::a01098
@@ -6792,7 +6792,7 @@ a01097:
   ldsfld int32 [rvastatic2]A::a01098
   ldc.i4 99
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int16 [rvastatic2]A::a01099
@@ -6802,7 +6802,7 @@ a01098:
   ldsfld int16 [rvastatic2]A::a01099
   ldc.i4 100
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int8 [rvastatic2]A::a010100
@@ -6812,7 +6812,7 @@ a01099:
   ldsfld int8 [rvastatic2]A::a010100
   ldc.i4 101
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld float32 [rvastatic2]A::a010101
@@ -6822,7 +6822,7 @@ a010100:
   ldsfld float32 [rvastatic2]A::a010101
   ldc.r4 102.0
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld float32 [rvastatic2]A::a010102
@@ -6832,7 +6832,7 @@ a010101:
   ldsfld float32 [rvastatic2]A::a010102
   ldc.r4 103.0
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int8 [rvastatic2]A::a010103
@@ -6842,7 +6842,7 @@ a010102:
   ldsfld int8 [rvastatic2]A::a010103
   ldc.i4 104
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int16 [rvastatic2]A::a010104
@@ -6852,7 +6852,7 @@ a010103:
   ldsfld int16 [rvastatic2]A::a010104
   ldc.i4 105
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int8 [rvastatic2]A::a010105
@@ -6862,7 +6862,7 @@ a010104:
   ldsfld int8 [rvastatic2]A::a010105
   ldc.i4 106
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int32 [rvastatic2]A::a010106
@@ -6872,7 +6872,7 @@ a010105:
   ldsfld int32 [rvastatic2]A::a010106
   ldc.i4 107
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld float32 [rvastatic2]A::a010107
@@ -6882,7 +6882,7 @@ a010106:
   ldsfld float32 [rvastatic2]A::a010107
   ldc.r4 108.0
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int16 [rvastatic2]A::a010108
@@ -6892,7 +6892,7 @@ a010107:
   ldsfld int16 [rvastatic2]A::a010108
   ldc.i4 109
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int8 [rvastatic2]A::a010109
@@ -6902,7 +6902,7 @@ a010108:
   ldsfld int8 [rvastatic2]A::a010109
   ldc.i4 110
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int8 [rvastatic2]A::a010110
@@ -6912,7 +6912,7 @@ a010109:
   ldsfld int8 [rvastatic2]A::a010110
   ldc.i4 111
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int16 [rvastatic2]A::a010111
@@ -6922,7 +6922,7 @@ a010110:
   ldsfld int16 [rvastatic2]A::a010111
   ldc.i4 112
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int16 [rvastatic2]A::a010112
@@ -6932,7 +6932,7 @@ a010111:
   ldsfld int16 [rvastatic2]A::a010112
   ldc.i4 113
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld float32 [rvastatic2]A::a010113
@@ -6942,7 +6942,7 @@ a010112:
   ldsfld float32 [rvastatic2]A::a010113
   ldc.r4 114.0
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int16 [rvastatic2]A::a010114
@@ -6952,7 +6952,7 @@ a010113:
   ldsfld int16 [rvastatic2]A::a010114
   ldc.i4 115
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int8 [rvastatic2]A::a010115
@@ -6962,7 +6962,7 @@ a010114:
   ldsfld int8 [rvastatic2]A::a010115
   ldc.i4 116
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int8 [rvastatic2]A::a010116
@@ -6972,7 +6972,7 @@ a010115:
   ldsfld int8 [rvastatic2]A::a010116
   ldc.i4 117
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int64 [rvastatic2]A::a010117
@@ -6982,7 +6982,7 @@ a010116:
   ldsfld int64 [rvastatic2]A::a010117
   ldc.i8 118
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int8 [rvastatic2]A::a010118
@@ -6992,7 +6992,7 @@ a010117:
   ldsfld int8 [rvastatic2]A::a010118
   ldc.i4 119
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int32 [rvastatic2]A::a010119
@@ -7002,7 +7002,7 @@ a010118:
   ldsfld int32 [rvastatic2]A::a010119
   ldc.i4 120
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld float32 [rvastatic2]A::a010120
@@ -7012,7 +7012,7 @@ a010119:
   ldsfld float32 [rvastatic2]A::a010120
   ldc.r4 121.0
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int16 [rvastatic2]A::a010121
@@ -7022,7 +7022,7 @@ a010120:
   ldsfld int16 [rvastatic2]A::a010121
   ldc.i4 122
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int32 [rvastatic2]A::a010122
@@ -7032,7 +7032,7 @@ a010121:
   ldsfld int32 [rvastatic2]A::a010122
   ldc.i4 123
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int32 [rvastatic2]A::a010123
@@ -7042,7 +7042,7 @@ a010122:
   ldsfld int32 [rvastatic2]A::a010123
   ldc.i4 124
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int64 [rvastatic2]A::a010124
@@ -7052,7 +7052,7 @@ a010123:
   ldsfld int64 [rvastatic2]A::a010124
   ldc.i8 125
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int32 [rvastatic2]A::a010125
@@ -7062,7 +7062,7 @@ a010124:
   ldsfld int32 [rvastatic2]A::a010125
   ldc.i4 126
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int8 [rvastatic2]A::a010126
@@ -7072,7 +7072,7 @@ a010125:
   ldsfld int8 [rvastatic2]A::a010126
   ldc.i4 7
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int64 [rvastatic2]A::a010127
@@ -7082,7 +7082,7 @@ a010126:
   ldsfld int64 [rvastatic2]A::a010127
   ldc.i8 128
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ret}

--- a/tests/src/JIT/Directed/rvastatics/rvastatic3.il
+++ b/tests/src/JIT/Directed/rvastatics/rvastatic3.il
@@ -29,769 +29,769 @@
   ldsfld int64 [rvastatic3]A::a0100
   ldc.i8 0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld int64 [rvastatic3]A::a0101
   ldc.i8 1
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld float32 [rvastatic3]A::a0102
   ldc.r4 2.0
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int64 [rvastatic3]A::a0103
   ldc.i8 3
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int64 [rvastatic3]A::a0104
   ldc.i8 4
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int16 [rvastatic3]A::a0105
   ldc.i4 5
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld int16 [rvastatic3]A::a0106
   ldc.i4 6
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld float32 [rvastatic3]A::a0107
   ldc.r4 7.0
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int32 [rvastatic3]A::a0108
   ldc.i4 8
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int8 [rvastatic3]A::a0109
   ldc.i4 9
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int32 [rvastatic3]A::a01010
   ldc.i4 10
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int64 [rvastatic3]A::a01011
   ldc.i8 11
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int32 [rvastatic3]A::a01012
   ldc.i4 12
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld int8 [rvastatic3]A::a01013
   ldc.i4 13
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int16 [rvastatic3]A::a01014
   ldc.i4 14
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int16 [rvastatic3]A::a01015
   ldc.i4 15
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld float32 [rvastatic3]A::a01016
   ldc.r4 16.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld float32 [rvastatic3]A::a01017
   ldc.r4 17.0
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int32 [rvastatic3]A::a01018
   ldc.i4 18
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int8 [rvastatic3]A::a01019
   ldc.i4 19
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int32 [rvastatic3]A::a01020
   ldc.i4 20
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int32 [rvastatic3]A::a01021
   ldc.i4 21
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int64 [rvastatic3]A::a01022
   ldc.i8 22
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int32 [rvastatic3]A::a01023
   ldc.i4 23
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int8 [rvastatic3]A::a01024
   ldc.i4 24
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int8 [rvastatic3]A::a01025
   ldc.i4 25
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int16 [rvastatic3]A::a01026
   ldc.i4 26
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int8 [rvastatic3]A::a01027
   ldc.i4 27
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int16 [rvastatic3]A::a01028
   ldc.i4 28
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int64 [rvastatic3]A::a01029
   ldc.i8 29
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int32 [rvastatic3]A::a01030
   ldc.i4 30
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int32 [rvastatic3]A::a01031
   ldc.i4 31
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int32 [rvastatic3]A::a01032
   ldc.i4 32
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int8 [rvastatic3]A::a01033
   ldc.i4 33
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int16 [rvastatic3]A::a01034
   ldc.i4 34
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int32 [rvastatic3]A::a01035
   ldc.i4 35
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int32 [rvastatic3]A::a01036
   ldc.i4 36
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int16 [rvastatic3]A::a01037
   ldc.i4 37
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld float32 [rvastatic3]A::a01038
   ldc.r4 38.0
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int8 [rvastatic3]A::a01039
   ldc.i4 39
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int8 [rvastatic3]A::a01040
   ldc.i4 40
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld float32 [rvastatic3]A::a01041
   ldc.r4 41.0
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int32 [rvastatic3]A::a01042
   ldc.i4 42
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int32 [rvastatic3]A::a01043
   ldc.i4 43
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int32 [rvastatic3]A::a01044
   ldc.i4 44
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int64 [rvastatic3]A::a01045
   ldc.i8 45
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int64 [rvastatic3]A::a01046
   ldc.i8 46
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int64 [rvastatic3]A::a01047
   ldc.i8 47
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld float32 [rvastatic3]A::a01048
   ldc.r4 48.0
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int64 [rvastatic3]A::a01049
   ldc.i8 49
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int32 [rvastatic3]A::a01050
   ldc.i4 50
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld float32 [rvastatic3]A::a01051
   ldc.r4 51.0
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int32 [rvastatic3]A::a01052
   ldc.i4 52
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int64 [rvastatic3]A::a01053
   ldc.i8 53
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int8 [rvastatic3]A::a01054
   ldc.i4 54
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int8 [rvastatic3]A::a01055
   ldc.i4 55
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld float32 [rvastatic3]A::a01056
   ldc.r4 56.0
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int32 [rvastatic3]A::a01057
   ldc.i4 57
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int64 [rvastatic3]A::a01058
   ldc.i8 58
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int64 [rvastatic3]A::a01059
   ldc.i8 59
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int8 [rvastatic3]A::a01060
   ldc.i4 60
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int16 [rvastatic3]A::a01061
   ldc.i4 61
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int64 [rvastatic3]A::a01062
   ldc.i8 62
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld float32 [rvastatic3]A::a01063
   ldc.r4 63.0
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int64 [rvastatic3]A::a01064
   ldc.i8 64
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld float32 [rvastatic3]A::a01065
   ldc.r4 65.0
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int8 [rvastatic3]A::a01066
   ldc.i4 66
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int16 [rvastatic3]A::a01067
   ldc.i4 67
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int64 [rvastatic3]A::a01068
   ldc.i8 68
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int64 [rvastatic3]A::a01069
   ldc.i8 69
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int64 [rvastatic3]A::a01070
   ldc.i8 70
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int32 [rvastatic3]A::a01071
   ldc.i4 71
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int8 [rvastatic3]A::a01072
   ldc.i4 72
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int32 [rvastatic3]A::a01073
   ldc.i4 73
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld float32 [rvastatic3]A::a01074
   ldc.r4 74.0
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int64 [rvastatic3]A::a01075
   ldc.i8 75
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int8 [rvastatic3]A::a01076
   ldc.i4 76
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int8 [rvastatic3]A::a01077
   ldc.i4 77
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int8 [rvastatic3]A::a01078
   ldc.i4 78
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld int32 [rvastatic3]A::a01079
   ldc.i4 79
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld int16 [rvastatic3]A::a01080
   ldc.i4 80
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld int32 [rvastatic3]A::a01081
   ldc.i4 81
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int8 [rvastatic3]A::a01082
   ldc.i4 82
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int32 [rvastatic3]A::a01083
   ldc.i4 83
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int8 [rvastatic3]A::a01084
   ldc.i4 84
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int32 [rvastatic3]A::a01085
   ldc.i4 85
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int8 [rvastatic3]A::a01086
   ldc.i4 86
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int64 [rvastatic3]A::a01087
   ldc.i8 87
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int8 [rvastatic3]A::a01088
   ldc.i4 88
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int16 [rvastatic3]A::a01089
   ldc.i4 89
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int64 [rvastatic3]A::a01090
   ldc.i8 90
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int8 [rvastatic3]A::a01091
   ldc.i4 91
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int64 [rvastatic3]A::a01092
   ldc.i8 92
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int16 [rvastatic3]A::a01093
   ldc.i4 93
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int8 [rvastatic3]A::a01094
   ldc.i4 94
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld float32 [rvastatic3]A::a01095
   ldc.r4 95.0
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int16 [rvastatic3]A::a01096
   ldc.i4 96
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int64 [rvastatic3]A::a01097
   ldc.i8 97
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld float32 [rvastatic3]A::a01098
   ldc.r4 98.0
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int32 [rvastatic3]A::a01099
   ldc.i4 99
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int32 [rvastatic3]A::a010100
   ldc.i4 100
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int32 [rvastatic3]A::a010101
   ldc.i4 101
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int8 [rvastatic3]A::a010102
   ldc.i4 102
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int16 [rvastatic3]A::a010103
   ldc.i4 103
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int8 [rvastatic3]A::a010104
   ldc.i4 104
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld float32 [rvastatic3]A::a010105
   ldc.r4 105.0
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld float32 [rvastatic3]A::a010106
   ldc.r4 106.0
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int8 [rvastatic3]A::a010107
   ldc.i4 107
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld float32 [rvastatic3]A::a010108
   ldc.r4 108.0
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int16 [rvastatic3]A::a010109
   ldc.i4 109
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int8 [rvastatic3]A::a010110
   ldc.i4 110
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int64 [rvastatic3]A::a010111
   ldc.i8 111
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int16 [rvastatic3]A::a010112
   ldc.i4 112
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int16 [rvastatic3]A::a010113
   ldc.i4 113
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int32 [rvastatic3]A::a010114
   ldc.i4 114
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int32 [rvastatic3]A::a010115
   ldc.i4 115
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int8 [rvastatic3]A::a010116
   ldc.i4 116
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int16 [rvastatic3]A::a010117
   ldc.i4 117
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int64 [rvastatic3]A::a010118
   ldc.i8 118
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int8 [rvastatic3]A::a010119
   ldc.i4 119
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int64 [rvastatic3]A::a010120
   ldc.i8 120
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int32 [rvastatic3]A::a010121
   ldc.i4 121
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int8 [rvastatic3]A::a010122
   ldc.i4 2
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int32 [rvastatic3]A::a010123
   ldc.i4 123
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int8 [rvastatic3]A::a010124
   ldc.i4 4
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int64 [rvastatic3]A::a010125
   ldc.i8 125
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld float32 [rvastatic3]A::a010126
   ldc.r4 126.0
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ldsfld int64 [rvastatic3]A::a010127
   ldc.i8 127
   beq a010128
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010128:
  ret}
@@ -800,896 +800,896 @@ a010128:
   ldind.i8
   ldc.i8 0
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsflda int64 [rvastatic3]A::a0101
   ldind.i8
   ldc.i8 1
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsflda float32 [rvastatic3]A::a0102
   ldind.r4
   ldc.r4 2.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsflda int64 [rvastatic3]A::a0103
   ldind.i8
   ldc.i8 3
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsflda int64 [rvastatic3]A::a0104
   ldind.i8
   ldc.i8 4
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsflda int16 [rvastatic3]A::a0105
   ldind.i2
   ldc.i4 5
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsflda int16 [rvastatic3]A::a0106
   ldind.i2
   ldc.i4 6
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsflda float32 [rvastatic3]A::a0107
   ldind.r4
   ldc.r4 7.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsflda int32 [rvastatic3]A::a0108
   ldind.i4
   ldc.i4 8
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsflda int8 [rvastatic3]A::a0109
   ldind.i1
   ldc.i4 9
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsflda int32 [rvastatic3]A::a01010
   ldind.i4
   ldc.i4 10
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsflda int64 [rvastatic3]A::a01011
   ldind.i8
   ldc.i8 11
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsflda int32 [rvastatic3]A::a01012
   ldind.i4
   ldc.i4 12
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsflda int8 [rvastatic3]A::a01013
   ldind.i1
   ldc.i4 13
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsflda int16 [rvastatic3]A::a01014
   ldind.i2
   ldc.i4 14
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsflda int16 [rvastatic3]A::a01015
   ldind.i2
   ldc.i4 15
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsflda float32 [rvastatic3]A::a01016
   ldind.r4
   ldc.r4 16.0
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsflda float32 [rvastatic3]A::a01017
   ldind.r4
   ldc.r4 17.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsflda int32 [rvastatic3]A::a01018
   ldind.i4
   ldc.i4 18
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsflda int8 [rvastatic3]A::a01019
   ldind.i1
   ldc.i4 19
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsflda int32 [rvastatic3]A::a01020
   ldind.i4
   ldc.i4 20
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsflda int32 [rvastatic3]A::a01021
   ldind.i4
   ldc.i4 21
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsflda int64 [rvastatic3]A::a01022
   ldind.i8
   ldc.i8 22
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsflda int32 [rvastatic3]A::a01023
   ldind.i4
   ldc.i4 23
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsflda int8 [rvastatic3]A::a01024
   ldind.i1
   ldc.i4 24
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsflda int8 [rvastatic3]A::a01025
   ldind.i1
   ldc.i4 25
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsflda int16 [rvastatic3]A::a01026
   ldind.i2
   ldc.i4 26
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsflda int8 [rvastatic3]A::a01027
   ldind.i1
   ldc.i4 27
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsflda int16 [rvastatic3]A::a01028
   ldind.i2
   ldc.i4 28
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsflda int64 [rvastatic3]A::a01029
   ldind.i8
   ldc.i8 29
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsflda int32 [rvastatic3]A::a01030
   ldind.i4
   ldc.i4 30
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsflda int32 [rvastatic3]A::a01031
   ldind.i4
   ldc.i4 31
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsflda int32 [rvastatic3]A::a01032
   ldind.i4
   ldc.i4 32
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsflda int8 [rvastatic3]A::a01033
   ldind.i1
   ldc.i4 33
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsflda int16 [rvastatic3]A::a01034
   ldind.i2
   ldc.i4 34
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsflda int32 [rvastatic3]A::a01035
   ldind.i4
   ldc.i4 35
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsflda int32 [rvastatic3]A::a01036
   ldind.i4
   ldc.i4 36
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsflda int16 [rvastatic3]A::a01037
   ldind.i2
   ldc.i4 37
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsflda float32 [rvastatic3]A::a01038
   ldind.r4
   ldc.r4 38.0
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsflda int8 [rvastatic3]A::a01039
   ldind.i1
   ldc.i4 39
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsflda int8 [rvastatic3]A::a01040
   ldind.i1
   ldc.i4 40
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsflda float32 [rvastatic3]A::a01041
   ldind.r4
   ldc.r4 41.0
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsflda int32 [rvastatic3]A::a01042
   ldind.i4
   ldc.i4 42
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsflda int32 [rvastatic3]A::a01043
   ldind.i4
   ldc.i4 43
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsflda int32 [rvastatic3]A::a01044
   ldind.i4
   ldc.i4 44
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsflda int64 [rvastatic3]A::a01045
   ldind.i8
   ldc.i8 45
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsflda int64 [rvastatic3]A::a01046
   ldind.i8
   ldc.i8 46
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsflda int64 [rvastatic3]A::a01047
   ldind.i8
   ldc.i8 47
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsflda float32 [rvastatic3]A::a01048
   ldind.r4
   ldc.r4 48.0
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsflda int64 [rvastatic3]A::a01049
   ldind.i8
   ldc.i8 49
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsflda int32 [rvastatic3]A::a01050
   ldind.i4
   ldc.i4 50
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsflda float32 [rvastatic3]A::a01051
   ldind.r4
   ldc.r4 51.0
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsflda int32 [rvastatic3]A::a01052
   ldind.i4
   ldc.i4 52
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsflda int64 [rvastatic3]A::a01053
   ldind.i8
   ldc.i8 53
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsflda int8 [rvastatic3]A::a01054
   ldind.i1
   ldc.i4 54
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsflda int8 [rvastatic3]A::a01055
   ldind.i1
   ldc.i4 55
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsflda float32 [rvastatic3]A::a01056
   ldind.r4
   ldc.r4 56.0
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsflda int32 [rvastatic3]A::a01057
   ldind.i4
   ldc.i4 57
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsflda int64 [rvastatic3]A::a01058
   ldind.i8
   ldc.i8 58
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsflda int64 [rvastatic3]A::a01059
   ldind.i8
   ldc.i8 59
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsflda int8 [rvastatic3]A::a01060
   ldind.i1
   ldc.i4 60
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsflda int16 [rvastatic3]A::a01061
   ldind.i2
   ldc.i4 61
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsflda int64 [rvastatic3]A::a01062
   ldind.i8
   ldc.i8 62
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsflda float32 [rvastatic3]A::a01063
   ldind.r4
   ldc.r4 63.0
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsflda int64 [rvastatic3]A::a01064
   ldind.i8
   ldc.i8 64
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsflda float32 [rvastatic3]A::a01065
   ldind.r4
   ldc.r4 65.0
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsflda int8 [rvastatic3]A::a01066
   ldind.i1
   ldc.i4 66
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsflda int16 [rvastatic3]A::a01067
   ldind.i2
   ldc.i4 67
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsflda int64 [rvastatic3]A::a01068
   ldind.i8
   ldc.i8 68
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsflda int64 [rvastatic3]A::a01069
   ldind.i8
   ldc.i8 69
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsflda int64 [rvastatic3]A::a01070
   ldind.i8
   ldc.i8 70
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsflda int32 [rvastatic3]A::a01071
   ldind.i4
   ldc.i4 71
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsflda int8 [rvastatic3]A::a01072
   ldind.i1
   ldc.i4 72
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsflda int32 [rvastatic3]A::a01073
   ldind.i4
   ldc.i4 73
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsflda float32 [rvastatic3]A::a01074
   ldind.r4
   ldc.r4 74.0
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsflda int64 [rvastatic3]A::a01075
   ldind.i8
   ldc.i8 75
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsflda int8 [rvastatic3]A::a01076
   ldind.i1
   ldc.i4 76
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsflda int8 [rvastatic3]A::a01077
   ldind.i1
   ldc.i4 77
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsflda int8 [rvastatic3]A::a01078
   ldind.i1
   ldc.i4 78
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsflda int32 [rvastatic3]A::a01079
   ldind.i4
   ldc.i4 79
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsflda int16 [rvastatic3]A::a01080
   ldind.i2
   ldc.i4 80
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsflda int32 [rvastatic3]A::a01081
   ldind.i4
   ldc.i4 81
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsflda int8 [rvastatic3]A::a01082
   ldind.i1
   ldc.i4 82
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsflda int32 [rvastatic3]A::a01083
   ldind.i4
   ldc.i4 83
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsflda int8 [rvastatic3]A::a01084
   ldind.i1
   ldc.i4 84
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsflda int32 [rvastatic3]A::a01085
   ldind.i4
   ldc.i4 85
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsflda int8 [rvastatic3]A::a01086
   ldind.i1
   ldc.i4 86
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsflda int64 [rvastatic3]A::a01087
   ldind.i8
   ldc.i8 87
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsflda int8 [rvastatic3]A::a01088
   ldind.i1
   ldc.i4 88
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsflda int16 [rvastatic3]A::a01089
   ldind.i2
   ldc.i4 89
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsflda int64 [rvastatic3]A::a01090
   ldind.i8
   ldc.i8 90
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsflda int8 [rvastatic3]A::a01091
   ldind.i1
   ldc.i4 91
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsflda int64 [rvastatic3]A::a01092
   ldind.i8
   ldc.i8 92
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsflda int16 [rvastatic3]A::a01093
   ldind.i2
   ldc.i4 93
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsflda int8 [rvastatic3]A::a01094
   ldind.i1
   ldc.i4 94
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsflda float32 [rvastatic3]A::a01095
   ldind.r4
   ldc.r4 95.0
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsflda int16 [rvastatic3]A::a01096
   ldind.i2
   ldc.i4 96
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsflda int64 [rvastatic3]A::a01097
   ldind.i8
   ldc.i8 97
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsflda float32 [rvastatic3]A::a01098
   ldind.r4
   ldc.r4 98.0
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsflda int32 [rvastatic3]A::a01099
   ldind.i4
   ldc.i4 99
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsflda int32 [rvastatic3]A::a010100
   ldind.i4
   ldc.i4 100
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsflda int32 [rvastatic3]A::a010101
   ldind.i4
   ldc.i4 101
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsflda int8 [rvastatic3]A::a010102
   ldind.i1
   ldc.i4 102
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsflda int16 [rvastatic3]A::a010103
   ldind.i2
   ldc.i4 103
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsflda int8 [rvastatic3]A::a010104
   ldind.i1
   ldc.i4 104
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsflda float32 [rvastatic3]A::a010105
   ldind.r4
   ldc.r4 105.0
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsflda float32 [rvastatic3]A::a010106
   ldind.r4
   ldc.r4 106.0
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsflda int8 [rvastatic3]A::a010107
   ldind.i1
   ldc.i4 107
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsflda float32 [rvastatic3]A::a010108
   ldind.r4
   ldc.r4 108.0
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsflda int16 [rvastatic3]A::a010109
   ldind.i2
   ldc.i4 109
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsflda int8 [rvastatic3]A::a010110
   ldind.i1
   ldc.i4 110
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsflda int64 [rvastatic3]A::a010111
   ldind.i8
   ldc.i8 111
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsflda int16 [rvastatic3]A::a010112
   ldind.i2
   ldc.i4 112
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsflda int16 [rvastatic3]A::a010113
   ldind.i2
   ldc.i4 113
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsflda int32 [rvastatic3]A::a010114
   ldind.i4
   ldc.i4 114
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsflda int32 [rvastatic3]A::a010115
   ldind.i4
   ldc.i4 115
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsflda int8 [rvastatic3]A::a010116
   ldind.i1
   ldc.i4 116
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsflda int16 [rvastatic3]A::a010117
   ldind.i2
   ldc.i4 117
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsflda int64 [rvastatic3]A::a010118
   ldind.i8
   ldc.i8 118
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsflda int8 [rvastatic3]A::a010119
   ldind.i1
   ldc.i4 119
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsflda int64 [rvastatic3]A::a010120
   ldind.i8
   ldc.i8 120
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsflda int32 [rvastatic3]A::a010121
   ldind.i4
   ldc.i4 121
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsflda int8 [rvastatic3]A::a010122
   ldind.i1
   ldc.i4 2
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsflda int32 [rvastatic3]A::a010123
   ldind.i4
   ldc.i4 123
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsflda int8 [rvastatic3]A::a010124
   ldind.i1
   ldc.i4 4
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsflda int64 [rvastatic3]A::a010125
   ldind.i8
   ldc.i8 125
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsflda float32 [rvastatic3]A::a010126
   ldind.r4
   ldc.r4 126.0
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsflda int64 [rvastatic3]A::a010127
   ldind.i8
   ldc.i8 127
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
  ret}
@@ -1697,769 +1697,769 @@ a010127:
   ldsfld int32 [rvastatic3]A::a01044
   ldc.i4 44
   beq a010129
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010129:
   ldsfld float32 [rvastatic3]A::a01056
   ldc.r4 56.0
   beq a010130
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010130:
   ldsfld int16 [rvastatic3]A::a01028
   ldc.i4 28
   beq a010131
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010131:
   ldsfld int8 [rvastatic3]A::a01066
   ldc.i4 66
   beq a010132
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010132:
   ldsfld int64 [rvastatic3]A::a010125
   ldc.i8 125
   beq a010133
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010133:
   ldsfld int16 [rvastatic3]A::a010109
   ldc.i4 109
   beq a010134
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010134:
   ldsfld int64 [rvastatic3]A::a01058
   ldc.i8 58
   beq a010135
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010135:
   ldsfld int8 [rvastatic3]A::a010107
   ldc.i4 107
   beq a010136
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010136:
   ldsfld int64 [rvastatic3]A::a01047
   ldc.i8 47
   beq a010137
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010137:
   ldsfld int32 [rvastatic3]A::a01030
   ldc.i4 30
   beq a010138
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010138:
   ldsfld int16 [rvastatic3]A::a01067
   ldc.i4 67
   beq a010139
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010139:
   ldsfld int32 [rvastatic3]A::a01012
   ldc.i4 12
   beq a010140
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010140:
   ldsfld int32 [rvastatic3]A::a010100
   ldc.i4 100
   beq a010141
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010141:
   ldsfld int32 [rvastatic3]A::a010100
   ldc.i4 100
   beq a010142
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010142:
   ldsfld int8 [rvastatic3]A::a01019
   ldc.i4 19
   beq a010143
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010143:
   ldsfld int16 [rvastatic3]A::a010103
   ldc.i4 103
   beq a010144
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010144:
   ldsfld int16 [rvastatic3]A::a01093
   ldc.i4 93
   beq a010145
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010145:
   ldsfld int64 [rvastatic3]A::a01058
   ldc.i8 58
   beq a010146
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010146:
   ldsfld float32 [rvastatic3]A::a010106
   ldc.r4 106.0
   beq a010147
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010147:
   ldsfld int16 [rvastatic3]A::a01061
   ldc.i4 61
   beq a010148
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010148:
   ldsfld int16 [rvastatic3]A::a010103
   ldc.i4 103
   beq a010149
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010149:
   ldsfld float32 [rvastatic3]A::a0102
   ldc.r4 2.0
   beq a010150
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010150:
   ldsfld int16 [rvastatic3]A::a010109
   ldc.i4 109
   beq a010151
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010151:
   ldsfld float32 [rvastatic3]A::a010105
   ldc.r4 105.0
   beq a010152
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010152:
   ldsfld int64 [rvastatic3]A::a01097
   ldc.i8 97
   beq a010153
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010153:
   ldsfld int32 [rvastatic3]A::a010114
   ldc.i4 114
   beq a010154
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010154:
   ldsfld int32 [rvastatic3]A::a01043
   ldc.i4 43
   beq a010155
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010155:
   ldsfld int32 [rvastatic3]A::a01073
   ldc.i4 73
   beq a010156
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010156:
   ldsfld float32 [rvastatic3]A::a0102
   ldc.r4 2.0
   beq a010157
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010157:
   ldsfld int64 [rvastatic3]A::a01046
   ldc.i8 46
   beq a010158
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010158:
   ldsfld int16 [rvastatic3]A::a01015
   ldc.i4 15
   beq a010159
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010159:
   ldsfld int32 [rvastatic3]A::a01023
   ldc.i4 23
   beq a010160
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010160:
   ldsfld int64 [rvastatic3]A::a01068
   ldc.i8 68
   beq a010161
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010161:
   ldsfld int64 [rvastatic3]A::a010120
   ldc.i8 120
   beq a010162
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010162:
   ldsfld int16 [rvastatic3]A::a0106
   ldc.i4 6
   beq a010163
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010163:
   ldsfld int32 [rvastatic3]A::a01079
   ldc.i4 79
   beq a010164
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010164:
   ldsfld int32 [rvastatic3]A::a01073
   ldc.i4 73
   beq a010165
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010165:
   ldsfld int8 [rvastatic3]A::a010104
   ldc.i4 104
   beq a010166
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010166:
   ldsfld int8 [rvastatic3]A::a01033
   ldc.i4 33
   beq a010167
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010167:
   ldsfld int32 [rvastatic3]A::a01071
   ldc.i4 71
   beq a010168
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010168:
   ldsfld int32 [rvastatic3]A::a0108
   ldc.i4 8
   beq a010169
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010169:
   ldsfld float32 [rvastatic3]A::a01041
   ldc.r4 41.0
   beq a010170
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010170:
   ldsfld int16 [rvastatic3]A::a010112
   ldc.i4 112
   beq a010171
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010171:
   ldsfld float32 [rvastatic3]A::a01065
   ldc.r4 65.0
   beq a010172
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010172:
   ldsfld int8 [rvastatic3]A::a01078
   ldc.i4 78
   beq a010173
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010173:
   ldsfld int16 [rvastatic3]A::a01089
   ldc.i4 89
   beq a010174
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010174:
   ldsfld float32 [rvastatic3]A::a01095
   ldc.r4 95.0
   beq a010175
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010175:
   ldsfld int8 [rvastatic3]A::a01039
   ldc.i4 39
   beq a010176
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010176:
   ldsfld int32 [rvastatic3]A::a01043
   ldc.i4 43
   beq a010177
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010177:
   ldsfld float32 [rvastatic3]A::a01048
   ldc.r4 48.0
   beq a010178
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010178:
   ldsfld int8 [rvastatic3]A::a010122
   ldc.i4 2
   beq a010179
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010179:
   ldsfld int64 [rvastatic3]A::a01047
   ldc.i8 47
   beq a010180
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010180:
   ldsfld int8 [rvastatic3]A::a010119
   ldc.i4 119
   beq a010181
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010181:
   ldsfld float32 [rvastatic3]A::a010126
   ldc.r4 126.0
   beq a010182
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010182:
   ldsfld float32 [rvastatic3]A::a01017
   ldc.r4 17.0
   beq a010183
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010183:
   ldsfld float32 [rvastatic3]A::a01041
   ldc.r4 41.0
   beq a010184
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010184:
   ldsfld int64 [rvastatic3]A::a01075
   ldc.i8 75
   beq a010185
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010185:
   ldsfld int32 [rvastatic3]A::a01050
   ldc.i4 50
   beq a010186
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010186:
   ldsfld int16 [rvastatic3]A::a01096
   ldc.i4 96
   beq a010187
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010187:
   ldsfld int32 [rvastatic3]A::a01010
   ldc.i4 10
   beq a010188
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010188:
   ldsfld int8 [rvastatic3]A::a01066
   ldc.i4 66
   beq a010189
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010189:
   ldsfld int16 [rvastatic3]A::a010113
   ldc.i4 113
   beq a010190
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010190:
   ldsfld int8 [rvastatic3]A::a010104
   ldc.i4 104
   beq a010191
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010191:
   ldsfld int64 [rvastatic3]A::a0101
   ldc.i8 1
   beq a010192
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010192:
   ldsfld int16 [rvastatic3]A::a01015
   ldc.i4 15
   beq a010193
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010193:
   ldsfld int32 [rvastatic3]A::a01043
   ldc.i4 43
   beq a010194
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010194:
   ldsfld int32 [rvastatic3]A::a01071
   ldc.i4 71
   beq a010195
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010195:
   ldsfld int8 [rvastatic3]A::a010107
   ldc.i4 107
   beq a010196
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010196:
   ldsfld int8 [rvastatic3]A::a01094
   ldc.i4 94
   beq a010197
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010197:
   ldsfld int64 [rvastatic3]A::a01068
   ldc.i8 68
   beq a010198
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010198:
   ldsfld int64 [rvastatic3]A::a01029
   ldc.i8 29
   beq a010199
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010199:
   ldsfld int8 [rvastatic3]A::a010116
   ldc.i4 116
   beq a010200
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010200:
   ldsfld int8 [rvastatic3]A::a01025
   ldc.i4 25
   beq a010201
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010201:
   ldsfld int16 [rvastatic3]A::a01034
   ldc.i4 34
   beq a010202
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010202:
   ldsfld int32 [rvastatic3]A::a01052
   ldc.i4 52
   beq a010203
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010203:
   ldsfld int16 [rvastatic3]A::a01061
   ldc.i4 61
   beq a010204
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010204:
   ldsfld int32 [rvastatic3]A::a01018
   ldc.i4 18
   beq a010205
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010205:
   ldsfld int32 [rvastatic3]A::a01043
   ldc.i4 43
   beq a010206
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010206:
   ldsfld int16 [rvastatic3]A::a01026
   ldc.i4 26
   beq a010207
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010207:
   ldsfld float32 [rvastatic3]A::a0107
   ldc.r4 7.0
   beq a010208
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010208:
   ldsfld int32 [rvastatic3]A::a01018
   ldc.i4 18
   beq a010209
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010209:
   ldsfld int64 [rvastatic3]A::a0104
   ldc.i8 4
   beq a010210
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010210:
   ldsfld int64 [rvastatic3]A::a01029
   ldc.i8 29
   beq a010211
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010211:
   ldsfld int8 [rvastatic3]A::a01082
   ldc.i4 82
   beq a010212
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010212:
   ldsfld int32 [rvastatic3]A::a01052
   ldc.i4 52
   beq a010213
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010213:
   ldsfld float32 [rvastatic3]A::a01095
   ldc.r4 95.0
   beq a010214
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010214:
   ldsfld int32 [rvastatic3]A::a01032
   ldc.i4 32
   beq a010215
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010215:
   ldsfld int64 [rvastatic3]A::a01069
   ldc.i8 69
   beq a010216
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010216:
   ldsfld int16 [rvastatic3]A::a010103
   ldc.i4 103
   beq a010217
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010217:
   ldsfld int64 [rvastatic3]A::a01092
   ldc.i8 92
   beq a010218
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010218:
   ldsfld int64 [rvastatic3]A::a0104
   ldc.i8 4
   beq a010219
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010219:
   ldsfld int64 [rvastatic3]A::a01022
   ldc.i8 22
   beq a010220
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010220:
   ldsfld float32 [rvastatic3]A::a0107
   ldc.r4 7.0
   beq a010221
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010221:
   ldsfld int64 [rvastatic3]A::a01022
   ldc.i8 22
   beq a010222
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010222:
   ldsfld int16 [rvastatic3]A::a0105
   ldc.i4 5
   beq a010223
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010223:
   ldsfld int32 [rvastatic3]A::a01023
   ldc.i4 23
   beq a010224
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010224:
   ldsfld int64 [rvastatic3]A::a01064
   ldc.i8 64
   beq a010225
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010225:
   ldsfld int8 [rvastatic3]A::a010110
   ldc.i4 110
   beq a010226
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010226:
   ldsfld int32 [rvastatic3]A::a01050
   ldc.i4 50
   beq a010227
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010227:
   ldsfld int32 [rvastatic3]A::a01035
   ldc.i4 35
   beq a010228
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010228:
   ldsfld float32 [rvastatic3]A::a01017
   ldc.r4 17.0
   beq a010229
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010229:
   ldsfld int8 [rvastatic3]A::a010116
   ldc.i4 116
   beq a010230
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010230:
   ldsfld int8 [rvastatic3]A::a01072
   ldc.i4 72
   beq a010231
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010231:
   ldsfld int16 [rvastatic3]A::a010103
   ldc.i4 103
   beq a010232
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010232:
   ldsfld int32 [rvastatic3]A::a01018
   ldc.i4 18
   beq a010233
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010233:
   ldsfld int16 [rvastatic3]A::a0105
   ldc.i4 5
   beq a010234
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010234:
   ldsfld int64 [rvastatic3]A::a01022
   ldc.i8 22
   beq a010235
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010235:
   ldsfld int8 [rvastatic3]A::a01084
   ldc.i4 84
   beq a010236
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010236:
   ldsfld int32 [rvastatic3]A::a01073
   ldc.i4 73
   beq a010237
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010237:
   ldsfld int32 [rvastatic3]A::a01083
   ldc.i4 83
   beq a010238
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010238:
   ldsfld int32 [rvastatic3]A::a01023
   ldc.i4 23
   beq a010239
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010239:
   ldsfld int32 [rvastatic3]A::a01031
   ldc.i4 31
   beq a010240
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010240:
   ldsfld int32 [rvastatic3]A::a01023
   ldc.i4 23
   beq a010241
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010241:
   ldsfld int16 [rvastatic3]A::a01089
   ldc.i4 89
   beq a010242
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010242:
   ldsfld int64 [rvastatic3]A::a010120
   ldc.i8 120
   beq a010243
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010243:
   ldsfld int16 [rvastatic3]A::a01061
   ldc.i4 61
   beq a010244
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010244:
   ldsfld int32 [rvastatic3]A::a01083
   ldc.i4 83
   beq a010245
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010245:
   ldsfld int64 [rvastatic3]A::a01022
   ldc.i8 22
   beq a010246
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010246:
   ldsfld int8 [rvastatic3]A::a01076
   ldc.i4 76
   beq a010247
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010247:
   ldsfld int64 [rvastatic3]A::a01047
   ldc.i8 47
   beq a010248
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010248:
   ldsfld int32 [rvastatic3]A::a01010
   ldc.i4 10
   beq a010249
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010249:
   ldsfld int64 [rvastatic3]A::a0101
   ldc.i8 1
   beq a010250
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010250:
   ldsfld int64 [rvastatic3]A::a0103
   ldc.i8 3
   beq a010251
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010251:
   ldsfld int64 [rvastatic3]A::a0101
   ldc.i8 1
   beq a010252
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010252:
   ldsfld int64 [rvastatic3]A::a01064
   ldc.i8 64
   beq a010253
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010253:
   ldsfld int16 [rvastatic3]A::a0106
   ldc.i4 6
   beq a010254
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010254:
   ldsfld int16 [rvastatic3]A::a010109
   ldc.i4 109
   beq a010255
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010255:
   ldsfld int64 [rvastatic3]A::a0103
   ldc.i8 3
   beq a010256
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010256:
  ret}
@@ -2477,7 +2477,7 @@ a010256:
   ldc.i8 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda int64 [rvastatic3]A::a0101
@@ -2492,7 +2492,7 @@ a0100:
   ldc.i8 1
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda float32 [rvastatic3]A::a0102
@@ -2511,7 +2511,7 @@ a0101:
   ldc.r4 2.0
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int64 [rvastatic3]A::a0103
@@ -2527,7 +2527,7 @@ a0102:
   ldc.i8 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int64 [rvastatic3]A::a0104
@@ -2546,7 +2546,7 @@ a0103:
   ldc.i8 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int16 [rvastatic3]A::a0105
@@ -2560,7 +2560,7 @@ a0104:
   ldc.i4 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int16 [rvastatic3]A::a0106
@@ -2576,7 +2576,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda float32 [rvastatic3]A::a0107
@@ -2592,7 +2592,7 @@ a0106:
   ldc.r4 7.0
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda int32 [rvastatic3]A::a0108
@@ -2606,7 +2606,7 @@ a0107:
   ldc.i4 8
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int8 [rvastatic3]A::a0109
@@ -2625,7 +2625,7 @@ a0108:
   ldc.i4 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int32 [rvastatic3]A::a01010
@@ -2640,7 +2640,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int64 [rvastatic3]A::a01011
@@ -2654,7 +2654,7 @@ a01010:
   ldc.i8 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int32 [rvastatic3]A::a01012
@@ -2673,7 +2673,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda int8 [rvastatic3]A::a01013
@@ -2692,7 +2692,7 @@ a01012:
   ldc.i4 13
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda int16 [rvastatic3]A::a01014
@@ -2711,7 +2711,7 @@ a01013:
   ldc.i4 14
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int16 [rvastatic3]A::a01015
@@ -2726,7 +2726,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda float32 [rvastatic3]A::a01016
@@ -2745,7 +2745,7 @@ a01015:
   ldc.r4 16.0
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda float32 [rvastatic3]A::a01017
@@ -2759,7 +2759,7 @@ a01016:
   ldc.r4 17.0
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int32 [rvastatic3]A::a01018
@@ -2774,7 +2774,7 @@ a01017:
   ldc.i4 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int8 [rvastatic3]A::a01019
@@ -2789,7 +2789,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int32 [rvastatic3]A::a01020
@@ -2808,7 +2808,7 @@ a01019:
   ldc.i4 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda int32 [rvastatic3]A::a01021
@@ -2824,7 +2824,7 @@ a01020:
   ldc.i4 21
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int64 [rvastatic3]A::a01022
@@ -2840,7 +2840,7 @@ a01021:
   ldc.i8 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int32 [rvastatic3]A::a01023
@@ -2859,7 +2859,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int8 [rvastatic3]A::a01024
@@ -2873,7 +2873,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int8 [rvastatic3]A::a01025
@@ -2889,7 +2889,7 @@ a01024:
   ldc.i4 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int16 [rvastatic3]A::a01026
@@ -2904,7 +2904,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int8 [rvastatic3]A::a01027
@@ -2923,7 +2923,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int16 [rvastatic3]A::a01028
@@ -2942,7 +2942,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int64 [rvastatic3]A::a01029
@@ -2957,7 +2957,7 @@ a01028:
   ldc.i8 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int32 [rvastatic3]A::a01030
@@ -2972,7 +2972,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int32 [rvastatic3]A::a01031
@@ -2988,7 +2988,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int32 [rvastatic3]A::a01032
@@ -3004,7 +3004,7 @@ a01031:
   ldc.i4 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda int8 [rvastatic3]A::a01033
@@ -3018,7 +3018,7 @@ a01032:
   ldc.i4 33
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int16 [rvastatic3]A::a01034
@@ -3032,7 +3032,7 @@ a01033:
   ldc.i4 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int32 [rvastatic3]A::a01035
@@ -3046,7 +3046,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int32 [rvastatic3]A::a01036
@@ -3065,7 +3065,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int16 [rvastatic3]A::a01037
@@ -3080,7 +3080,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda float32 [rvastatic3]A::a01038
@@ -3099,7 +3099,7 @@ a01037:
   ldc.r4 38.0
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int8 [rvastatic3]A::a01039
@@ -3113,7 +3113,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int8 [rvastatic3]A::a01040
@@ -3128,7 +3128,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda float32 [rvastatic3]A::a01041
@@ -3143,7 +3143,7 @@ a01040:
   ldc.r4 41.0
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int32 [rvastatic3]A::a01042
@@ -3157,7 +3157,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int32 [rvastatic3]A::a01043
@@ -3176,7 +3176,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int32 [rvastatic3]A::a01044
@@ -3195,7 +3195,7 @@ a01043:
   ldc.i4 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int64 [rvastatic3]A::a01045
@@ -3214,7 +3214,7 @@ a01044:
   ldc.i8 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int64 [rvastatic3]A::a01046
@@ -3229,7 +3229,7 @@ a01045:
   ldc.i8 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int64 [rvastatic3]A::a01047
@@ -3248,7 +3248,7 @@ a01046:
   ldc.i8 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda float32 [rvastatic3]A::a01048
@@ -3263,7 +3263,7 @@ a01047:
   ldc.r4 48.0
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int64 [rvastatic3]A::a01049
@@ -3278,7 +3278,7 @@ a01048:
   ldc.i8 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int32 [rvastatic3]A::a01050
@@ -3297,7 +3297,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda float32 [rvastatic3]A::a01051
@@ -3313,7 +3313,7 @@ a01050:
   ldc.r4 51.0
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int32 [rvastatic3]A::a01052
@@ -3332,7 +3332,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int64 [rvastatic3]A::a01053
@@ -3351,7 +3351,7 @@ a01052:
   ldc.i8 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda int8 [rvastatic3]A::a01054
@@ -3370,7 +3370,7 @@ a01053:
   ldc.i4 54
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int8 [rvastatic3]A::a01055
@@ -3385,7 +3385,7 @@ a01054:
   ldc.i4 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda float32 [rvastatic3]A::a01056
@@ -3400,7 +3400,7 @@ a01055:
   ldc.r4 56.0
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int32 [rvastatic3]A::a01057
@@ -3415,7 +3415,7 @@ a01056:
   ldc.i4 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int64 [rvastatic3]A::a01058
@@ -3429,7 +3429,7 @@ a01057:
   ldc.i8 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int64 [rvastatic3]A::a01059
@@ -3444,7 +3444,7 @@ a01058:
   ldc.i8 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int8 [rvastatic3]A::a01060
@@ -3463,7 +3463,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int16 [rvastatic3]A::a01061
@@ -3478,7 +3478,7 @@ a01060:
   ldc.i4 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int64 [rvastatic3]A::a01062
@@ -3497,7 +3497,7 @@ a01061:
   ldc.i8 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda float32 [rvastatic3]A::a01063
@@ -3512,7 +3512,7 @@ a01062:
   ldc.r4 63.0
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int64 [rvastatic3]A::a01064
@@ -3528,7 +3528,7 @@ a01063:
   ldc.i8 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda float32 [rvastatic3]A::a01065
@@ -3543,7 +3543,7 @@ a01064:
   ldc.r4 65.0
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int8 [rvastatic3]A::a01066
@@ -3559,7 +3559,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int16 [rvastatic3]A::a01067
@@ -3575,7 +3575,7 @@ a01066:
   ldc.i4 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int64 [rvastatic3]A::a01068
@@ -3589,7 +3589,7 @@ a01067:
   ldc.i8 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int64 [rvastatic3]A::a01069
@@ -3608,7 +3608,7 @@ a01068:
   ldc.i8 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda int64 [rvastatic3]A::a01070
@@ -3624,7 +3624,7 @@ a01069:
   ldc.i8 70
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int32 [rvastatic3]A::a01071
@@ -3638,7 +3638,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda int8 [rvastatic3]A::a01072
@@ -3652,7 +3652,7 @@ a01071:
   ldc.i4 72
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int32 [rvastatic3]A::a01073
@@ -3671,7 +3671,7 @@ a01072:
   ldc.i4 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda float32 [rvastatic3]A::a01074
@@ -3686,7 +3686,7 @@ a01073:
   ldc.r4 74.0
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int64 [rvastatic3]A::a01075
@@ -3700,7 +3700,7 @@ a01074:
   ldc.i8 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int8 [rvastatic3]A::a01076
@@ -3715,7 +3715,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int8 [rvastatic3]A::a01077
@@ -3734,7 +3734,7 @@ a01076:
   ldc.i4 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int8 [rvastatic3]A::a01078
@@ -3750,7 +3750,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda int32 [rvastatic3]A::a01079
@@ -3766,7 +3766,7 @@ a01078:
   ldc.i4 79
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda int16 [rvastatic3]A::a01080
@@ -3782,7 +3782,7 @@ a01079:
   ldc.i4 80
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda int32 [rvastatic3]A::a01081
@@ -3796,7 +3796,7 @@ a01080:
   ldc.i4 81
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda int8 [rvastatic3]A::a01082
@@ -3811,7 +3811,7 @@ a01081:
   ldc.i4 82
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int32 [rvastatic3]A::a01083
@@ -3825,7 +3825,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int8 [rvastatic3]A::a01084
@@ -3839,7 +3839,7 @@ a01083:
   ldc.i4 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int32 [rvastatic3]A::a01085
@@ -3853,7 +3853,7 @@ a01084:
   ldc.i4 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int8 [rvastatic3]A::a01086
@@ -3869,7 +3869,7 @@ a01085:
   ldc.i4 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int64 [rvastatic3]A::a01087
@@ -3884,7 +3884,7 @@ a01086:
   ldc.i8 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int8 [rvastatic3]A::a01088
@@ -3898,7 +3898,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int16 [rvastatic3]A::a01089
@@ -3917,7 +3917,7 @@ a01088:
   ldc.i4 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int64 [rvastatic3]A::a01090
@@ -3932,7 +3932,7 @@ a01089:
   ldc.i8 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int8 [rvastatic3]A::a01091
@@ -3951,7 +3951,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int64 [rvastatic3]A::a01092
@@ -3967,7 +3967,7 @@ a01091:
   ldc.i8 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int16 [rvastatic3]A::a01093
@@ -3982,7 +3982,7 @@ a01092:
   ldc.i4 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int8 [rvastatic3]A::a01094
@@ -3997,7 +3997,7 @@ a01093:
   ldc.i4 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda float32 [rvastatic3]A::a01095
@@ -4011,7 +4011,7 @@ a01094:
   ldc.r4 95.0
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda int16 [rvastatic3]A::a01096
@@ -4025,7 +4025,7 @@ a01095:
   ldc.i4 96
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int64 [rvastatic3]A::a01097
@@ -4040,7 +4040,7 @@ a01096:
   ldc.i8 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda float32 [rvastatic3]A::a01098
@@ -4059,7 +4059,7 @@ a01097:
   ldc.r4 98.0
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int32 [rvastatic3]A::a01099
@@ -4078,7 +4078,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int32 [rvastatic3]A::a010100
@@ -4093,7 +4093,7 @@ a01099:
   ldc.i4 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int32 [rvastatic3]A::a010101
@@ -4109,7 +4109,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda int8 [rvastatic3]A::a010102
@@ -4123,7 +4123,7 @@ a010101:
   ldc.i4 102
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int16 [rvastatic3]A::a010103
@@ -4137,7 +4137,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int8 [rvastatic3]A::a010104
@@ -4156,7 +4156,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda float32 [rvastatic3]A::a010105
@@ -4175,7 +4175,7 @@ a010104:
   ldc.r4 105.0
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda float32 [rvastatic3]A::a010106
@@ -4194,7 +4194,7 @@ a010105:
   ldc.r4 106.0
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda int8 [rvastatic3]A::a010107
@@ -4208,7 +4208,7 @@ a010106:
   ldc.i4 107
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda float32 [rvastatic3]A::a010108
@@ -4224,7 +4224,7 @@ a010107:
   ldc.r4 108.0
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int16 [rvastatic3]A::a010109
@@ -4240,7 +4240,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int8 [rvastatic3]A::a010110
@@ -4255,7 +4255,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int64 [rvastatic3]A::a010111
@@ -4269,7 +4269,7 @@ a010110:
   ldc.i8 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int16 [rvastatic3]A::a010112
@@ -4288,7 +4288,7 @@ a010111:
   ldc.i4 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int16 [rvastatic3]A::a010113
@@ -4302,7 +4302,7 @@ a010112:
   ldc.i4 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int32 [rvastatic3]A::a010114
@@ -4317,7 +4317,7 @@ a010113:
   ldc.i4 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int32 [rvastatic3]A::a010115
@@ -4331,7 +4331,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int8 [rvastatic3]A::a010116
@@ -4347,7 +4347,7 @@ a010115:
   ldc.i4 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int16 [rvastatic3]A::a010117
@@ -4366,7 +4366,7 @@ a010116:
   ldc.i4 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int64 [rvastatic3]A::a010118
@@ -4380,7 +4380,7 @@ a010117:
   ldc.i8 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int8 [rvastatic3]A::a010119
@@ -4396,7 +4396,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int64 [rvastatic3]A::a010120
@@ -4411,7 +4411,7 @@ a010119:
   ldc.i8 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int32 [rvastatic3]A::a010121
@@ -4425,7 +4425,7 @@ a010120:
   ldc.i4 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int8 [rvastatic3]A::a010122
@@ -4440,7 +4440,7 @@ a010121:
   ldc.i4 2
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int32 [rvastatic3]A::a010123
@@ -4459,7 +4459,7 @@ a010122:
   ldc.i4 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int8 [rvastatic3]A::a010124
@@ -4475,7 +4475,7 @@ a010123:
   ldc.i4 4
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int64 [rvastatic3]A::a010125
@@ -4490,7 +4490,7 @@ a010124:
   ldc.i8 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda float32 [rvastatic3]A::a010126
@@ -4505,7 +4505,7 @@ a010125:
   ldc.r4 126.0
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int64 [rvastatic3]A::a010127
@@ -4520,7 +4520,7 @@ a010126:
   ldc.i8 127
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -4532,7 +4532,7 @@ a010127:
   ldc.i8 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda int64 [rvastatic3]A::a0101
@@ -4542,7 +4542,7 @@ a0100:
   ldc.i8 1
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda float32 [rvastatic3]A::a0102
@@ -4552,7 +4552,7 @@ a0101:
   ldc.r4 2.0
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int64 [rvastatic3]A::a0103
@@ -4562,7 +4562,7 @@ a0102:
   ldc.i8 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int64 [rvastatic3]A::a0104
@@ -4572,7 +4572,7 @@ a0103:
   ldc.i8 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int16 [rvastatic3]A::a0105
@@ -4582,7 +4582,7 @@ a0104:
   ldc.i4 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int16 [rvastatic3]A::a0106
@@ -4592,7 +4592,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda float32 [rvastatic3]A::a0107
@@ -4602,7 +4602,7 @@ a0106:
   ldc.r4 7.0
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda int32 [rvastatic3]A::a0108
@@ -4612,7 +4612,7 @@ a0107:
   ldc.i4 8
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int8 [rvastatic3]A::a0109
@@ -4622,7 +4622,7 @@ a0108:
   ldc.i4 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int32 [rvastatic3]A::a01010
@@ -4632,7 +4632,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int64 [rvastatic3]A::a01011
@@ -4642,7 +4642,7 @@ a01010:
   ldc.i8 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int32 [rvastatic3]A::a01012
@@ -4652,7 +4652,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda int8 [rvastatic3]A::a01013
@@ -4662,7 +4662,7 @@ a01012:
   ldc.i4 13
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda int16 [rvastatic3]A::a01014
@@ -4672,7 +4672,7 @@ a01013:
   ldc.i4 14
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int16 [rvastatic3]A::a01015
@@ -4682,7 +4682,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda float32 [rvastatic3]A::a01016
@@ -4692,7 +4692,7 @@ a01015:
   ldc.r4 16.0
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda float32 [rvastatic3]A::a01017
@@ -4702,7 +4702,7 @@ a01016:
   ldc.r4 17.0
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int32 [rvastatic3]A::a01018
@@ -4712,7 +4712,7 @@ a01017:
   ldc.i4 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int8 [rvastatic3]A::a01019
@@ -4722,7 +4722,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int32 [rvastatic3]A::a01020
@@ -4732,7 +4732,7 @@ a01019:
   ldc.i4 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda int32 [rvastatic3]A::a01021
@@ -4742,7 +4742,7 @@ a01020:
   ldc.i4 21
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int64 [rvastatic3]A::a01022
@@ -4752,7 +4752,7 @@ a01021:
   ldc.i8 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int32 [rvastatic3]A::a01023
@@ -4762,7 +4762,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int8 [rvastatic3]A::a01024
@@ -4772,7 +4772,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int8 [rvastatic3]A::a01025
@@ -4782,7 +4782,7 @@ a01024:
   ldc.i4 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int16 [rvastatic3]A::a01026
@@ -4792,7 +4792,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int8 [rvastatic3]A::a01027
@@ -4802,7 +4802,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int16 [rvastatic3]A::a01028
@@ -4812,7 +4812,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int64 [rvastatic3]A::a01029
@@ -4822,7 +4822,7 @@ a01028:
   ldc.i8 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int32 [rvastatic3]A::a01030
@@ -4832,7 +4832,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int32 [rvastatic3]A::a01031
@@ -4842,7 +4842,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int32 [rvastatic3]A::a01032
@@ -4852,7 +4852,7 @@ a01031:
   ldc.i4 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda int8 [rvastatic3]A::a01033
@@ -4862,7 +4862,7 @@ a01032:
   ldc.i4 33
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int16 [rvastatic3]A::a01034
@@ -4872,7 +4872,7 @@ a01033:
   ldc.i4 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int32 [rvastatic3]A::a01035
@@ -4882,7 +4882,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int32 [rvastatic3]A::a01036
@@ -4892,7 +4892,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int16 [rvastatic3]A::a01037
@@ -4902,7 +4902,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda float32 [rvastatic3]A::a01038
@@ -4912,7 +4912,7 @@ a01037:
   ldc.r4 38.0
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int8 [rvastatic3]A::a01039
@@ -4922,7 +4922,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int8 [rvastatic3]A::a01040
@@ -4932,7 +4932,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda float32 [rvastatic3]A::a01041
@@ -4942,7 +4942,7 @@ a01040:
   ldc.r4 41.0
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int32 [rvastatic3]A::a01042
@@ -4952,7 +4952,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int32 [rvastatic3]A::a01043
@@ -4962,7 +4962,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int32 [rvastatic3]A::a01044
@@ -4972,7 +4972,7 @@ a01043:
   ldc.i4 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int64 [rvastatic3]A::a01045
@@ -4982,7 +4982,7 @@ a01044:
   ldc.i8 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int64 [rvastatic3]A::a01046
@@ -4992,7 +4992,7 @@ a01045:
   ldc.i8 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int64 [rvastatic3]A::a01047
@@ -5002,7 +5002,7 @@ a01046:
   ldc.i8 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda float32 [rvastatic3]A::a01048
@@ -5012,7 +5012,7 @@ a01047:
   ldc.r4 48.0
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int64 [rvastatic3]A::a01049
@@ -5022,7 +5022,7 @@ a01048:
   ldc.i8 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int32 [rvastatic3]A::a01050
@@ -5032,7 +5032,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda float32 [rvastatic3]A::a01051
@@ -5042,7 +5042,7 @@ a01050:
   ldc.r4 51.0
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int32 [rvastatic3]A::a01052
@@ -5052,7 +5052,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int64 [rvastatic3]A::a01053
@@ -5062,7 +5062,7 @@ a01052:
   ldc.i8 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda int8 [rvastatic3]A::a01054
@@ -5072,7 +5072,7 @@ a01053:
   ldc.i4 54
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int8 [rvastatic3]A::a01055
@@ -5082,7 +5082,7 @@ a01054:
   ldc.i4 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda float32 [rvastatic3]A::a01056
@@ -5092,7 +5092,7 @@ a01055:
   ldc.r4 56.0
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int32 [rvastatic3]A::a01057
@@ -5102,7 +5102,7 @@ a01056:
   ldc.i4 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int64 [rvastatic3]A::a01058
@@ -5112,7 +5112,7 @@ a01057:
   ldc.i8 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int64 [rvastatic3]A::a01059
@@ -5122,7 +5122,7 @@ a01058:
   ldc.i8 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int8 [rvastatic3]A::a01060
@@ -5132,7 +5132,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int16 [rvastatic3]A::a01061
@@ -5142,7 +5142,7 @@ a01060:
   ldc.i4 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int64 [rvastatic3]A::a01062
@@ -5152,7 +5152,7 @@ a01061:
   ldc.i8 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda float32 [rvastatic3]A::a01063
@@ -5162,7 +5162,7 @@ a01062:
   ldc.r4 63.0
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int64 [rvastatic3]A::a01064
@@ -5172,7 +5172,7 @@ a01063:
   ldc.i8 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda float32 [rvastatic3]A::a01065
@@ -5182,7 +5182,7 @@ a01064:
   ldc.r4 65.0
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int8 [rvastatic3]A::a01066
@@ -5192,7 +5192,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int16 [rvastatic3]A::a01067
@@ -5202,7 +5202,7 @@ a01066:
   ldc.i4 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int64 [rvastatic3]A::a01068
@@ -5212,7 +5212,7 @@ a01067:
   ldc.i8 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int64 [rvastatic3]A::a01069
@@ -5222,7 +5222,7 @@ a01068:
   ldc.i8 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda int64 [rvastatic3]A::a01070
@@ -5232,7 +5232,7 @@ a01069:
   ldc.i8 70
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int32 [rvastatic3]A::a01071
@@ -5242,7 +5242,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda int8 [rvastatic3]A::a01072
@@ -5252,7 +5252,7 @@ a01071:
   ldc.i4 72
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int32 [rvastatic3]A::a01073
@@ -5262,7 +5262,7 @@ a01072:
   ldc.i4 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda float32 [rvastatic3]A::a01074
@@ -5272,7 +5272,7 @@ a01073:
   ldc.r4 74.0
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int64 [rvastatic3]A::a01075
@@ -5282,7 +5282,7 @@ a01074:
   ldc.i8 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int8 [rvastatic3]A::a01076
@@ -5292,7 +5292,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int8 [rvastatic3]A::a01077
@@ -5302,7 +5302,7 @@ a01076:
   ldc.i4 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int8 [rvastatic3]A::a01078
@@ -5312,7 +5312,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda int32 [rvastatic3]A::a01079
@@ -5322,7 +5322,7 @@ a01078:
   ldc.i4 79
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda int16 [rvastatic3]A::a01080
@@ -5332,7 +5332,7 @@ a01079:
   ldc.i4 80
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda int32 [rvastatic3]A::a01081
@@ -5342,7 +5342,7 @@ a01080:
   ldc.i4 81
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda int8 [rvastatic3]A::a01082
@@ -5352,7 +5352,7 @@ a01081:
   ldc.i4 82
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int32 [rvastatic3]A::a01083
@@ -5362,7 +5362,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int8 [rvastatic3]A::a01084
@@ -5372,7 +5372,7 @@ a01083:
   ldc.i4 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int32 [rvastatic3]A::a01085
@@ -5382,7 +5382,7 @@ a01084:
   ldc.i4 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int8 [rvastatic3]A::a01086
@@ -5392,7 +5392,7 @@ a01085:
   ldc.i4 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int64 [rvastatic3]A::a01087
@@ -5402,7 +5402,7 @@ a01086:
   ldc.i8 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int8 [rvastatic3]A::a01088
@@ -5412,7 +5412,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int16 [rvastatic3]A::a01089
@@ -5422,7 +5422,7 @@ a01088:
   ldc.i4 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int64 [rvastatic3]A::a01090
@@ -5432,7 +5432,7 @@ a01089:
   ldc.i8 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int8 [rvastatic3]A::a01091
@@ -5442,7 +5442,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int64 [rvastatic3]A::a01092
@@ -5452,7 +5452,7 @@ a01091:
   ldc.i8 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int16 [rvastatic3]A::a01093
@@ -5462,7 +5462,7 @@ a01092:
   ldc.i4 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int8 [rvastatic3]A::a01094
@@ -5472,7 +5472,7 @@ a01093:
   ldc.i4 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda float32 [rvastatic3]A::a01095
@@ -5482,7 +5482,7 @@ a01094:
   ldc.r4 95.0
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda int16 [rvastatic3]A::a01096
@@ -5492,7 +5492,7 @@ a01095:
   ldc.i4 96
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int64 [rvastatic3]A::a01097
@@ -5502,7 +5502,7 @@ a01096:
   ldc.i8 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda float32 [rvastatic3]A::a01098
@@ -5512,7 +5512,7 @@ a01097:
   ldc.r4 98.0
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int32 [rvastatic3]A::a01099
@@ -5522,7 +5522,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int32 [rvastatic3]A::a010100
@@ -5532,7 +5532,7 @@ a01099:
   ldc.i4 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int32 [rvastatic3]A::a010101
@@ -5542,7 +5542,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda int8 [rvastatic3]A::a010102
@@ -5552,7 +5552,7 @@ a010101:
   ldc.i4 102
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int16 [rvastatic3]A::a010103
@@ -5562,7 +5562,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int8 [rvastatic3]A::a010104
@@ -5572,7 +5572,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda float32 [rvastatic3]A::a010105
@@ -5582,7 +5582,7 @@ a010104:
   ldc.r4 105.0
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda float32 [rvastatic3]A::a010106
@@ -5592,7 +5592,7 @@ a010105:
   ldc.r4 106.0
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda int8 [rvastatic3]A::a010107
@@ -5602,7 +5602,7 @@ a010106:
   ldc.i4 107
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda float32 [rvastatic3]A::a010108
@@ -5612,7 +5612,7 @@ a010107:
   ldc.r4 108.0
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int16 [rvastatic3]A::a010109
@@ -5622,7 +5622,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int8 [rvastatic3]A::a010110
@@ -5632,7 +5632,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int64 [rvastatic3]A::a010111
@@ -5642,7 +5642,7 @@ a010110:
   ldc.i8 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int16 [rvastatic3]A::a010112
@@ -5652,7 +5652,7 @@ a010111:
   ldc.i4 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int16 [rvastatic3]A::a010113
@@ -5662,7 +5662,7 @@ a010112:
   ldc.i4 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int32 [rvastatic3]A::a010114
@@ -5672,7 +5672,7 @@ a010113:
   ldc.i4 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int32 [rvastatic3]A::a010115
@@ -5682,7 +5682,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int8 [rvastatic3]A::a010116
@@ -5692,7 +5692,7 @@ a010115:
   ldc.i4 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int16 [rvastatic3]A::a010117
@@ -5702,7 +5702,7 @@ a010116:
   ldc.i4 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int64 [rvastatic3]A::a010118
@@ -5712,7 +5712,7 @@ a010117:
   ldc.i8 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int8 [rvastatic3]A::a010119
@@ -5722,7 +5722,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int64 [rvastatic3]A::a010120
@@ -5732,7 +5732,7 @@ a010119:
   ldc.i8 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int32 [rvastatic3]A::a010121
@@ -5742,7 +5742,7 @@ a010120:
   ldc.i4 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int8 [rvastatic3]A::a010122
@@ -5752,7 +5752,7 @@ a010121:
   ldc.i4 2
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int32 [rvastatic3]A::a010123
@@ -5762,7 +5762,7 @@ a010122:
   ldc.i4 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int8 [rvastatic3]A::a010124
@@ -5772,7 +5772,7 @@ a010123:
   ldc.i4 4
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int64 [rvastatic3]A::a010125
@@ -5782,7 +5782,7 @@ a010124:
   ldc.i8 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda float32 [rvastatic3]A::a010126
@@ -5792,7 +5792,7 @@ a010125:
   ldc.r4 126.0
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int64 [rvastatic3]A::a010127
@@ -5802,7 +5802,7 @@ a010126:
   ldc.i8 127
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -5814,7 +5814,7 @@ a010127:
   ldsfld int64 [rvastatic3]A::a0100
   ldc.i8 1
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsfld int64 [rvastatic3]A::a0101
@@ -5824,7 +5824,7 @@ a0100:
   ldsfld int64 [rvastatic3]A::a0101
   ldc.i8 2
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld float32 [rvastatic3]A::a0102
@@ -5834,7 +5834,7 @@ a0101:
   ldsfld float32 [rvastatic3]A::a0102
   ldc.r4 3.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int64 [rvastatic3]A::a0103
@@ -5844,7 +5844,7 @@ a0102:
   ldsfld int64 [rvastatic3]A::a0103
   ldc.i8 4
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int64 [rvastatic3]A::a0104
@@ -5854,7 +5854,7 @@ a0103:
   ldsfld int64 [rvastatic3]A::a0104
   ldc.i8 5
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int16 [rvastatic3]A::a0105
@@ -5864,7 +5864,7 @@ a0104:
   ldsfld int16 [rvastatic3]A::a0105
   ldc.i4 6
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int16 [rvastatic3]A::a0106
@@ -5874,7 +5874,7 @@ a0105:
   ldsfld int16 [rvastatic3]A::a0106
   ldc.i4 7
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld float32 [rvastatic3]A::a0107
@@ -5884,7 +5884,7 @@ a0106:
   ldsfld float32 [rvastatic3]A::a0107
   ldc.r4 8.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld int32 [rvastatic3]A::a0108
@@ -5894,7 +5894,7 @@ a0107:
   ldsfld int32 [rvastatic3]A::a0108
   ldc.i4 9
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int8 [rvastatic3]A::a0109
@@ -5904,7 +5904,7 @@ a0108:
   ldsfld int8 [rvastatic3]A::a0109
   ldc.i4 10
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int32 [rvastatic3]A::a01010
@@ -5914,7 +5914,7 @@ a0109:
   ldsfld int32 [rvastatic3]A::a01010
   ldc.i4 11
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int64 [rvastatic3]A::a01011
@@ -5924,7 +5924,7 @@ a01010:
   ldsfld int64 [rvastatic3]A::a01011
   ldc.i8 12
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int32 [rvastatic3]A::a01012
@@ -5934,7 +5934,7 @@ a01011:
   ldsfld int32 [rvastatic3]A::a01012
   ldc.i4 13
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int8 [rvastatic3]A::a01013
@@ -5944,7 +5944,7 @@ a01012:
   ldsfld int8 [rvastatic3]A::a01013
   ldc.i4 14
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld int16 [rvastatic3]A::a01014
@@ -5954,7 +5954,7 @@ a01013:
   ldsfld int16 [rvastatic3]A::a01014
   ldc.i4 15
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int16 [rvastatic3]A::a01015
@@ -5964,7 +5964,7 @@ a01014:
   ldsfld int16 [rvastatic3]A::a01015
   ldc.i4 16
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld float32 [rvastatic3]A::a01016
@@ -5974,7 +5974,7 @@ a01015:
   ldsfld float32 [rvastatic3]A::a01016
   ldc.r4 17.0
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld float32 [rvastatic3]A::a01017
@@ -5984,7 +5984,7 @@ a01016:
   ldsfld float32 [rvastatic3]A::a01017
   ldc.r4 18.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int32 [rvastatic3]A::a01018
@@ -5994,7 +5994,7 @@ a01017:
   ldsfld int32 [rvastatic3]A::a01018
   ldc.i4 19
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int8 [rvastatic3]A::a01019
@@ -6004,7 +6004,7 @@ a01018:
   ldsfld int8 [rvastatic3]A::a01019
   ldc.i4 20
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int32 [rvastatic3]A::a01020
@@ -6014,7 +6014,7 @@ a01019:
   ldsfld int32 [rvastatic3]A::a01020
   ldc.i4 21
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int32 [rvastatic3]A::a01021
@@ -6024,7 +6024,7 @@ a01020:
   ldsfld int32 [rvastatic3]A::a01021
   ldc.i4 22
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int64 [rvastatic3]A::a01022
@@ -6034,7 +6034,7 @@ a01021:
   ldsfld int64 [rvastatic3]A::a01022
   ldc.i8 23
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int32 [rvastatic3]A::a01023
@@ -6044,7 +6044,7 @@ a01022:
   ldsfld int32 [rvastatic3]A::a01023
   ldc.i4 24
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int8 [rvastatic3]A::a01024
@@ -6054,7 +6054,7 @@ a01023:
   ldsfld int8 [rvastatic3]A::a01024
   ldc.i4 25
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int8 [rvastatic3]A::a01025
@@ -6064,7 +6064,7 @@ a01024:
   ldsfld int8 [rvastatic3]A::a01025
   ldc.i4 26
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int16 [rvastatic3]A::a01026
@@ -6074,7 +6074,7 @@ a01025:
   ldsfld int16 [rvastatic3]A::a01026
   ldc.i4 27
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int8 [rvastatic3]A::a01027
@@ -6084,7 +6084,7 @@ a01026:
   ldsfld int8 [rvastatic3]A::a01027
   ldc.i4 28
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int16 [rvastatic3]A::a01028
@@ -6094,7 +6094,7 @@ a01027:
   ldsfld int16 [rvastatic3]A::a01028
   ldc.i4 29
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int64 [rvastatic3]A::a01029
@@ -6104,7 +6104,7 @@ a01028:
   ldsfld int64 [rvastatic3]A::a01029
   ldc.i8 30
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int32 [rvastatic3]A::a01030
@@ -6114,7 +6114,7 @@ a01029:
   ldsfld int32 [rvastatic3]A::a01030
   ldc.i4 31
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int32 [rvastatic3]A::a01031
@@ -6124,7 +6124,7 @@ a01030:
   ldsfld int32 [rvastatic3]A::a01031
   ldc.i4 32
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int32 [rvastatic3]A::a01032
@@ -6134,7 +6134,7 @@ a01031:
   ldsfld int32 [rvastatic3]A::a01032
   ldc.i4 33
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int8 [rvastatic3]A::a01033
@@ -6144,7 +6144,7 @@ a01032:
   ldsfld int8 [rvastatic3]A::a01033
   ldc.i4 34
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int16 [rvastatic3]A::a01034
@@ -6154,7 +6154,7 @@ a01033:
   ldsfld int16 [rvastatic3]A::a01034
   ldc.i4 35
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int32 [rvastatic3]A::a01035
@@ -6164,7 +6164,7 @@ a01034:
   ldsfld int32 [rvastatic3]A::a01035
   ldc.i4 36
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int32 [rvastatic3]A::a01036
@@ -6174,7 +6174,7 @@ a01035:
   ldsfld int32 [rvastatic3]A::a01036
   ldc.i4 37
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int16 [rvastatic3]A::a01037
@@ -6184,7 +6184,7 @@ a01036:
   ldsfld int16 [rvastatic3]A::a01037
   ldc.i4 38
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld float32 [rvastatic3]A::a01038
@@ -6194,7 +6194,7 @@ a01037:
   ldsfld float32 [rvastatic3]A::a01038
   ldc.r4 39.0
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int8 [rvastatic3]A::a01039
@@ -6204,7 +6204,7 @@ a01038:
   ldsfld int8 [rvastatic3]A::a01039
   ldc.i4 40
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int8 [rvastatic3]A::a01040
@@ -6214,7 +6214,7 @@ a01039:
   ldsfld int8 [rvastatic3]A::a01040
   ldc.i4 41
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld float32 [rvastatic3]A::a01041
@@ -6224,7 +6224,7 @@ a01040:
   ldsfld float32 [rvastatic3]A::a01041
   ldc.r4 42.0
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int32 [rvastatic3]A::a01042
@@ -6234,7 +6234,7 @@ a01041:
   ldsfld int32 [rvastatic3]A::a01042
   ldc.i4 43
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int32 [rvastatic3]A::a01043
@@ -6244,7 +6244,7 @@ a01042:
   ldsfld int32 [rvastatic3]A::a01043
   ldc.i4 44
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int32 [rvastatic3]A::a01044
@@ -6254,7 +6254,7 @@ a01043:
   ldsfld int32 [rvastatic3]A::a01044
   ldc.i4 45
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int64 [rvastatic3]A::a01045
@@ -6264,7 +6264,7 @@ a01044:
   ldsfld int64 [rvastatic3]A::a01045
   ldc.i8 46
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int64 [rvastatic3]A::a01046
@@ -6274,7 +6274,7 @@ a01045:
   ldsfld int64 [rvastatic3]A::a01046
   ldc.i8 47
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int64 [rvastatic3]A::a01047
@@ -6284,7 +6284,7 @@ a01046:
   ldsfld int64 [rvastatic3]A::a01047
   ldc.i8 48
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld float32 [rvastatic3]A::a01048
@@ -6294,7 +6294,7 @@ a01047:
   ldsfld float32 [rvastatic3]A::a01048
   ldc.r4 49.0
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int64 [rvastatic3]A::a01049
@@ -6304,7 +6304,7 @@ a01048:
   ldsfld int64 [rvastatic3]A::a01049
   ldc.i8 50
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int32 [rvastatic3]A::a01050
@@ -6314,7 +6314,7 @@ a01049:
   ldsfld int32 [rvastatic3]A::a01050
   ldc.i4 51
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld float32 [rvastatic3]A::a01051
@@ -6324,7 +6324,7 @@ a01050:
   ldsfld float32 [rvastatic3]A::a01051
   ldc.r4 52.0
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int32 [rvastatic3]A::a01052
@@ -6334,7 +6334,7 @@ a01051:
   ldsfld int32 [rvastatic3]A::a01052
   ldc.i4 53
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int64 [rvastatic3]A::a01053
@@ -6344,7 +6344,7 @@ a01052:
   ldsfld int64 [rvastatic3]A::a01053
   ldc.i8 54
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int8 [rvastatic3]A::a01054
@@ -6354,7 +6354,7 @@ a01053:
   ldsfld int8 [rvastatic3]A::a01054
   ldc.i4 55
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int8 [rvastatic3]A::a01055
@@ -6364,7 +6364,7 @@ a01054:
   ldsfld int8 [rvastatic3]A::a01055
   ldc.i4 56
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld float32 [rvastatic3]A::a01056
@@ -6374,7 +6374,7 @@ a01055:
   ldsfld float32 [rvastatic3]A::a01056
   ldc.r4 57.0
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld int32 [rvastatic3]A::a01057
@@ -6384,7 +6384,7 @@ a01056:
   ldsfld int32 [rvastatic3]A::a01057
   ldc.i4 58
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int64 [rvastatic3]A::a01058
@@ -6394,7 +6394,7 @@ a01057:
   ldsfld int64 [rvastatic3]A::a01058
   ldc.i8 59
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int64 [rvastatic3]A::a01059
@@ -6404,7 +6404,7 @@ a01058:
   ldsfld int64 [rvastatic3]A::a01059
   ldc.i8 60
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int8 [rvastatic3]A::a01060
@@ -6414,7 +6414,7 @@ a01059:
   ldsfld int8 [rvastatic3]A::a01060
   ldc.i4 61
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int16 [rvastatic3]A::a01061
@@ -6424,7 +6424,7 @@ a01060:
   ldsfld int16 [rvastatic3]A::a01061
   ldc.i4 62
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int64 [rvastatic3]A::a01062
@@ -6434,7 +6434,7 @@ a01061:
   ldsfld int64 [rvastatic3]A::a01062
   ldc.i8 63
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld float32 [rvastatic3]A::a01063
@@ -6444,7 +6444,7 @@ a01062:
   ldsfld float32 [rvastatic3]A::a01063
   ldc.r4 64.0
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int64 [rvastatic3]A::a01064
@@ -6454,7 +6454,7 @@ a01063:
   ldsfld int64 [rvastatic3]A::a01064
   ldc.i8 65
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld float32 [rvastatic3]A::a01065
@@ -6464,7 +6464,7 @@ a01064:
   ldsfld float32 [rvastatic3]A::a01065
   ldc.r4 66.0
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int8 [rvastatic3]A::a01066
@@ -6474,7 +6474,7 @@ a01065:
   ldsfld int8 [rvastatic3]A::a01066
   ldc.i4 67
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int16 [rvastatic3]A::a01067
@@ -6484,7 +6484,7 @@ a01066:
   ldsfld int16 [rvastatic3]A::a01067
   ldc.i4 68
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int64 [rvastatic3]A::a01068
@@ -6494,7 +6494,7 @@ a01067:
   ldsfld int64 [rvastatic3]A::a01068
   ldc.i8 69
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int64 [rvastatic3]A::a01069
@@ -6504,7 +6504,7 @@ a01068:
   ldsfld int64 [rvastatic3]A::a01069
   ldc.i8 70
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int64 [rvastatic3]A::a01070
@@ -6514,7 +6514,7 @@ a01069:
   ldsfld int64 [rvastatic3]A::a01070
   ldc.i8 71
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int32 [rvastatic3]A::a01071
@@ -6524,7 +6524,7 @@ a01070:
   ldsfld int32 [rvastatic3]A::a01071
   ldc.i4 72
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int8 [rvastatic3]A::a01072
@@ -6534,7 +6534,7 @@ a01071:
   ldsfld int8 [rvastatic3]A::a01072
   ldc.i4 73
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int32 [rvastatic3]A::a01073
@@ -6544,7 +6544,7 @@ a01072:
   ldsfld int32 [rvastatic3]A::a01073
   ldc.i4 74
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld float32 [rvastatic3]A::a01074
@@ -6554,7 +6554,7 @@ a01073:
   ldsfld float32 [rvastatic3]A::a01074
   ldc.r4 75.0
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int64 [rvastatic3]A::a01075
@@ -6564,7 +6564,7 @@ a01074:
   ldsfld int64 [rvastatic3]A::a01075
   ldc.i8 76
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int8 [rvastatic3]A::a01076
@@ -6574,7 +6574,7 @@ a01075:
   ldsfld int8 [rvastatic3]A::a01076
   ldc.i4 77
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int8 [rvastatic3]A::a01077
@@ -6584,7 +6584,7 @@ a01076:
   ldsfld int8 [rvastatic3]A::a01077
   ldc.i4 78
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int8 [rvastatic3]A::a01078
@@ -6594,7 +6594,7 @@ a01077:
   ldsfld int8 [rvastatic3]A::a01078
   ldc.i4 79
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int32 [rvastatic3]A::a01079
@@ -6604,7 +6604,7 @@ a01078:
   ldsfld int32 [rvastatic3]A::a01079
   ldc.i4 80
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld int16 [rvastatic3]A::a01080
@@ -6614,7 +6614,7 @@ a01079:
   ldsfld int16 [rvastatic3]A::a01080
   ldc.i4 81
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld int32 [rvastatic3]A::a01081
@@ -6624,7 +6624,7 @@ a01080:
   ldsfld int32 [rvastatic3]A::a01081
   ldc.i4 82
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld int8 [rvastatic3]A::a01082
@@ -6634,7 +6634,7 @@ a01081:
   ldsfld int8 [rvastatic3]A::a01082
   ldc.i4 83
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int32 [rvastatic3]A::a01083
@@ -6644,7 +6644,7 @@ a01082:
   ldsfld int32 [rvastatic3]A::a01083
   ldc.i4 84
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int8 [rvastatic3]A::a01084
@@ -6654,7 +6654,7 @@ a01083:
   ldsfld int8 [rvastatic3]A::a01084
   ldc.i4 85
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int32 [rvastatic3]A::a01085
@@ -6664,7 +6664,7 @@ a01084:
   ldsfld int32 [rvastatic3]A::a01085
   ldc.i4 86
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int8 [rvastatic3]A::a01086
@@ -6674,7 +6674,7 @@ a01085:
   ldsfld int8 [rvastatic3]A::a01086
   ldc.i4 87
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int64 [rvastatic3]A::a01087
@@ -6684,7 +6684,7 @@ a01086:
   ldsfld int64 [rvastatic3]A::a01087
   ldc.i8 88
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int8 [rvastatic3]A::a01088
@@ -6694,7 +6694,7 @@ a01087:
   ldsfld int8 [rvastatic3]A::a01088
   ldc.i4 89
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int16 [rvastatic3]A::a01089
@@ -6704,7 +6704,7 @@ a01088:
   ldsfld int16 [rvastatic3]A::a01089
   ldc.i4 90
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int64 [rvastatic3]A::a01090
@@ -6714,7 +6714,7 @@ a01089:
   ldsfld int64 [rvastatic3]A::a01090
   ldc.i8 91
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int8 [rvastatic3]A::a01091
@@ -6724,7 +6724,7 @@ a01090:
   ldsfld int8 [rvastatic3]A::a01091
   ldc.i4 92
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int64 [rvastatic3]A::a01092
@@ -6734,7 +6734,7 @@ a01091:
   ldsfld int64 [rvastatic3]A::a01092
   ldc.i8 93
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int16 [rvastatic3]A::a01093
@@ -6744,7 +6744,7 @@ a01092:
   ldsfld int16 [rvastatic3]A::a01093
   ldc.i4 94
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int8 [rvastatic3]A::a01094
@@ -6754,7 +6754,7 @@ a01093:
   ldsfld int8 [rvastatic3]A::a01094
   ldc.i4 95
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld float32 [rvastatic3]A::a01095
@@ -6764,7 +6764,7 @@ a01094:
   ldsfld float32 [rvastatic3]A::a01095
   ldc.r4 96.0
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int16 [rvastatic3]A::a01096
@@ -6774,7 +6774,7 @@ a01095:
   ldsfld int16 [rvastatic3]A::a01096
   ldc.i4 97
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int64 [rvastatic3]A::a01097
@@ -6784,7 +6784,7 @@ a01096:
   ldsfld int64 [rvastatic3]A::a01097
   ldc.i8 98
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld float32 [rvastatic3]A::a01098
@@ -6794,7 +6794,7 @@ a01097:
   ldsfld float32 [rvastatic3]A::a01098
   ldc.r4 99.0
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int32 [rvastatic3]A::a01099
@@ -6804,7 +6804,7 @@ a01098:
   ldsfld int32 [rvastatic3]A::a01099
   ldc.i4 100
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int32 [rvastatic3]A::a010100
@@ -6814,7 +6814,7 @@ a01099:
   ldsfld int32 [rvastatic3]A::a010100
   ldc.i4 101
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int32 [rvastatic3]A::a010101
@@ -6824,7 +6824,7 @@ a010100:
   ldsfld int32 [rvastatic3]A::a010101
   ldc.i4 102
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int8 [rvastatic3]A::a010102
@@ -6834,7 +6834,7 @@ a010101:
   ldsfld int8 [rvastatic3]A::a010102
   ldc.i4 103
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int16 [rvastatic3]A::a010103
@@ -6844,7 +6844,7 @@ a010102:
   ldsfld int16 [rvastatic3]A::a010103
   ldc.i4 104
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int8 [rvastatic3]A::a010104
@@ -6854,7 +6854,7 @@ a010103:
   ldsfld int8 [rvastatic3]A::a010104
   ldc.i4 105
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld float32 [rvastatic3]A::a010105
@@ -6864,7 +6864,7 @@ a010104:
   ldsfld float32 [rvastatic3]A::a010105
   ldc.r4 106.0
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld float32 [rvastatic3]A::a010106
@@ -6874,7 +6874,7 @@ a010105:
   ldsfld float32 [rvastatic3]A::a010106
   ldc.r4 107.0
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld int8 [rvastatic3]A::a010107
@@ -6884,7 +6884,7 @@ a010106:
   ldsfld int8 [rvastatic3]A::a010107
   ldc.i4 108
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld float32 [rvastatic3]A::a010108
@@ -6894,7 +6894,7 @@ a010107:
   ldsfld float32 [rvastatic3]A::a010108
   ldc.r4 109.0
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int16 [rvastatic3]A::a010109
@@ -6904,7 +6904,7 @@ a010108:
   ldsfld int16 [rvastatic3]A::a010109
   ldc.i4 110
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int8 [rvastatic3]A::a010110
@@ -6914,7 +6914,7 @@ a010109:
   ldsfld int8 [rvastatic3]A::a010110
   ldc.i4 111
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int64 [rvastatic3]A::a010111
@@ -6924,7 +6924,7 @@ a010110:
   ldsfld int64 [rvastatic3]A::a010111
   ldc.i8 112
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int16 [rvastatic3]A::a010112
@@ -6934,7 +6934,7 @@ a010111:
   ldsfld int16 [rvastatic3]A::a010112
   ldc.i4 113
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int16 [rvastatic3]A::a010113
@@ -6944,7 +6944,7 @@ a010112:
   ldsfld int16 [rvastatic3]A::a010113
   ldc.i4 114
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int32 [rvastatic3]A::a010114
@@ -6954,7 +6954,7 @@ a010113:
   ldsfld int32 [rvastatic3]A::a010114
   ldc.i4 115
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int32 [rvastatic3]A::a010115
@@ -6964,7 +6964,7 @@ a010114:
   ldsfld int32 [rvastatic3]A::a010115
   ldc.i4 116
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int8 [rvastatic3]A::a010116
@@ -6974,7 +6974,7 @@ a010115:
   ldsfld int8 [rvastatic3]A::a010116
   ldc.i4 117
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int16 [rvastatic3]A::a010117
@@ -6984,7 +6984,7 @@ a010116:
   ldsfld int16 [rvastatic3]A::a010117
   ldc.i4 118
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int64 [rvastatic3]A::a010118
@@ -6994,7 +6994,7 @@ a010117:
   ldsfld int64 [rvastatic3]A::a010118
   ldc.i8 119
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int8 [rvastatic3]A::a010119
@@ -7004,7 +7004,7 @@ a010118:
   ldsfld int8 [rvastatic3]A::a010119
   ldc.i4 120
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int64 [rvastatic3]A::a010120
@@ -7014,7 +7014,7 @@ a010119:
   ldsfld int64 [rvastatic3]A::a010120
   ldc.i8 121
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int32 [rvastatic3]A::a010121
@@ -7024,7 +7024,7 @@ a010120:
   ldsfld int32 [rvastatic3]A::a010121
   ldc.i4 122
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int8 [rvastatic3]A::a010122
@@ -7034,7 +7034,7 @@ a010121:
   ldsfld int8 [rvastatic3]A::a010122
   ldc.i4 3
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int32 [rvastatic3]A::a010123
@@ -7044,7 +7044,7 @@ a010122:
   ldsfld int32 [rvastatic3]A::a010123
   ldc.i4 124
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int8 [rvastatic3]A::a010124
@@ -7054,7 +7054,7 @@ a010123:
   ldsfld int8 [rvastatic3]A::a010124
   ldc.i4 5
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int64 [rvastatic3]A::a010125
@@ -7064,7 +7064,7 @@ a010124:
   ldsfld int64 [rvastatic3]A::a010125
   ldc.i8 126
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld float32 [rvastatic3]A::a010126
@@ -7074,7 +7074,7 @@ a010125:
   ldsfld float32 [rvastatic3]A::a010126
   ldc.r4 127.0
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int64 [rvastatic3]A::a010127
@@ -7084,7 +7084,7 @@ a010126:
   ldsfld int64 [rvastatic3]A::a010127
   ldc.i8 128
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ret}

--- a/tests/src/JIT/Directed/rvastatics/rvastatic4.il
+++ b/tests/src/JIT/Directed/rvastatics/rvastatic4.il
@@ -43,769 +43,769 @@
   ldsfld int32 [rvastatic4]A::a0100
   ldc.i4 0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld int64 [rvastatic4]A::a0101
   ldc.i8 1
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld float32 [rvastatic4]A::a0102
   ldc.r4 2.0
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int16 [rvastatic4]A::a0103
   ldc.i4 3
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int16 [rvastatic4]A::a0104
   ldc.i4 4
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int64 [rvastatic4]A::a0105
   ldc.i8 5
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld int16 [rvastatic4]A::a0106
   ldc.i4 6
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld int8 [rvastatic4]A::a0107
   ldc.i4 7
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int64 [rvastatic4]A::a0108
   ldc.i8 8
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int32 [rvastatic4]A::a0109
   ldc.i4 9
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int16 [rvastatic4]A::a01010
   ldc.i4 10
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld float32 [rvastatic4]A::a01011
   ldc.r4 11.0
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int16 [rvastatic4]A::a01012
   ldc.i4 12
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld float32 [rvastatic4]A::a01013
   ldc.r4 13.0
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld float32 [rvastatic4]A::a01014
   ldc.r4 14.0
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int8 [rvastatic4]A::a01015
   ldc.i4 15
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld float32 [rvastatic4]A::a01016
   ldc.r4 16.0
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int8 [rvastatic4]A::a01017
   ldc.i4 17
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld float32 [rvastatic4]A::a01018
   ldc.r4 18.0
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld float32 [rvastatic4]A::a01019
   ldc.r4 19.0
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld int8 [rvastatic4]A::a01020
   ldc.i4 20
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld float32 [rvastatic4]A::a01021
   ldc.r4 21.0
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int64 [rvastatic4]A::a01022
   ldc.i8 22
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int8 [rvastatic4]A::a01023
   ldc.i4 23
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int32 [rvastatic4]A::a01024
   ldc.i4 24
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int64 [rvastatic4]A::a01025
   ldc.i8 25
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int16 [rvastatic4]A::a01026
   ldc.i4 26
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int8 [rvastatic4]A::a01027
   ldc.i4 27
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int16 [rvastatic4]A::a01028
   ldc.i4 28
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int16 [rvastatic4]A::a01029
   ldc.i4 29
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int8 [rvastatic4]A::a01030
   ldc.i4 30
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int8 [rvastatic4]A::a01031
   ldc.i4 31
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int64 [rvastatic4]A::a01032
   ldc.i8 32
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld float32 [rvastatic4]A::a01033
   ldc.r4 33.0
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int16 [rvastatic4]A::a01034
   ldc.i4 34
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int8 [rvastatic4]A::a01035
   ldc.i4 35
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int8 [rvastatic4]A::a01036
   ldc.i4 36
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int32 [rvastatic4]A::a01037
   ldc.i4 37
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int16 [rvastatic4]A::a01038
   ldc.i4 38
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int8 [rvastatic4]A::a01039
   ldc.i4 39
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int8 [rvastatic4]A::a01040
   ldc.i4 40
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int32 [rvastatic4]A::a01041
   ldc.i4 41
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int64 [rvastatic4]A::a01042
   ldc.i8 42
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int16 [rvastatic4]A::a01043
   ldc.i4 43
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int64 [rvastatic4]A::a01044
   ldc.i8 44
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int64 [rvastatic4]A::a01045
   ldc.i8 45
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld float32 [rvastatic4]A::a01046
   ldc.r4 46.0
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int16 [rvastatic4]A::a01047
   ldc.i4 47
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int64 [rvastatic4]A::a01048
   ldc.i8 48
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int16 [rvastatic4]A::a01049
   ldc.i4 49
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int32 [rvastatic4]A::a01050
   ldc.i4 50
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int16 [rvastatic4]A::a01051
   ldc.i4 51
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int32 [rvastatic4]A::a01052
   ldc.i4 52
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int16 [rvastatic4]A::a01053
   ldc.i4 53
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld float32 [rvastatic4]A::a01054
   ldc.r4 54.0
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int64 [rvastatic4]A::a01055
   ldc.i8 55
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld float32 [rvastatic4]A::a01056
   ldc.r4 56.0
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int64 [rvastatic4]A::a01057
   ldc.i8 57
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int64 [rvastatic4]A::a01058
   ldc.i8 58
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int64 [rvastatic4]A::a01059
   ldc.i8 59
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int16 [rvastatic4]A::a01060
   ldc.i4 60
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int8 [rvastatic4]A::a01061
   ldc.i4 61
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int64 [rvastatic4]A::a01062
   ldc.i8 62
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int16 [rvastatic4]A::a01063
   ldc.i4 63
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int32 [rvastatic4]A::a01064
   ldc.i4 64
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int16 [rvastatic4]A::a01065
   ldc.i4 65
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int8 [rvastatic4]A::a01066
   ldc.i4 66
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int16 [rvastatic4]A::a01067
   ldc.i4 67
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int32 [rvastatic4]A::a01068
   ldc.i4 68
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld float32 [rvastatic4]A::a01069
   ldc.r4 69.0
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld float32 [rvastatic4]A::a01070
   ldc.r4 70.0
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int16 [rvastatic4]A::a01071
   ldc.i4 71
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld float32 [rvastatic4]A::a01072
   ldc.r4 72.0
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int64 [rvastatic4]A::a01073
   ldc.i8 73
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int64 [rvastatic4]A::a01074
   ldc.i8 74
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int32 [rvastatic4]A::a01075
   ldc.i4 75
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int8 [rvastatic4]A::a01076
   ldc.i4 76
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int32 [rvastatic4]A::a01077
   ldc.i4 77
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int16 [rvastatic4]A::a01078
   ldc.i4 78
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld float32 [rvastatic4]A::a01079
   ldc.r4 79.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld float32 [rvastatic4]A::a01080
   ldc.r4 80.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld float32 [rvastatic4]A::a01081
   ldc.r4 81.0
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int32 [rvastatic4]A::a01082
   ldc.i4 82
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int8 [rvastatic4]A::a01083
   ldc.i4 83
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int64 [rvastatic4]A::a01084
   ldc.i8 84
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int64 [rvastatic4]A::a01085
   ldc.i8 85
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int32 [rvastatic4]A::a01086
   ldc.i4 86
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int32 [rvastatic4]A::a01087
   ldc.i4 87
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int8 [rvastatic4]A::a01088
   ldc.i4 88
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int64 [rvastatic4]A::a01089
   ldc.i8 89
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int8 [rvastatic4]A::a01090
   ldc.i4 90
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int16 [rvastatic4]A::a01091
   ldc.i4 91
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld float32 [rvastatic4]A::a01092
   ldc.r4 92.0
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int64 [rvastatic4]A::a01093
   ldc.i8 93
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int64 [rvastatic4]A::a01094
   ldc.i8 94
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int8 [rvastatic4]A::a01095
   ldc.i4 95
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld float32 [rvastatic4]A::a01096
   ldc.r4 96.0
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int16 [rvastatic4]A::a01097
   ldc.i4 97
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld float32 [rvastatic4]A::a01098
   ldc.r4 98.0
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int32 [rvastatic4]A::a01099
   ldc.i4 99
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int64 [rvastatic4]A::a010100
   ldc.i8 100
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int32 [rvastatic4]A::a010101
   ldc.i4 101
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld float32 [rvastatic4]A::a010102
   ldc.r4 102.0
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int64 [rvastatic4]A::a010103
   ldc.i8 103
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int32 [rvastatic4]A::a010104
   ldc.i4 104
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int16 [rvastatic4]A::a010105
   ldc.i4 105
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld int16 [rvastatic4]A::a010106
   ldc.i4 106
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld float32 [rvastatic4]A::a010107
   ldc.r4 107.0
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int32 [rvastatic4]A::a010108
   ldc.i4 108
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int16 [rvastatic4]A::a010109
   ldc.i4 109
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int32 [rvastatic4]A::a010110
   ldc.i4 110
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int32 [rvastatic4]A::a010111
   ldc.i4 111
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int32 [rvastatic4]A::a010112
   ldc.i4 112
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int64 [rvastatic4]A::a010113
   ldc.i8 113
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int64 [rvastatic4]A::a010114
   ldc.i8 114
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int16 [rvastatic4]A::a010115
   ldc.i4 115
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int64 [rvastatic4]A::a010116
   ldc.i8 116
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int64 [rvastatic4]A::a010117
   ldc.i8 117
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int32 [rvastatic4]A::a010118
   ldc.i4 118
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int64 [rvastatic4]A::a010119
   ldc.i8 119
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int64 [rvastatic4]A::a010120
   ldc.i8 120
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int64 [rvastatic4]A::a010121
   ldc.i8 121
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int16 [rvastatic4]A::a010122
   ldc.i4 122
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int64 [rvastatic4]A::a010123
   ldc.i8 123
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int64 [rvastatic4]A::a010124
   ldc.i8 124
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int32 [rvastatic4]A::a010125
   ldc.i4 125
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int16 [rvastatic4]A::a010126
   ldc.i4 126
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ldsfld int16 [rvastatic4]A::a010127
   ldc.i4 127
   beq a010128
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010128:
  ret}
@@ -814,896 +814,896 @@ a010128:
   ldind.i4
   ldc.i4 0
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsflda int64 [rvastatic4]A::a0101
   ldind.i8
   ldc.i8 1
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsflda float32 [rvastatic4]A::a0102
   ldind.r4
   ldc.r4 2.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsflda int16 [rvastatic4]A::a0103
   ldind.i2
   ldc.i4 3
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsflda int16 [rvastatic4]A::a0104
   ldind.i2
   ldc.i4 4
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsflda int64 [rvastatic4]A::a0105
   ldind.i8
   ldc.i8 5
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsflda int16 [rvastatic4]A::a0106
   ldind.i2
   ldc.i4 6
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsflda int8 [rvastatic4]A::a0107
   ldind.i1
   ldc.i4 7
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsflda int64 [rvastatic4]A::a0108
   ldind.i8
   ldc.i8 8
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsflda int32 [rvastatic4]A::a0109
   ldind.i4
   ldc.i4 9
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsflda int16 [rvastatic4]A::a01010
   ldind.i2
   ldc.i4 10
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsflda float32 [rvastatic4]A::a01011
   ldind.r4
   ldc.r4 11.0
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsflda int16 [rvastatic4]A::a01012
   ldind.i2
   ldc.i4 12
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsflda float32 [rvastatic4]A::a01013
   ldind.r4
   ldc.r4 13.0
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsflda float32 [rvastatic4]A::a01014
   ldind.r4
   ldc.r4 14.0
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsflda int8 [rvastatic4]A::a01015
   ldind.i1
   ldc.i4 15
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsflda float32 [rvastatic4]A::a01016
   ldind.r4
   ldc.r4 16.0
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsflda int8 [rvastatic4]A::a01017
   ldind.i1
   ldc.i4 17
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsflda float32 [rvastatic4]A::a01018
   ldind.r4
   ldc.r4 18.0
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsflda float32 [rvastatic4]A::a01019
   ldind.r4
   ldc.r4 19.0
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsflda int8 [rvastatic4]A::a01020
   ldind.i1
   ldc.i4 20
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsflda float32 [rvastatic4]A::a01021
   ldind.r4
   ldc.r4 21.0
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsflda int64 [rvastatic4]A::a01022
   ldind.i8
   ldc.i8 22
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsflda int8 [rvastatic4]A::a01023
   ldind.i1
   ldc.i4 23
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsflda int32 [rvastatic4]A::a01024
   ldind.i4
   ldc.i4 24
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsflda int64 [rvastatic4]A::a01025
   ldind.i8
   ldc.i8 25
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsflda int16 [rvastatic4]A::a01026
   ldind.i2
   ldc.i4 26
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsflda int8 [rvastatic4]A::a01027
   ldind.i1
   ldc.i4 27
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsflda int16 [rvastatic4]A::a01028
   ldind.i2
   ldc.i4 28
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsflda int16 [rvastatic4]A::a01029
   ldind.i2
   ldc.i4 29
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsflda int8 [rvastatic4]A::a01030
   ldind.i1
   ldc.i4 30
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsflda int8 [rvastatic4]A::a01031
   ldind.i1
   ldc.i4 31
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsflda int64 [rvastatic4]A::a01032
   ldind.i8
   ldc.i8 32
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsflda float32 [rvastatic4]A::a01033
   ldind.r4
   ldc.r4 33.0
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsflda int16 [rvastatic4]A::a01034
   ldind.i2
   ldc.i4 34
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsflda int8 [rvastatic4]A::a01035
   ldind.i1
   ldc.i4 35
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsflda int8 [rvastatic4]A::a01036
   ldind.i1
   ldc.i4 36
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsflda int32 [rvastatic4]A::a01037
   ldind.i4
   ldc.i4 37
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsflda int16 [rvastatic4]A::a01038
   ldind.i2
   ldc.i4 38
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsflda int8 [rvastatic4]A::a01039
   ldind.i1
   ldc.i4 39
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsflda int8 [rvastatic4]A::a01040
   ldind.i1
   ldc.i4 40
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsflda int32 [rvastatic4]A::a01041
   ldind.i4
   ldc.i4 41
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsflda int64 [rvastatic4]A::a01042
   ldind.i8
   ldc.i8 42
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsflda int16 [rvastatic4]A::a01043
   ldind.i2
   ldc.i4 43
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsflda int64 [rvastatic4]A::a01044
   ldind.i8
   ldc.i8 44
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsflda int64 [rvastatic4]A::a01045
   ldind.i8
   ldc.i8 45
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsflda float32 [rvastatic4]A::a01046
   ldind.r4
   ldc.r4 46.0
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsflda int16 [rvastatic4]A::a01047
   ldind.i2
   ldc.i4 47
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsflda int64 [rvastatic4]A::a01048
   ldind.i8
   ldc.i8 48
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsflda int16 [rvastatic4]A::a01049
   ldind.i2
   ldc.i4 49
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsflda int32 [rvastatic4]A::a01050
   ldind.i4
   ldc.i4 50
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsflda int16 [rvastatic4]A::a01051
   ldind.i2
   ldc.i4 51
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsflda int32 [rvastatic4]A::a01052
   ldind.i4
   ldc.i4 52
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsflda int16 [rvastatic4]A::a01053
   ldind.i2
   ldc.i4 53
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsflda float32 [rvastatic4]A::a01054
   ldind.r4
   ldc.r4 54.0
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsflda int64 [rvastatic4]A::a01055
   ldind.i8
   ldc.i8 55
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsflda float32 [rvastatic4]A::a01056
   ldind.r4
   ldc.r4 56.0
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsflda int64 [rvastatic4]A::a01057
   ldind.i8
   ldc.i8 57
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsflda int64 [rvastatic4]A::a01058
   ldind.i8
   ldc.i8 58
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsflda int64 [rvastatic4]A::a01059
   ldind.i8
   ldc.i8 59
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsflda int16 [rvastatic4]A::a01060
   ldind.i2
   ldc.i4 60
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsflda int8 [rvastatic4]A::a01061
   ldind.i1
   ldc.i4 61
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsflda int64 [rvastatic4]A::a01062
   ldind.i8
   ldc.i8 62
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsflda int16 [rvastatic4]A::a01063
   ldind.i2
   ldc.i4 63
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsflda int32 [rvastatic4]A::a01064
   ldind.i4
   ldc.i4 64
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsflda int16 [rvastatic4]A::a01065
   ldind.i2
   ldc.i4 65
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsflda int8 [rvastatic4]A::a01066
   ldind.i1
   ldc.i4 66
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsflda int16 [rvastatic4]A::a01067
   ldind.i2
   ldc.i4 67
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsflda int32 [rvastatic4]A::a01068
   ldind.i4
   ldc.i4 68
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsflda float32 [rvastatic4]A::a01069
   ldind.r4
   ldc.r4 69.0
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsflda float32 [rvastatic4]A::a01070
   ldind.r4
   ldc.r4 70.0
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsflda int16 [rvastatic4]A::a01071
   ldind.i2
   ldc.i4 71
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsflda float32 [rvastatic4]A::a01072
   ldind.r4
   ldc.r4 72.0
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsflda int64 [rvastatic4]A::a01073
   ldind.i8
   ldc.i8 73
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsflda int64 [rvastatic4]A::a01074
   ldind.i8
   ldc.i8 74
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsflda int32 [rvastatic4]A::a01075
   ldind.i4
   ldc.i4 75
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsflda int8 [rvastatic4]A::a01076
   ldind.i1
   ldc.i4 76
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsflda int32 [rvastatic4]A::a01077
   ldind.i4
   ldc.i4 77
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsflda int16 [rvastatic4]A::a01078
   ldind.i2
   ldc.i4 78
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsflda float32 [rvastatic4]A::a01079
   ldind.r4
   ldc.r4 79.0
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsflda float32 [rvastatic4]A::a01080
   ldind.r4
   ldc.r4 80.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsflda float32 [rvastatic4]A::a01081
   ldind.r4
   ldc.r4 81.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsflda int32 [rvastatic4]A::a01082
   ldind.i4
   ldc.i4 82
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsflda int8 [rvastatic4]A::a01083
   ldind.i1
   ldc.i4 83
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsflda int64 [rvastatic4]A::a01084
   ldind.i8
   ldc.i8 84
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsflda int64 [rvastatic4]A::a01085
   ldind.i8
   ldc.i8 85
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsflda int32 [rvastatic4]A::a01086
   ldind.i4
   ldc.i4 86
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsflda int32 [rvastatic4]A::a01087
   ldind.i4
   ldc.i4 87
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsflda int8 [rvastatic4]A::a01088
   ldind.i1
   ldc.i4 88
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsflda int64 [rvastatic4]A::a01089
   ldind.i8
   ldc.i8 89
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsflda int8 [rvastatic4]A::a01090
   ldind.i1
   ldc.i4 90
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsflda int16 [rvastatic4]A::a01091
   ldind.i2
   ldc.i4 91
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsflda float32 [rvastatic4]A::a01092
   ldind.r4
   ldc.r4 92.0
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsflda int64 [rvastatic4]A::a01093
   ldind.i8
   ldc.i8 93
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsflda int64 [rvastatic4]A::a01094
   ldind.i8
   ldc.i8 94
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsflda int8 [rvastatic4]A::a01095
   ldind.i1
   ldc.i4 95
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsflda float32 [rvastatic4]A::a01096
   ldind.r4
   ldc.r4 96.0
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsflda int16 [rvastatic4]A::a01097
   ldind.i2
   ldc.i4 97
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsflda float32 [rvastatic4]A::a01098
   ldind.r4
   ldc.r4 98.0
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsflda int32 [rvastatic4]A::a01099
   ldind.i4
   ldc.i4 99
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsflda int64 [rvastatic4]A::a010100
   ldind.i8
   ldc.i8 100
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsflda int32 [rvastatic4]A::a010101
   ldind.i4
   ldc.i4 101
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsflda float32 [rvastatic4]A::a010102
   ldind.r4
   ldc.r4 102.0
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsflda int64 [rvastatic4]A::a010103
   ldind.i8
   ldc.i8 103
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsflda int32 [rvastatic4]A::a010104
   ldind.i4
   ldc.i4 104
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsflda int16 [rvastatic4]A::a010105
   ldind.i2
   ldc.i4 105
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsflda int16 [rvastatic4]A::a010106
   ldind.i2
   ldc.i4 106
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsflda float32 [rvastatic4]A::a010107
   ldind.r4
   ldc.r4 107.0
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsflda int32 [rvastatic4]A::a010108
   ldind.i4
   ldc.i4 108
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsflda int16 [rvastatic4]A::a010109
   ldind.i2
   ldc.i4 109
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsflda int32 [rvastatic4]A::a010110
   ldind.i4
   ldc.i4 110
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsflda int32 [rvastatic4]A::a010111
   ldind.i4
   ldc.i4 111
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsflda int32 [rvastatic4]A::a010112
   ldind.i4
   ldc.i4 112
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsflda int64 [rvastatic4]A::a010113
   ldind.i8
   ldc.i8 113
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsflda int64 [rvastatic4]A::a010114
   ldind.i8
   ldc.i8 114
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsflda int16 [rvastatic4]A::a010115
   ldind.i2
   ldc.i4 115
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsflda int64 [rvastatic4]A::a010116
   ldind.i8
   ldc.i8 116
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsflda int64 [rvastatic4]A::a010117
   ldind.i8
   ldc.i8 117
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsflda int32 [rvastatic4]A::a010118
   ldind.i4
   ldc.i4 118
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsflda int64 [rvastatic4]A::a010119
   ldind.i8
   ldc.i8 119
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsflda int64 [rvastatic4]A::a010120
   ldind.i8
   ldc.i8 120
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsflda int64 [rvastatic4]A::a010121
   ldind.i8
   ldc.i8 121
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsflda int16 [rvastatic4]A::a010122
   ldind.i2
   ldc.i4 122
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsflda int64 [rvastatic4]A::a010123
   ldind.i8
   ldc.i8 123
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsflda int64 [rvastatic4]A::a010124
   ldind.i8
   ldc.i8 124
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsflda int32 [rvastatic4]A::a010125
   ldind.i4
   ldc.i4 125
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsflda int16 [rvastatic4]A::a010126
   ldind.i2
   ldc.i4 126
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsflda int16 [rvastatic4]A::a010127
   ldind.i2
   ldc.i4 127
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
  ret}
@@ -1711,769 +1711,769 @@ a010127:
   ldsfld float32 [rvastatic4]A::a01079
   ldc.r4 79.0
   beq a010129
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010129:
   ldsfld int32 [rvastatic4]A::a010111
   ldc.i4 111
   beq a010130
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010130:
   ldsfld int16 [rvastatic4]A::a01034
   ldc.i4 34
   beq a010131
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010131:
   ldsfld int8 [rvastatic4]A::a01040
   ldc.i4 40
   beq a010132
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010132:
   ldsfld int16 [rvastatic4]A::a01012
   ldc.i4 12
   beq a010133
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010133:
   ldsfld int64 [rvastatic4]A::a01089
   ldc.i8 89
   beq a010134
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010134:
   ldsfld float32 [rvastatic4]A::a01070
   ldc.r4 70.0
   beq a010135
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010135:
   ldsfld int8 [rvastatic4]A::a01066
   ldc.i4 66
   beq a010136
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010136:
   ldsfld int64 [rvastatic4]A::a01048
   ldc.i8 48
   beq a010137
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010137:
   ldsfld float32 [rvastatic4]A::a01080
   ldc.r4 80.0
   beq a010138
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010138:
   ldsfld int32 [rvastatic4]A::a010104
   ldc.i4 104
   beq a010139
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010139:
   ldsfld int16 [rvastatic4]A::a01091
   ldc.i4 91
   beq a010140
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010140:
   ldsfld int32 [rvastatic4]A::a01024
   ldc.i4 24
   beq a010141
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010141:
   ldsfld float32 [rvastatic4]A::a01081
   ldc.r4 81.0
   beq a010142
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010142:
   ldsfld int64 [rvastatic4]A::a010121
   ldc.i8 121
   beq a010143
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010143:
   ldsfld int8 [rvastatic4]A::a01017
   ldc.i4 17
   beq a010144
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010144:
   ldsfld float32 [rvastatic4]A::a010107
   ldc.r4 107.0
   beq a010145
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010145:
   ldsfld int16 [rvastatic4]A::a01047
   ldc.i4 47
   beq a010146
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010146:
   ldsfld int64 [rvastatic4]A::a01048
   ldc.i8 48
   beq a010147
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010147:
   ldsfld int8 [rvastatic4]A::a01020
   ldc.i4 20
   beq a010148
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010148:
   ldsfld int16 [rvastatic4]A::a010115
   ldc.i4 115
   beq a010149
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010149:
   ldsfld int32 [rvastatic4]A::a01024
   ldc.i4 24
   beq a010150
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010150:
   ldsfld float32 [rvastatic4]A::a010102
   ldc.r4 102.0
   beq a010151
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010151:
   ldsfld int64 [rvastatic4]A::a010124
   ldc.i8 124
   beq a010152
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010152:
   ldsfld int16 [rvastatic4]A::a01028
   ldc.i4 28
   beq a010153
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010153:
   ldsfld int16 [rvastatic4]A::a01012
   ldc.i4 12
   beq a010154
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010154:
   ldsfld int64 [rvastatic4]A::a0105
   ldc.i8 5
   beq a010155
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010155:
   ldsfld int16 [rvastatic4]A::a010115
   ldc.i4 115
   beq a010156
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010156:
   ldsfld int64 [rvastatic4]A::a010113
   ldc.i8 113
   beq a010157
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010157:
   ldsfld int64 [rvastatic4]A::a0101
   ldc.i8 1
   beq a010158
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010158:
   ldsfld int16 [rvastatic4]A::a010122
   ldc.i4 122
   beq a010159
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010159:
   ldsfld int32 [rvastatic4]A::a010108
   ldc.i4 108
   beq a010160
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010160:
   ldsfld int8 [rvastatic4]A::a01090
   ldc.i4 90
   beq a010161
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010161:
   ldsfld int8 [rvastatic4]A::a01090
   ldc.i4 90
   beq a010162
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010162:
   ldsfld int32 [rvastatic4]A::a010112
   ldc.i4 112
   beq a010163
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010163:
   ldsfld int16 [rvastatic4]A::a01067
   ldc.i4 67
   beq a010164
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010164:
   ldsfld int32 [rvastatic4]A::a01064
   ldc.i4 64
   beq a010165
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010165:
   ldsfld int64 [rvastatic4]A::a01057
   ldc.i8 57
   beq a010166
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010166:
   ldsfld int32 [rvastatic4]A::a01037
   ldc.i4 37
   beq a010167
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010167:
   ldsfld int64 [rvastatic4]A::a010120
   ldc.i8 120
   beq a010168
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010168:
   ldsfld float32 [rvastatic4]A::a01019
   ldc.r4 19.0
   beq a010169
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010169:
   ldsfld int64 [rvastatic4]A::a010124
   ldc.i8 124
   beq a010170
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010170:
   ldsfld int32 [rvastatic4]A::a01037
   ldc.i4 37
   beq a010171
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010171:
   ldsfld int8 [rvastatic4]A::a0107
   ldc.i4 7
   beq a010172
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010172:
   ldsfld int16 [rvastatic4]A::a010106
   ldc.i4 106
   beq a010173
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010173:
   ldsfld int64 [rvastatic4]A::a01073
   ldc.i8 73
   beq a010174
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010174:
   ldsfld int64 [rvastatic4]A::a01074
   ldc.i8 74
   beq a010175
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010175:
   ldsfld int8 [rvastatic4]A::a01015
   ldc.i4 15
   beq a010176
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010176:
   ldsfld int32 [rvastatic4]A::a01077
   ldc.i4 77
   beq a010177
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010177:
   ldsfld int8 [rvastatic4]A::a01031
   ldc.i4 31
   beq a010178
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010178:
   ldsfld int16 [rvastatic4]A::a01067
   ldc.i4 67
   beq a010179
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010179:
   ldsfld int16 [rvastatic4]A::a01071
   ldc.i4 71
   beq a010180
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010180:
   ldsfld int16 [rvastatic4]A::a01047
   ldc.i4 47
   beq a010181
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010181:
   ldsfld int8 [rvastatic4]A::a01061
   ldc.i4 61
   beq a010182
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010182:
   ldsfld int64 [rvastatic4]A::a010114
   ldc.i8 114
   beq a010183
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010183:
   ldsfld float32 [rvastatic4]A::a01054
   ldc.r4 54.0
   beq a010184
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010184:
   ldsfld int32 [rvastatic4]A::a0109
   ldc.i4 9
   beq a010185
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010185:
   ldsfld int32 [rvastatic4]A::a01037
   ldc.i4 37
   beq a010186
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010186:
   ldsfld int16 [rvastatic4]A::a01012
   ldc.i4 12
   beq a010187
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010187:
   ldsfld int32 [rvastatic4]A::a0100
   ldc.i4 0
   beq a010188
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010188:
   ldsfld int8 [rvastatic4]A::a01083
   ldc.i4 83
   beq a010189
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010189:
   ldsfld int32 [rvastatic4]A::a01082
   ldc.i4 82
   beq a010190
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010190:
   ldsfld float32 [rvastatic4]A::a01081
   ldc.r4 81.0
   beq a010191
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010191:
   ldsfld float32 [rvastatic4]A::a01046
   ldc.r4 46.0
   beq a010192
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010192:
   ldsfld int64 [rvastatic4]A::a01085
   ldc.i8 85
   beq a010193
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010193:
   ldsfld int64 [rvastatic4]A::a010123
   ldc.i8 123
   beq a010194
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010194:
   ldsfld int32 [rvastatic4]A::a0100
   ldc.i4 0
   beq a010195
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010195:
   ldsfld int64 [rvastatic4]A::a01062
   ldc.i8 62
   beq a010196
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010196:
   ldsfld float32 [rvastatic4]A::a01096
   ldc.r4 96.0
   beq a010197
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010197:
   ldsfld int16 [rvastatic4]A::a01053
   ldc.i4 53
   beq a010198
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010198:
   ldsfld float32 [rvastatic4]A::a01081
   ldc.r4 81.0
   beq a010199
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010199:
   ldsfld int16 [rvastatic4]A::a01049
   ldc.i4 49
   beq a010200
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010200:
   ldsfld int32 [rvastatic4]A::a0109
   ldc.i4 9
   beq a010201
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010201:
   ldsfld float32 [rvastatic4]A::a01056
   ldc.r4 56.0
   beq a010202
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010202:
   ldsfld int64 [rvastatic4]A::a0101
   ldc.i8 1
   beq a010203
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010203:
   ldsfld int64 [rvastatic4]A::a010119
   ldc.i8 119
   beq a010204
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010204:
   ldsfld int16 [rvastatic4]A::a010115
   ldc.i4 115
   beq a010205
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010205:
   ldsfld int64 [rvastatic4]A::a01094
   ldc.i8 94
   beq a010206
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010206:
   ldsfld int8 [rvastatic4]A::a01017
   ldc.i4 17
   beq a010207
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010207:
   ldsfld int32 [rvastatic4]A::a01082
   ldc.i4 82
   beq a010208
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010208:
   ldsfld int16 [rvastatic4]A::a01065
   ldc.i4 65
   beq a010209
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010209:
   ldsfld int64 [rvastatic4]A::a010117
   ldc.i8 117
   beq a010210
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010210:
   ldsfld int16 [rvastatic4]A::a01038
   ldc.i4 38
   beq a010211
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010211:
   ldsfld int32 [rvastatic4]A::a01082
   ldc.i4 82
   beq a010212
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010212:
   ldsfld int64 [rvastatic4]A::a01062
   ldc.i8 62
   beq a010213
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010213:
   ldsfld int32 [rvastatic4]A::a01050
   ldc.i4 50
   beq a010214
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010214:
   ldsfld int8 [rvastatic4]A::a01061
   ldc.i4 61
   beq a010215
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010215:
   ldsfld int16 [rvastatic4]A::a01029
   ldc.i4 29
   beq a010216
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010216:
   ldsfld int32 [rvastatic4]A::a010104
   ldc.i4 104
   beq a010217
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010217:
   ldsfld int64 [rvastatic4]A::a01057
   ldc.i8 57
   beq a010218
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010218:
   ldsfld int64 [rvastatic4]A::a01057
   ldc.i8 57
   beq a010219
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010219:
   ldsfld int16 [rvastatic4]A::a01026
   ldc.i4 26
   beq a010220
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010220:
   ldsfld int64 [rvastatic4]A::a01045
   ldc.i8 45
   beq a010221
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010221:
   ldsfld int32 [rvastatic4]A::a01037
   ldc.i4 37
   beq a010222
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010222:
   ldsfld int8 [rvastatic4]A::a01036
   ldc.i4 36
   beq a010223
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010223:
   ldsfld int32 [rvastatic4]A::a01064
   ldc.i4 64
   beq a010224
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010224:
   ldsfld int16 [rvastatic4]A::a01043
   ldc.i4 43
   beq a010225
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010225:
   ldsfld int32 [rvastatic4]A::a010118
   ldc.i4 118
   beq a010226
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010226:
   ldsfld int32 [rvastatic4]A::a01050
   ldc.i4 50
   beq a010227
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010227:
   ldsfld int32 [rvastatic4]A::a010111
   ldc.i4 111
   beq a010228
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010228:
   ldsfld float32 [rvastatic4]A::a01072
   ldc.r4 72.0
   beq a010229
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010229:
   ldsfld int16 [rvastatic4]A::a01012
   ldc.i4 12
   beq a010230
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010230:
   ldsfld float32 [rvastatic4]A::a01046
   ldc.r4 46.0
   beq a010231
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010231:
   ldsfld int8 [rvastatic4]A::a01023
   ldc.i4 23
   beq a010232
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010232:
   ldsfld int32 [rvastatic4]A::a01077
   ldc.i4 77
   beq a010233
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010233:
   ldsfld float32 [rvastatic4]A::a01018
   ldc.r4 18.0
   beq a010234
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010234:
   ldsfld int8 [rvastatic4]A::a01061
   ldc.i4 61
   beq a010235
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010235:
   ldsfld int32 [rvastatic4]A::a010118
   ldc.i4 118
   beq a010236
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010236:
   ldsfld int64 [rvastatic4]A::a01059
   ldc.i8 59
   beq a010237
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010237:
   ldsfld int16 [rvastatic4]A::a010122
   ldc.i4 122
   beq a010238
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010238:
   ldsfld int8 [rvastatic4]A::a01066
   ldc.i4 66
   beq a010239
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010239:
   ldsfld int16 [rvastatic4]A::a01043
   ldc.i4 43
   beq a010240
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010240:
   ldsfld int8 [rvastatic4]A::a01020
   ldc.i4 20
   beq a010241
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010241:
   ldsfld int64 [rvastatic4]A::a01058
   ldc.i8 58
   beq a010242
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010242:
   ldsfld int64 [rvastatic4]A::a01062
   ldc.i8 62
   beq a010243
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010243:
   ldsfld int64 [rvastatic4]A::a01094
   ldc.i8 94
   beq a010244
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010244:
   ldsfld int64 [rvastatic4]A::a01044
   ldc.i8 44
   beq a010245
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010245:
   ldsfld int16 [rvastatic4]A::a010126
   ldc.i4 126
   beq a010246
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010246:
   ldsfld int32 [rvastatic4]A::a010112
   ldc.i4 112
   beq a010247
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010247:
   ldsfld int16 [rvastatic4]A::a01034
   ldc.i4 34
   beq a010248
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010248:
   ldsfld int64 [rvastatic4]A::a01062
   ldc.i8 62
   beq a010249
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010249:
   ldsfld int32 [rvastatic4]A::a01099
   ldc.i4 99
   beq a010250
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010250:
   ldsfld int64 [rvastatic4]A::a01085
   ldc.i8 85
   beq a010251
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010251:
   ldsfld int8 [rvastatic4]A::a01039
   ldc.i4 39
   beq a010252
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010252:
   ldsfld int64 [rvastatic4]A::a010124
   ldc.i8 124
   beq a010253
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010253:
   ldsfld int64 [rvastatic4]A::a01055
   ldc.i8 55
   beq a010254
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010254:
   ldsfld int16 [rvastatic4]A::a0104
   ldc.i4 4
   beq a010255
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010255:
   ldsfld int64 [rvastatic4]A::a010100
   ldc.i8 100
   beq a010256
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010256:
  ret}
@@ -2490,7 +2490,7 @@ a010256:
   ldc.i4 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda int64 [rvastatic4]A::a0101
@@ -2509,7 +2509,7 @@ a0100:
   ldc.i8 1
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda float32 [rvastatic4]A::a0102
@@ -2524,7 +2524,7 @@ a0101:
   ldc.r4 2.0
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int16 [rvastatic4]A::a0103
@@ -2543,7 +2543,7 @@ a0102:
   ldc.i4 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int16 [rvastatic4]A::a0104
@@ -2558,7 +2558,7 @@ a0103:
   ldc.i4 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int64 [rvastatic4]A::a0105
@@ -2572,7 +2572,7 @@ a0104:
   ldc.i8 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int16 [rvastatic4]A::a0106
@@ -2587,7 +2587,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda int8 [rvastatic4]A::a0107
@@ -2603,7 +2603,7 @@ a0106:
   ldc.i4 7
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda int64 [rvastatic4]A::a0108
@@ -2618,7 +2618,7 @@ a0107:
   ldc.i8 8
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int32 [rvastatic4]A::a0109
@@ -2634,7 +2634,7 @@ a0108:
   ldc.i4 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int16 [rvastatic4]A::a01010
@@ -2648,7 +2648,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda float32 [rvastatic4]A::a01011
@@ -2667,7 +2667,7 @@ a01010:
   ldc.r4 11.0
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int16 [rvastatic4]A::a01012
@@ -2681,7 +2681,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda float32 [rvastatic4]A::a01013
@@ -2696,7 +2696,7 @@ a01012:
   ldc.r4 13.0
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda float32 [rvastatic4]A::a01014
@@ -2715,7 +2715,7 @@ a01013:
   ldc.r4 14.0
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int8 [rvastatic4]A::a01015
@@ -2731,7 +2731,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda float32 [rvastatic4]A::a01016
@@ -2750,7 +2750,7 @@ a01015:
   ldc.r4 16.0
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda int8 [rvastatic4]A::a01017
@@ -2765,7 +2765,7 @@ a01016:
   ldc.i4 17
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda float32 [rvastatic4]A::a01018
@@ -2779,7 +2779,7 @@ a01017:
   ldc.r4 18.0
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda float32 [rvastatic4]A::a01019
@@ -2795,7 +2795,7 @@ a01018:
   ldc.r4 19.0
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int8 [rvastatic4]A::a01020
@@ -2810,7 +2810,7 @@ a01019:
   ldc.i4 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda float32 [rvastatic4]A::a01021
@@ -2825,7 +2825,7 @@ a01020:
   ldc.r4 21.0
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int64 [rvastatic4]A::a01022
@@ -2844,7 +2844,7 @@ a01021:
   ldc.i8 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int8 [rvastatic4]A::a01023
@@ -2860,7 +2860,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int32 [rvastatic4]A::a01024
@@ -2879,7 +2879,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int64 [rvastatic4]A::a01025
@@ -2898,7 +2898,7 @@ a01024:
   ldc.i8 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int16 [rvastatic4]A::a01026
@@ -2912,7 +2912,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int8 [rvastatic4]A::a01027
@@ -2931,7 +2931,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int16 [rvastatic4]A::a01028
@@ -2950,7 +2950,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int16 [rvastatic4]A::a01029
@@ -2969,7 +2969,7 @@ a01028:
   ldc.i4 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int8 [rvastatic4]A::a01030
@@ -2983,7 +2983,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int8 [rvastatic4]A::a01031
@@ -2998,7 +2998,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int64 [rvastatic4]A::a01032
@@ -3013,7 +3013,7 @@ a01031:
   ldc.i8 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda float32 [rvastatic4]A::a01033
@@ -3027,7 +3027,7 @@ a01032:
   ldc.r4 33.0
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int16 [rvastatic4]A::a01034
@@ -3041,7 +3041,7 @@ a01033:
   ldc.i4 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int8 [rvastatic4]A::a01035
@@ -3055,7 +3055,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int8 [rvastatic4]A::a01036
@@ -3070,7 +3070,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int32 [rvastatic4]A::a01037
@@ -3085,7 +3085,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int16 [rvastatic4]A::a01038
@@ -3104,7 +3104,7 @@ a01037:
   ldc.i4 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int8 [rvastatic4]A::a01039
@@ -3118,7 +3118,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int8 [rvastatic4]A::a01040
@@ -3133,7 +3133,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int32 [rvastatic4]A::a01041
@@ -3152,7 +3152,7 @@ a01040:
   ldc.i4 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int64 [rvastatic4]A::a01042
@@ -3168,7 +3168,7 @@ a01041:
   ldc.i8 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int16 [rvastatic4]A::a01043
@@ -3187,7 +3187,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int64 [rvastatic4]A::a01044
@@ -3203,7 +3203,7 @@ a01043:
   ldc.i8 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int64 [rvastatic4]A::a01045
@@ -3218,7 +3218,7 @@ a01044:
   ldc.i8 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda float32 [rvastatic4]A::a01046
@@ -3232,7 +3232,7 @@ a01045:
   ldc.r4 46.0
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int16 [rvastatic4]A::a01047
@@ -3246,7 +3246,7 @@ a01046:
   ldc.i4 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda int64 [rvastatic4]A::a01048
@@ -3260,7 +3260,7 @@ a01047:
   ldc.i8 48
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int16 [rvastatic4]A::a01049
@@ -3274,7 +3274,7 @@ a01048:
   ldc.i4 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int32 [rvastatic4]A::a01050
@@ -3293,7 +3293,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int16 [rvastatic4]A::a01051
@@ -3307,7 +3307,7 @@ a01050:
   ldc.i4 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int32 [rvastatic4]A::a01052
@@ -3326,7 +3326,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int16 [rvastatic4]A::a01053
@@ -3341,7 +3341,7 @@ a01052:
   ldc.i4 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda float32 [rvastatic4]A::a01054
@@ -3356,7 +3356,7 @@ a01053:
   ldc.r4 54.0
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int64 [rvastatic4]A::a01055
@@ -3370,7 +3370,7 @@ a01054:
   ldc.i8 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda float32 [rvastatic4]A::a01056
@@ -3384,7 +3384,7 @@ a01055:
   ldc.r4 56.0
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int64 [rvastatic4]A::a01057
@@ -3399,7 +3399,7 @@ a01056:
   ldc.i8 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int64 [rvastatic4]A::a01058
@@ -3413,7 +3413,7 @@ a01057:
   ldc.i8 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int64 [rvastatic4]A::a01059
@@ -3428,7 +3428,7 @@ a01058:
   ldc.i8 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int16 [rvastatic4]A::a01060
@@ -3444,7 +3444,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int8 [rvastatic4]A::a01061
@@ -3463,7 +3463,7 @@ a01060:
   ldc.i4 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int64 [rvastatic4]A::a01062
@@ -3477,7 +3477,7 @@ a01061:
   ldc.i8 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda int16 [rvastatic4]A::a01063
@@ -3491,7 +3491,7 @@ a01062:
   ldc.i4 63
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int32 [rvastatic4]A::a01064
@@ -3505,7 +3505,7 @@ a01063:
   ldc.i4 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int16 [rvastatic4]A::a01065
@@ -3519,7 +3519,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int8 [rvastatic4]A::a01066
@@ -3535,7 +3535,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int16 [rvastatic4]A::a01067
@@ -3554,7 +3554,7 @@ a01066:
   ldc.i4 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int32 [rvastatic4]A::a01068
@@ -3570,7 +3570,7 @@ a01067:
   ldc.i4 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda float32 [rvastatic4]A::a01069
@@ -3584,7 +3584,7 @@ a01068:
   ldc.r4 69.0
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda float32 [rvastatic4]A::a01070
@@ -3599,7 +3599,7 @@ a01069:
   ldc.r4 70.0
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int16 [rvastatic4]A::a01071
@@ -3614,7 +3614,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda float32 [rvastatic4]A::a01072
@@ -3630,7 +3630,7 @@ a01071:
   ldc.r4 72.0
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int64 [rvastatic4]A::a01073
@@ -3645,7 +3645,7 @@ a01072:
   ldc.i8 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda int64 [rvastatic4]A::a01074
@@ -3659,7 +3659,7 @@ a01073:
   ldc.i8 74
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int32 [rvastatic4]A::a01075
@@ -3674,7 +3674,7 @@ a01074:
   ldc.i4 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int8 [rvastatic4]A::a01076
@@ -3693,7 +3693,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int32 [rvastatic4]A::a01077
@@ -3709,7 +3709,7 @@ a01076:
   ldc.i4 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int16 [rvastatic4]A::a01078
@@ -3728,7 +3728,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda float32 [rvastatic4]A::a01079
@@ -3743,7 +3743,7 @@ a01078:
   ldc.r4 79.0
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda float32 [rvastatic4]A::a01080
@@ -3762,7 +3762,7 @@ a01079:
   ldc.r4 80.0
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda float32 [rvastatic4]A::a01081
@@ -3778,7 +3778,7 @@ a01080:
   ldc.r4 81.0
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda int32 [rvastatic4]A::a01082
@@ -3793,7 +3793,7 @@ a01081:
   ldc.i4 82
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int8 [rvastatic4]A::a01083
@@ -3809,7 +3809,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int64 [rvastatic4]A::a01084
@@ -3828,7 +3828,7 @@ a01083:
   ldc.i8 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int64 [rvastatic4]A::a01085
@@ -3843,7 +3843,7 @@ a01084:
   ldc.i8 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int32 [rvastatic4]A::a01086
@@ -3857,7 +3857,7 @@ a01085:
   ldc.i4 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int32 [rvastatic4]A::a01087
@@ -3872,7 +3872,7 @@ a01086:
   ldc.i4 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int8 [rvastatic4]A::a01088
@@ -3891,7 +3891,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int64 [rvastatic4]A::a01089
@@ -3906,7 +3906,7 @@ a01088:
   ldc.i8 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int8 [rvastatic4]A::a01090
@@ -3921,7 +3921,7 @@ a01089:
   ldc.i4 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int16 [rvastatic4]A::a01091
@@ -3940,7 +3940,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda float32 [rvastatic4]A::a01092
@@ -3956,7 +3956,7 @@ a01091:
   ldc.r4 92.0
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int64 [rvastatic4]A::a01093
@@ -3971,7 +3971,7 @@ a01092:
   ldc.i8 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int64 [rvastatic4]A::a01094
@@ -3986,7 +3986,7 @@ a01093:
   ldc.i8 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int8 [rvastatic4]A::a01095
@@ -4000,7 +4000,7 @@ a01094:
   ldc.i4 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda float32 [rvastatic4]A::a01096
@@ -4016,7 +4016,7 @@ a01095:
   ldc.r4 96.0
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int16 [rvastatic4]A::a01097
@@ -4031,7 +4031,7 @@ a01096:
   ldc.i4 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda float32 [rvastatic4]A::a01098
@@ -4047,7 +4047,7 @@ a01097:
   ldc.r4 98.0
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int32 [rvastatic4]A::a01099
@@ -4062,7 +4062,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int64 [rvastatic4]A::a010100
@@ -4078,7 +4078,7 @@ a01099:
   ldc.i8 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int32 [rvastatic4]A::a010101
@@ -4092,7 +4092,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda float32 [rvastatic4]A::a010102
@@ -4108,7 +4108,7 @@ a010101:
   ldc.r4 102.0
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int64 [rvastatic4]A::a010103
@@ -4124,7 +4124,7 @@ a010102:
   ldc.i8 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int32 [rvastatic4]A::a010104
@@ -4139,7 +4139,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int16 [rvastatic4]A::a010105
@@ -4158,7 +4158,7 @@ a010104:
   ldc.i4 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda int16 [rvastatic4]A::a010106
@@ -4172,7 +4172,7 @@ a010105:
   ldc.i4 106
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda float32 [rvastatic4]A::a010107
@@ -4187,7 +4187,7 @@ a010106:
   ldc.r4 107.0
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int32 [rvastatic4]A::a010108
@@ -4206,7 +4206,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int16 [rvastatic4]A::a010109
@@ -4225,7 +4225,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int32 [rvastatic4]A::a010110
@@ -4241,7 +4241,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int32 [rvastatic4]A::a010111
@@ -4255,7 +4255,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int32 [rvastatic4]A::a010112
@@ -4269,7 +4269,7 @@ a010111:
   ldc.i4 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int64 [rvastatic4]A::a010113
@@ -4284,7 +4284,7 @@ a010112:
   ldc.i8 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int64 [rvastatic4]A::a010114
@@ -4299,7 +4299,7 @@ a010113:
   ldc.i8 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int16 [rvastatic4]A::a010115
@@ -4318,7 +4318,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int64 [rvastatic4]A::a010116
@@ -4332,7 +4332,7 @@ a010115:
   ldc.i8 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int64 [rvastatic4]A::a010117
@@ -4351,7 +4351,7 @@ a010116:
   ldc.i8 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int32 [rvastatic4]A::a010118
@@ -4366,7 +4366,7 @@ a010117:
   ldc.i4 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int64 [rvastatic4]A::a010119
@@ -4381,7 +4381,7 @@ a010118:
   ldc.i8 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int64 [rvastatic4]A::a010120
@@ -4400,7 +4400,7 @@ a010119:
   ldc.i8 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int64 [rvastatic4]A::a010121
@@ -4419,7 +4419,7 @@ a010120:
   ldc.i8 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int16 [rvastatic4]A::a010122
@@ -4434,7 +4434,7 @@ a010121:
   ldc.i4 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int64 [rvastatic4]A::a010123
@@ -4448,7 +4448,7 @@ a010122:
   ldc.i8 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int64 [rvastatic4]A::a010124
@@ -4464,7 +4464,7 @@ a010123:
   ldc.i8 124
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int32 [rvastatic4]A::a010125
@@ -4480,7 +4480,7 @@ a010124:
   ldc.i4 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int16 [rvastatic4]A::a010126
@@ -4494,7 +4494,7 @@ a010125:
   ldc.i4 126
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int16 [rvastatic4]A::a010127
@@ -4513,7 +4513,7 @@ a010126:
   ldc.i4 127
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -4525,7 +4525,7 @@ a010127:
   ldc.i4 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda int64 [rvastatic4]A::a0101
@@ -4535,7 +4535,7 @@ a0100:
   ldc.i8 1
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda float32 [rvastatic4]A::a0102
@@ -4545,7 +4545,7 @@ a0101:
   ldc.r4 2.0
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int16 [rvastatic4]A::a0103
@@ -4555,7 +4555,7 @@ a0102:
   ldc.i4 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int16 [rvastatic4]A::a0104
@@ -4565,7 +4565,7 @@ a0103:
   ldc.i4 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda int64 [rvastatic4]A::a0105
@@ -4575,7 +4575,7 @@ a0104:
   ldc.i8 5
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda int16 [rvastatic4]A::a0106
@@ -4585,7 +4585,7 @@ a0105:
   ldc.i4 6
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda int8 [rvastatic4]A::a0107
@@ -4595,7 +4595,7 @@ a0106:
   ldc.i4 7
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda int64 [rvastatic4]A::a0108
@@ -4605,7 +4605,7 @@ a0107:
   ldc.i8 8
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int32 [rvastatic4]A::a0109
@@ -4615,7 +4615,7 @@ a0108:
   ldc.i4 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int16 [rvastatic4]A::a01010
@@ -4625,7 +4625,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda float32 [rvastatic4]A::a01011
@@ -4635,7 +4635,7 @@ a01010:
   ldc.r4 11.0
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int16 [rvastatic4]A::a01012
@@ -4645,7 +4645,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda float32 [rvastatic4]A::a01013
@@ -4655,7 +4655,7 @@ a01012:
   ldc.r4 13.0
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda float32 [rvastatic4]A::a01014
@@ -4665,7 +4665,7 @@ a01013:
   ldc.r4 14.0
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int8 [rvastatic4]A::a01015
@@ -4675,7 +4675,7 @@ a01014:
   ldc.i4 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda float32 [rvastatic4]A::a01016
@@ -4685,7 +4685,7 @@ a01015:
   ldc.r4 16.0
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda int8 [rvastatic4]A::a01017
@@ -4695,7 +4695,7 @@ a01016:
   ldc.i4 17
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda float32 [rvastatic4]A::a01018
@@ -4705,7 +4705,7 @@ a01017:
   ldc.r4 18.0
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda float32 [rvastatic4]A::a01019
@@ -4715,7 +4715,7 @@ a01018:
   ldc.r4 19.0
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda int8 [rvastatic4]A::a01020
@@ -4725,7 +4725,7 @@ a01019:
   ldc.i4 20
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda float32 [rvastatic4]A::a01021
@@ -4735,7 +4735,7 @@ a01020:
   ldc.r4 21.0
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda int64 [rvastatic4]A::a01022
@@ -4745,7 +4745,7 @@ a01021:
   ldc.i8 22
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int8 [rvastatic4]A::a01023
@@ -4755,7 +4755,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda int32 [rvastatic4]A::a01024
@@ -4765,7 +4765,7 @@ a01023:
   ldc.i4 24
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int64 [rvastatic4]A::a01025
@@ -4775,7 +4775,7 @@ a01024:
   ldc.i8 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int16 [rvastatic4]A::a01026
@@ -4785,7 +4785,7 @@ a01025:
   ldc.i4 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int8 [rvastatic4]A::a01027
@@ -4795,7 +4795,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int16 [rvastatic4]A::a01028
@@ -4805,7 +4805,7 @@ a01027:
   ldc.i4 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int16 [rvastatic4]A::a01029
@@ -4815,7 +4815,7 @@ a01028:
   ldc.i4 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int8 [rvastatic4]A::a01030
@@ -4825,7 +4825,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int8 [rvastatic4]A::a01031
@@ -4835,7 +4835,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int64 [rvastatic4]A::a01032
@@ -4845,7 +4845,7 @@ a01031:
   ldc.i8 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda float32 [rvastatic4]A::a01033
@@ -4855,7 +4855,7 @@ a01032:
   ldc.r4 33.0
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int16 [rvastatic4]A::a01034
@@ -4865,7 +4865,7 @@ a01033:
   ldc.i4 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int8 [rvastatic4]A::a01035
@@ -4875,7 +4875,7 @@ a01034:
   ldc.i4 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int8 [rvastatic4]A::a01036
@@ -4885,7 +4885,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int32 [rvastatic4]A::a01037
@@ -4895,7 +4895,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int16 [rvastatic4]A::a01038
@@ -4905,7 +4905,7 @@ a01037:
   ldc.i4 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int8 [rvastatic4]A::a01039
@@ -4915,7 +4915,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda int8 [rvastatic4]A::a01040
@@ -4925,7 +4925,7 @@ a01039:
   ldc.i4 40
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int32 [rvastatic4]A::a01041
@@ -4935,7 +4935,7 @@ a01040:
   ldc.i4 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int64 [rvastatic4]A::a01042
@@ -4945,7 +4945,7 @@ a01041:
   ldc.i8 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int16 [rvastatic4]A::a01043
@@ -4955,7 +4955,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int64 [rvastatic4]A::a01044
@@ -4965,7 +4965,7 @@ a01043:
   ldc.i8 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int64 [rvastatic4]A::a01045
@@ -4975,7 +4975,7 @@ a01044:
   ldc.i8 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda float32 [rvastatic4]A::a01046
@@ -4985,7 +4985,7 @@ a01045:
   ldc.r4 46.0
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int16 [rvastatic4]A::a01047
@@ -4995,7 +4995,7 @@ a01046:
   ldc.i4 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda int64 [rvastatic4]A::a01048
@@ -5005,7 +5005,7 @@ a01047:
   ldc.i8 48
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int16 [rvastatic4]A::a01049
@@ -5015,7 +5015,7 @@ a01048:
   ldc.i4 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int32 [rvastatic4]A::a01050
@@ -5025,7 +5025,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int16 [rvastatic4]A::a01051
@@ -5035,7 +5035,7 @@ a01050:
   ldc.i4 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int32 [rvastatic4]A::a01052
@@ -5045,7 +5045,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int16 [rvastatic4]A::a01053
@@ -5055,7 +5055,7 @@ a01052:
   ldc.i4 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda float32 [rvastatic4]A::a01054
@@ -5065,7 +5065,7 @@ a01053:
   ldc.r4 54.0
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int64 [rvastatic4]A::a01055
@@ -5075,7 +5075,7 @@ a01054:
   ldc.i8 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda float32 [rvastatic4]A::a01056
@@ -5085,7 +5085,7 @@ a01055:
   ldc.r4 56.0
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda int64 [rvastatic4]A::a01057
@@ -5095,7 +5095,7 @@ a01056:
   ldc.i8 57
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int64 [rvastatic4]A::a01058
@@ -5105,7 +5105,7 @@ a01057:
   ldc.i8 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int64 [rvastatic4]A::a01059
@@ -5115,7 +5115,7 @@ a01058:
   ldc.i8 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int16 [rvastatic4]A::a01060
@@ -5125,7 +5125,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda int8 [rvastatic4]A::a01061
@@ -5135,7 +5135,7 @@ a01060:
   ldc.i4 61
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int64 [rvastatic4]A::a01062
@@ -5145,7 +5145,7 @@ a01061:
   ldc.i8 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda int16 [rvastatic4]A::a01063
@@ -5155,7 +5155,7 @@ a01062:
   ldc.i4 63
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int32 [rvastatic4]A::a01064
@@ -5165,7 +5165,7 @@ a01063:
   ldc.i4 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int16 [rvastatic4]A::a01065
@@ -5175,7 +5175,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int8 [rvastatic4]A::a01066
@@ -5185,7 +5185,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int16 [rvastatic4]A::a01067
@@ -5195,7 +5195,7 @@ a01066:
   ldc.i4 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int32 [rvastatic4]A::a01068
@@ -5205,7 +5205,7 @@ a01067:
   ldc.i4 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda float32 [rvastatic4]A::a01069
@@ -5215,7 +5215,7 @@ a01068:
   ldc.r4 69.0
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda float32 [rvastatic4]A::a01070
@@ -5225,7 +5225,7 @@ a01069:
   ldc.r4 70.0
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int16 [rvastatic4]A::a01071
@@ -5235,7 +5235,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda float32 [rvastatic4]A::a01072
@@ -5245,7 +5245,7 @@ a01071:
   ldc.r4 72.0
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda int64 [rvastatic4]A::a01073
@@ -5255,7 +5255,7 @@ a01072:
   ldc.i8 73
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda int64 [rvastatic4]A::a01074
@@ -5265,7 +5265,7 @@ a01073:
   ldc.i8 74
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int32 [rvastatic4]A::a01075
@@ -5275,7 +5275,7 @@ a01074:
   ldc.i4 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int8 [rvastatic4]A::a01076
@@ -5285,7 +5285,7 @@ a01075:
   ldc.i4 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int32 [rvastatic4]A::a01077
@@ -5295,7 +5295,7 @@ a01076:
   ldc.i4 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int16 [rvastatic4]A::a01078
@@ -5305,7 +5305,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda float32 [rvastatic4]A::a01079
@@ -5315,7 +5315,7 @@ a01078:
   ldc.r4 79.0
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda float32 [rvastatic4]A::a01080
@@ -5325,7 +5325,7 @@ a01079:
   ldc.r4 80.0
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda float32 [rvastatic4]A::a01081
@@ -5335,7 +5335,7 @@ a01080:
   ldc.r4 81.0
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda int32 [rvastatic4]A::a01082
@@ -5345,7 +5345,7 @@ a01081:
   ldc.i4 82
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int8 [rvastatic4]A::a01083
@@ -5355,7 +5355,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int64 [rvastatic4]A::a01084
@@ -5365,7 +5365,7 @@ a01083:
   ldc.i8 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int64 [rvastatic4]A::a01085
@@ -5375,7 +5375,7 @@ a01084:
   ldc.i8 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int32 [rvastatic4]A::a01086
@@ -5385,7 +5385,7 @@ a01085:
   ldc.i4 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int32 [rvastatic4]A::a01087
@@ -5395,7 +5395,7 @@ a01086:
   ldc.i4 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int8 [rvastatic4]A::a01088
@@ -5405,7 +5405,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int64 [rvastatic4]A::a01089
@@ -5415,7 +5415,7 @@ a01088:
   ldc.i8 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int8 [rvastatic4]A::a01090
@@ -5425,7 +5425,7 @@ a01089:
   ldc.i4 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int16 [rvastatic4]A::a01091
@@ -5435,7 +5435,7 @@ a01090:
   ldc.i4 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda float32 [rvastatic4]A::a01092
@@ -5445,7 +5445,7 @@ a01091:
   ldc.r4 92.0
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int64 [rvastatic4]A::a01093
@@ -5455,7 +5455,7 @@ a01092:
   ldc.i8 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int64 [rvastatic4]A::a01094
@@ -5465,7 +5465,7 @@ a01093:
   ldc.i8 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int8 [rvastatic4]A::a01095
@@ -5475,7 +5475,7 @@ a01094:
   ldc.i4 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda float32 [rvastatic4]A::a01096
@@ -5485,7 +5485,7 @@ a01095:
   ldc.r4 96.0
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int16 [rvastatic4]A::a01097
@@ -5495,7 +5495,7 @@ a01096:
   ldc.i4 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda float32 [rvastatic4]A::a01098
@@ -5505,7 +5505,7 @@ a01097:
   ldc.r4 98.0
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int32 [rvastatic4]A::a01099
@@ -5515,7 +5515,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda int64 [rvastatic4]A::a010100
@@ -5525,7 +5525,7 @@ a01099:
   ldc.i8 100
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int32 [rvastatic4]A::a010101
@@ -5535,7 +5535,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda float32 [rvastatic4]A::a010102
@@ -5545,7 +5545,7 @@ a010101:
   ldc.r4 102.0
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int64 [rvastatic4]A::a010103
@@ -5555,7 +5555,7 @@ a010102:
   ldc.i8 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda int32 [rvastatic4]A::a010104
@@ -5565,7 +5565,7 @@ a010103:
   ldc.i4 104
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int16 [rvastatic4]A::a010105
@@ -5575,7 +5575,7 @@ a010104:
   ldc.i4 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda int16 [rvastatic4]A::a010106
@@ -5585,7 +5585,7 @@ a010105:
   ldc.i4 106
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda float32 [rvastatic4]A::a010107
@@ -5595,7 +5595,7 @@ a010106:
   ldc.r4 107.0
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int32 [rvastatic4]A::a010108
@@ -5605,7 +5605,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda int16 [rvastatic4]A::a010109
@@ -5615,7 +5615,7 @@ a010108:
   ldc.i4 109
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda int32 [rvastatic4]A::a010110
@@ -5625,7 +5625,7 @@ a010109:
   ldc.i4 110
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int32 [rvastatic4]A::a010111
@@ -5635,7 +5635,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int32 [rvastatic4]A::a010112
@@ -5645,7 +5645,7 @@ a010111:
   ldc.i4 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int64 [rvastatic4]A::a010113
@@ -5655,7 +5655,7 @@ a010112:
   ldc.i8 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int64 [rvastatic4]A::a010114
@@ -5665,7 +5665,7 @@ a010113:
   ldc.i8 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int16 [rvastatic4]A::a010115
@@ -5675,7 +5675,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda int64 [rvastatic4]A::a010116
@@ -5685,7 +5685,7 @@ a010115:
   ldc.i8 116
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int64 [rvastatic4]A::a010117
@@ -5695,7 +5695,7 @@ a010116:
   ldc.i8 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int32 [rvastatic4]A::a010118
@@ -5705,7 +5705,7 @@ a010117:
   ldc.i4 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int64 [rvastatic4]A::a010119
@@ -5715,7 +5715,7 @@ a010118:
   ldc.i8 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int64 [rvastatic4]A::a010120
@@ -5725,7 +5725,7 @@ a010119:
   ldc.i8 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int64 [rvastatic4]A::a010121
@@ -5735,7 +5735,7 @@ a010120:
   ldc.i8 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int16 [rvastatic4]A::a010122
@@ -5745,7 +5745,7 @@ a010121:
   ldc.i4 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda int64 [rvastatic4]A::a010123
@@ -5755,7 +5755,7 @@ a010122:
   ldc.i8 123
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int64 [rvastatic4]A::a010124
@@ -5765,7 +5765,7 @@ a010123:
   ldc.i8 124
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int32 [rvastatic4]A::a010125
@@ -5775,7 +5775,7 @@ a010124:
   ldc.i4 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int16 [rvastatic4]A::a010126
@@ -5785,7 +5785,7 @@ a010125:
   ldc.i4 126
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int16 [rvastatic4]A::a010127
@@ -5795,7 +5795,7 @@ a010126:
   ldc.i4 127
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -5807,7 +5807,7 @@ a010127:
   ldsfld int32 [rvastatic4]A::a0100
   ldc.i4 1
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsfld int64 [rvastatic4]A::a0101
@@ -5817,7 +5817,7 @@ a0100:
   ldsfld int64 [rvastatic4]A::a0101
   ldc.i8 2
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld float32 [rvastatic4]A::a0102
@@ -5827,7 +5827,7 @@ a0101:
   ldsfld float32 [rvastatic4]A::a0102
   ldc.r4 3.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int16 [rvastatic4]A::a0103
@@ -5837,7 +5837,7 @@ a0102:
   ldsfld int16 [rvastatic4]A::a0103
   ldc.i4 4
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int16 [rvastatic4]A::a0104
@@ -5847,7 +5847,7 @@ a0103:
   ldsfld int16 [rvastatic4]A::a0104
   ldc.i4 5
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int64 [rvastatic4]A::a0105
@@ -5857,7 +5857,7 @@ a0104:
   ldsfld int64 [rvastatic4]A::a0105
   ldc.i8 6
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld int16 [rvastatic4]A::a0106
@@ -5867,7 +5867,7 @@ a0105:
   ldsfld int16 [rvastatic4]A::a0106
   ldc.i4 7
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld int8 [rvastatic4]A::a0107
@@ -5877,7 +5877,7 @@ a0106:
   ldsfld int8 [rvastatic4]A::a0107
   ldc.i4 8
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld int64 [rvastatic4]A::a0108
@@ -5887,7 +5887,7 @@ a0107:
   ldsfld int64 [rvastatic4]A::a0108
   ldc.i8 9
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int32 [rvastatic4]A::a0109
@@ -5897,7 +5897,7 @@ a0108:
   ldsfld int32 [rvastatic4]A::a0109
   ldc.i4 10
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int16 [rvastatic4]A::a01010
@@ -5907,7 +5907,7 @@ a0109:
   ldsfld int16 [rvastatic4]A::a01010
   ldc.i4 11
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld float32 [rvastatic4]A::a01011
@@ -5917,7 +5917,7 @@ a01010:
   ldsfld float32 [rvastatic4]A::a01011
   ldc.r4 12.0
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int16 [rvastatic4]A::a01012
@@ -5927,7 +5927,7 @@ a01011:
   ldsfld int16 [rvastatic4]A::a01012
   ldc.i4 13
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld float32 [rvastatic4]A::a01013
@@ -5937,7 +5937,7 @@ a01012:
   ldsfld float32 [rvastatic4]A::a01013
   ldc.r4 14.0
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld float32 [rvastatic4]A::a01014
@@ -5947,7 +5947,7 @@ a01013:
   ldsfld float32 [rvastatic4]A::a01014
   ldc.r4 15.0
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int8 [rvastatic4]A::a01015
@@ -5957,7 +5957,7 @@ a01014:
   ldsfld int8 [rvastatic4]A::a01015
   ldc.i4 16
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld float32 [rvastatic4]A::a01016
@@ -5967,7 +5967,7 @@ a01015:
   ldsfld float32 [rvastatic4]A::a01016
   ldc.r4 17.0
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld int8 [rvastatic4]A::a01017
@@ -5977,7 +5977,7 @@ a01016:
   ldsfld int8 [rvastatic4]A::a01017
   ldc.i4 18
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld float32 [rvastatic4]A::a01018
@@ -5987,7 +5987,7 @@ a01017:
   ldsfld float32 [rvastatic4]A::a01018
   ldc.r4 19.0
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld float32 [rvastatic4]A::a01019
@@ -5997,7 +5997,7 @@ a01018:
   ldsfld float32 [rvastatic4]A::a01019
   ldc.r4 20.0
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int8 [rvastatic4]A::a01020
@@ -6007,7 +6007,7 @@ a01019:
   ldsfld int8 [rvastatic4]A::a01020
   ldc.i4 21
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld float32 [rvastatic4]A::a01021
@@ -6017,7 +6017,7 @@ a01020:
   ldsfld float32 [rvastatic4]A::a01021
   ldc.r4 22.0
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld int64 [rvastatic4]A::a01022
@@ -6027,7 +6027,7 @@ a01021:
   ldsfld int64 [rvastatic4]A::a01022
   ldc.i8 23
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int8 [rvastatic4]A::a01023
@@ -6037,7 +6037,7 @@ a01022:
   ldsfld int8 [rvastatic4]A::a01023
   ldc.i4 24
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int32 [rvastatic4]A::a01024
@@ -6047,7 +6047,7 @@ a01023:
   ldsfld int32 [rvastatic4]A::a01024
   ldc.i4 25
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int64 [rvastatic4]A::a01025
@@ -6057,7 +6057,7 @@ a01024:
   ldsfld int64 [rvastatic4]A::a01025
   ldc.i8 26
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int16 [rvastatic4]A::a01026
@@ -6067,7 +6067,7 @@ a01025:
   ldsfld int16 [rvastatic4]A::a01026
   ldc.i4 27
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int8 [rvastatic4]A::a01027
@@ -6077,7 +6077,7 @@ a01026:
   ldsfld int8 [rvastatic4]A::a01027
   ldc.i4 28
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int16 [rvastatic4]A::a01028
@@ -6087,7 +6087,7 @@ a01027:
   ldsfld int16 [rvastatic4]A::a01028
   ldc.i4 29
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int16 [rvastatic4]A::a01029
@@ -6097,7 +6097,7 @@ a01028:
   ldsfld int16 [rvastatic4]A::a01029
   ldc.i4 30
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int8 [rvastatic4]A::a01030
@@ -6107,7 +6107,7 @@ a01029:
   ldsfld int8 [rvastatic4]A::a01030
   ldc.i4 31
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int8 [rvastatic4]A::a01031
@@ -6117,7 +6117,7 @@ a01030:
   ldsfld int8 [rvastatic4]A::a01031
   ldc.i4 32
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int64 [rvastatic4]A::a01032
@@ -6127,7 +6127,7 @@ a01031:
   ldsfld int64 [rvastatic4]A::a01032
   ldc.i8 33
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld float32 [rvastatic4]A::a01033
@@ -6137,7 +6137,7 @@ a01032:
   ldsfld float32 [rvastatic4]A::a01033
   ldc.r4 34.0
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int16 [rvastatic4]A::a01034
@@ -6147,7 +6147,7 @@ a01033:
   ldsfld int16 [rvastatic4]A::a01034
   ldc.i4 35
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int8 [rvastatic4]A::a01035
@@ -6157,7 +6157,7 @@ a01034:
   ldsfld int8 [rvastatic4]A::a01035
   ldc.i4 36
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int8 [rvastatic4]A::a01036
@@ -6167,7 +6167,7 @@ a01035:
   ldsfld int8 [rvastatic4]A::a01036
   ldc.i4 37
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int32 [rvastatic4]A::a01037
@@ -6177,7 +6177,7 @@ a01036:
   ldsfld int32 [rvastatic4]A::a01037
   ldc.i4 38
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int16 [rvastatic4]A::a01038
@@ -6187,7 +6187,7 @@ a01037:
   ldsfld int16 [rvastatic4]A::a01038
   ldc.i4 39
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int8 [rvastatic4]A::a01039
@@ -6197,7 +6197,7 @@ a01038:
   ldsfld int8 [rvastatic4]A::a01039
   ldc.i4 40
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int8 [rvastatic4]A::a01040
@@ -6207,7 +6207,7 @@ a01039:
   ldsfld int8 [rvastatic4]A::a01040
   ldc.i4 41
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int32 [rvastatic4]A::a01041
@@ -6217,7 +6217,7 @@ a01040:
   ldsfld int32 [rvastatic4]A::a01041
   ldc.i4 42
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int64 [rvastatic4]A::a01042
@@ -6227,7 +6227,7 @@ a01041:
   ldsfld int64 [rvastatic4]A::a01042
   ldc.i8 43
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int16 [rvastatic4]A::a01043
@@ -6237,7 +6237,7 @@ a01042:
   ldsfld int16 [rvastatic4]A::a01043
   ldc.i4 44
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int64 [rvastatic4]A::a01044
@@ -6247,7 +6247,7 @@ a01043:
   ldsfld int64 [rvastatic4]A::a01044
   ldc.i8 45
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int64 [rvastatic4]A::a01045
@@ -6257,7 +6257,7 @@ a01044:
   ldsfld int64 [rvastatic4]A::a01045
   ldc.i8 46
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld float32 [rvastatic4]A::a01046
@@ -6267,7 +6267,7 @@ a01045:
   ldsfld float32 [rvastatic4]A::a01046
   ldc.r4 47.0
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int16 [rvastatic4]A::a01047
@@ -6277,7 +6277,7 @@ a01046:
   ldsfld int16 [rvastatic4]A::a01047
   ldc.i4 48
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int64 [rvastatic4]A::a01048
@@ -6287,7 +6287,7 @@ a01047:
   ldsfld int64 [rvastatic4]A::a01048
   ldc.i8 49
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int16 [rvastatic4]A::a01049
@@ -6297,7 +6297,7 @@ a01048:
   ldsfld int16 [rvastatic4]A::a01049
   ldc.i4 50
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int32 [rvastatic4]A::a01050
@@ -6307,7 +6307,7 @@ a01049:
   ldsfld int32 [rvastatic4]A::a01050
   ldc.i4 51
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int16 [rvastatic4]A::a01051
@@ -6317,7 +6317,7 @@ a01050:
   ldsfld int16 [rvastatic4]A::a01051
   ldc.i4 52
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int32 [rvastatic4]A::a01052
@@ -6327,7 +6327,7 @@ a01051:
   ldsfld int32 [rvastatic4]A::a01052
   ldc.i4 53
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int16 [rvastatic4]A::a01053
@@ -6337,7 +6337,7 @@ a01052:
   ldsfld int16 [rvastatic4]A::a01053
   ldc.i4 54
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld float32 [rvastatic4]A::a01054
@@ -6347,7 +6347,7 @@ a01053:
   ldsfld float32 [rvastatic4]A::a01054
   ldc.r4 55.0
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int64 [rvastatic4]A::a01055
@@ -6357,7 +6357,7 @@ a01054:
   ldsfld int64 [rvastatic4]A::a01055
   ldc.i8 56
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld float32 [rvastatic4]A::a01056
@@ -6367,7 +6367,7 @@ a01055:
   ldsfld float32 [rvastatic4]A::a01056
   ldc.r4 57.0
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld int64 [rvastatic4]A::a01057
@@ -6377,7 +6377,7 @@ a01056:
   ldsfld int64 [rvastatic4]A::a01057
   ldc.i8 58
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int64 [rvastatic4]A::a01058
@@ -6387,7 +6387,7 @@ a01057:
   ldsfld int64 [rvastatic4]A::a01058
   ldc.i8 59
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int64 [rvastatic4]A::a01059
@@ -6397,7 +6397,7 @@ a01058:
   ldsfld int64 [rvastatic4]A::a01059
   ldc.i8 60
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int16 [rvastatic4]A::a01060
@@ -6407,7 +6407,7 @@ a01059:
   ldsfld int16 [rvastatic4]A::a01060
   ldc.i4 61
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int8 [rvastatic4]A::a01061
@@ -6417,7 +6417,7 @@ a01060:
   ldsfld int8 [rvastatic4]A::a01061
   ldc.i4 62
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int64 [rvastatic4]A::a01062
@@ -6427,7 +6427,7 @@ a01061:
   ldsfld int64 [rvastatic4]A::a01062
   ldc.i8 63
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int16 [rvastatic4]A::a01063
@@ -6437,7 +6437,7 @@ a01062:
   ldsfld int16 [rvastatic4]A::a01063
   ldc.i4 64
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int32 [rvastatic4]A::a01064
@@ -6447,7 +6447,7 @@ a01063:
   ldsfld int32 [rvastatic4]A::a01064
   ldc.i4 65
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int16 [rvastatic4]A::a01065
@@ -6457,7 +6457,7 @@ a01064:
   ldsfld int16 [rvastatic4]A::a01065
   ldc.i4 66
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int8 [rvastatic4]A::a01066
@@ -6467,7 +6467,7 @@ a01065:
   ldsfld int8 [rvastatic4]A::a01066
   ldc.i4 67
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int16 [rvastatic4]A::a01067
@@ -6477,7 +6477,7 @@ a01066:
   ldsfld int16 [rvastatic4]A::a01067
   ldc.i4 68
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int32 [rvastatic4]A::a01068
@@ -6487,7 +6487,7 @@ a01067:
   ldsfld int32 [rvastatic4]A::a01068
   ldc.i4 69
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld float32 [rvastatic4]A::a01069
@@ -6497,7 +6497,7 @@ a01068:
   ldsfld float32 [rvastatic4]A::a01069
   ldc.r4 70.0
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld float32 [rvastatic4]A::a01070
@@ -6507,7 +6507,7 @@ a01069:
   ldsfld float32 [rvastatic4]A::a01070
   ldc.r4 71.0
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int16 [rvastatic4]A::a01071
@@ -6517,7 +6517,7 @@ a01070:
   ldsfld int16 [rvastatic4]A::a01071
   ldc.i4 72
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld float32 [rvastatic4]A::a01072
@@ -6527,7 +6527,7 @@ a01071:
   ldsfld float32 [rvastatic4]A::a01072
   ldc.r4 73.0
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int64 [rvastatic4]A::a01073
@@ -6537,7 +6537,7 @@ a01072:
   ldsfld int64 [rvastatic4]A::a01073
   ldc.i8 74
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int64 [rvastatic4]A::a01074
@@ -6547,7 +6547,7 @@ a01073:
   ldsfld int64 [rvastatic4]A::a01074
   ldc.i8 75
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int32 [rvastatic4]A::a01075
@@ -6557,7 +6557,7 @@ a01074:
   ldsfld int32 [rvastatic4]A::a01075
   ldc.i4 76
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int8 [rvastatic4]A::a01076
@@ -6567,7 +6567,7 @@ a01075:
   ldsfld int8 [rvastatic4]A::a01076
   ldc.i4 77
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int32 [rvastatic4]A::a01077
@@ -6577,7 +6577,7 @@ a01076:
   ldsfld int32 [rvastatic4]A::a01077
   ldc.i4 78
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int16 [rvastatic4]A::a01078
@@ -6587,7 +6587,7 @@ a01077:
   ldsfld int16 [rvastatic4]A::a01078
   ldc.i4 79
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld float32 [rvastatic4]A::a01079
@@ -6597,7 +6597,7 @@ a01078:
   ldsfld float32 [rvastatic4]A::a01079
   ldc.r4 80.0
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld float32 [rvastatic4]A::a01080
@@ -6607,7 +6607,7 @@ a01079:
   ldsfld float32 [rvastatic4]A::a01080
   ldc.r4 81.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld float32 [rvastatic4]A::a01081
@@ -6617,7 +6617,7 @@ a01080:
   ldsfld float32 [rvastatic4]A::a01081
   ldc.r4 82.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld int32 [rvastatic4]A::a01082
@@ -6627,7 +6627,7 @@ a01081:
   ldsfld int32 [rvastatic4]A::a01082
   ldc.i4 83
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int8 [rvastatic4]A::a01083
@@ -6637,7 +6637,7 @@ a01082:
   ldsfld int8 [rvastatic4]A::a01083
   ldc.i4 84
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int64 [rvastatic4]A::a01084
@@ -6647,7 +6647,7 @@ a01083:
   ldsfld int64 [rvastatic4]A::a01084
   ldc.i8 85
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int64 [rvastatic4]A::a01085
@@ -6657,7 +6657,7 @@ a01084:
   ldsfld int64 [rvastatic4]A::a01085
   ldc.i8 86
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int32 [rvastatic4]A::a01086
@@ -6667,7 +6667,7 @@ a01085:
   ldsfld int32 [rvastatic4]A::a01086
   ldc.i4 87
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int32 [rvastatic4]A::a01087
@@ -6677,7 +6677,7 @@ a01086:
   ldsfld int32 [rvastatic4]A::a01087
   ldc.i4 88
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int8 [rvastatic4]A::a01088
@@ -6687,7 +6687,7 @@ a01087:
   ldsfld int8 [rvastatic4]A::a01088
   ldc.i4 89
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int64 [rvastatic4]A::a01089
@@ -6697,7 +6697,7 @@ a01088:
   ldsfld int64 [rvastatic4]A::a01089
   ldc.i8 90
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int8 [rvastatic4]A::a01090
@@ -6707,7 +6707,7 @@ a01089:
   ldsfld int8 [rvastatic4]A::a01090
   ldc.i4 91
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int16 [rvastatic4]A::a01091
@@ -6717,7 +6717,7 @@ a01090:
   ldsfld int16 [rvastatic4]A::a01091
   ldc.i4 92
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld float32 [rvastatic4]A::a01092
@@ -6727,7 +6727,7 @@ a01091:
   ldsfld float32 [rvastatic4]A::a01092
   ldc.r4 93.0
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int64 [rvastatic4]A::a01093
@@ -6737,7 +6737,7 @@ a01092:
   ldsfld int64 [rvastatic4]A::a01093
   ldc.i8 94
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int64 [rvastatic4]A::a01094
@@ -6747,7 +6747,7 @@ a01093:
   ldsfld int64 [rvastatic4]A::a01094
   ldc.i8 95
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int8 [rvastatic4]A::a01095
@@ -6757,7 +6757,7 @@ a01094:
   ldsfld int8 [rvastatic4]A::a01095
   ldc.i4 96
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld float32 [rvastatic4]A::a01096
@@ -6767,7 +6767,7 @@ a01095:
   ldsfld float32 [rvastatic4]A::a01096
   ldc.r4 97.0
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int16 [rvastatic4]A::a01097
@@ -6777,7 +6777,7 @@ a01096:
   ldsfld int16 [rvastatic4]A::a01097
   ldc.i4 98
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld float32 [rvastatic4]A::a01098
@@ -6787,7 +6787,7 @@ a01097:
   ldsfld float32 [rvastatic4]A::a01098
   ldc.r4 99.0
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int32 [rvastatic4]A::a01099
@@ -6797,7 +6797,7 @@ a01098:
   ldsfld int32 [rvastatic4]A::a01099
   ldc.i4 100
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int64 [rvastatic4]A::a010100
@@ -6807,7 +6807,7 @@ a01099:
   ldsfld int64 [rvastatic4]A::a010100
   ldc.i8 101
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int32 [rvastatic4]A::a010101
@@ -6817,7 +6817,7 @@ a010100:
   ldsfld int32 [rvastatic4]A::a010101
   ldc.i4 102
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld float32 [rvastatic4]A::a010102
@@ -6827,7 +6827,7 @@ a010101:
   ldsfld float32 [rvastatic4]A::a010102
   ldc.r4 103.0
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int64 [rvastatic4]A::a010103
@@ -6837,7 +6837,7 @@ a010102:
   ldsfld int64 [rvastatic4]A::a010103
   ldc.i8 104
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int32 [rvastatic4]A::a010104
@@ -6847,7 +6847,7 @@ a010103:
   ldsfld int32 [rvastatic4]A::a010104
   ldc.i4 105
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int16 [rvastatic4]A::a010105
@@ -6857,7 +6857,7 @@ a010104:
   ldsfld int16 [rvastatic4]A::a010105
   ldc.i4 106
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int16 [rvastatic4]A::a010106
@@ -6867,7 +6867,7 @@ a010105:
   ldsfld int16 [rvastatic4]A::a010106
   ldc.i4 107
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld float32 [rvastatic4]A::a010107
@@ -6877,7 +6877,7 @@ a010106:
   ldsfld float32 [rvastatic4]A::a010107
   ldc.r4 108.0
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int32 [rvastatic4]A::a010108
@@ -6887,7 +6887,7 @@ a010107:
   ldsfld int32 [rvastatic4]A::a010108
   ldc.i4 109
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int16 [rvastatic4]A::a010109
@@ -6897,7 +6897,7 @@ a010108:
   ldsfld int16 [rvastatic4]A::a010109
   ldc.i4 110
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld int32 [rvastatic4]A::a010110
@@ -6907,7 +6907,7 @@ a010109:
   ldsfld int32 [rvastatic4]A::a010110
   ldc.i4 111
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int32 [rvastatic4]A::a010111
@@ -6917,7 +6917,7 @@ a010110:
   ldsfld int32 [rvastatic4]A::a010111
   ldc.i4 112
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int32 [rvastatic4]A::a010112
@@ -6927,7 +6927,7 @@ a010111:
   ldsfld int32 [rvastatic4]A::a010112
   ldc.i4 113
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int64 [rvastatic4]A::a010113
@@ -6937,7 +6937,7 @@ a010112:
   ldsfld int64 [rvastatic4]A::a010113
   ldc.i8 114
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int64 [rvastatic4]A::a010114
@@ -6947,7 +6947,7 @@ a010113:
   ldsfld int64 [rvastatic4]A::a010114
   ldc.i8 115
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int16 [rvastatic4]A::a010115
@@ -6957,7 +6957,7 @@ a010114:
   ldsfld int16 [rvastatic4]A::a010115
   ldc.i4 116
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int64 [rvastatic4]A::a010116
@@ -6967,7 +6967,7 @@ a010115:
   ldsfld int64 [rvastatic4]A::a010116
   ldc.i8 117
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int64 [rvastatic4]A::a010117
@@ -6977,7 +6977,7 @@ a010116:
   ldsfld int64 [rvastatic4]A::a010117
   ldc.i8 118
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int32 [rvastatic4]A::a010118
@@ -6987,7 +6987,7 @@ a010117:
   ldsfld int32 [rvastatic4]A::a010118
   ldc.i4 119
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int64 [rvastatic4]A::a010119
@@ -6997,7 +6997,7 @@ a010118:
   ldsfld int64 [rvastatic4]A::a010119
   ldc.i8 120
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int64 [rvastatic4]A::a010120
@@ -7007,7 +7007,7 @@ a010119:
   ldsfld int64 [rvastatic4]A::a010120
   ldc.i8 121
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int64 [rvastatic4]A::a010121
@@ -7017,7 +7017,7 @@ a010120:
   ldsfld int64 [rvastatic4]A::a010121
   ldc.i8 122
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int16 [rvastatic4]A::a010122
@@ -7027,7 +7027,7 @@ a010121:
   ldsfld int16 [rvastatic4]A::a010122
   ldc.i4 123
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int64 [rvastatic4]A::a010123
@@ -7037,7 +7037,7 @@ a010122:
   ldsfld int64 [rvastatic4]A::a010123
   ldc.i8 124
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int64 [rvastatic4]A::a010124
@@ -7047,7 +7047,7 @@ a010123:
   ldsfld int64 [rvastatic4]A::a010124
   ldc.i8 125
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int32 [rvastatic4]A::a010125
@@ -7057,7 +7057,7 @@ a010124:
   ldsfld int32 [rvastatic4]A::a010125
   ldc.i4 126
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int16 [rvastatic4]A::a010126
@@ -7067,7 +7067,7 @@ a010125:
   ldsfld int16 [rvastatic4]A::a010126
   ldc.i4 127
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int16 [rvastatic4]A::a010127
@@ -7077,7 +7077,7 @@ a010126:
   ldsfld int16 [rvastatic4]A::a010127
   ldc.i4 128
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ret}

--- a/tests/src/JIT/Directed/rvastatics/rvastatic5.il
+++ b/tests/src/JIT/Directed/rvastatics/rvastatic5.il
@@ -34,769 +34,769 @@
   ldsfld int32 [rvastatic5]A::a0100
   ldc.i4 0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld float32 [rvastatic5]A::a0101
   ldc.r4 1.0
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int16 [rvastatic5]A::a0102
   ldc.i4 2
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int8 [rvastatic5]A::a0103
   ldc.i4 3
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld int32 [rvastatic5]A::a0104
   ldc.i4 4
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld float32 [rvastatic5]A::a0105
   ldc.r4 5.0
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld float32 [rvastatic5]A::a0106
   ldc.r4 6.0
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld int16 [rvastatic5]A::a0107
   ldc.i4 7
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int64 [rvastatic5]A::a0108
   ldc.i8 8
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int64 [rvastatic5]A::a0109
   ldc.i8 9
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int32 [rvastatic5]A::a01010
   ldc.i4 10
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int32 [rvastatic5]A::a01011
   ldc.i4 11
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int8 [rvastatic5]A::a01012
   ldc.i4 12
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld int64 [rvastatic5]A::a01013
   ldc.i8 13
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int16 [rvastatic5]A::a01014
   ldc.i4 14
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int64 [rvastatic5]A::a01015
   ldc.i8 15
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld int8 [rvastatic5]A::a01016
   ldc.i4 16
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int8 [rvastatic5]A::a01017
   ldc.i4 17
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int32 [rvastatic5]A::a01018
   ldc.i4 18
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld int16 [rvastatic5]A::a01019
   ldc.i4 19
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld float32 [rvastatic5]A::a01020
   ldc.r4 20.0
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld float32 [rvastatic5]A::a01021
   ldc.r4 21.0
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld float32 [rvastatic5]A::a01022
   ldc.r4 22.0
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld int16 [rvastatic5]A::a01023
   ldc.i4 23
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld float32 [rvastatic5]A::a01024
   ldc.r4 24.0
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int16 [rvastatic5]A::a01025
   ldc.i4 25
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int64 [rvastatic5]A::a01026
   ldc.i8 26
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int8 [rvastatic5]A::a01027
   ldc.i4 27
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int64 [rvastatic5]A::a01028
   ldc.i8 28
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int64 [rvastatic5]A::a01029
   ldc.i8 29
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int32 [rvastatic5]A::a01030
   ldc.i4 30
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int16 [rvastatic5]A::a01031
   ldc.i4 31
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld int16 [rvastatic5]A::a01032
   ldc.i4 32
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld float32 [rvastatic5]A::a01033
   ldc.r4 33.0
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int16 [rvastatic5]A::a01034
   ldc.i4 34
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int64 [rvastatic5]A::a01035
   ldc.i8 35
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int32 [rvastatic5]A::a01036
   ldc.i4 36
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int32 [rvastatic5]A::a01037
   ldc.i4 37
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int64 [rvastatic5]A::a01038
   ldc.i8 38
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld int32 [rvastatic5]A::a01039
   ldc.i4 39
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld float32 [rvastatic5]A::a01040
   ldc.r4 40.0
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int32 [rvastatic5]A::a01041
   ldc.i4 41
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int16 [rvastatic5]A::a01042
   ldc.i4 42
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int32 [rvastatic5]A::a01043
   ldc.i4 43
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int16 [rvastatic5]A::a01044
   ldc.i4 44
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int8 [rvastatic5]A::a01045
   ldc.i4 45
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int16 [rvastatic5]A::a01046
   ldc.i4 46
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int64 [rvastatic5]A::a01047
   ldc.i8 47
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int8 [rvastatic5]A::a01048
   ldc.i4 48
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int16 [rvastatic5]A::a01049
   ldc.i4 49
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int16 [rvastatic5]A::a01050
   ldc.i4 50
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int16 [rvastatic5]A::a01051
   ldc.i4 51
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int32 [rvastatic5]A::a01052
   ldc.i4 52
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int64 [rvastatic5]A::a01053
   ldc.i8 53
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int16 [rvastatic5]A::a01054
   ldc.i4 54
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld int32 [rvastatic5]A::a01055
   ldc.i4 55
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld float32 [rvastatic5]A::a01056
   ldc.r4 56.0
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld float32 [rvastatic5]A::a01057
   ldc.r4 57.0
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int16 [rvastatic5]A::a01058
   ldc.i4 58
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int16 [rvastatic5]A::a01059
   ldc.i4 59
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld int16 [rvastatic5]A::a01060
   ldc.i4 60
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld float32 [rvastatic5]A::a01061
   ldc.r4 61.0
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld int32 [rvastatic5]A::a01062
   ldc.i4 62
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld float32 [rvastatic5]A::a01063
   ldc.r4 63.0
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int16 [rvastatic5]A::a01064
   ldc.i4 64
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int16 [rvastatic5]A::a01065
   ldc.i4 65
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int8 [rvastatic5]A::a01066
   ldc.i4 66
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int16 [rvastatic5]A::a01067
   ldc.i4 67
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int32 [rvastatic5]A::a01068
   ldc.i4 68
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int32 [rvastatic5]A::a01069
   ldc.i4 69
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int16 [rvastatic5]A::a01070
   ldc.i4 70
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int32 [rvastatic5]A::a01071
   ldc.i4 71
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld int32 [rvastatic5]A::a01072
   ldc.i4 72
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld float32 [rvastatic5]A::a01073
   ldc.r4 73.0
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int16 [rvastatic5]A::a01074
   ldc.i4 74
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int32 [rvastatic5]A::a01075
   ldc.i4 75
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int64 [rvastatic5]A::a01076
   ldc.i8 76
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int32 [rvastatic5]A::a01077
   ldc.i4 77
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld int8 [rvastatic5]A::a01078
   ldc.i4 78
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld float32 [rvastatic5]A::a01079
   ldc.r4 79.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld float32 [rvastatic5]A::a01080
   ldc.r4 80.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld float32 [rvastatic5]A::a01081
   ldc.r4 81.0
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld float32 [rvastatic5]A::a01082
   ldc.r4 82.0
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int32 [rvastatic5]A::a01083
   ldc.i4 83
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int32 [rvastatic5]A::a01084
   ldc.i4 84
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int8 [rvastatic5]A::a01085
   ldc.i4 85
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int64 [rvastatic5]A::a01086
   ldc.i8 86
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int64 [rvastatic5]A::a01087
   ldc.i8 87
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int32 [rvastatic5]A::a01088
   ldc.i4 88
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int64 [rvastatic5]A::a01089
   ldc.i8 89
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int64 [rvastatic5]A::a01090
   ldc.i8 90
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int64 [rvastatic5]A::a01091
   ldc.i8 91
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int16 [rvastatic5]A::a01092
   ldc.i4 92
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int16 [rvastatic5]A::a01093
   ldc.i4 93
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int8 [rvastatic5]A::a01094
   ldc.i4 94
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld int8 [rvastatic5]A::a01095
   ldc.i4 95
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld float32 [rvastatic5]A::a01096
   ldc.r4 96.0
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int16 [rvastatic5]A::a01097
   ldc.i4 97
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int16 [rvastatic5]A::a01098
   ldc.i4 98
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld int8 [rvastatic5]A::a01099
   ldc.i4 99
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld float32 [rvastatic5]A::a010100
   ldc.r4 100.0
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int8 [rvastatic5]A::a010101
   ldc.i4 101
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int16 [rvastatic5]A::a010102
   ldc.i4 102
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld int32 [rvastatic5]A::a010103
   ldc.i4 103
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld float32 [rvastatic5]A::a010104
   ldc.r4 104.0
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld int64 [rvastatic5]A::a010105
   ldc.i8 105
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld float32 [rvastatic5]A::a010106
   ldc.r4 106.0
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int64 [rvastatic5]A::a010107
   ldc.i8 107
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld int16 [rvastatic5]A::a010108
   ldc.i4 108
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld float32 [rvastatic5]A::a010109
   ldc.r4 109.0
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld float32 [rvastatic5]A::a010110
   ldc.r4 110.0
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int32 [rvastatic5]A::a010111
   ldc.i4 111
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int64 [rvastatic5]A::a010112
   ldc.i8 112
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int32 [rvastatic5]A::a010113
   ldc.i4 113
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int16 [rvastatic5]A::a010114
   ldc.i4 114
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld int32 [rvastatic5]A::a010115
   ldc.i4 115
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld float32 [rvastatic5]A::a010116
   ldc.r4 116.0
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int8 [rvastatic5]A::a010117
   ldc.i4 117
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int32 [rvastatic5]A::a010118
   ldc.i4 118
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int8 [rvastatic5]A::a010119
   ldc.i4 119
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int32 [rvastatic5]A::a010120
   ldc.i4 120
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int32 [rvastatic5]A::a010121
   ldc.i4 121
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld int64 [rvastatic5]A::a010122
   ldc.i8 122
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld float32 [rvastatic5]A::a010123
   ldc.r4 123.0
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int64 [rvastatic5]A::a010124
   ldc.i8 124
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int64 [rvastatic5]A::a010125
   ldc.i8 125
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int16 [rvastatic5]A::a010126
   ldc.i4 126
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ldsfld int8 [rvastatic5]A::a010127
   ldc.i4 7
   beq a010128
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010128:
  ret}
@@ -805,896 +805,896 @@ a010128:
   ldind.i4
   ldc.i4 0
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsflda float32 [rvastatic5]A::a0101
   ldind.r4
   ldc.r4 1.0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsflda int16 [rvastatic5]A::a0102
   ldind.i2
   ldc.i4 2
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsflda int8 [rvastatic5]A::a0103
   ldind.i1
   ldc.i4 3
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsflda int32 [rvastatic5]A::a0104
   ldind.i4
   ldc.i4 4
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsflda float32 [rvastatic5]A::a0105
   ldind.r4
   ldc.r4 5.0
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsflda float32 [rvastatic5]A::a0106
   ldind.r4
   ldc.r4 6.0
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsflda int16 [rvastatic5]A::a0107
   ldind.i2
   ldc.i4 7
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsflda int64 [rvastatic5]A::a0108
   ldind.i8
   ldc.i8 8
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsflda int64 [rvastatic5]A::a0109
   ldind.i8
   ldc.i8 9
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsflda int32 [rvastatic5]A::a01010
   ldind.i4
   ldc.i4 10
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsflda int32 [rvastatic5]A::a01011
   ldind.i4
   ldc.i4 11
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsflda int8 [rvastatic5]A::a01012
   ldind.i1
   ldc.i4 12
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsflda int64 [rvastatic5]A::a01013
   ldind.i8
   ldc.i8 13
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsflda int16 [rvastatic5]A::a01014
   ldind.i2
   ldc.i4 14
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsflda int64 [rvastatic5]A::a01015
   ldind.i8
   ldc.i8 15
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsflda int8 [rvastatic5]A::a01016
   ldind.i1
   ldc.i4 16
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsflda int8 [rvastatic5]A::a01017
   ldind.i1
   ldc.i4 17
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsflda int32 [rvastatic5]A::a01018
   ldind.i4
   ldc.i4 18
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsflda int16 [rvastatic5]A::a01019
   ldind.i2
   ldc.i4 19
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsflda float32 [rvastatic5]A::a01020
   ldind.r4
   ldc.r4 20.0
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsflda float32 [rvastatic5]A::a01021
   ldind.r4
   ldc.r4 21.0
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsflda float32 [rvastatic5]A::a01022
   ldind.r4
   ldc.r4 22.0
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsflda int16 [rvastatic5]A::a01023
   ldind.i2
   ldc.i4 23
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsflda float32 [rvastatic5]A::a01024
   ldind.r4
   ldc.r4 24.0
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsflda int16 [rvastatic5]A::a01025
   ldind.i2
   ldc.i4 25
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsflda int64 [rvastatic5]A::a01026
   ldind.i8
   ldc.i8 26
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsflda int8 [rvastatic5]A::a01027
   ldind.i1
   ldc.i4 27
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsflda int64 [rvastatic5]A::a01028
   ldind.i8
   ldc.i8 28
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsflda int64 [rvastatic5]A::a01029
   ldind.i8
   ldc.i8 29
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsflda int32 [rvastatic5]A::a01030
   ldind.i4
   ldc.i4 30
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsflda int16 [rvastatic5]A::a01031
   ldind.i2
   ldc.i4 31
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsflda int16 [rvastatic5]A::a01032
   ldind.i2
   ldc.i4 32
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsflda float32 [rvastatic5]A::a01033
   ldind.r4
   ldc.r4 33.0
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsflda int16 [rvastatic5]A::a01034
   ldind.i2
   ldc.i4 34
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsflda int64 [rvastatic5]A::a01035
   ldind.i8
   ldc.i8 35
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsflda int32 [rvastatic5]A::a01036
   ldind.i4
   ldc.i4 36
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsflda int32 [rvastatic5]A::a01037
   ldind.i4
   ldc.i4 37
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsflda int64 [rvastatic5]A::a01038
   ldind.i8
   ldc.i8 38
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsflda int32 [rvastatic5]A::a01039
   ldind.i4
   ldc.i4 39
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsflda float32 [rvastatic5]A::a01040
   ldind.r4
   ldc.r4 40.0
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsflda int32 [rvastatic5]A::a01041
   ldind.i4
   ldc.i4 41
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsflda int16 [rvastatic5]A::a01042
   ldind.i2
   ldc.i4 42
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsflda int32 [rvastatic5]A::a01043
   ldind.i4
   ldc.i4 43
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsflda int16 [rvastatic5]A::a01044
   ldind.i2
   ldc.i4 44
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsflda int8 [rvastatic5]A::a01045
   ldind.i1
   ldc.i4 45
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsflda int16 [rvastatic5]A::a01046
   ldind.i2
   ldc.i4 46
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsflda int64 [rvastatic5]A::a01047
   ldind.i8
   ldc.i8 47
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsflda int8 [rvastatic5]A::a01048
   ldind.i1
   ldc.i4 48
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsflda int16 [rvastatic5]A::a01049
   ldind.i2
   ldc.i4 49
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsflda int16 [rvastatic5]A::a01050
   ldind.i2
   ldc.i4 50
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsflda int16 [rvastatic5]A::a01051
   ldind.i2
   ldc.i4 51
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsflda int32 [rvastatic5]A::a01052
   ldind.i4
   ldc.i4 52
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsflda int64 [rvastatic5]A::a01053
   ldind.i8
   ldc.i8 53
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsflda int16 [rvastatic5]A::a01054
   ldind.i2
   ldc.i4 54
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsflda int32 [rvastatic5]A::a01055
   ldind.i4
   ldc.i4 55
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsflda float32 [rvastatic5]A::a01056
   ldind.r4
   ldc.r4 56.0
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsflda float32 [rvastatic5]A::a01057
   ldind.r4
   ldc.r4 57.0
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsflda int16 [rvastatic5]A::a01058
   ldind.i2
   ldc.i4 58
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsflda int16 [rvastatic5]A::a01059
   ldind.i2
   ldc.i4 59
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsflda int16 [rvastatic5]A::a01060
   ldind.i2
   ldc.i4 60
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsflda float32 [rvastatic5]A::a01061
   ldind.r4
   ldc.r4 61.0
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsflda int32 [rvastatic5]A::a01062
   ldind.i4
   ldc.i4 62
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsflda float32 [rvastatic5]A::a01063
   ldind.r4
   ldc.r4 63.0
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsflda int16 [rvastatic5]A::a01064
   ldind.i2
   ldc.i4 64
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsflda int16 [rvastatic5]A::a01065
   ldind.i2
   ldc.i4 65
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsflda int8 [rvastatic5]A::a01066
   ldind.i1
   ldc.i4 66
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsflda int16 [rvastatic5]A::a01067
   ldind.i2
   ldc.i4 67
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsflda int32 [rvastatic5]A::a01068
   ldind.i4
   ldc.i4 68
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsflda int32 [rvastatic5]A::a01069
   ldind.i4
   ldc.i4 69
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsflda int16 [rvastatic5]A::a01070
   ldind.i2
   ldc.i4 70
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsflda int32 [rvastatic5]A::a01071
   ldind.i4
   ldc.i4 71
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsflda int32 [rvastatic5]A::a01072
   ldind.i4
   ldc.i4 72
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsflda float32 [rvastatic5]A::a01073
   ldind.r4
   ldc.r4 73.0
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsflda int16 [rvastatic5]A::a01074
   ldind.i2
   ldc.i4 74
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsflda int32 [rvastatic5]A::a01075
   ldind.i4
   ldc.i4 75
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsflda int64 [rvastatic5]A::a01076
   ldind.i8
   ldc.i8 76
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsflda int32 [rvastatic5]A::a01077
   ldind.i4
   ldc.i4 77
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsflda int8 [rvastatic5]A::a01078
   ldind.i1
   ldc.i4 78
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsflda float32 [rvastatic5]A::a01079
   ldind.r4
   ldc.r4 79.0
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsflda float32 [rvastatic5]A::a01080
   ldind.r4
   ldc.r4 80.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsflda float32 [rvastatic5]A::a01081
   ldind.r4
   ldc.r4 81.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsflda float32 [rvastatic5]A::a01082
   ldind.r4
   ldc.r4 82.0
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsflda int32 [rvastatic5]A::a01083
   ldind.i4
   ldc.i4 83
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsflda int32 [rvastatic5]A::a01084
   ldind.i4
   ldc.i4 84
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsflda int8 [rvastatic5]A::a01085
   ldind.i1
   ldc.i4 85
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsflda int64 [rvastatic5]A::a01086
   ldind.i8
   ldc.i8 86
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsflda int64 [rvastatic5]A::a01087
   ldind.i8
   ldc.i8 87
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsflda int32 [rvastatic5]A::a01088
   ldind.i4
   ldc.i4 88
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsflda int64 [rvastatic5]A::a01089
   ldind.i8
   ldc.i8 89
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsflda int64 [rvastatic5]A::a01090
   ldind.i8
   ldc.i8 90
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsflda int64 [rvastatic5]A::a01091
   ldind.i8
   ldc.i8 91
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsflda int16 [rvastatic5]A::a01092
   ldind.i2
   ldc.i4 92
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsflda int16 [rvastatic5]A::a01093
   ldind.i2
   ldc.i4 93
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsflda int8 [rvastatic5]A::a01094
   ldind.i1
   ldc.i4 94
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsflda int8 [rvastatic5]A::a01095
   ldind.i1
   ldc.i4 95
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsflda float32 [rvastatic5]A::a01096
   ldind.r4
   ldc.r4 96.0
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsflda int16 [rvastatic5]A::a01097
   ldind.i2
   ldc.i4 97
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsflda int16 [rvastatic5]A::a01098
   ldind.i2
   ldc.i4 98
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsflda int8 [rvastatic5]A::a01099
   ldind.i1
   ldc.i4 99
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsflda float32 [rvastatic5]A::a010100
   ldind.r4
   ldc.r4 100.0
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsflda int8 [rvastatic5]A::a010101
   ldind.i1
   ldc.i4 101
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsflda int16 [rvastatic5]A::a010102
   ldind.i2
   ldc.i4 102
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsflda int32 [rvastatic5]A::a010103
   ldind.i4
   ldc.i4 103
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsflda float32 [rvastatic5]A::a010104
   ldind.r4
   ldc.r4 104.0
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsflda int64 [rvastatic5]A::a010105
   ldind.i8
   ldc.i8 105
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsflda float32 [rvastatic5]A::a010106
   ldind.r4
   ldc.r4 106.0
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsflda int64 [rvastatic5]A::a010107
   ldind.i8
   ldc.i8 107
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsflda int16 [rvastatic5]A::a010108
   ldind.i2
   ldc.i4 108
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsflda float32 [rvastatic5]A::a010109
   ldind.r4
   ldc.r4 109.0
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsflda float32 [rvastatic5]A::a010110
   ldind.r4
   ldc.r4 110.0
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsflda int32 [rvastatic5]A::a010111
   ldind.i4
   ldc.i4 111
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsflda int64 [rvastatic5]A::a010112
   ldind.i8
   ldc.i8 112
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsflda int32 [rvastatic5]A::a010113
   ldind.i4
   ldc.i4 113
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsflda int16 [rvastatic5]A::a010114
   ldind.i2
   ldc.i4 114
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsflda int32 [rvastatic5]A::a010115
   ldind.i4
   ldc.i4 115
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsflda float32 [rvastatic5]A::a010116
   ldind.r4
   ldc.r4 116.0
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsflda int8 [rvastatic5]A::a010117
   ldind.i1
   ldc.i4 117
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsflda int32 [rvastatic5]A::a010118
   ldind.i4
   ldc.i4 118
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsflda int8 [rvastatic5]A::a010119
   ldind.i1
   ldc.i4 119
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsflda int32 [rvastatic5]A::a010120
   ldind.i4
   ldc.i4 120
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsflda int32 [rvastatic5]A::a010121
   ldind.i4
   ldc.i4 121
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsflda int64 [rvastatic5]A::a010122
   ldind.i8
   ldc.i8 122
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsflda float32 [rvastatic5]A::a010123
   ldind.r4
   ldc.r4 123.0
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsflda int64 [rvastatic5]A::a010124
   ldind.i8
   ldc.i8 124
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsflda int64 [rvastatic5]A::a010125
   ldind.i8
   ldc.i8 125
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsflda int16 [rvastatic5]A::a010126
   ldind.i2
   ldc.i4 126
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsflda int8 [rvastatic5]A::a010127
   ldind.i1
   ldc.i4 7
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
  ret}
@@ -1702,769 +1702,769 @@ a010127:
   ldsfld int16 [rvastatic5]A::a01031
   ldc.i4 31
   beq a010129
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010129:
   ldsfld int64 [rvastatic5]A::a01013
   ldc.i8 13
   beq a010130
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010130:
   ldsfld int32 [rvastatic5]A::a010115
   ldc.i4 115
   beq a010131
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010131:
   ldsfld float32 [rvastatic5]A::a010100
   ldc.r4 100.0
   beq a010132
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010132:
   ldsfld int64 [rvastatic5]A::a01090
   ldc.i8 90
   beq a010133
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010133:
   ldsfld int32 [rvastatic5]A::a01055
   ldc.i4 55
   beq a010134
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010134:
   ldsfld int16 [rvastatic5]A::a01065
   ldc.i4 65
   beq a010135
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010135:
   ldsfld int8 [rvastatic5]A::a01099
   ldc.i4 99
   beq a010136
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010136:
   ldsfld int64 [rvastatic5]A::a01028
   ldc.i8 28
   beq a010137
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010137:
   ldsfld int64 [rvastatic5]A::a0109
   ldc.i8 9
   beq a010138
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010138:
   ldsfld int32 [rvastatic5]A::a01041
   ldc.i4 41
   beq a010139
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010139:
   ldsfld int8 [rvastatic5]A::a01085
   ldc.i4 85
   beq a010140
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010140:
   ldsfld int64 [rvastatic5]A::a01090
   ldc.i8 90
   beq a010141
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010141:
   ldsfld int64 [rvastatic5]A::a01035
   ldc.i8 35
   beq a010142
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010142:
   ldsfld float32 [rvastatic5]A::a010104
   ldc.r4 104.0
   beq a010143
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010143:
   ldsfld int64 [rvastatic5]A::a010112
   ldc.i8 112
   beq a010144
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010144:
   ldsfld float32 [rvastatic5]A::a0101
   ldc.r4 1.0
   beq a010145
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010145:
   ldsfld int64 [rvastatic5]A::a01087
   ldc.i8 87
   beq a010146
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010146:
   ldsfld int32 [rvastatic5]A::a01041
   ldc.i4 41
   beq a010147
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010147:
   ldsfld float32 [rvastatic5]A::a010116
   ldc.r4 116.0
   beq a010148
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010148:
   ldsfld int8 [rvastatic5]A::a010119
   ldc.i4 119
   beq a010149
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010149:
   ldsfld int64 [rvastatic5]A::a01015
   ldc.i8 15
   beq a010150
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010150:
   ldsfld int16 [rvastatic5]A::a01059
   ldc.i4 59
   beq a010151
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010151:
   ldsfld int16 [rvastatic5]A::a01064
   ldc.i4 64
   beq a010152
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010152:
   ldsfld int32 [rvastatic5]A::a01055
   ldc.i4 55
   beq a010153
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010153:
   ldsfld int16 [rvastatic5]A::a01051
   ldc.i4 51
   beq a010154
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010154:
   ldsfld float32 [rvastatic5]A::a010104
   ldc.r4 104.0
   beq a010155
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010155:
   ldsfld int16 [rvastatic5]A::a01042
   ldc.i4 42
   beq a010156
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010156:
   ldsfld float32 [rvastatic5]A::a01061
   ldc.r4 61.0
   beq a010157
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010157:
   ldsfld float32 [rvastatic5]A::a010104
   ldc.r4 104.0
   beq a010158
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010158:
   ldsfld float32 [rvastatic5]A::a01096
   ldc.r4 96.0
   beq a010159
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010159:
   ldsfld int8 [rvastatic5]A::a01017
   ldc.i4 17
   beq a010160
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010160:
   ldsfld int32 [rvastatic5]A::a01052
   ldc.i4 52
   beq a010161
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010161:
   ldsfld int32 [rvastatic5]A::a01083
   ldc.i4 83
   beq a010162
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010162:
   ldsfld int32 [rvastatic5]A::a01030
   ldc.i4 30
   beq a010163
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010163:
   ldsfld int64 [rvastatic5]A::a01087
   ldc.i8 87
   beq a010164
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010164:
   ldsfld int16 [rvastatic5]A::a01065
   ldc.i4 65
   beq a010165
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010165:
   ldsfld int64 [rvastatic5]A::a01076
   ldc.i8 76
   beq a010166
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010166:
   ldsfld int64 [rvastatic5]A::a01090
   ldc.i8 90
   beq a010167
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010167:
   ldsfld int16 [rvastatic5]A::a01049
   ldc.i4 49
   beq a010168
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010168:
   ldsfld int16 [rvastatic5]A::a01070
   ldc.i4 70
   beq a010169
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010169:
   ldsfld int32 [rvastatic5]A::a01083
   ldc.i4 83
   beq a010170
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010170:
   ldsfld float32 [rvastatic5]A::a010110
   ldc.r4 110.0
   beq a010171
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010171:
   ldsfld int16 [rvastatic5]A::a01059
   ldc.i4 59
   beq a010172
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010172:
   ldsfld int32 [rvastatic5]A::a01011
   ldc.i4 11
   beq a010173
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010173:
   ldsfld int16 [rvastatic5]A::a0102
   ldc.i4 2
   beq a010174
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010174:
   ldsfld int64 [rvastatic5]A::a01013
   ldc.i8 13
   beq a010175
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010175:
   ldsfld int16 [rvastatic5]A::a01058
   ldc.i4 58
   beq a010176
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010176:
   ldsfld int64 [rvastatic5]A::a010107
   ldc.i8 107
   beq a010177
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010177:
   ldsfld int16 [rvastatic5]A::a01044
   ldc.i4 44
   beq a010178
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010178:
   ldsfld int32 [rvastatic5]A::a01010
   ldc.i4 10
   beq a010179
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010179:
   ldsfld float32 [rvastatic5]A::a01024
   ldc.r4 24.0
   beq a010180
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010180:
   ldsfld int32 [rvastatic5]A::a010113
   ldc.i4 113
   beq a010181
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010181:
   ldsfld int16 [rvastatic5]A::a01070
   ldc.i4 70
   beq a010182
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010182:
   ldsfld int16 [rvastatic5]A::a01044
   ldc.i4 44
   beq a010183
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010183:
   ldsfld int64 [rvastatic5]A::a01015
   ldc.i8 15
   beq a010184
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010184:
   ldsfld float32 [rvastatic5]A::a01082
   ldc.r4 82.0
   beq a010185
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010185:
   ldsfld int16 [rvastatic5]A::a01050
   ldc.i4 50
   beq a010186
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010186:
   ldsfld int8 [rvastatic5]A::a01045
   ldc.i4 45
   beq a010187
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010187:
   ldsfld int32 [rvastatic5]A::a01039
   ldc.i4 39
   beq a010188
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010188:
   ldsfld int8 [rvastatic5]A::a01078
   ldc.i4 78
   beq a010189
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010189:
   ldsfld float32 [rvastatic5]A::a01022
   ldc.r4 22.0
   beq a010190
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010190:
   ldsfld int64 [rvastatic5]A::a01038
   ldc.i8 38
   beq a010191
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010191:
   ldsfld int32 [rvastatic5]A::a01052
   ldc.i4 52
   beq a010192
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010192:
   ldsfld int32 [rvastatic5]A::a01041
   ldc.i4 41
   beq a010193
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010193:
   ldsfld float32 [rvastatic5]A::a01024
   ldc.r4 24.0
   beq a010194
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010194:
   ldsfld float32 [rvastatic5]A::a01033
   ldc.r4 33.0
   beq a010195
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010195:
   ldsfld float32 [rvastatic5]A::a0106
   ldc.r4 6.0
   beq a010196
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010196:
   ldsfld int32 [rvastatic5]A::a0104
   ldc.i4 4
   beq a010197
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010197:
   ldsfld int8 [rvastatic5]A::a01017
   ldc.i4 17
   beq a010198
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010198:
   ldsfld int64 [rvastatic5]A::a01047
   ldc.i8 47
   beq a010199
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010199:
   ldsfld int64 [rvastatic5]A::a01053
   ldc.i8 53
   beq a010200
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010200:
   ldsfld int64 [rvastatic5]A::a010124
   ldc.i8 124
   beq a010201
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010201:
   ldsfld int8 [rvastatic5]A::a010119
   ldc.i4 119
   beq a010202
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010202:
   ldsfld int8 [rvastatic5]A::a01045
   ldc.i4 45
   beq a010203
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010203:
   ldsfld int64 [rvastatic5]A::a01035
   ldc.i8 35
   beq a010204
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010204:
   ldsfld int16 [rvastatic5]A::a01032
   ldc.i4 32
   beq a010205
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010205:
   ldsfld int32 [rvastatic5]A::a0100
   ldc.i4 0
   beq a010206
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010206:
   ldsfld int64 [rvastatic5]A::a01053
   ldc.i8 53
   beq a010207
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010207:
   ldsfld int32 [rvastatic5]A::a01052
   ldc.i4 52
   beq a010208
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010208:
   ldsfld int64 [rvastatic5]A::a01038
   ldc.i8 38
   beq a010209
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010209:
   ldsfld int16 [rvastatic5]A::a01046
   ldc.i4 46
   beq a010210
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010210:
   ldsfld float32 [rvastatic5]A::a01063
   ldc.r4 63.0
   beq a010211
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010211:
   ldsfld int8 [rvastatic5]A::a01016
   ldc.i4 16
   beq a010212
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010212:
   ldsfld int8 [rvastatic5]A::a01094
   ldc.i4 94
   beq a010213
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010213:
   ldsfld int32 [rvastatic5]A::a01072
   ldc.i4 72
   beq a010214
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010214:
   ldsfld int16 [rvastatic5]A::a01032
   ldc.i4 32
   beq a010215
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010215:
   ldsfld float32 [rvastatic5]A::a010109
   ldc.r4 109.0
   beq a010216
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010216:
   ldsfld int32 [rvastatic5]A::a01039
   ldc.i4 39
   beq a010217
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010217:
   ldsfld int64 [rvastatic5]A::a01015
   ldc.i8 15
   beq a010218
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010218:
   ldsfld float32 [rvastatic5]A::a0105
   ldc.r4 5.0
   beq a010219
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010219:
   ldsfld int64 [rvastatic5]A::a01015
   ldc.i8 15
   beq a010220
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010220:
   ldsfld int16 [rvastatic5]A::a01031
   ldc.i4 31
   beq a010221
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010221:
   ldsfld int16 [rvastatic5]A::a01051
   ldc.i4 51
   beq a010222
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010222:
   ldsfld int8 [rvastatic5]A::a01099
   ldc.i4 99
   beq a010223
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010223:
   ldsfld int64 [rvastatic5]A::a01047
   ldc.i8 47
   beq a010224
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010224:
   ldsfld int8 [rvastatic5]A::a01045
   ldc.i4 45
   beq a010225
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010225:
   ldsfld int16 [rvastatic5]A::a01058
   ldc.i4 58
   beq a010226
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010226:
   ldsfld int8 [rvastatic5]A::a01017
   ldc.i4 17
   beq a010227
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010227:
   ldsfld int32 [rvastatic5]A::a010115
   ldc.i4 115
   beq a010228
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010228:
   ldsfld int16 [rvastatic5]A::a01097
   ldc.i4 97
   beq a010229
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010229:
   ldsfld float32 [rvastatic5]A::a0106
   ldc.r4 6.0
   beq a010230
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010230:
   ldsfld int64 [rvastatic5]A::a01053
   ldc.i8 53
   beq a010231
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010231:
   ldsfld int64 [rvastatic5]A::a01089
   ldc.i8 89
   beq a010232
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010232:
   ldsfld int64 [rvastatic5]A::a010125
   ldc.i8 125
   beq a010233
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010233:
   ldsfld int32 [rvastatic5]A::a01084
   ldc.i4 84
   beq a010234
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010234:
   ldsfld int8 [rvastatic5]A::a01027
   ldc.i4 27
   beq a010235
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010235:
   ldsfld int32 [rvastatic5]A::a010121
   ldc.i4 121
   beq a010236
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010236:
   ldsfld float32 [rvastatic5]A::a01024
   ldc.r4 24.0
   beq a010237
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010237:
   ldsfld int64 [rvastatic5]A::a0109
   ldc.i8 9
   beq a010238
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010238:
   ldsfld int32 [rvastatic5]A::a010111
   ldc.i4 111
   beq a010239
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010239:
   ldsfld float32 [rvastatic5]A::a01081
   ldc.r4 81.0
   beq a010240
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010240:
   ldsfld int64 [rvastatic5]A::a010125
   ldc.i8 125
   beq a010241
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010241:
   ldsfld int32 [rvastatic5]A::a010120
   ldc.i4 120
   beq a010242
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010242:
   ldsfld int32 [rvastatic5]A::a0100
   ldc.i4 0
   beq a010243
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010243:
   ldsfld int16 [rvastatic5]A::a01032
   ldc.i4 32
   beq a010244
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010244:
   ldsfld int64 [rvastatic5]A::a01086
   ldc.i8 86
   beq a010245
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010245:
   ldsfld float32 [rvastatic5]A::a01021
   ldc.r4 21.0
   beq a010246
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010246:
   ldsfld int64 [rvastatic5]A::a01086
   ldc.i8 86
   beq a010247
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010247:
   ldsfld float32 [rvastatic5]A::a01096
   ldc.r4 96.0
   beq a010248
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010248:
   ldsfld int8 [rvastatic5]A::a010119
   ldc.i4 119
   beq a010249
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010249:
   ldsfld int16 [rvastatic5]A::a01051
   ldc.i4 51
   beq a010250
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010250:
   ldsfld int8 [rvastatic5]A::a01095
   ldc.i4 95
   beq a010251
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010251:
   ldsfld int8 [rvastatic5]A::a010117
   ldc.i4 117
   beq a010252
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010252:
   ldsfld int8 [rvastatic5]A::a01012
   ldc.i4 12
   beq a010253
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010253:
   ldsfld int16 [rvastatic5]A::a01031
   ldc.i4 31
   beq a010254
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010254:
   ldsfld float32 [rvastatic5]A::a01022
   ldc.r4 22.0
   beq a010255
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010255:
   ldsfld int32 [rvastatic5]A::a01072
   ldc.i4 72
   beq a010256
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010256:
  ret}
@@ -2485,7 +2485,7 @@ a010256:
   ldc.i4 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda float32 [rvastatic5]A::a0101
@@ -2500,7 +2500,7 @@ a0100:
   ldc.r4 1.0
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda int16 [rvastatic5]A::a0102
@@ -2515,7 +2515,7 @@ a0101:
   ldc.i4 2
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int8 [rvastatic5]A::a0103
@@ -2530,7 +2530,7 @@ a0102:
   ldc.i4 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int32 [rvastatic5]A::a0104
@@ -2546,7 +2546,7 @@ a0103:
   ldc.i4 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda float32 [rvastatic5]A::a0105
@@ -2562,7 +2562,7 @@ a0104:
   ldc.r4 5.0
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda float32 [rvastatic5]A::a0106
@@ -2577,7 +2577,7 @@ a0105:
   ldc.r4 6.0
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda int16 [rvastatic5]A::a0107
@@ -2596,7 +2596,7 @@ a0106:
   ldc.i4 7
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda int64 [rvastatic5]A::a0108
@@ -2610,7 +2610,7 @@ a0107:
   ldc.i8 8
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int64 [rvastatic5]A::a0109
@@ -2626,7 +2626,7 @@ a0108:
   ldc.i8 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int32 [rvastatic5]A::a01010
@@ -2645,7 +2645,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int32 [rvastatic5]A::a01011
@@ -2660,7 +2660,7 @@ a01010:
   ldc.i4 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int8 [rvastatic5]A::a01012
@@ -2676,7 +2676,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda int64 [rvastatic5]A::a01013
@@ -2691,7 +2691,7 @@ a01012:
   ldc.i8 13
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda int16 [rvastatic5]A::a01014
@@ -2705,7 +2705,7 @@ a01013:
   ldc.i4 14
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int64 [rvastatic5]A::a01015
@@ -2721,7 +2721,7 @@ a01014:
   ldc.i8 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda int8 [rvastatic5]A::a01016
@@ -2736,7 +2736,7 @@ a01015:
   ldc.i4 16
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda int8 [rvastatic5]A::a01017
@@ -2750,7 +2750,7 @@ a01016:
   ldc.i4 17
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int32 [rvastatic5]A::a01018
@@ -2765,7 +2765,7 @@ a01017:
   ldc.i4 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int16 [rvastatic5]A::a01019
@@ -2779,7 +2779,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda float32 [rvastatic5]A::a01020
@@ -2794,7 +2794,7 @@ a01019:
   ldc.r4 20.0
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda float32 [rvastatic5]A::a01021
@@ -2810,7 +2810,7 @@ a01020:
   ldc.r4 21.0
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda float32 [rvastatic5]A::a01022
@@ -2826,7 +2826,7 @@ a01021:
   ldc.r4 22.0
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int16 [rvastatic5]A::a01023
@@ -2840,7 +2840,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda float32 [rvastatic5]A::a01024
@@ -2859,7 +2859,7 @@ a01023:
   ldc.r4 24.0
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int16 [rvastatic5]A::a01025
@@ -2878,7 +2878,7 @@ a01024:
   ldc.i4 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int64 [rvastatic5]A::a01026
@@ -2897,7 +2897,7 @@ a01025:
   ldc.i8 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int8 [rvastatic5]A::a01027
@@ -2912,7 +2912,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int64 [rvastatic5]A::a01028
@@ -2927,7 +2927,7 @@ a01027:
   ldc.i8 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int64 [rvastatic5]A::a01029
@@ -2942,7 +2942,7 @@ a01028:
   ldc.i8 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int32 [rvastatic5]A::a01030
@@ -2957,7 +2957,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int16 [rvastatic5]A::a01031
@@ -2972,7 +2972,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int16 [rvastatic5]A::a01032
@@ -2987,7 +2987,7 @@ a01031:
   ldc.i4 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda float32 [rvastatic5]A::a01033
@@ -3002,7 +3002,7 @@ a01032:
   ldc.r4 33.0
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int16 [rvastatic5]A::a01034
@@ -3017,7 +3017,7 @@ a01033:
   ldc.i4 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int64 [rvastatic5]A::a01035
@@ -3032,7 +3032,7 @@ a01034:
   ldc.i8 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int32 [rvastatic5]A::a01036
@@ -3047,7 +3047,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int32 [rvastatic5]A::a01037
@@ -3062,7 +3062,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int64 [rvastatic5]A::a01038
@@ -3081,7 +3081,7 @@ a01037:
   ldc.i8 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int32 [rvastatic5]A::a01039
@@ -3096,7 +3096,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda float32 [rvastatic5]A::a01040
@@ -3111,7 +3111,7 @@ a01039:
   ldc.r4 40.0
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int32 [rvastatic5]A::a01041
@@ -3125,7 +3125,7 @@ a01040:
   ldc.i4 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int16 [rvastatic5]A::a01042
@@ -3144,7 +3144,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int32 [rvastatic5]A::a01043
@@ -3159,7 +3159,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int16 [rvastatic5]A::a01044
@@ -3173,7 +3173,7 @@ a01043:
   ldc.i4 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int8 [rvastatic5]A::a01045
@@ -3188,7 +3188,7 @@ a01044:
   ldc.i4 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int16 [rvastatic5]A::a01046
@@ -3202,7 +3202,7 @@ a01045:
   ldc.i4 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int64 [rvastatic5]A::a01047
@@ -3221,7 +3221,7 @@ a01046:
   ldc.i8 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda int8 [rvastatic5]A::a01048
@@ -3235,7 +3235,7 @@ a01047:
   ldc.i4 48
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int16 [rvastatic5]A::a01049
@@ -3254,7 +3254,7 @@ a01048:
   ldc.i4 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int16 [rvastatic5]A::a01050
@@ -3273,7 +3273,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int16 [rvastatic5]A::a01051
@@ -3288,7 +3288,7 @@ a01050:
   ldc.i4 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int32 [rvastatic5]A::a01052
@@ -3302,7 +3302,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int64 [rvastatic5]A::a01053
@@ -3318,7 +3318,7 @@ a01052:
   ldc.i8 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda int16 [rvastatic5]A::a01054
@@ -3333,7 +3333,7 @@ a01053:
   ldc.i4 54
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int32 [rvastatic5]A::a01055
@@ -3348,7 +3348,7 @@ a01054:
   ldc.i4 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda float32 [rvastatic5]A::a01056
@@ -3367,7 +3367,7 @@ a01055:
   ldc.r4 56.0
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda float32 [rvastatic5]A::a01057
@@ -3382,7 +3382,7 @@ a01056:
   ldc.r4 57.0
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int16 [rvastatic5]A::a01058
@@ -3396,7 +3396,7 @@ a01057:
   ldc.i4 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int16 [rvastatic5]A::a01059
@@ -3411,7 +3411,7 @@ a01058:
   ldc.i4 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int16 [rvastatic5]A::a01060
@@ -3430,7 +3430,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda float32 [rvastatic5]A::a01061
@@ -3445,7 +3445,7 @@ a01060:
   ldc.r4 61.0
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int32 [rvastatic5]A::a01062
@@ -3464,7 +3464,7 @@ a01061:
   ldc.i4 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda float32 [rvastatic5]A::a01063
@@ -3483,7 +3483,7 @@ a01062:
   ldc.r4 63.0
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int16 [rvastatic5]A::a01064
@@ -3499,7 +3499,7 @@ a01063:
   ldc.i4 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int16 [rvastatic5]A::a01065
@@ -3514,7 +3514,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int8 [rvastatic5]A::a01066
@@ -3530,7 +3530,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int16 [rvastatic5]A::a01067
@@ -3545,7 +3545,7 @@ a01066:
   ldc.i4 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int32 [rvastatic5]A::a01068
@@ -3559,7 +3559,7 @@ a01067:
   ldc.i4 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int32 [rvastatic5]A::a01069
@@ -3573,7 +3573,7 @@ a01068:
   ldc.i4 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda int16 [rvastatic5]A::a01070
@@ -3589,7 +3589,7 @@ a01069:
   ldc.i4 70
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int32 [rvastatic5]A::a01071
@@ -3604,7 +3604,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda int32 [rvastatic5]A::a01072
@@ -3623,7 +3623,7 @@ a01071:
   ldc.i4 72
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda float32 [rvastatic5]A::a01073
@@ -3638,7 +3638,7 @@ a01072:
   ldc.r4 73.0
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda int16 [rvastatic5]A::a01074
@@ -3654,7 +3654,7 @@ a01073:
   ldc.i4 74
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int32 [rvastatic5]A::a01075
@@ -3668,7 +3668,7 @@ a01074:
   ldc.i4 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int64 [rvastatic5]A::a01076
@@ -3683,7 +3683,7 @@ a01075:
   ldc.i8 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int32 [rvastatic5]A::a01077
@@ -3698,7 +3698,7 @@ a01076:
   ldc.i4 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int8 [rvastatic5]A::a01078
@@ -3712,7 +3712,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda float32 [rvastatic5]A::a01079
@@ -3727,7 +3727,7 @@ a01078:
   ldc.r4 79.0
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda float32 [rvastatic5]A::a01080
@@ -3742,7 +3742,7 @@ a01079:
   ldc.r4 80.0
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda float32 [rvastatic5]A::a01081
@@ -3757,7 +3757,7 @@ a01080:
   ldc.r4 81.0
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda float32 [rvastatic5]A::a01082
@@ -3776,7 +3776,7 @@ a01081:
   ldc.r4 82.0
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int32 [rvastatic5]A::a01083
@@ -3791,7 +3791,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int32 [rvastatic5]A::a01084
@@ -3806,7 +3806,7 @@ a01083:
   ldc.i4 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int8 [rvastatic5]A::a01085
@@ -3821,7 +3821,7 @@ a01084:
   ldc.i4 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int64 [rvastatic5]A::a01086
@@ -3840,7 +3840,7 @@ a01085:
   ldc.i8 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int64 [rvastatic5]A::a01087
@@ -3859,7 +3859,7 @@ a01086:
   ldc.i8 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int32 [rvastatic5]A::a01088
@@ -3878,7 +3878,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int64 [rvastatic5]A::a01089
@@ -3893,7 +3893,7 @@ a01088:
   ldc.i8 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int64 [rvastatic5]A::a01090
@@ -3908,7 +3908,7 @@ a01089:
   ldc.i8 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int64 [rvastatic5]A::a01091
@@ -3927,7 +3927,7 @@ a01090:
   ldc.i8 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int16 [rvastatic5]A::a01092
@@ -3942,7 +3942,7 @@ a01091:
   ldc.i4 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int16 [rvastatic5]A::a01093
@@ -3957,7 +3957,7 @@ a01092:
   ldc.i4 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int8 [rvastatic5]A::a01094
@@ -3971,7 +3971,7 @@ a01093:
   ldc.i4 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int8 [rvastatic5]A::a01095
@@ -3987,7 +3987,7 @@ a01094:
   ldc.i4 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda float32 [rvastatic5]A::a01096
@@ -4003,7 +4003,7 @@ a01095:
   ldc.r4 96.0
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int16 [rvastatic5]A::a01097
@@ -4017,7 +4017,7 @@ a01096:
   ldc.i4 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda int16 [rvastatic5]A::a01098
@@ -4036,7 +4036,7 @@ a01097:
   ldc.i4 98
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int8 [rvastatic5]A::a01099
@@ -4050,7 +4050,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda float32 [rvastatic5]A::a010100
@@ -4066,7 +4066,7 @@ a01099:
   ldc.r4 100.0
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int8 [rvastatic5]A::a010101
@@ -4085,7 +4085,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda int16 [rvastatic5]A::a010102
@@ -4101,7 +4101,7 @@ a010101:
   ldc.i4 102
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int32 [rvastatic5]A::a010103
@@ -4120,7 +4120,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda float32 [rvastatic5]A::a010104
@@ -4134,7 +4134,7 @@ a010103:
   ldc.r4 104.0
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int64 [rvastatic5]A::a010105
@@ -4153,7 +4153,7 @@ a010104:
   ldc.i8 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda float32 [rvastatic5]A::a010106
@@ -4168,7 +4168,7 @@ a010105:
   ldc.r4 106.0
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda int64 [rvastatic5]A::a010107
@@ -4182,7 +4182,7 @@ a010106:
   ldc.i8 107
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int16 [rvastatic5]A::a010108
@@ -4201,7 +4201,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda float32 [rvastatic5]A::a010109
@@ -4215,7 +4215,7 @@ a010108:
   ldc.r4 109.0
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda float32 [rvastatic5]A::a010110
@@ -4231,7 +4231,7 @@ a010109:
   ldc.r4 110.0
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int32 [rvastatic5]A::a010111
@@ -4245,7 +4245,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int64 [rvastatic5]A::a010112
@@ -4264,7 +4264,7 @@ a010111:
   ldc.i8 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int32 [rvastatic5]A::a010113
@@ -4279,7 +4279,7 @@ a010112:
   ldc.i4 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int16 [rvastatic5]A::a010114
@@ -4298,7 +4298,7 @@ a010113:
   ldc.i4 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int32 [rvastatic5]A::a010115
@@ -4312,7 +4312,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda float32 [rvastatic5]A::a010116
@@ -4327,7 +4327,7 @@ a010115:
   ldc.r4 116.0
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int8 [rvastatic5]A::a010117
@@ -4341,7 +4341,7 @@ a010116:
   ldc.i4 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int32 [rvastatic5]A::a010118
@@ -4356,7 +4356,7 @@ a010117:
   ldc.i4 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int8 [rvastatic5]A::a010119
@@ -4372,7 +4372,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int32 [rvastatic5]A::a010120
@@ -4388,7 +4388,7 @@ a010119:
   ldc.i4 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int32 [rvastatic5]A::a010121
@@ -4404,7 +4404,7 @@ a010120:
   ldc.i4 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int64 [rvastatic5]A::a010122
@@ -4420,7 +4420,7 @@ a010121:
   ldc.i8 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda float32 [rvastatic5]A::a010123
@@ -4434,7 +4434,7 @@ a010122:
   ldc.r4 123.0
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int64 [rvastatic5]A::a010124
@@ -4449,7 +4449,7 @@ a010123:
   ldc.i8 124
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int64 [rvastatic5]A::a010125
@@ -4464,7 +4464,7 @@ a010124:
   ldc.i8 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int16 [rvastatic5]A::a010126
@@ -4478,7 +4478,7 @@ a010125:
   ldc.i4 126
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int8 [rvastatic5]A::a010127
@@ -4497,7 +4497,7 @@ a010126:
   ldc.i4 7
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -4509,7 +4509,7 @@ a010127:
   ldc.i4 0
   beq a0100
   ldstr "a0100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0100:
   ldsflda float32 [rvastatic5]A::a0101
@@ -4519,7 +4519,7 @@ a0100:
   ldc.r4 1.0
   beq a0101
   ldstr "a0101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0101:
   ldsflda int16 [rvastatic5]A::a0102
@@ -4529,7 +4529,7 @@ a0101:
   ldc.i4 2
   beq a0102
   ldstr "a0102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0102:
   ldsflda int8 [rvastatic5]A::a0103
@@ -4539,7 +4539,7 @@ a0102:
   ldc.i4 3
   beq a0103
   ldstr "a0103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0103:
   ldsflda int32 [rvastatic5]A::a0104
@@ -4549,7 +4549,7 @@ a0103:
   ldc.i4 4
   beq a0104
   ldstr "a0104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0104:
   ldsflda float32 [rvastatic5]A::a0105
@@ -4559,7 +4559,7 @@ a0104:
   ldc.r4 5.0
   beq a0105
   ldstr "a0105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0105:
   ldsflda float32 [rvastatic5]A::a0106
@@ -4569,7 +4569,7 @@ a0105:
   ldc.r4 6.0
   beq a0106
   ldstr "a0106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0106:
   ldsflda int16 [rvastatic5]A::a0107
@@ -4579,7 +4579,7 @@ a0106:
   ldc.i4 7
   beq a0107
   ldstr "a0107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0107:
   ldsflda int64 [rvastatic5]A::a0108
@@ -4589,7 +4589,7 @@ a0107:
   ldc.i8 8
   beq a0108
   ldstr "a0108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0108:
   ldsflda int64 [rvastatic5]A::a0109
@@ -4599,7 +4599,7 @@ a0108:
   ldc.i8 9
   beq a0109
   ldstr "a0109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a0109:
   ldsflda int32 [rvastatic5]A::a01010
@@ -4609,7 +4609,7 @@ a0109:
   ldc.i4 10
   beq a01010
   ldstr "a01010"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01010:
   ldsflda int32 [rvastatic5]A::a01011
@@ -4619,7 +4619,7 @@ a01010:
   ldc.i4 11
   beq a01011
   ldstr "a01011"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01011:
   ldsflda int8 [rvastatic5]A::a01012
@@ -4629,7 +4629,7 @@ a01011:
   ldc.i4 12
   beq a01012
   ldstr "a01012"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01012:
   ldsflda int64 [rvastatic5]A::a01013
@@ -4639,7 +4639,7 @@ a01012:
   ldc.i8 13
   beq a01013
   ldstr "a01013"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01013:
   ldsflda int16 [rvastatic5]A::a01014
@@ -4649,7 +4649,7 @@ a01013:
   ldc.i4 14
   beq a01014
   ldstr "a01014"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01014:
   ldsflda int64 [rvastatic5]A::a01015
@@ -4659,7 +4659,7 @@ a01014:
   ldc.i8 15
   beq a01015
   ldstr "a01015"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01015:
   ldsflda int8 [rvastatic5]A::a01016
@@ -4669,7 +4669,7 @@ a01015:
   ldc.i4 16
   beq a01016
   ldstr "a01016"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01016:
   ldsflda int8 [rvastatic5]A::a01017
@@ -4679,7 +4679,7 @@ a01016:
   ldc.i4 17
   beq a01017
   ldstr "a01017"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01017:
   ldsflda int32 [rvastatic5]A::a01018
@@ -4689,7 +4689,7 @@ a01017:
   ldc.i4 18
   beq a01018
   ldstr "a01018"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01018:
   ldsflda int16 [rvastatic5]A::a01019
@@ -4699,7 +4699,7 @@ a01018:
   ldc.i4 19
   beq a01019
   ldstr "a01019"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01019:
   ldsflda float32 [rvastatic5]A::a01020
@@ -4709,7 +4709,7 @@ a01019:
   ldc.r4 20.0
   beq a01020
   ldstr "a01020"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01020:
   ldsflda float32 [rvastatic5]A::a01021
@@ -4719,7 +4719,7 @@ a01020:
   ldc.r4 21.0
   beq a01021
   ldstr "a01021"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01021:
   ldsflda float32 [rvastatic5]A::a01022
@@ -4729,7 +4729,7 @@ a01021:
   ldc.r4 22.0
   beq a01022
   ldstr "a01022"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01022:
   ldsflda int16 [rvastatic5]A::a01023
@@ -4739,7 +4739,7 @@ a01022:
   ldc.i4 23
   beq a01023
   ldstr "a01023"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01023:
   ldsflda float32 [rvastatic5]A::a01024
@@ -4749,7 +4749,7 @@ a01023:
   ldc.r4 24.0
   beq a01024
   ldstr "a01024"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01024:
   ldsflda int16 [rvastatic5]A::a01025
@@ -4759,7 +4759,7 @@ a01024:
   ldc.i4 25
   beq a01025
   ldstr "a01025"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01025:
   ldsflda int64 [rvastatic5]A::a01026
@@ -4769,7 +4769,7 @@ a01025:
   ldc.i8 26
   beq a01026
   ldstr "a01026"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01026:
   ldsflda int8 [rvastatic5]A::a01027
@@ -4779,7 +4779,7 @@ a01026:
   ldc.i4 27
   beq a01027
   ldstr "a01027"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01027:
   ldsflda int64 [rvastatic5]A::a01028
@@ -4789,7 +4789,7 @@ a01027:
   ldc.i8 28
   beq a01028
   ldstr "a01028"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01028:
   ldsflda int64 [rvastatic5]A::a01029
@@ -4799,7 +4799,7 @@ a01028:
   ldc.i8 29
   beq a01029
   ldstr "a01029"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01029:
   ldsflda int32 [rvastatic5]A::a01030
@@ -4809,7 +4809,7 @@ a01029:
   ldc.i4 30
   beq a01030
   ldstr "a01030"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01030:
   ldsflda int16 [rvastatic5]A::a01031
@@ -4819,7 +4819,7 @@ a01030:
   ldc.i4 31
   beq a01031
   ldstr "a01031"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01031:
   ldsflda int16 [rvastatic5]A::a01032
@@ -4829,7 +4829,7 @@ a01031:
   ldc.i4 32
   beq a01032
   ldstr "a01032"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01032:
   ldsflda float32 [rvastatic5]A::a01033
@@ -4839,7 +4839,7 @@ a01032:
   ldc.r4 33.0
   beq a01033
   ldstr "a01033"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01033:
   ldsflda int16 [rvastatic5]A::a01034
@@ -4849,7 +4849,7 @@ a01033:
   ldc.i4 34
   beq a01034
   ldstr "a01034"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01034:
   ldsflda int64 [rvastatic5]A::a01035
@@ -4859,7 +4859,7 @@ a01034:
   ldc.i8 35
   beq a01035
   ldstr "a01035"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01035:
   ldsflda int32 [rvastatic5]A::a01036
@@ -4869,7 +4869,7 @@ a01035:
   ldc.i4 36
   beq a01036
   ldstr "a01036"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01036:
   ldsflda int32 [rvastatic5]A::a01037
@@ -4879,7 +4879,7 @@ a01036:
   ldc.i4 37
   beq a01037
   ldstr "a01037"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01037:
   ldsflda int64 [rvastatic5]A::a01038
@@ -4889,7 +4889,7 @@ a01037:
   ldc.i8 38
   beq a01038
   ldstr "a01038"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01038:
   ldsflda int32 [rvastatic5]A::a01039
@@ -4899,7 +4899,7 @@ a01038:
   ldc.i4 39
   beq a01039
   ldstr "a01039"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01039:
   ldsflda float32 [rvastatic5]A::a01040
@@ -4909,7 +4909,7 @@ a01039:
   ldc.r4 40.0
   beq a01040
   ldstr "a01040"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01040:
   ldsflda int32 [rvastatic5]A::a01041
@@ -4919,7 +4919,7 @@ a01040:
   ldc.i4 41
   beq a01041
   ldstr "a01041"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01041:
   ldsflda int16 [rvastatic5]A::a01042
@@ -4929,7 +4929,7 @@ a01041:
   ldc.i4 42
   beq a01042
   ldstr "a01042"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01042:
   ldsflda int32 [rvastatic5]A::a01043
@@ -4939,7 +4939,7 @@ a01042:
   ldc.i4 43
   beq a01043
   ldstr "a01043"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01043:
   ldsflda int16 [rvastatic5]A::a01044
@@ -4949,7 +4949,7 @@ a01043:
   ldc.i4 44
   beq a01044
   ldstr "a01044"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01044:
   ldsflda int8 [rvastatic5]A::a01045
@@ -4959,7 +4959,7 @@ a01044:
   ldc.i4 45
   beq a01045
   ldstr "a01045"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01045:
   ldsflda int16 [rvastatic5]A::a01046
@@ -4969,7 +4969,7 @@ a01045:
   ldc.i4 46
   beq a01046
   ldstr "a01046"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01046:
   ldsflda int64 [rvastatic5]A::a01047
@@ -4979,7 +4979,7 @@ a01046:
   ldc.i8 47
   beq a01047
   ldstr "a01047"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01047:
   ldsflda int8 [rvastatic5]A::a01048
@@ -4989,7 +4989,7 @@ a01047:
   ldc.i4 48
   beq a01048
   ldstr "a01048"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01048:
   ldsflda int16 [rvastatic5]A::a01049
@@ -4999,7 +4999,7 @@ a01048:
   ldc.i4 49
   beq a01049
   ldstr "a01049"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01049:
   ldsflda int16 [rvastatic5]A::a01050
@@ -5009,7 +5009,7 @@ a01049:
   ldc.i4 50
   beq a01050
   ldstr "a01050"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01050:
   ldsflda int16 [rvastatic5]A::a01051
@@ -5019,7 +5019,7 @@ a01050:
   ldc.i4 51
   beq a01051
   ldstr "a01051"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01051:
   ldsflda int32 [rvastatic5]A::a01052
@@ -5029,7 +5029,7 @@ a01051:
   ldc.i4 52
   beq a01052
   ldstr "a01052"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01052:
   ldsflda int64 [rvastatic5]A::a01053
@@ -5039,7 +5039,7 @@ a01052:
   ldc.i8 53
   beq a01053
   ldstr "a01053"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01053:
   ldsflda int16 [rvastatic5]A::a01054
@@ -5049,7 +5049,7 @@ a01053:
   ldc.i4 54
   beq a01054
   ldstr "a01054"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01054:
   ldsflda int32 [rvastatic5]A::a01055
@@ -5059,7 +5059,7 @@ a01054:
   ldc.i4 55
   beq a01055
   ldstr "a01055"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01055:
   ldsflda float32 [rvastatic5]A::a01056
@@ -5069,7 +5069,7 @@ a01055:
   ldc.r4 56.0
   beq a01056
   ldstr "a01056"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01056:
   ldsflda float32 [rvastatic5]A::a01057
@@ -5079,7 +5079,7 @@ a01056:
   ldc.r4 57.0
   beq a01057
   ldstr "a01057"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01057:
   ldsflda int16 [rvastatic5]A::a01058
@@ -5089,7 +5089,7 @@ a01057:
   ldc.i4 58
   beq a01058
   ldstr "a01058"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01058:
   ldsflda int16 [rvastatic5]A::a01059
@@ -5099,7 +5099,7 @@ a01058:
   ldc.i4 59
   beq a01059
   ldstr "a01059"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01059:
   ldsflda int16 [rvastatic5]A::a01060
@@ -5109,7 +5109,7 @@ a01059:
   ldc.i4 60
   beq a01060
   ldstr "a01060"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01060:
   ldsflda float32 [rvastatic5]A::a01061
@@ -5119,7 +5119,7 @@ a01060:
   ldc.r4 61.0
   beq a01061
   ldstr "a01061"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01061:
   ldsflda int32 [rvastatic5]A::a01062
@@ -5129,7 +5129,7 @@ a01061:
   ldc.i4 62
   beq a01062
   ldstr "a01062"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01062:
   ldsflda float32 [rvastatic5]A::a01063
@@ -5139,7 +5139,7 @@ a01062:
   ldc.r4 63.0
   beq a01063
   ldstr "a01063"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01063:
   ldsflda int16 [rvastatic5]A::a01064
@@ -5149,7 +5149,7 @@ a01063:
   ldc.i4 64
   beq a01064
   ldstr "a01064"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01064:
   ldsflda int16 [rvastatic5]A::a01065
@@ -5159,7 +5159,7 @@ a01064:
   ldc.i4 65
   beq a01065
   ldstr "a01065"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01065:
   ldsflda int8 [rvastatic5]A::a01066
@@ -5169,7 +5169,7 @@ a01065:
   ldc.i4 66
   beq a01066
   ldstr "a01066"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01066:
   ldsflda int16 [rvastatic5]A::a01067
@@ -5179,7 +5179,7 @@ a01066:
   ldc.i4 67
   beq a01067
   ldstr "a01067"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01067:
   ldsflda int32 [rvastatic5]A::a01068
@@ -5189,7 +5189,7 @@ a01067:
   ldc.i4 68
   beq a01068
   ldstr "a01068"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01068:
   ldsflda int32 [rvastatic5]A::a01069
@@ -5199,7 +5199,7 @@ a01068:
   ldc.i4 69
   beq a01069
   ldstr "a01069"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01069:
   ldsflda int16 [rvastatic5]A::a01070
@@ -5209,7 +5209,7 @@ a01069:
   ldc.i4 70
   beq a01070
   ldstr "a01070"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01070:
   ldsflda int32 [rvastatic5]A::a01071
@@ -5219,7 +5219,7 @@ a01070:
   ldc.i4 71
   beq a01071
   ldstr "a01071"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01071:
   ldsflda int32 [rvastatic5]A::a01072
@@ -5229,7 +5229,7 @@ a01071:
   ldc.i4 72
   beq a01072
   ldstr "a01072"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01072:
   ldsflda float32 [rvastatic5]A::a01073
@@ -5239,7 +5239,7 @@ a01072:
   ldc.r4 73.0
   beq a01073
   ldstr "a01073"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01073:
   ldsflda int16 [rvastatic5]A::a01074
@@ -5249,7 +5249,7 @@ a01073:
   ldc.i4 74
   beq a01074
   ldstr "a01074"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01074:
   ldsflda int32 [rvastatic5]A::a01075
@@ -5259,7 +5259,7 @@ a01074:
   ldc.i4 75
   beq a01075
   ldstr "a01075"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01075:
   ldsflda int64 [rvastatic5]A::a01076
@@ -5269,7 +5269,7 @@ a01075:
   ldc.i8 76
   beq a01076
   ldstr "a01076"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01076:
   ldsflda int32 [rvastatic5]A::a01077
@@ -5279,7 +5279,7 @@ a01076:
   ldc.i4 77
   beq a01077
   ldstr "a01077"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01077:
   ldsflda int8 [rvastatic5]A::a01078
@@ -5289,7 +5289,7 @@ a01077:
   ldc.i4 78
   beq a01078
   ldstr "a01078"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01078:
   ldsflda float32 [rvastatic5]A::a01079
@@ -5299,7 +5299,7 @@ a01078:
   ldc.r4 79.0
   beq a01079
   ldstr "a01079"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01079:
   ldsflda float32 [rvastatic5]A::a01080
@@ -5309,7 +5309,7 @@ a01079:
   ldc.r4 80.0
   beq a01080
   ldstr "a01080"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01080:
   ldsflda float32 [rvastatic5]A::a01081
@@ -5319,7 +5319,7 @@ a01080:
   ldc.r4 81.0
   beq a01081
   ldstr "a01081"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01081:
   ldsflda float32 [rvastatic5]A::a01082
@@ -5329,7 +5329,7 @@ a01081:
   ldc.r4 82.0
   beq a01082
   ldstr "a01082"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01082:
   ldsflda int32 [rvastatic5]A::a01083
@@ -5339,7 +5339,7 @@ a01082:
   ldc.i4 83
   beq a01083
   ldstr "a01083"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01083:
   ldsflda int32 [rvastatic5]A::a01084
@@ -5349,7 +5349,7 @@ a01083:
   ldc.i4 84
   beq a01084
   ldstr "a01084"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01084:
   ldsflda int8 [rvastatic5]A::a01085
@@ -5359,7 +5359,7 @@ a01084:
   ldc.i4 85
   beq a01085
   ldstr "a01085"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01085:
   ldsflda int64 [rvastatic5]A::a01086
@@ -5369,7 +5369,7 @@ a01085:
   ldc.i8 86
   beq a01086
   ldstr "a01086"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01086:
   ldsflda int64 [rvastatic5]A::a01087
@@ -5379,7 +5379,7 @@ a01086:
   ldc.i8 87
   beq a01087
   ldstr "a01087"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01087:
   ldsflda int32 [rvastatic5]A::a01088
@@ -5389,7 +5389,7 @@ a01087:
   ldc.i4 88
   beq a01088
   ldstr "a01088"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01088:
   ldsflda int64 [rvastatic5]A::a01089
@@ -5399,7 +5399,7 @@ a01088:
   ldc.i8 89
   beq a01089
   ldstr "a01089"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01089:
   ldsflda int64 [rvastatic5]A::a01090
@@ -5409,7 +5409,7 @@ a01089:
   ldc.i8 90
   beq a01090
   ldstr "a01090"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01090:
   ldsflda int64 [rvastatic5]A::a01091
@@ -5419,7 +5419,7 @@ a01090:
   ldc.i8 91
   beq a01091
   ldstr "a01091"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01091:
   ldsflda int16 [rvastatic5]A::a01092
@@ -5429,7 +5429,7 @@ a01091:
   ldc.i4 92
   beq a01092
   ldstr "a01092"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01092:
   ldsflda int16 [rvastatic5]A::a01093
@@ -5439,7 +5439,7 @@ a01092:
   ldc.i4 93
   beq a01093
   ldstr "a01093"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01093:
   ldsflda int8 [rvastatic5]A::a01094
@@ -5449,7 +5449,7 @@ a01093:
   ldc.i4 94
   beq a01094
   ldstr "a01094"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01094:
   ldsflda int8 [rvastatic5]A::a01095
@@ -5459,7 +5459,7 @@ a01094:
   ldc.i4 95
   beq a01095
   ldstr "a01095"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01095:
   ldsflda float32 [rvastatic5]A::a01096
@@ -5469,7 +5469,7 @@ a01095:
   ldc.r4 96.0
   beq a01096
   ldstr "a01096"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01096:
   ldsflda int16 [rvastatic5]A::a01097
@@ -5479,7 +5479,7 @@ a01096:
   ldc.i4 97
   beq a01097
   ldstr "a01097"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01097:
   ldsflda int16 [rvastatic5]A::a01098
@@ -5489,7 +5489,7 @@ a01097:
   ldc.i4 98
   beq a01098
   ldstr "a01098"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01098:
   ldsflda int8 [rvastatic5]A::a01099
@@ -5499,7 +5499,7 @@ a01098:
   ldc.i4 99
   beq a01099
   ldstr "a01099"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a01099:
   ldsflda float32 [rvastatic5]A::a010100
@@ -5509,7 +5509,7 @@ a01099:
   ldc.r4 100.0
   beq a010100
   ldstr "a010100"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010100:
   ldsflda int8 [rvastatic5]A::a010101
@@ -5519,7 +5519,7 @@ a010100:
   ldc.i4 101
   beq a010101
   ldstr "a010101"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010101:
   ldsflda int16 [rvastatic5]A::a010102
@@ -5529,7 +5529,7 @@ a010101:
   ldc.i4 102
   beq a010102
   ldstr "a010102"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010102:
   ldsflda int32 [rvastatic5]A::a010103
@@ -5539,7 +5539,7 @@ a010102:
   ldc.i4 103
   beq a010103
   ldstr "a010103"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010103:
   ldsflda float32 [rvastatic5]A::a010104
@@ -5549,7 +5549,7 @@ a010103:
   ldc.r4 104.0
   beq a010104
   ldstr "a010104"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010104:
   ldsflda int64 [rvastatic5]A::a010105
@@ -5559,7 +5559,7 @@ a010104:
   ldc.i8 105
   beq a010105
   ldstr "a010105"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010105:
   ldsflda float32 [rvastatic5]A::a010106
@@ -5569,7 +5569,7 @@ a010105:
   ldc.r4 106.0
   beq a010106
   ldstr "a010106"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010106:
   ldsflda int64 [rvastatic5]A::a010107
@@ -5579,7 +5579,7 @@ a010106:
   ldc.i8 107
   beq a010107
   ldstr "a010107"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010107:
   ldsflda int16 [rvastatic5]A::a010108
@@ -5589,7 +5589,7 @@ a010107:
   ldc.i4 108
   beq a010108
   ldstr "a010108"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010108:
   ldsflda float32 [rvastatic5]A::a010109
@@ -5599,7 +5599,7 @@ a010108:
   ldc.r4 109.0
   beq a010109
   ldstr "a010109"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010109:
   ldsflda float32 [rvastatic5]A::a010110
@@ -5609,7 +5609,7 @@ a010109:
   ldc.r4 110.0
   beq a010110
   ldstr "a010110"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010110:
   ldsflda int32 [rvastatic5]A::a010111
@@ -5619,7 +5619,7 @@ a010110:
   ldc.i4 111
   beq a010111
   ldstr "a010111"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010111:
   ldsflda int64 [rvastatic5]A::a010112
@@ -5629,7 +5629,7 @@ a010111:
   ldc.i8 112
   beq a010112
   ldstr "a010112"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010112:
   ldsflda int32 [rvastatic5]A::a010113
@@ -5639,7 +5639,7 @@ a010112:
   ldc.i4 113
   beq a010113
   ldstr "a010113"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010113:
   ldsflda int16 [rvastatic5]A::a010114
@@ -5649,7 +5649,7 @@ a010113:
   ldc.i4 114
   beq a010114
   ldstr "a010114"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010114:
   ldsflda int32 [rvastatic5]A::a010115
@@ -5659,7 +5659,7 @@ a010114:
   ldc.i4 115
   beq a010115
   ldstr "a010115"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010115:
   ldsflda float32 [rvastatic5]A::a010116
@@ -5669,7 +5669,7 @@ a010115:
   ldc.r4 116.0
   beq a010116
   ldstr "a010116"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010116:
   ldsflda int8 [rvastatic5]A::a010117
@@ -5679,7 +5679,7 @@ a010116:
   ldc.i4 117
   beq a010117
   ldstr "a010117"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010117:
   ldsflda int32 [rvastatic5]A::a010118
@@ -5689,7 +5689,7 @@ a010117:
   ldc.i4 118
   beq a010118
   ldstr "a010118"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010118:
   ldsflda int8 [rvastatic5]A::a010119
@@ -5699,7 +5699,7 @@ a010118:
   ldc.i4 119
   beq a010119
   ldstr "a010119"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010119:
   ldsflda int32 [rvastatic5]A::a010120
@@ -5709,7 +5709,7 @@ a010119:
   ldc.i4 120
   beq a010120
   ldstr "a010120"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010120:
   ldsflda int32 [rvastatic5]A::a010121
@@ -5719,7 +5719,7 @@ a010120:
   ldc.i4 121
   beq a010121
   ldstr "a010121"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010121:
   ldsflda int64 [rvastatic5]A::a010122
@@ -5729,7 +5729,7 @@ a010121:
   ldc.i8 122
   beq a010122
   ldstr "a010122"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010122:
   ldsflda float32 [rvastatic5]A::a010123
@@ -5739,7 +5739,7 @@ a010122:
   ldc.r4 123.0
   beq a010123
   ldstr "a010123"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010123:
   ldsflda int64 [rvastatic5]A::a010124
@@ -5749,7 +5749,7 @@ a010123:
   ldc.i8 124
   beq a010124
   ldstr "a010124"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010124:
   ldsflda int64 [rvastatic5]A::a010125
@@ -5759,7 +5759,7 @@ a010124:
   ldc.i8 125
   beq a010125
   ldstr "a010125"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010125:
   ldsflda int16 [rvastatic5]A::a010126
@@ -5769,7 +5769,7 @@ a010125:
   ldc.i4 126
   beq a010126
   ldstr "a010126"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010126:
   ldsflda int8 [rvastatic5]A::a010127
@@ -5779,7 +5779,7 @@ a010126:
   ldc.i4 7
   beq a010127
   ldstr "a010127"
-  newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+  newobj instance void [mscorlib]System.Exception::.ctor(string)
   throw
 a010127:
  ret}
@@ -5791,7 +5791,7 @@ a010127:
   ldsfld int32 [rvastatic5]A::a0100
   ldc.i4 1
   beq a0100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0100:
   ldsfld float32 [rvastatic5]A::a0101
@@ -5801,7 +5801,7 @@ a0100:
   ldsfld float32 [rvastatic5]A::a0101
   ldc.r4 2.0
   beq a0101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0101:
   ldsfld int16 [rvastatic5]A::a0102
@@ -5811,7 +5811,7 @@ a0101:
   ldsfld int16 [rvastatic5]A::a0102
   ldc.i4 3
   beq a0102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0102:
   ldsfld int8 [rvastatic5]A::a0103
@@ -5821,7 +5821,7 @@ a0102:
   ldsfld int8 [rvastatic5]A::a0103
   ldc.i4 4
   beq a0103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0103:
   ldsfld int32 [rvastatic5]A::a0104
@@ -5831,7 +5831,7 @@ a0103:
   ldsfld int32 [rvastatic5]A::a0104
   ldc.i4 5
   beq a0104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0104:
   ldsfld float32 [rvastatic5]A::a0105
@@ -5841,7 +5841,7 @@ a0104:
   ldsfld float32 [rvastatic5]A::a0105
   ldc.r4 6.0
   beq a0105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0105:
   ldsfld float32 [rvastatic5]A::a0106
@@ -5851,7 +5851,7 @@ a0105:
   ldsfld float32 [rvastatic5]A::a0106
   ldc.r4 7.0
   beq a0106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0106:
   ldsfld int16 [rvastatic5]A::a0107
@@ -5861,7 +5861,7 @@ a0106:
   ldsfld int16 [rvastatic5]A::a0107
   ldc.i4 8
   beq a0107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0107:
   ldsfld int64 [rvastatic5]A::a0108
@@ -5871,7 +5871,7 @@ a0107:
   ldsfld int64 [rvastatic5]A::a0108
   ldc.i8 9
   beq a0108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0108:
   ldsfld int64 [rvastatic5]A::a0109
@@ -5881,7 +5881,7 @@ a0108:
   ldsfld int64 [rvastatic5]A::a0109
   ldc.i8 10
   beq a0109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a0109:
   ldsfld int32 [rvastatic5]A::a01010
@@ -5891,7 +5891,7 @@ a0109:
   ldsfld int32 [rvastatic5]A::a01010
   ldc.i4 11
   beq a01010
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01010:
   ldsfld int32 [rvastatic5]A::a01011
@@ -5901,7 +5901,7 @@ a01010:
   ldsfld int32 [rvastatic5]A::a01011
   ldc.i4 12
   beq a01011
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01011:
   ldsfld int8 [rvastatic5]A::a01012
@@ -5911,7 +5911,7 @@ a01011:
   ldsfld int8 [rvastatic5]A::a01012
   ldc.i4 13
   beq a01012
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01012:
   ldsfld int64 [rvastatic5]A::a01013
@@ -5921,7 +5921,7 @@ a01012:
   ldsfld int64 [rvastatic5]A::a01013
   ldc.i8 14
   beq a01013
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01013:
   ldsfld int16 [rvastatic5]A::a01014
@@ -5931,7 +5931,7 @@ a01013:
   ldsfld int16 [rvastatic5]A::a01014
   ldc.i4 15
   beq a01014
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01014:
   ldsfld int64 [rvastatic5]A::a01015
@@ -5941,7 +5941,7 @@ a01014:
   ldsfld int64 [rvastatic5]A::a01015
   ldc.i8 16
   beq a01015
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01015:
   ldsfld int8 [rvastatic5]A::a01016
@@ -5951,7 +5951,7 @@ a01015:
   ldsfld int8 [rvastatic5]A::a01016
   ldc.i4 17
   beq a01016
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01016:
   ldsfld int8 [rvastatic5]A::a01017
@@ -5961,7 +5961,7 @@ a01016:
   ldsfld int8 [rvastatic5]A::a01017
   ldc.i4 18
   beq a01017
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01017:
   ldsfld int32 [rvastatic5]A::a01018
@@ -5971,7 +5971,7 @@ a01017:
   ldsfld int32 [rvastatic5]A::a01018
   ldc.i4 19
   beq a01018
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01018:
   ldsfld int16 [rvastatic5]A::a01019
@@ -5981,7 +5981,7 @@ a01018:
   ldsfld int16 [rvastatic5]A::a01019
   ldc.i4 20
   beq a01019
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01019:
   ldsfld float32 [rvastatic5]A::a01020
@@ -5991,7 +5991,7 @@ a01019:
   ldsfld float32 [rvastatic5]A::a01020
   ldc.r4 21.0
   beq a01020
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01020:
   ldsfld float32 [rvastatic5]A::a01021
@@ -6001,7 +6001,7 @@ a01020:
   ldsfld float32 [rvastatic5]A::a01021
   ldc.r4 22.0
   beq a01021
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01021:
   ldsfld float32 [rvastatic5]A::a01022
@@ -6011,7 +6011,7 @@ a01021:
   ldsfld float32 [rvastatic5]A::a01022
   ldc.r4 23.0
   beq a01022
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01022:
   ldsfld int16 [rvastatic5]A::a01023
@@ -6021,7 +6021,7 @@ a01022:
   ldsfld int16 [rvastatic5]A::a01023
   ldc.i4 24
   beq a01023
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01023:
   ldsfld float32 [rvastatic5]A::a01024
@@ -6031,7 +6031,7 @@ a01023:
   ldsfld float32 [rvastatic5]A::a01024
   ldc.r4 25.0
   beq a01024
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01024:
   ldsfld int16 [rvastatic5]A::a01025
@@ -6041,7 +6041,7 @@ a01024:
   ldsfld int16 [rvastatic5]A::a01025
   ldc.i4 26
   beq a01025
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01025:
   ldsfld int64 [rvastatic5]A::a01026
@@ -6051,7 +6051,7 @@ a01025:
   ldsfld int64 [rvastatic5]A::a01026
   ldc.i8 27
   beq a01026
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01026:
   ldsfld int8 [rvastatic5]A::a01027
@@ -6061,7 +6061,7 @@ a01026:
   ldsfld int8 [rvastatic5]A::a01027
   ldc.i4 28
   beq a01027
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01027:
   ldsfld int64 [rvastatic5]A::a01028
@@ -6071,7 +6071,7 @@ a01027:
   ldsfld int64 [rvastatic5]A::a01028
   ldc.i8 29
   beq a01028
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01028:
   ldsfld int64 [rvastatic5]A::a01029
@@ -6081,7 +6081,7 @@ a01028:
   ldsfld int64 [rvastatic5]A::a01029
   ldc.i8 30
   beq a01029
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01029:
   ldsfld int32 [rvastatic5]A::a01030
@@ -6091,7 +6091,7 @@ a01029:
   ldsfld int32 [rvastatic5]A::a01030
   ldc.i4 31
   beq a01030
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01030:
   ldsfld int16 [rvastatic5]A::a01031
@@ -6101,7 +6101,7 @@ a01030:
   ldsfld int16 [rvastatic5]A::a01031
   ldc.i4 32
   beq a01031
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01031:
   ldsfld int16 [rvastatic5]A::a01032
@@ -6111,7 +6111,7 @@ a01031:
   ldsfld int16 [rvastatic5]A::a01032
   ldc.i4 33
   beq a01032
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01032:
   ldsfld float32 [rvastatic5]A::a01033
@@ -6121,7 +6121,7 @@ a01032:
   ldsfld float32 [rvastatic5]A::a01033
   ldc.r4 34.0
   beq a01033
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01033:
   ldsfld int16 [rvastatic5]A::a01034
@@ -6131,7 +6131,7 @@ a01033:
   ldsfld int16 [rvastatic5]A::a01034
   ldc.i4 35
   beq a01034
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01034:
   ldsfld int64 [rvastatic5]A::a01035
@@ -6141,7 +6141,7 @@ a01034:
   ldsfld int64 [rvastatic5]A::a01035
   ldc.i8 36
   beq a01035
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01035:
   ldsfld int32 [rvastatic5]A::a01036
@@ -6151,7 +6151,7 @@ a01035:
   ldsfld int32 [rvastatic5]A::a01036
   ldc.i4 37
   beq a01036
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01036:
   ldsfld int32 [rvastatic5]A::a01037
@@ -6161,7 +6161,7 @@ a01036:
   ldsfld int32 [rvastatic5]A::a01037
   ldc.i4 38
   beq a01037
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01037:
   ldsfld int64 [rvastatic5]A::a01038
@@ -6171,7 +6171,7 @@ a01037:
   ldsfld int64 [rvastatic5]A::a01038
   ldc.i8 39
   beq a01038
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01038:
   ldsfld int32 [rvastatic5]A::a01039
@@ -6181,7 +6181,7 @@ a01038:
   ldsfld int32 [rvastatic5]A::a01039
   ldc.i4 40
   beq a01039
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01039:
   ldsfld float32 [rvastatic5]A::a01040
@@ -6191,7 +6191,7 @@ a01039:
   ldsfld float32 [rvastatic5]A::a01040
   ldc.r4 41.0
   beq a01040
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01040:
   ldsfld int32 [rvastatic5]A::a01041
@@ -6201,7 +6201,7 @@ a01040:
   ldsfld int32 [rvastatic5]A::a01041
   ldc.i4 42
   beq a01041
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01041:
   ldsfld int16 [rvastatic5]A::a01042
@@ -6211,7 +6211,7 @@ a01041:
   ldsfld int16 [rvastatic5]A::a01042
   ldc.i4 43
   beq a01042
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01042:
   ldsfld int32 [rvastatic5]A::a01043
@@ -6221,7 +6221,7 @@ a01042:
   ldsfld int32 [rvastatic5]A::a01043
   ldc.i4 44
   beq a01043
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01043:
   ldsfld int16 [rvastatic5]A::a01044
@@ -6231,7 +6231,7 @@ a01043:
   ldsfld int16 [rvastatic5]A::a01044
   ldc.i4 45
   beq a01044
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01044:
   ldsfld int8 [rvastatic5]A::a01045
@@ -6241,7 +6241,7 @@ a01044:
   ldsfld int8 [rvastatic5]A::a01045
   ldc.i4 46
   beq a01045
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01045:
   ldsfld int16 [rvastatic5]A::a01046
@@ -6251,7 +6251,7 @@ a01045:
   ldsfld int16 [rvastatic5]A::a01046
   ldc.i4 47
   beq a01046
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01046:
   ldsfld int64 [rvastatic5]A::a01047
@@ -6261,7 +6261,7 @@ a01046:
   ldsfld int64 [rvastatic5]A::a01047
   ldc.i8 48
   beq a01047
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01047:
   ldsfld int8 [rvastatic5]A::a01048
@@ -6271,7 +6271,7 @@ a01047:
   ldsfld int8 [rvastatic5]A::a01048
   ldc.i4 49
   beq a01048
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01048:
   ldsfld int16 [rvastatic5]A::a01049
@@ -6281,7 +6281,7 @@ a01048:
   ldsfld int16 [rvastatic5]A::a01049
   ldc.i4 50
   beq a01049
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01049:
   ldsfld int16 [rvastatic5]A::a01050
@@ -6291,7 +6291,7 @@ a01049:
   ldsfld int16 [rvastatic5]A::a01050
   ldc.i4 51
   beq a01050
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01050:
   ldsfld int16 [rvastatic5]A::a01051
@@ -6301,7 +6301,7 @@ a01050:
   ldsfld int16 [rvastatic5]A::a01051
   ldc.i4 52
   beq a01051
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01051:
   ldsfld int32 [rvastatic5]A::a01052
@@ -6311,7 +6311,7 @@ a01051:
   ldsfld int32 [rvastatic5]A::a01052
   ldc.i4 53
   beq a01052
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01052:
   ldsfld int64 [rvastatic5]A::a01053
@@ -6321,7 +6321,7 @@ a01052:
   ldsfld int64 [rvastatic5]A::a01053
   ldc.i8 54
   beq a01053
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01053:
   ldsfld int16 [rvastatic5]A::a01054
@@ -6331,7 +6331,7 @@ a01053:
   ldsfld int16 [rvastatic5]A::a01054
   ldc.i4 55
   beq a01054
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01054:
   ldsfld int32 [rvastatic5]A::a01055
@@ -6341,7 +6341,7 @@ a01054:
   ldsfld int32 [rvastatic5]A::a01055
   ldc.i4 56
   beq a01055
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01055:
   ldsfld float32 [rvastatic5]A::a01056
@@ -6351,7 +6351,7 @@ a01055:
   ldsfld float32 [rvastatic5]A::a01056
   ldc.r4 57.0
   beq a01056
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01056:
   ldsfld float32 [rvastatic5]A::a01057
@@ -6361,7 +6361,7 @@ a01056:
   ldsfld float32 [rvastatic5]A::a01057
   ldc.r4 58.0
   beq a01057
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01057:
   ldsfld int16 [rvastatic5]A::a01058
@@ -6371,7 +6371,7 @@ a01057:
   ldsfld int16 [rvastatic5]A::a01058
   ldc.i4 59
   beq a01058
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01058:
   ldsfld int16 [rvastatic5]A::a01059
@@ -6381,7 +6381,7 @@ a01058:
   ldsfld int16 [rvastatic5]A::a01059
   ldc.i4 60
   beq a01059
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01059:
   ldsfld int16 [rvastatic5]A::a01060
@@ -6391,7 +6391,7 @@ a01059:
   ldsfld int16 [rvastatic5]A::a01060
   ldc.i4 61
   beq a01060
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01060:
   ldsfld float32 [rvastatic5]A::a01061
@@ -6401,7 +6401,7 @@ a01060:
   ldsfld float32 [rvastatic5]A::a01061
   ldc.r4 62.0
   beq a01061
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01061:
   ldsfld int32 [rvastatic5]A::a01062
@@ -6411,7 +6411,7 @@ a01061:
   ldsfld int32 [rvastatic5]A::a01062
   ldc.i4 63
   beq a01062
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01062:
   ldsfld float32 [rvastatic5]A::a01063
@@ -6421,7 +6421,7 @@ a01062:
   ldsfld float32 [rvastatic5]A::a01063
   ldc.r4 64.0
   beq a01063
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01063:
   ldsfld int16 [rvastatic5]A::a01064
@@ -6431,7 +6431,7 @@ a01063:
   ldsfld int16 [rvastatic5]A::a01064
   ldc.i4 65
   beq a01064
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01064:
   ldsfld int16 [rvastatic5]A::a01065
@@ -6441,7 +6441,7 @@ a01064:
   ldsfld int16 [rvastatic5]A::a01065
   ldc.i4 66
   beq a01065
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01065:
   ldsfld int8 [rvastatic5]A::a01066
@@ -6451,7 +6451,7 @@ a01065:
   ldsfld int8 [rvastatic5]A::a01066
   ldc.i4 67
   beq a01066
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01066:
   ldsfld int16 [rvastatic5]A::a01067
@@ -6461,7 +6461,7 @@ a01066:
   ldsfld int16 [rvastatic5]A::a01067
   ldc.i4 68
   beq a01067
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01067:
   ldsfld int32 [rvastatic5]A::a01068
@@ -6471,7 +6471,7 @@ a01067:
   ldsfld int32 [rvastatic5]A::a01068
   ldc.i4 69
   beq a01068
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01068:
   ldsfld int32 [rvastatic5]A::a01069
@@ -6481,7 +6481,7 @@ a01068:
   ldsfld int32 [rvastatic5]A::a01069
   ldc.i4 70
   beq a01069
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01069:
   ldsfld int16 [rvastatic5]A::a01070
@@ -6491,7 +6491,7 @@ a01069:
   ldsfld int16 [rvastatic5]A::a01070
   ldc.i4 71
   beq a01070
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01070:
   ldsfld int32 [rvastatic5]A::a01071
@@ -6501,7 +6501,7 @@ a01070:
   ldsfld int32 [rvastatic5]A::a01071
   ldc.i4 72
   beq a01071
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01071:
   ldsfld int32 [rvastatic5]A::a01072
@@ -6511,7 +6511,7 @@ a01071:
   ldsfld int32 [rvastatic5]A::a01072
   ldc.i4 73
   beq a01072
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01072:
   ldsfld float32 [rvastatic5]A::a01073
@@ -6521,7 +6521,7 @@ a01072:
   ldsfld float32 [rvastatic5]A::a01073
   ldc.r4 74.0
   beq a01073
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01073:
   ldsfld int16 [rvastatic5]A::a01074
@@ -6531,7 +6531,7 @@ a01073:
   ldsfld int16 [rvastatic5]A::a01074
   ldc.i4 75
   beq a01074
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01074:
   ldsfld int32 [rvastatic5]A::a01075
@@ -6541,7 +6541,7 @@ a01074:
   ldsfld int32 [rvastatic5]A::a01075
   ldc.i4 76
   beq a01075
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01075:
   ldsfld int64 [rvastatic5]A::a01076
@@ -6551,7 +6551,7 @@ a01075:
   ldsfld int64 [rvastatic5]A::a01076
   ldc.i8 77
   beq a01076
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01076:
   ldsfld int32 [rvastatic5]A::a01077
@@ -6561,7 +6561,7 @@ a01076:
   ldsfld int32 [rvastatic5]A::a01077
   ldc.i4 78
   beq a01077
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01077:
   ldsfld int8 [rvastatic5]A::a01078
@@ -6571,7 +6571,7 @@ a01077:
   ldsfld int8 [rvastatic5]A::a01078
   ldc.i4 79
   beq a01078
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01078:
   ldsfld float32 [rvastatic5]A::a01079
@@ -6581,7 +6581,7 @@ a01078:
   ldsfld float32 [rvastatic5]A::a01079
   ldc.r4 80.0
   beq a01079
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01079:
   ldsfld float32 [rvastatic5]A::a01080
@@ -6591,7 +6591,7 @@ a01079:
   ldsfld float32 [rvastatic5]A::a01080
   ldc.r4 81.0
   beq a01080
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01080:
   ldsfld float32 [rvastatic5]A::a01081
@@ -6601,7 +6601,7 @@ a01080:
   ldsfld float32 [rvastatic5]A::a01081
   ldc.r4 82.0
   beq a01081
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01081:
   ldsfld float32 [rvastatic5]A::a01082
@@ -6611,7 +6611,7 @@ a01081:
   ldsfld float32 [rvastatic5]A::a01082
   ldc.r4 83.0
   beq a01082
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01082:
   ldsfld int32 [rvastatic5]A::a01083
@@ -6621,7 +6621,7 @@ a01082:
   ldsfld int32 [rvastatic5]A::a01083
   ldc.i4 84
   beq a01083
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01083:
   ldsfld int32 [rvastatic5]A::a01084
@@ -6631,7 +6631,7 @@ a01083:
   ldsfld int32 [rvastatic5]A::a01084
   ldc.i4 85
   beq a01084
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01084:
   ldsfld int8 [rvastatic5]A::a01085
@@ -6641,7 +6641,7 @@ a01084:
   ldsfld int8 [rvastatic5]A::a01085
   ldc.i4 86
   beq a01085
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01085:
   ldsfld int64 [rvastatic5]A::a01086
@@ -6651,7 +6651,7 @@ a01085:
   ldsfld int64 [rvastatic5]A::a01086
   ldc.i8 87
   beq a01086
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01086:
   ldsfld int64 [rvastatic5]A::a01087
@@ -6661,7 +6661,7 @@ a01086:
   ldsfld int64 [rvastatic5]A::a01087
   ldc.i8 88
   beq a01087
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01087:
   ldsfld int32 [rvastatic5]A::a01088
@@ -6671,7 +6671,7 @@ a01087:
   ldsfld int32 [rvastatic5]A::a01088
   ldc.i4 89
   beq a01088
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01088:
   ldsfld int64 [rvastatic5]A::a01089
@@ -6681,7 +6681,7 @@ a01088:
   ldsfld int64 [rvastatic5]A::a01089
   ldc.i8 90
   beq a01089
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01089:
   ldsfld int64 [rvastatic5]A::a01090
@@ -6691,7 +6691,7 @@ a01089:
   ldsfld int64 [rvastatic5]A::a01090
   ldc.i8 91
   beq a01090
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01090:
   ldsfld int64 [rvastatic5]A::a01091
@@ -6701,7 +6701,7 @@ a01090:
   ldsfld int64 [rvastatic5]A::a01091
   ldc.i8 92
   beq a01091
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01091:
   ldsfld int16 [rvastatic5]A::a01092
@@ -6711,7 +6711,7 @@ a01091:
   ldsfld int16 [rvastatic5]A::a01092
   ldc.i4 93
   beq a01092
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01092:
   ldsfld int16 [rvastatic5]A::a01093
@@ -6721,7 +6721,7 @@ a01092:
   ldsfld int16 [rvastatic5]A::a01093
   ldc.i4 94
   beq a01093
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01093:
   ldsfld int8 [rvastatic5]A::a01094
@@ -6731,7 +6731,7 @@ a01093:
   ldsfld int8 [rvastatic5]A::a01094
   ldc.i4 95
   beq a01094
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01094:
   ldsfld int8 [rvastatic5]A::a01095
@@ -6741,7 +6741,7 @@ a01094:
   ldsfld int8 [rvastatic5]A::a01095
   ldc.i4 96
   beq a01095
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01095:
   ldsfld float32 [rvastatic5]A::a01096
@@ -6751,7 +6751,7 @@ a01095:
   ldsfld float32 [rvastatic5]A::a01096
   ldc.r4 97.0
   beq a01096
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01096:
   ldsfld int16 [rvastatic5]A::a01097
@@ -6761,7 +6761,7 @@ a01096:
   ldsfld int16 [rvastatic5]A::a01097
   ldc.i4 98
   beq a01097
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01097:
   ldsfld int16 [rvastatic5]A::a01098
@@ -6771,7 +6771,7 @@ a01097:
   ldsfld int16 [rvastatic5]A::a01098
   ldc.i4 99
   beq a01098
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01098:
   ldsfld int8 [rvastatic5]A::a01099
@@ -6781,7 +6781,7 @@ a01098:
   ldsfld int8 [rvastatic5]A::a01099
   ldc.i4 100
   beq a01099
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a01099:
   ldsfld float32 [rvastatic5]A::a010100
@@ -6791,7 +6791,7 @@ a01099:
   ldsfld float32 [rvastatic5]A::a010100
   ldc.r4 101.0
   beq a010100
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010100:
   ldsfld int8 [rvastatic5]A::a010101
@@ -6801,7 +6801,7 @@ a010100:
   ldsfld int8 [rvastatic5]A::a010101
   ldc.i4 102
   beq a010101
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010101:
   ldsfld int16 [rvastatic5]A::a010102
@@ -6811,7 +6811,7 @@ a010101:
   ldsfld int16 [rvastatic5]A::a010102
   ldc.i4 103
   beq a010102
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010102:
   ldsfld int32 [rvastatic5]A::a010103
@@ -6821,7 +6821,7 @@ a010102:
   ldsfld int32 [rvastatic5]A::a010103
   ldc.i4 104
   beq a010103
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010103:
   ldsfld float32 [rvastatic5]A::a010104
@@ -6831,7 +6831,7 @@ a010103:
   ldsfld float32 [rvastatic5]A::a010104
   ldc.r4 105.0
   beq a010104
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010104:
   ldsfld int64 [rvastatic5]A::a010105
@@ -6841,7 +6841,7 @@ a010104:
   ldsfld int64 [rvastatic5]A::a010105
   ldc.i8 106
   beq a010105
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010105:
   ldsfld float32 [rvastatic5]A::a010106
@@ -6851,7 +6851,7 @@ a010105:
   ldsfld float32 [rvastatic5]A::a010106
   ldc.r4 107.0
   beq a010106
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010106:
   ldsfld int64 [rvastatic5]A::a010107
@@ -6861,7 +6861,7 @@ a010106:
   ldsfld int64 [rvastatic5]A::a010107
   ldc.i8 108
   beq a010107
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010107:
   ldsfld int16 [rvastatic5]A::a010108
@@ -6871,7 +6871,7 @@ a010107:
   ldsfld int16 [rvastatic5]A::a010108
   ldc.i4 109
   beq a010108
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010108:
   ldsfld float32 [rvastatic5]A::a010109
@@ -6881,7 +6881,7 @@ a010108:
   ldsfld float32 [rvastatic5]A::a010109
   ldc.r4 110.0
   beq a010109
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010109:
   ldsfld float32 [rvastatic5]A::a010110
@@ -6891,7 +6891,7 @@ a010109:
   ldsfld float32 [rvastatic5]A::a010110
   ldc.r4 111.0
   beq a010110
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010110:
   ldsfld int32 [rvastatic5]A::a010111
@@ -6901,7 +6901,7 @@ a010110:
   ldsfld int32 [rvastatic5]A::a010111
   ldc.i4 112
   beq a010111
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010111:
   ldsfld int64 [rvastatic5]A::a010112
@@ -6911,7 +6911,7 @@ a010111:
   ldsfld int64 [rvastatic5]A::a010112
   ldc.i8 113
   beq a010112
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010112:
   ldsfld int32 [rvastatic5]A::a010113
@@ -6921,7 +6921,7 @@ a010112:
   ldsfld int32 [rvastatic5]A::a010113
   ldc.i4 114
   beq a010113
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010113:
   ldsfld int16 [rvastatic5]A::a010114
@@ -6931,7 +6931,7 @@ a010113:
   ldsfld int16 [rvastatic5]A::a010114
   ldc.i4 115
   beq a010114
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010114:
   ldsfld int32 [rvastatic5]A::a010115
@@ -6941,7 +6941,7 @@ a010114:
   ldsfld int32 [rvastatic5]A::a010115
   ldc.i4 116
   beq a010115
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010115:
   ldsfld float32 [rvastatic5]A::a010116
@@ -6951,7 +6951,7 @@ a010115:
   ldsfld float32 [rvastatic5]A::a010116
   ldc.r4 117.0
   beq a010116
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010116:
   ldsfld int8 [rvastatic5]A::a010117
@@ -6961,7 +6961,7 @@ a010116:
   ldsfld int8 [rvastatic5]A::a010117
   ldc.i4 118
   beq a010117
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010117:
   ldsfld int32 [rvastatic5]A::a010118
@@ -6971,7 +6971,7 @@ a010117:
   ldsfld int32 [rvastatic5]A::a010118
   ldc.i4 119
   beq a010118
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010118:
   ldsfld int8 [rvastatic5]A::a010119
@@ -6981,7 +6981,7 @@ a010118:
   ldsfld int8 [rvastatic5]A::a010119
   ldc.i4 120
   beq a010119
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010119:
   ldsfld int32 [rvastatic5]A::a010120
@@ -6991,7 +6991,7 @@ a010119:
   ldsfld int32 [rvastatic5]A::a010120
   ldc.i4 121
   beq a010120
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010120:
   ldsfld int32 [rvastatic5]A::a010121
@@ -7001,7 +7001,7 @@ a010120:
   ldsfld int32 [rvastatic5]A::a010121
   ldc.i4 122
   beq a010121
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010121:
   ldsfld int64 [rvastatic5]A::a010122
@@ -7011,7 +7011,7 @@ a010121:
   ldsfld int64 [rvastatic5]A::a010122
   ldc.i8 123
   beq a010122
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010122:
   ldsfld float32 [rvastatic5]A::a010123
@@ -7021,7 +7021,7 @@ a010122:
   ldsfld float32 [rvastatic5]A::a010123
   ldc.r4 124.0
   beq a010123
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010123:
   ldsfld int64 [rvastatic5]A::a010124
@@ -7031,7 +7031,7 @@ a010123:
   ldsfld int64 [rvastatic5]A::a010124
   ldc.i8 125
   beq a010124
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010124:
   ldsfld int64 [rvastatic5]A::a010125
@@ -7041,7 +7041,7 @@ a010124:
   ldsfld int64 [rvastatic5]A::a010125
   ldc.i8 126
   beq a010125
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010125:
   ldsfld int16 [rvastatic5]A::a010126
@@ -7051,7 +7051,7 @@ a010125:
   ldsfld int16 [rvastatic5]A::a010126
   ldc.i4 127
   beq a010126
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010126:
   ldsfld int8 [rvastatic5]A::a010127
@@ -7061,7 +7061,7 @@ a010126:
   ldsfld int8 [rvastatic5]A::a010127
   ldc.i4 8
   beq a010127
-  newobj instance void [mscorlib]System.ApplicationException::.ctor()
+  newobj instance void [mscorlib]System.Exception::.ctor()
   throw
 a010127:
   ret}

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_b.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_b.il
@@ -325,7 +325,7 @@
       					int32, int32, int32, int32)
 				brtrue pass1_5
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -439,7 +439,7 @@
       			ldind.i1
       			brtrue pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_i4.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_i4.il
@@ -330,7 +330,7 @@
       			ceq
       			brtrue pass1_5
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -447,7 +447,7 @@
      			call void [mscorlib]System.GC::Collect()
       			brtrue pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_objref.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_objref.il
@@ -386,7 +386,7 @@
       			br pass1_5
       			
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -519,7 +519,7 @@
       			call       void [System.Console]System.Console::WriteLine(string)
       			br pass2
 
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_r4.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_r4.il
@@ -348,7 +348,7 @@
       			ceq
       			brtrue pass1_5
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -475,7 +475,7 @@
      			call void [mscorlib]System.GC::Collect()
       			brtrue pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_r8.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_r8.il
@@ -348,7 +348,7 @@
       			ceq
       			brtrue pass1_5
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -475,7 +475,7 @@
      			call void [mscorlib]System.GC::Collect()
       			brtrue pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_struct.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_struct.il
@@ -385,7 +385,7 @@
       			br pass1_5
       			
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -511,7 +511,7 @@
       			brfalse throw0
       			br pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/huge/huge_u8.il
+++ b/tests/src/JIT/Methodical/Arrays/huge/huge_u8.il
@@ -332,7 +332,7 @@
       			ceq
       			brtrue pass1_5
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -451,7 +451,7 @@
      			call void [mscorlib]System.GC::Collect()
       			brtrue pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/Arrays/lcs/lcs_ldlen.il
+++ b/tests/src/JIT/Methodical/Arrays/lcs/lcs_ldlen.il
@@ -203,7 +203,7 @@
       IL_00c0:  stloc.3
       IL_00c1:  br.s       IL_00c9
 
-      IL_00c3:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_00c3:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_00c8:  throw
 
       IL_00c9:  ldloc.3
@@ -451,7 +451,7 @@
       IL_0108:  ldc.i4.0
       IL_0109:  bge.s      IL_0111
 
-      IL_010b:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_010b:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0110:  throw
 
       IL_0111:  ldarg.0

--- a/tests/src/JIT/Methodical/Arrays/misc/address.il
+++ b/tests/src/JIT/Methodical/Arrays/misc/address.il
@@ -69,7 +69,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/misc/arrres.il
+++ b/tests/src/JIT/Methodical/Arrays/misc/arrres.il
@@ -64,7 +64,7 @@
       IL_000c:  ldarg.0
       IL_000d:  beq.s      IL_0015
 
-      IL_000f:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_000f:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0014:  throw
 
       IL_0015:  ret
@@ -95,7 +95,7 @@
       IL_000b:  callvirt   instance class GCTest.Test class GCTest.Test[-100...100]::Get(int32)
       IL_000c:  brfalse.s  IL_0014
 
-      IL_000e:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_000e:  newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       IL_0014:  ldsfld     class GCTest.Test[-100...100] GCTest.Test::arr

--- a/tests/src/JIT/Methodical/Arrays/misc/gcarr.il
+++ b/tests/src/JIT/Methodical/Arrays/misc/gcarr.il
@@ -34,7 +34,7 @@
       IL_0006:  ldc.i4     0x12345678
       IL_000b:  beq.s      IL_0013
 
-      IL_000d:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_000d:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0012:  throw
 
       IL_0013:  ret

--- a/tests/src/JIT/Methodical/Arrays/misc/ldelem_get.il
+++ b/tests/src/JIT/Methodical/Arrays/misc/ldelem_get.il
@@ -65,7 +65,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/misc/length0.il
+++ b/tests/src/JIT/Methodical/Arrays/misc/length0.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/float64_range1.il
+++ b/tests/src/JIT/Methodical/Arrays/range/float64_range1.il
@@ -65,7 +65,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/float64_range2.il
+++ b/tests/src/JIT/Methodical/Arrays/range/float64_range2.il
@@ -65,7 +65,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_0.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_0.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_0_5a.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_0_5a.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_0_5b.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_0_5b.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_1.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_1.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_m1.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_m1.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_neg_range.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_neg_range.il
@@ -62,7 +62,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_range1.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_range1.il
@@ -63,7 +63,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Arrays/range/int32_range2.il
+++ b/tests/src/JIT/Methodical/Arrays/range/int32_range2.il
@@ -63,7 +63,7 @@
 			
         	ldstr      "READ-WRITE FAILED"
         	call       void [System.Console]System.Console::WriteLine(string)
-        	newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+        	newobj		instance void [mscorlib]System.Exception::.ctor()
         	throw
         	
 		aaa:

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/finally.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/finally.il
@@ -171,7 +171,7 @@
       IL_01dc:  beq.s      IL_DROP
 
       IL_01de:  ldstr      "Loss of precision or unbox error"
-      IL_01e3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_01e3:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_01e8:  throw
 
 		IL_DROP:

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/huge_filter.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/huge_filter.il
@@ -21,10 +21,10 @@
       IL_TRY:
       			ldstr      "in try."
       			call       void [System.Console]System.Console::WriteLine(string)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.ArgumentException::.ctor()
       			throw
       IL_FILTER:
-      			castclass  [mscorlib]System.ApplicationException
+      			castclass  [mscorlib]System.ArgumentException
       			pop
       			ldstr      "in filter."
       			call       void [System.Console]System.Console::WriteLine(string)

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/jump.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/jump.il
@@ -167,7 +167,7 @@
       IL_01dc:  beq.s      IL_END
 
       IL_01de:  ldstr      "Loss of precision or unbox error"
-      IL_01e3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_01e3:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_01e8:  throw
 
 		IL_END:

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/localloc.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/localloc.il
@@ -170,7 +170,7 @@
       IL_01dc:  beq.s      IL_01e9
 
       IL_01de:  ldstr      "Loss of precision or unbox error"
-      IL_01e3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_01e3:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_01e8:  throw
 
       IL_01e9:  ret

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/simple.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/simple.il
@@ -165,7 +165,7 @@
       IL_01dc:  beq.s      IL_01e9
 
       IL_01de:  ldstr      "Loss of precision or unbox error"
-      IL_01e3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_01e3:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_01e8:  throw
 
       IL_01e9:  ret

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/tailcall.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/tailcall.il
@@ -165,7 +165,7 @@
       IL_01dc:  beq.s      IL_END
 
       IL_01de:  ldstr      "Loss of precision or unbox error"
-      IL_01e3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_01e3:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_01e8:  throw
 
 		IL_END:

--- a/tests/src/JIT/Methodical/Boxing/boxunbox/try.il
+++ b/tests/src/JIT/Methodical/Boxing/boxunbox/try.il
@@ -166,7 +166,7 @@
       IL_01dc:  beq.s      IL_DROP
 
       IL_01de:  ldstr      "Loss of precision or unbox error"
-      IL_01e3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_01e3:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_01e8:  throw
 
 		IL_DROP:

--- a/tests/src/JIT/Methodical/Boxing/callconv/instance.il
+++ b/tests/src/JIT/Methodical/Boxing/callconv/instance.il
@@ -52,7 +52,7 @@
       IL_001d:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0022:  beq.s      IL_002a
 
-      IL_0024:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0024:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0029:  throw
 
       IL_002a:  ldarg.0

--- a/tests/src/JIT/Methodical/Boxing/functional/fibo.il
+++ b/tests/src/JIT/Methodical/Boxing/functional/fibo.il
@@ -27,7 +27,7 @@
       			pop
       			br      further
 
-      bad:  	newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      bad:  	newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
 	  further:

--- a/tests/src/JIT/Methodical/Boxing/misc/nestval.il
+++ b/tests/src/JIT/Methodical/Boxing/misc/nestval.il
@@ -39,7 +39,7 @@
       IL_000b:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0010:  beq.s      IL_0018
 
-      IL_0012:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0012:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0017:  throw
 
       IL_0018:  ldarg.0

--- a/tests/src/JIT/Methodical/Boxing/misc/typedref.il
+++ b/tests/src/JIT/Methodical/Boxing/misc/typedref.il
@@ -34,7 +34,7 @@
 				br equal_types
 						       	
 	  bad:
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
       
 equal_types:

--- a/tests/src/JIT/Methodical/Boxing/seh/fault.il
+++ b/tests/src/JIT/Methodical/Boxing/seh/fault.il
@@ -15,7 +15,7 @@
 }
 .namespace SinCalc
 {
-  .class auto ansi MistakeException extends [mscorlib]System.ApplicationException
+  .class auto ansi MistakeException extends [mscorlib]System.Exception
   {
     .field public class System.Object mistake
     .method public hidebysig specialname rtspecialname 
@@ -24,7 +24,7 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldstr      "Mistake!"
-      IL_0006:  call       instance void [mscorlib]System.ApplicationException::.ctor(class System.String)
+      IL_0006:  call       instance void [mscorlib]System.Exception::.ctor(class System.String)
       IL_000b:  ldarg.0
       IL_000c:  ldarg.s   m
       IL_000e:  box        [mscorlib]System.Double

--- a/tests/src/JIT/Methodical/Boxing/seh/filter.il
+++ b/tests/src/JIT/Methodical/Boxing/seh/filter.il
@@ -11,7 +11,7 @@
 .assembly 'filter' { }
 .namespace SinCalc
 {
-  .class auto ansi MistakeException extends [mscorlib]System.ApplicationException
+  .class auto ansi MistakeException extends [mscorlib]System.Exception
   {
     .field public class System.Object mistake
     .method public hidebysig specialname rtspecialname 
@@ -20,7 +20,7 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldstr      "Mistake!"
-      IL_0006:  call       instance void [mscorlib]System.ApplicationException::.ctor(class System.String)
+      IL_0006:  call       instance void [mscorlib]System.Exception::.ctor(class System.String)
       IL_000b:  ldarg.0
       IL_000c:  ldarg.s   m
       IL_000e:  box       [mscorlib]System.Double

--- a/tests/src/JIT/Methodical/Boxing/seh/try.il
+++ b/tests/src/JIT/Methodical/Boxing/seh/try.il
@@ -11,7 +11,7 @@
 .assembly 'try' { }
 .namespace SinCalc
 {
-  .class auto ansi MistakeException extends [mscorlib]System.ApplicationException
+  .class auto ansi MistakeException extends [mscorlib]System.Exception
   {
     .field public class System.Object mistake
     .method public hidebysig specialname rtspecialname 
@@ -20,7 +20,7 @@
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldstr      "Mistake!"
-      IL_0006:  call       instance void [mscorlib]System.ApplicationException::.ctor(class System.String)
+      IL_0006:  call       instance void [mscorlib]System.Exception::.ctor(class System.String)
       IL_000b:  ldarg.0
       IL_000c:  ldarg.s   m
       IL_000e:  box       [mscorlib]System.Double

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge-i386.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge-i386.il
@@ -36,7 +36,7 @@ loop_begin:
 	ldloc.3
 	switch (err1,a1,a1,a1,a1,a2,a2,a2,a2)
 err1:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 a1:
 	ldloc.0
@@ -54,7 +54,7 @@ end_a:
 	dup
 	switch (err2,b1,b2,b1,b2,b1,b2,b1,b2)
 err2:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 b1:
 	stelem.i
@@ -73,10 +73,10 @@ end_b:
 	dup
 	switch (err3,c1,c1,c2,c2,c1,c1,c2,c2)
 err3:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 err4:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 c1:
 	ldelem.i

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge-ia64.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_array_merge-ia64.il
@@ -35,7 +35,7 @@ loop_begin:
 	ldloc.3
 	switch (err1,a1,a1,a1,a1,a2,a2,a2,a2)
 err1:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 a1:
 	ldloc.0
@@ -52,7 +52,7 @@ end_a:
 	dup
 	switch (err2,b1,b2,b1,b2,b1,b2,b1,b2)
 err2:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 b1:
 	stelem.i
@@ -71,10 +71,10 @@ end_b:
 	dup
 	switch (err3,c1,c1,c2,c2,c1,c1,c2,c2)
 err3:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 err4:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 c1:
 	ldelem.i

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_box.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/i_box.il
@@ -34,7 +34,7 @@
     	unbox [mscorlib]System.IntPtr
     	ldind.i
     	beq go
-    	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+    	newobj instance void [mscorlib]System.Exception::.ctor()
     	throw
     go:
     	ldarg.1

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge-i386.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge-i386.il
@@ -36,7 +36,7 @@ loop_begin:
 	ldloc.3
 	switch (err1,a1,a1,a1,a1,a2,a2,a2,a2)
 err1:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 a1:
 	ldloc.0
@@ -54,7 +54,7 @@ end_a:
 	dup
 	switch (err2,b1,b2,b1,b2,b1,b2,b1,b2)
 err2:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 b1:
 	stelem.i
@@ -73,10 +73,10 @@ end_b:
 	dup
 	switch (err3,c1,c1,c2,c2,c1,c1,c2,c2)
 err3:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 err4:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 c1:
 	ldelem.i

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge-ia64.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_array_merge-ia64.il
@@ -35,7 +35,7 @@ loop_begin:
 	ldloc.3
 	switch (err1,a1,a1,a1,a1,a2,a2,a2,a2)
 err1:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 a1:
 	ldloc.0
@@ -52,7 +52,7 @@ end_a:
 	dup
 	switch (err2,b1,b2,b1,b2,b1,b2,b1,b2)
 err2:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 b1:
 	stelem.i
@@ -71,10 +71,10 @@ end_b:
 	dup
 	switch (err3,c1,c1,c2,c2,c1,c1,c2,c2)
 err3:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 err4:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 c1:
 	ldelem.i

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_box.il
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/u_box.il
@@ -34,7 +34,7 @@
     	unbox [mscorlib]System.UIntPtr
     	ldind.i
     	beq go
-    	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+    	newobj instance void [mscorlib]System.Exception::.ctor()
     	throw
     go:
     	ldarg.1

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfault.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfault.il
@@ -57,7 +57,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -120,7 +120,7 @@
           IL_0026:  stelem.i4
           IL_0027:  ldstr      "Shouldn't have reached here."
           IL_002c:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0031:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0031:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_0036:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfault_jmp.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfault_jmp.il
@@ -58,7 +58,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -121,7 +121,7 @@
           IL_0026:  stelem.i4
           IL_0027:  ldstr      "Shouldn't have reached here."
           IL_002c:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0031:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0031:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_0036:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfault_tail.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfault_tail.il
@@ -58,7 +58,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -121,7 +121,7 @@
           IL_0026:  stelem.i4
           IL_0027:  ldstr      "Shouldn't have reached here."
           IL_002c:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0031:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0031:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_0036:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_ind.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_ind.il
@@ -66,7 +66,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -144,7 +144,7 @@
           IL_002a:  stelem.i4
           IL_002b:  ldstr      "Shouldn't have reached here."
           IL_0030:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0035:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0035:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_003a:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_jmp.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_jmp.il
@@ -58,7 +58,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -126,7 +126,7 @@
           IL_002a:  stelem.i4
           IL_002b:  ldstr      "Shouldn't have reached here."
           IL_0030:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0035:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0035:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_003a:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_jmpind.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_jmpind.il
@@ -58,7 +58,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -126,7 +126,7 @@
           IL_002a:  stelem.i4
           IL_002b:  ldstr      "Shouldn't have reached here."
           IL_0030:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0035:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0035:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_003a:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_tail.il
+++ b/tests/src/JIT/Methodical/Invoke/SEH/catchfinally_tail.il
@@ -58,7 +58,7 @@
         IL_0024:  stelem.i4
         IL_0025:  ldstr      "Shouldn't have reached here."
         IL_002a:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_002f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0034:  throw
 
       }  // end .try
@@ -126,7 +126,7 @@
           IL_002a:  stelem.i4
           IL_002b:  ldstr      "Shouldn't have reached here."
           IL_0030:  call       void [System.Console]System.Console::WriteLine(class System.String)
-          IL_0035:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+          IL_0035:  newobj     instance void ['mscorlib']System.Exception::.ctor()
           IL_003a:  throw
 
         }  // end .try

--- a/tests/src/JIT/Methodical/Invoke/deep/deep1.il
+++ b/tests/src/JIT/Methodical/Invoke/deep/deep1.il
@@ -260,7 +260,7 @@
         IL_0021:  ldc.r8     18.
         IL_002a:  beq.s      IL_0032
 
-        IL_002c:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002c:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0031:  throw
 
         IL_0032:  ldc.r8     0.

--- a/tests/src/JIT/Methodical/Invoke/deep/deep2.il
+++ b/tests/src/JIT/Methodical/Invoke/deep/deep2.il
@@ -254,7 +254,7 @@
         IL_0021:  ldc.r8     18.
         IL_002a:  beq.s      IL_0032
 
-        IL_002c:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_002c:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0031:  throw
 
         IL_0032:  ldc.r8     0.

--- a/tests/src/JIT/Methodical/Invoke/implicit/fr4.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/fr4.il
@@ -52,7 +52,7 @@
 
 		throwex:
 				pop
-      			newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      			newobj     instance void ['mscorlib']System.Exception::.ctor()
       			throw
     } // end of method 'Test::MulTest'
 

--- a/tests/src/JIT/Methodical/Invoke/implicit/fr8.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/fr8.il
@@ -52,7 +52,7 @@
 
 		throwex:
 				pop
-      			newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      			newobj     instance void ['mscorlib']System.Exception::.ctor()
       			throw
     } // end of method 'Test::MulTest'
 

--- a/tests/src/JIT/Methodical/Invoke/implicit/i4i1.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/i4i1.il
@@ -53,7 +53,7 @@
   			ldc.i4	   0xffffff00
   			beq.s      looks_good
   throwex:
-  			newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+  			newobj     instance void ['mscorlib']System.Exception::.ctor()
   			throw
   looks_good:
 
@@ -102,7 +102,7 @@
                 ldc.i4.0
                 ceq
                 brtrue check_done
-                newobj	instance void [mscorlib]System.ApplicationException::.ctor()
+                newobj	instance void [mscorlib]System.Exception::.ctor()
                 throw
 		check_done:
 		

--- a/tests/src/JIT/Methodical/Invoke/implicit/i4i2.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/i4i2.il
@@ -53,7 +53,7 @@
   			ldc.i4	   0xffff0000
   			beq.s      looks_good
   throwex:
-  			newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+  			newobj     instance void ['mscorlib']System.Exception::.ctor()
   			throw
   looks_good:
   
@@ -102,7 +102,7 @@
                 ldc.i4.0
                 ceq
                 brtrue check_done
-                newobj	instance void [mscorlib]System.ApplicationException::.ctor()
+                newobj	instance void [mscorlib]System.Exception::.ctor()
                 throw
 		check_done:
       			

--- a/tests/src/JIT/Methodical/Invoke/implicit/i4u1.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/i4u1.il
@@ -47,7 +47,7 @@
       			brfalse		story_about_good
       		
       	story_about_bad:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       			throw
       	story_about_good:
      IL_0000:  ldarg.0

--- a/tests/src/JIT/Methodical/Invoke/implicit/ii1.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/ii1.il
@@ -51,7 +51,7 @@
   			ldc.i4	   0xffffff00
   			beq.s      looks_good
   throwex:
-  			newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+  			newobj     instance void ['mscorlib']System.Exception::.ctor()
   			throw
   looks_good:
       	

--- a/tests/src/JIT/Methodical/Invoke/implicit/ii2.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/ii2.il
@@ -51,7 +51,7 @@
   			ldc.i4	   0xffff0000
   			beq.s      looks_good
   throwex:
-  			newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+  			newobj     instance void ['mscorlib']System.Exception::.ctor()
   			throw
   looks_good:
   

--- a/tests/src/JIT/Methodical/Invoke/implicit/iu1.il
+++ b/tests/src/JIT/Methodical/Invoke/implicit/iu1.il
@@ -47,7 +47,7 @@
       			brfalse		story_about_good
       		
       	story_about_bad:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       			throw
       	story_about_good:
       	

--- a/tests/src/JIT/Methodical/NaN/intrinsic_nonf.il
+++ b/tests/src/JIT/Methodical/NaN/intrinsic_nonf.il
@@ -69,7 +69,7 @@
       IL_0040:  stelem.ref
       IL_0041:  ldloc.0
       IL_0042:  call       string [mscorlib]System.String::Concat(string[])
-      IL_0047:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_0047:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_004c:  throw
     } // end of method Test::Fail
 
@@ -127,7 +127,7 @@
       IL_0053:  stelem.ref
       IL_0054:  ldloc.0
       IL_0055:  call       string [mscorlib]System.String::Concat(string[])
-      IL_005a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+      IL_005a:  newobj     instance void [mscorlib]System.Exception::.ctor(string)
       IL_005f:  throw
     } // end of method Test::Fail2
 

--- a/tests/src/JIT/Methodical/VT/callconv/jumps1.il
+++ b/tests/src/JIT/Methodical/VT/callconv/jumps1.il
@@ -42,7 +42,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"
@@ -76,7 +76,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"

--- a/tests/src/JIT/Methodical/VT/callconv/jumps2.il
+++ b/tests/src/JIT/Methodical/VT/callconv/jumps2.il
@@ -43,7 +43,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"
@@ -77,7 +77,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"

--- a/tests/src/JIT/Methodical/VT/callconv/jumps3.il
+++ b/tests/src/JIT/Methodical/VT/callconv/jumps3.il
@@ -42,7 +42,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"
@@ -80,7 +80,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"

--- a/tests/src/JIT/Methodical/VT/callconv/jumps4.il
+++ b/tests/src/JIT/Methodical/VT/callconv/jumps4.il
@@ -37,7 +37,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "--VT--"
@@ -78,7 +78,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "--VT--"

--- a/tests/src/JIT/Methodical/VT/callconv/jumps5.il
+++ b/tests/src/JIT/Methodical/VT/callconv/jumps5.il
@@ -43,7 +43,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"
@@ -77,7 +77,7 @@
       			ldarg.0
       			ldfld      int32 MS.VT::target
       			switch     (case0, case1, case2)
-      			newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj     instance void [mscorlib]System.Exception::.ctor()
       			throw
 
       case0:	ldstr      "VT"

--- a/tests/src/JIT/Methodical/VT/etc/han3.il
+++ b/tests/src/JIT/Methodical/VT/etc/han3.il
@@ -121,7 +121,7 @@
       IL_0023:  ldfld      int32 JitTest.Ring::size
       IL_0028:  bgt.s      IL_0030
 
-      IL_002a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_002a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_002f:  throw
 
       IL_0030:  ldloc.0

--- a/tests/src/JIT/Methodical/VT/etc/han3_ctor.il
+++ b/tests/src/JIT/Methodical/VT/etc/han3_ctor.il
@@ -121,7 +121,7 @@
       IL_0023:  ldfld      int32 JitTest.Ring::size
       IL_0028:  bgt.s      IL_0030
 
-      IL_002a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_002a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_002f:  throw
 
       IL_0030:  ldloc.0

--- a/tests/src/JIT/Methodical/VT/etc/han3_ref.il
+++ b/tests/src/JIT/Methodical/VT/etc/han3_ref.il
@@ -121,7 +121,7 @@
       IL_0023:  ldfld      int32 JitTest.Ring::size
       IL_0028:  bgt.s      IL_0030
 
-      IL_002a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_002a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_002f:  throw
 
       IL_0030:  ldloc.0

--- a/tests/src/JIT/Methodical/VT/etc/hanoi.il
+++ b/tests/src/JIT/Methodical/VT/etc/hanoi.il
@@ -54,7 +54,7 @@
       IL_001b:  ldelem.i4
       IL_001c:  bgt.s      IL_0024
 
-      IL_001e:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_001e:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0023:  throw
 
       IL_0024:  ldloc.1

--- a/tests/src/JIT/Methodical/VT/etc/hanoi2.il
+++ b/tests/src/JIT/Methodical/VT/etc/hanoi2.il
@@ -52,7 +52,7 @@
       IL_001b:  ldelem.i4
       IL_001c:  bgt.s      IL_0024
 
-      IL_001e:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_001e:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0023:  throw
 
       IL_0024:  ldloc.1

--- a/tests/src/JIT/Methodical/VT/etc/knight.il
+++ b/tests/src/JIT/Methodical/VT/etc/knight.il
@@ -129,7 +129,7 @@
       IL_00bb:  add
       IL_00bc:  beq.s      IL_00c4
 
-      IL_00be:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_00be:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_00c3:  throw
 
       IL_00c4:  ldloc.0

--- a/tests/src/JIT/Methodical/VT/etc/nested.il
+++ b/tests/src/JIT/Methodical/VT/etc/nested.il
@@ -36,7 +36,7 @@
         IL_000f:  conv.i8
         IL_0010:  beq.s      IL_0018
 
-        IL_0012:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+        IL_0012:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_0017:  throw
 
         IL_0018:  ret
@@ -61,7 +61,7 @@
       IL_000f:  conv.i8
       IL_0010:  beq.s      IL_0018
 
-      IL_0012:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0012:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0017:  throw
 
       IL_0018:  ldarg.0

--- a/tests/src/JIT/Methodical/VT/port/huge_gcref.il
+++ b/tests/src/JIT/Methodical/VT/port/huge_gcref.il
@@ -384,7 +384,7 @@
       			br pass1_5
       			
       		throw0:
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -510,7 +510,7 @@
       			brfalse throw0
       			br pass2
       			
-      			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+      			newobj		instance void [mscorlib]System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/casts/SEH/castclass_catch_neg.il
+++ b/tests/src/JIT/Methodical/casts/SEH/castclass_catch_neg.il
@@ -22,7 +22,6 @@
       .locals (int32 V_0,
                int32 V_1,
                class [mscorlib]System.Exception V_2,
-               class [mscorlib]System.ApplicationException V_3,
                int32 V_4)
       .try
       {
@@ -46,7 +45,7 @@
         }
         catch [mscorlib]System.Exception 
         {
-          IL_0020:  castclass  [mscorlib]System.ApplicationException
+          IL_0020:  castclass  [mscorlib]System.ArgumentException
           IL_0027:  call       void [System.Console]System.Console::WriteLine(object)
           IL_002c:  ldstr      "failed (2)"
           IL_0031:  call       void [System.Console]System.Console::WriteLine(string)

--- a/tests/src/JIT/Methodical/casts/SEH/isinst_catch_neg.il
+++ b/tests/src/JIT/Methodical/casts/SEH/isinst_catch_neg.il
@@ -22,7 +22,6 @@
       .locals (int32 V_0,
                int32 V_1,
                class [mscorlib]System.Exception V_2,
-               class [mscorlib]System.ApplicationException V_3,
                int32 V_4)
       .try
       {
@@ -46,7 +45,7 @@
         }
         catch [mscorlib]System.Exception 
         {
-          IL_0020:  isinst  [mscorlib]System.ApplicationException
+          IL_0020:  isinst  [mscorlib]System.ArgumentException
           			dup
           			brinst inst
 					newobj instance void [mscorlib]System.InvalidCastException::.ctor()

--- a/tests/src/JIT/Methodical/eh/interactions/throw1dimarray.il
+++ b/tests/src/JIT/Methodical/eh/interactions/throw1dimarray.il
@@ -281,7 +281,7 @@
 } 
 
 .class private auto ansi beforefieldinit MyException
-       extends [mscorlib]System.ApplicationException
+       extends [mscorlib]System.Exception
 {
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor(string msg) cil managed
@@ -289,7 +289,7 @@
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
-    IL_0002:  call       instance void [mscorlib]System.ApplicationException::.ctor(string)
+    IL_0002:  call       instance void [mscorlib]System.Exception::.ctor(string)
     IL_0007:  ldarg.0
     IL_0008:  ldstr      "http://NotARealURL.Microsoft.com/help.html"
     IL_000d:  callvirt   instance void [mscorlib]System.Exception::set_HelpLink(string)

--- a/tests/src/JIT/Methodical/eh/interactions/throw2dimarray.il
+++ b/tests/src/JIT/Methodical/eh/interactions/throw2dimarray.il
@@ -387,7 +387,7 @@
 } 
 
 .class private auto ansi beforefieldinit MyException
-       extends [mscorlib]System.ApplicationException
+       extends [mscorlib]System.Exception
 {
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor(string msg) cil managed
@@ -395,7 +395,7 @@
     .maxstack  2
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
-    IL_0002:  call       instance void [mscorlib]System.ApplicationException::.ctor(string)
+    IL_0002:  call       instance void [mscorlib]System.Exception::.ctor(string)
     IL_0007:  ldarg.0
     IL_0008:  ldstr      "http://NotARealURL.Microsoft.com/help.html"
     IL_000d:  callvirt   instance void [mscorlib]System.Exception::set_HelpLink(string)

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_c.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_c.il
@@ -63,7 +63,7 @@
       IL_0010:  ldc.i4.s   11
       IL_0012:  beq.s      IL_001a
 
-      IL_0014:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0014:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0019:  throw
 
       IL_001a:  ldarg.0
@@ -80,7 +80,7 @@
       IL_0032:  ldc.i4.s   11
       IL_0034:  beq.s      IL_003c
 
-      IL_0036:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0036:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_003b:  throw
 
       IL_003c:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_f4.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_f4.il
@@ -87,7 +87,7 @@
       IL_0013:  ldc.r4     11.314
       IL_0018:  beq.s      IL_0020
 
-      IL_001a:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_001a:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_001f:  throw
 
       IL_0020:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_f8.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_f8.il
@@ -87,7 +87,7 @@
       IL_0017:  ldc.r8     11.314
       IL_0020:  beq.s      IL_0028
 
-      IL_0022:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0022:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0027:  throw
 
       IL_0028:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_i1.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_i1.il
@@ -84,7 +84,7 @@
         IL_0034:  ldc.i4.s   11
         IL_0036:  beq.s      IL_003e
 
-        IL_0038:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0038:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_003d:  throw
 
         IL_003e:  leave.s    IL_004d

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_i2.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_i2.il
@@ -41,7 +41,7 @@
       IL_0013:  ldc.i4.s   11
       IL_0015:  beq.s      IL_001d
 
-      IL_0017:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0017:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_001c:  throw
 
       IL_001d:  ldarg.0
@@ -58,7 +58,7 @@
       IL_0038:  ldc.i4.s   11
       IL_003a:  beq.s      IL_0042
 
-      IL_003c:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_003c:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0041:  throw
 
       IL_0042:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_i4.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_i4.il
@@ -89,7 +89,7 @@
       IL_0000:  ldarg.0
       IL_0001:  brtrue.s   IL_0009
 
-      IL_0003:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0003:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0008:  throw
 
       IL_0009:  ldarg.0
@@ -102,7 +102,7 @@
       IL_001c:  ldc.i4.s   11
       IL_001e:  beq.s      IL_0026
 
-      IL_0020:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0020:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0025:  throw
 
       IL_0026:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_o.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_o.il
@@ -63,7 +63,7 @@
       IL_0010:  ldc.i4.s   11
       IL_0012:  beq.s      IL_001a
 
-      IL_0014:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0014:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0019:  throw
 
       IL_001a:  ldarg.0
@@ -82,7 +82,7 @@
       IL_003c:  ldc.i4.s   11
       IL_003e:  beq.s      IL_0046
 
-      IL_0040:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0040:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0045:  throw
 
       IL_0046:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refarg_s.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refarg_s.il
@@ -65,7 +65,7 @@
                                                                   class System.String)
       IL_001a:  brtrue.s   IL_0022
 
-      IL_001c:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_001c:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0021:  throw
 
       IL_0022:  ldarg.0
@@ -84,7 +84,7 @@
                                                                   class System.String)
       IL_0044:  brtrue.s   IL_004c
 
-      IL_0046:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0046:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_004b:  throw
 
       IL_004c:  ret

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_c.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_c.il
@@ -39,7 +39,7 @@
       			ldc.i4 84
       IL_002c:  beq.s      IL_0034
 
-      IL_002e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_002e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0033:  throw
 
       IL_0034:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_i1.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_i1.il
@@ -39,7 +39,7 @@
       			ldc.i4 45
       IL_002c:  beq.s      IL_0034
 
-      IL_002e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_002e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0033:  throw
 
       IL_0034:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_i2.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_i2.il
@@ -39,7 +39,7 @@
       			ldc.i4 -45
       IL_002c:  beq.s      IL_0034
 
-      IL_002e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_002e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0033:  throw
 
       IL_0034:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_i4.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_i4.il
@@ -39,7 +39,7 @@
       			ldc.i4 45
       IL_002c:  beq.s      IL_0034
 
-      IL_002e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_002e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0033:  throw
 
       IL_0034:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_r4.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_r4.il
@@ -41,7 +41,7 @@
       			ldc.r4     45.119999
       IL_0056:  beq.s      IL_005e
 
-      IL_0058:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0058:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_005d:  throw
 
       IL_005e:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_r8.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_r8.il
@@ -39,7 +39,7 @@
       			ldc.r8     -45.119999999999997
       IL_002c:  beq.s      IL_0034
 
-      IL_002e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_002e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0033:  throw
 
       IL_0034:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/basic/refloc_u2.il
+++ b/tests/src/JIT/Methodical/explicit/basic/refloc_u2.il
@@ -40,7 +40,7 @@
       			ldc.i4.s   45
       IL_002e:  beq.s      IL_0036
 
-      IL_0030:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0030:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0035:  throw
 
       IL_0036:  ldc.i4.1

--- a/tests/src/JIT/Methodical/explicit/rotate/rotarg_double.il
+++ b/tests/src/JIT/Methodical/explicit/rotate/rotarg_double.il
@@ -250,7 +250,7 @@
 
         IL_013e:  ldstr      "left weight do not match."
         IL_0143:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_0148:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0148:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_014d:  throw
 
         IL_014e:  ldarg.0
@@ -298,7 +298,7 @@
 
         IL_01c9:  ldstr      "right weight do not match."
         IL_01ce:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_01d3:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_01d3:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_01d8:  throw
 
         IL_01d9:  ret

--- a/tests/src/JIT/Methodical/explicit/rotate/rotarg_float.il
+++ b/tests/src/JIT/Methodical/explicit/rotate/rotarg_float.il
@@ -250,7 +250,7 @@
 
         IL_0137:  ldstr      "left weight do not match."
         IL_013c:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_0141:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0141:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0146:  throw
 
         IL_0147:  ldarg.0
@@ -298,7 +298,7 @@
 
         IL_01bb:  ldstr      "right weight do not match."
         IL_01c0:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_01c5:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_01c5:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_01ca:  throw
 
         IL_01cb:  ret

--- a/tests/src/JIT/Methodical/explicit/rotate/rotarg_objref.il
+++ b/tests/src/JIT/Methodical/explicit/rotate/rotarg_objref.il
@@ -268,7 +268,7 @@
 
         IL_0133:  ldstr      "left weight do not match."
         IL_0138:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_013d:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_013d:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0142:  throw
 
         IL_0143:  ldarg.0
@@ -316,7 +316,7 @@
 
         IL_01b3:  ldstr      "right weight do not match."
         IL_01b8:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_01bd:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_01bd:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_01c2:  throw
 
         IL_01c3:  ret

--- a/tests/src/JIT/Methodical/explicit/rotate/rotarg_valref.il
+++ b/tests/src/JIT/Methodical/explicit/rotate/rotarg_valref.il
@@ -280,7 +280,7 @@
 
         IL_0144:  ldstr      "left weight do not match."
         IL_0149:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_014e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_014e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0153:  throw
 
         IL_0154:  ldarg.0
@@ -330,7 +330,7 @@
 
         IL_01d5:  ldstr      "right weight do not match."
         IL_01da:  call       void [System.Console]System.Console::WriteLine(class System.String)
-        IL_01df:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_01df:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_01e4:  throw
 
         IL_01e5:  ret

--- a/tests/src/JIT/Methodical/explicit/rotate/rotate_i4.il
+++ b/tests/src/JIT/Methodical/explicit/rotate/rotate_i4.il
@@ -176,7 +176,7 @@
         IL_00d8:  ldfld      int32 Rotate.App/App$Node::m_weight
         IL_00dd:  beq.s      IL_00e5
 
-        IL_00df:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00df:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00e4:  throw
 
         IL_00e5:  ldarg.0
@@ -193,7 +193,7 @@
         IL_0100:  ldfld      int32 Rotate.App/App$Node::m_weight
         IL_0105:  beq.s      IL_010d
 
-        IL_0107:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0107:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_010c:  throw
 
         IL_010d:  ret

--- a/tests/src/JIT/Methodical/explicit/rotate/rotate_u2.il
+++ b/tests/src/JIT/Methodical/explicit/rotate/rotate_u2.il
@@ -190,7 +190,7 @@
         IL_00e6:  conv.i4
         IL_00e7:  beq.s      IL_00ef
 
-        IL_00e9:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00e9:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00ee:  throw
 
         IL_00ef:  ldarg.0
@@ -209,7 +209,7 @@
         IL_0110:  conv.i4
         IL_0111:  beq.s      IL_0119
 
-        IL_0113:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0113:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0118:  throw
 
         IL_0119:  ret

--- a/tests/src/JIT/Methodical/int64/arrays/hugedim.il
+++ b/tests/src/JIT/Methodical/int64/arrays/hugedim.il
@@ -363,7 +363,7 @@
       			ceq
       			brtrue pass1_5
       		throw0:
-      			newobj		instance void ['mscorlib']System.ApplicationException::.ctor()
+      			newobj		instance void ['mscorlib']System.Exception::.ctor()
       		throw1:
 				throw
 				
@@ -496,7 +496,7 @@
      			call void ['mscorlib']System.GC::Collect()
       			brtrue pass2
       			
-      			newobj		instance void ['mscorlib']System.ApplicationException::.ctor()
+      			newobj		instance void ['mscorlib']System.Exception::.ctor()
 				br throw1
     } // end of method 'Test::Main'
 

--- a/tests/src/JIT/Methodical/int64/arrays/lcs_long.il
+++ b/tests/src/JIT/Methodical/int64/arrays/lcs_long.il
@@ -174,7 +174,7 @@
       IL_00a6:  stloc.s    V_4
       IL_00a8:  br.s       IL_00b0
 
-      IL_00aa:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_00aa:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_00af:  throw
 
       IL_00b0:  ldloc.s    V_4
@@ -477,7 +477,7 @@
       IL_013e:  conv.i8
       IL_013f:  bge.s      IL_0147
 
-      IL_0141:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_0141:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_0146:  throw
 
       IL_0147:  ldarg.0

--- a/tests/src/JIT/Methodical/int64/arrays/lcs_ulong.il
+++ b/tests/src/JIT/Methodical/int64/arrays/lcs_ulong.il
@@ -174,7 +174,7 @@
       IL_00a6:  stloc.s    V_4
       IL_00a8:  br.s       IL_00b0
 
-      IL_00aa:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_00aa:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_00af:  throw
 
       IL_00b0:  ldloc.s    V_4
@@ -486,7 +486,7 @@
       IL_0147:  conv.i8
       IL_0148:  bne.un.s   IL_0150
 
-      IL_014a:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_014a:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_014f:  throw
 
       IL_0150:  ldarg.0

--- a/tests/src/JIT/Methodical/int64/signed/s_addsub.il
+++ b/tests/src/JIT/Methodical/int64/signed/s_addsub.il
@@ -139,7 +139,7 @@
         IL_008c:  ldc.i8     0x100000000
         IL_0095:  blt.un.s   IL_009d
 
-        IL_0097:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0097:  newobj     instance void ['mscorlib']System.ArgumentException::.ctor()
         IL_009c:  throw
 
         IL_009d:  ldloc.s    V_8
@@ -151,7 +151,7 @@
         IL_00a6:  sub.ovf.un
         IL_00a7:  bgt.un.s   IL_00af
 
-        IL_00a9:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00a9:  newobj     instance void ['mscorlib']System.ArgumentException::.ctor()
         IL_00ae:  throw
 
         IL_00af:  leave.s    IL_00c3
@@ -169,7 +169,7 @@
       IL_00ba:  ldarg.1
       IL_00bb:  beq.s      IL_00c3
 
-      IL_00bd:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_00bd:  newobj     instance void ['mscorlib']System.ArgumentException::.ctor()
       IL_00c2:  throw
 
       IL_00c3:  ret

--- a/tests/src/JIT/Methodical/int64/signed/s_muldiv.il
+++ b/tests/src/JIT/Methodical/int64/signed/s_muldiv.il
@@ -124,7 +124,7 @@
         IL_0068:  ldloc.2
         IL_0069:  beq.s      IL_0071
 
-        IL_006b:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_006b:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0070:  throw
 
         IL_0071:  ldloc.s    V_6
@@ -135,7 +135,7 @@
         IL_0080:  ldloc.3
         IL_0081:  beq.s      IL_0089
 
-        IL_0083:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0083:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0088:  throw
 
         IL_0089:  ldloc.s    V_4
@@ -181,7 +181,7 @@
         IL_00d1:  sub.ovf.un
         IL_00d2:  bgt.un.s   IL_00da
 
-        IL_00d4:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00d4:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00d9:  throw
 
         IL_00da:  leave.s    IL_0114
@@ -195,7 +195,7 @@
         IL_00df:  ldarg.0
         IL_00e0:  beq.s      IL_00e8
 
-        IL_00e2:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00e2:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00e7:  throw
 
         IL_00e8:  leave.s    IL_00f8
@@ -209,7 +209,7 @@
         IL_00ed:  conv.i8
         IL_00ee:  beq.s      IL_00f6
 
-        IL_00f0:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00f0:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00f5:  throw
 
         IL_00f6:  leave.s    IL_00f8
@@ -223,7 +223,7 @@
         IL_00fb:  ldarg.1
         IL_00fc:  beq.s      IL_0104
 
-        IL_00fe:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00fe:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0103:  throw
 
         IL_0104:  leave.s    IL_0114
@@ -237,7 +237,7 @@
         IL_0109:  conv.i8
         IL_010a:  beq.s      IL_0112
 
-        IL_010c:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_010c:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0111:  throw
 
         IL_0112:  leave.s    IL_0114

--- a/tests/src/JIT/Methodical/int64/unsigned/addsub.il
+++ b/tests/src/JIT/Methodical/int64/unsigned/addsub.il
@@ -53,7 +53,7 @@
         IL_000c:  ldarg.1
         IL_000d:  bge.un.s   IL_0015
 
-        IL_000f:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_000f:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0014:  throw
 
         IL_0015:  leave.s    IL_008e
@@ -109,7 +109,7 @@
         IL_0069:  ldc.i8     0x100000000
         IL_0072:  blt.un.s   IL_007a
 
-        IL_0074:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0074:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0079:  throw
 
         IL_007a:  ldloc.s    V_5
@@ -121,7 +121,7 @@
         IL_0083:  sub.ovf.un
         IL_0084:  bgt.un.s   IL_008c
 
-        IL_0086:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0086:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_008b:  throw
 
         IL_008c:  leave.s    IL_00a0
@@ -139,7 +139,7 @@
       IL_0097:  ldarg.1
       IL_0098:  beq.s      IL_00a0
 
-      IL_009a:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+      IL_009a:  newobj     instance void ['mscorlib']System.Exception::.ctor()
       IL_009f:  throw
 
       IL_00a0:  ret

--- a/tests/src/JIT/Methodical/int64/unsigned/muldiv.il
+++ b/tests/src/JIT/Methodical/int64/unsigned/muldiv.il
@@ -80,7 +80,7 @@
         IL_003b:  ldarg.0
         IL_003c:  beq.s      IL_0044
 
-        IL_003e:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_003e:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_0043:  throw
 
         IL_0044:  ldloc.3
@@ -91,7 +91,7 @@
         IL_0052:  ldarg.1
         IL_0053:  beq.s      IL_005b
 
-        IL_0055:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0055:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_005a:  throw
 
         IL_005b:  ldloc.1
@@ -129,7 +129,7 @@
         IL_0092:  sub.ovf.un
         IL_0093:  bgt.un.s   IL_009b
 
-        IL_0095:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_0095:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_009a:  throw
 
         IL_009b:  leave.s    IL_00d5
@@ -143,7 +143,7 @@
         IL_00a0:  ldarg.0
         IL_00a1:  beq.s      IL_00a9
 
-        IL_00a3:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00a3:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00a8:  throw
 
         IL_00a9:  leave.s    IL_00b9
@@ -157,7 +157,7 @@
         IL_00ae:  conv.i8
         IL_00af:  beq.s      IL_00b7
 
-        IL_00b1:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00b1:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00b6:  throw
 
         IL_00b7:  leave.s    IL_00b9
@@ -171,7 +171,7 @@
         IL_00bc:  ldarg.1
         IL_00bd:  beq.s      IL_00c5
 
-        IL_00bf:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00bf:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00c4:  throw
 
         IL_00c5:  leave.s    IL_00d5
@@ -185,7 +185,7 @@
         IL_00ca:  conv.i8
         IL_00cb:  beq.s      IL_00d3
 
-        IL_00cd:  newobj     instance void ['mscorlib']System.ApplicationException::.ctor()
+        IL_00cd:  newobj     instance void ['mscorlib']System.Exception::.ctor()
         IL_00d2:  throw
 
         IL_00d3:  leave.s    IL_00d5

--- a/tests/src/JIT/Methodical/nonvirtualcall/classic.il
+++ b/tests/src/JIT/Methodical/nonvirtualcall/classic.il
@@ -780,7 +780,7 @@
                                                                 object)
     IL_004c:  stloc.0
     IL_004d:  ldloc.0
-    IL_004e:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+    IL_004e:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string)
     IL_0053:  throw
 
     IL_0054:  ret

--- a/tests/src/JIT/Methodical/nonvirtualcall/delegate.il
+++ b/tests/src/JIT/Methodical/nonvirtualcall/delegate.il
@@ -677,7 +677,7 @@
                                                                 object)
     IL_004c:  stloc.0
     IL_004d:  ldloc.0
-    IL_004e:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+    IL_004e:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string)
     IL_0053:  throw
 
     IL_0054:  ret

--- a/tests/src/JIT/Methodical/nonvirtualcall/generics.il
+++ b/tests/src/JIT/Methodical/nonvirtualcall/generics.il
@@ -792,7 +792,7 @@
                                                                 object)
     IL_004c:  stloc.0
     IL_004d:  ldloc.0
-    IL_004e:  newobj     instance void [mscorlib]System.ApplicationException::.ctor(string)
+    IL_004e:  newobj     instance void [mscorlib]System.ArgumentException::.ctor(string)
     IL_0053:  throw
 
     IL_0054:  ret

--- a/tests/src/JIT/Methodical/refany/format.il
+++ b/tests/src/JIT/Methodical/refany/format.il
@@ -95,7 +95,7 @@
       IL_0053:  ldloc.0
       IL_0054:  blt.s      IL_005c
 
-      IL_0056:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0056:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_005b:  throw
 
       IL_005c:  ldc.i4.0
@@ -122,7 +122,7 @@
       IL_0084:  ldloc.0
       IL_0085:  blt.s      IL_008d
 
-      IL_0087:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0087:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_008c:  throw
 
       IL_008d:  ldloc.3
@@ -133,7 +133,7 @@
       IL_0092:  ldc.i4.1
       IL_0093:  bne.un.s   IL_009b
 
-      IL_0095:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0095:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_009a:  throw
 
       IL_009b:  ldloc.1
@@ -166,7 +166,7 @@
       IL_00ed:  ldind.i1
       IL_00ee:  brfalse.s  IL_00f6
 
-      IL_00f0:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_00f0:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_00f5:  throw
 
       IL_00f6:  ldarg.1
@@ -176,7 +176,7 @@
       IL_0103:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0108:  beq.s      IL_0110
 
-      IL_010a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_010a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_010f:  throw
 
       IL_0110:  ldarg.1
@@ -210,7 +210,7 @@
       IL_0152:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0157:  beq.s      IL_015f
 
-      IL_0159:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0159:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_015e:  throw
 
       IL_015f:  ldloc.2
@@ -229,7 +229,7 @@
       IL_0183:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0188:  beq.s      IL_0190
 
-      IL_018a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_018a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_018f:  throw
 
       IL_0190:  ldloc.2
@@ -253,7 +253,7 @@
       IL_01be:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_01c3:  beq.s      IL_01cb
 
-      IL_01c5:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_01c5:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_01ca:  throw
 
       IL_01cb:  ldloc.2
@@ -272,7 +272,7 @@
       IL_01ef:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_01f4:  beq.s      IL_01fc
 
-      IL_01f6:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_01f6:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_01fb:  throw
 
       IL_01fc:  ldloc.2
@@ -296,7 +296,7 @@
       IL_022a:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_022f:  beq.s      IL_0237
 
-      IL_0231:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0231:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0236:  throw
 
       IL_0237:  ldloc.2
@@ -315,7 +315,7 @@
       IL_025b:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0260:  beq.s      IL_0268
 
-      IL_0262:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0262:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0267:  throw
 
       IL_0268:  ldloc.2
@@ -332,7 +332,7 @@
       IL_0286:  ldind.i1
       IL_0287:  brfalse.s  IL_028f
 
-      IL_0289:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0289:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_028e:  throw
 
       IL_028f:  ldarg.1
@@ -342,7 +342,7 @@
       IL_029c:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_02a1:  beq.s      IL_02a9
 
-      IL_02a3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02a3:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02a8:  throw
 
       IL_02a9:  ldloc.2
@@ -367,7 +367,7 @@
       IL_02d3:  ldind.i1
       IL_02d4:  brfalse.s  IL_02dc
 
-      IL_02d6:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02d6:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02db:  throw
 
       IL_02dc:  ldarg.1
@@ -377,7 +377,7 @@
       IL_02e9:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_02ee:  beq.s      IL_02f6
 
-      IL_02f0:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02f0:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02f5:  throw
 
       IL_02f6:  ldloc.2
@@ -394,7 +394,7 @@
       IL_0314:  ldind.i1
       IL_0315:  brfalse.s  IL_031d
 
-      IL_0317:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0317:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_031c:  throw
 
       IL_031d:  ldarg.1
@@ -404,7 +404,7 @@
       IL_032a:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_032f:  beq.s      IL_0337
 
-      IL_0331:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0331:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0336:  throw
 
       IL_0337:  ldloc.2
@@ -423,7 +423,7 @@
       IL_0357:  ldind.i1
       IL_0358:  brfalse.s  IL_0360
 
-      IL_035a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_035a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_035f:  throw
 
       IL_0360:  ldarg.1
@@ -433,7 +433,7 @@
       IL_036d:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0372:  beq.s      IL_037a
 
-      IL_0374:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0374:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0379:  throw
 
       IL_037a:  ldarg.1
@@ -468,10 +468,10 @@
       IL_03bf:  stloc.2
       IL_03c0:  br.s       IL_03ce
 
-      IL_03c2:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_03c2:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_03c7:  throw
 
-      IL_03c8:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_03c8:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_03cd:  throw
 
       IL_03ce:  ldloc.s    V_4
@@ -532,7 +532,7 @@
       IL_003e:  ldloc.1
       IL_003f:  call       string [mscorlib]System.String::Concat(string[])
       IL_0044:  call       void [System.Console]System.Console::WriteLine(string)
-      IL_0049:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0049:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_004e:  throw
 
       IL_004f:  ret

--- a/tests/src/JIT/Methodical/refany/indcall.il
+++ b/tests/src/JIT/Methodical/refany/indcall.il
@@ -41,7 +41,7 @@
 			call class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle )
 			ceq
 			brtrue OK
-			newobj		instance void [mscorlib]System.ApplicationException::.ctor()
+			newobj		instance void [mscorlib]System.Exception::.ctor()
 			throw
 		OK:
 			ldarg.1

--- a/tests/src/JIT/Methodical/refany/lcs.il
+++ b/tests/src/JIT/Methodical/refany/lcs.il
@@ -183,7 +183,7 @@
                                                                      typedref)
       IL_00ee:  ret
 
-      IL_00ef:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_00ef:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_00f4:  throw
     } // end of method LCS::buildLCS
 
@@ -457,7 +457,7 @@
       IL_0132:  ldc.i4.0
       IL_0133:  bge.s      IL_013b
 
-      IL_0135:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0135:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_013a:  throw
 
       IL_013b:  ldarg.0

--- a/tests/src/JIT/Methodical/refany/longsig.il
+++ b/tests/src/JIT/Methodical/refany/longsig.il
@@ -95,7 +95,7 @@
       IL_0053:  ldloc.0
       IL_0054:  blt.s      IL_005c
 
-      IL_0056:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0056:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_005b:  throw
 
       IL_005c:  ldc.i4.0
@@ -122,7 +122,7 @@
       IL_0084:  ldloc.0
       IL_0085:  blt.s      IL_008d
 
-      IL_0087:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0087:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_008c:  throw
 
       IL_008d:  ldloc.3
@@ -133,7 +133,7 @@
       IL_0092:  ldc.i4.1
       IL_0093:  bne.un.s   IL_009b
 
-      IL_0095:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0095:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_009a:  throw
 
       IL_009b:  ldloc.1
@@ -166,7 +166,7 @@
       IL_00ed:  ldobj [mscorlib]System.Boolean
       IL_00ee:  brfalse.s  IL_00f6
 
-      IL_00f0:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_00f0:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_00f5:  throw
 
       IL_00f6:  ldarg.1
@@ -176,7 +176,7 @@
       IL_0103:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0108:  beq.s      IL_0110
 
-      IL_010a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_010a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_010f:  throw
 
       IL_0110:  ldarg.1
@@ -210,7 +210,7 @@
       IL_0152:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0157:  beq.s      IL_015f
 
-      IL_0159:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0159:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_015e:  throw
 
       IL_015f:  ldloc.2
@@ -229,7 +229,7 @@
       IL_0183:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0188:  beq.s      IL_0190
 
-      IL_018a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_018a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_018f:  throw
 
       IL_0190:  ldloc.2
@@ -253,7 +253,7 @@
       IL_01be:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_01c3:  beq.s      IL_01cb
 
-      IL_01c5:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_01c5:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_01ca:  throw
 
       IL_01cb:  ldloc.2
@@ -272,7 +272,7 @@
       IL_01ef:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_01f4:  beq.s      IL_01fc
 
-      IL_01f6:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_01f6:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_01fb:  throw
 
       IL_01fc:  ldloc.2
@@ -296,7 +296,7 @@
       IL_022a:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_022f:  beq.s      IL_0237
 
-      IL_0231:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0231:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0236:  throw
 
       IL_0237:  ldloc.2
@@ -315,7 +315,7 @@
       IL_025b:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0260:  beq.s      IL_0268
 
-      IL_0262:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0262:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0267:  throw
 
       IL_0268:  ldloc.2
@@ -332,7 +332,7 @@
       IL_0286:  ldobj [mscorlib]System.Boolean
       IL_0287:  brfalse.s  IL_028f
 
-      IL_0289:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0289:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_028e:  throw
 
       IL_028f:  ldarg.1
@@ -342,7 +342,7 @@
       IL_029c:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_02a1:  beq.s      IL_02a9
 
-      IL_02a3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02a3:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02a8:  throw
 
       IL_02a9:  ldloc.2
@@ -367,7 +367,7 @@
       IL_02d3:  ldobj [mscorlib]System.Boolean
       IL_02d4:  brfalse.s  IL_02dc
 
-      IL_02d6:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02d6:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02db:  throw
 
       IL_02dc:  ldarg.1
@@ -377,7 +377,7 @@
       IL_02e9:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_02ee:  beq.s      IL_02f6
 
-      IL_02f0:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02f0:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02f5:  throw
 
       IL_02f6:  ldloc.2
@@ -394,7 +394,7 @@
       IL_0314:  ldobj [mscorlib]System.Boolean
       IL_0315:  brfalse.s  IL_031d
 
-      IL_0317:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0317:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_031c:  throw
 
       IL_031d:  ldarg.1
@@ -404,7 +404,7 @@
       IL_032a:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_032f:  beq.s      IL_0337
 
-      IL_0331:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0331:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0336:  throw
 
       IL_0337:  ldloc.2
@@ -423,7 +423,7 @@
       IL_0357:  ldobj [mscorlib]System.Boolean
       IL_0358:  brfalse.s  IL_0360
 
-      IL_035a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_035a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_035f:  throw
 
       IL_0360:  ldarg.1
@@ -433,7 +433,7 @@
       IL_036d:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0372:  beq.s      IL_037a
 
-      IL_0374:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0374:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0379:  throw
 
       IL_037a:  ldarg.1
@@ -468,10 +468,10 @@
       IL_03bf:  stloc.2
       IL_03c0:  br.s       IL_03ce
 
-      IL_03c2:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_03c2:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_03c7:  throw
 
-      IL_03c8:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_03c8:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_03cd:  throw
 
       IL_03ce:  ldloc.s    V_4
@@ -532,7 +532,7 @@
       IL_003e:  ldloc.1
       IL_003f:  call       string [mscorlib]System.String::Concat(string[])
       IL_0044:  call       void [System.Console]System.Console::WriteLine(string)
-      IL_0049:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0049:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_004e:  throw
 
       IL_004f:  ret

--- a/tests/src/JIT/Methodical/refany/shortsig.il
+++ b/tests/src/JIT/Methodical/refany/shortsig.il
@@ -94,7 +94,7 @@
       IL_0053:  ldloc.0
       IL_0054:  blt.s      IL_005c
 
-      IL_0056:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0056:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_005b:  throw
 
       IL_005c:  ldc.i4.0
@@ -121,7 +121,7 @@
       IL_0084:  ldloc.0
       IL_0085:  blt.s      IL_008d
 
-      IL_0087:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0087:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_008c:  throw
 
       IL_008d:  ldloc.3
@@ -132,7 +132,7 @@
       IL_0092:  ldc.i4.1
       IL_0093:  bne.un.s   IL_009b
 
-      IL_0095:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0095:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_009a:  throw
 
       IL_009b:  ldloc.1
@@ -165,7 +165,7 @@
       IL_00ed:  ldind.i1
       IL_00ee:  brfalse.s  IL_00f6
 
-      IL_00f0:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_00f0:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_00f5:  throw
 
       IL_00f6:  ldarg.1
@@ -175,7 +175,7 @@
       IL_0103:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0108:  beq.s      IL_0110
 
-      IL_010a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_010a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_010f:  throw
 
       IL_0110:  ldarg.1
@@ -209,7 +209,7 @@
       IL_0152:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0157:  beq.s      IL_015f
 
-      IL_0159:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0159:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_015e:  throw
 
       IL_015f:  ldloc.2
@@ -228,7 +228,7 @@
       IL_0183:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0188:  beq.s      IL_0190
 
-      IL_018a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_018a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_018f:  throw
 
       IL_0190:  ldloc.2
@@ -252,7 +252,7 @@
       IL_01be:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_01c3:  beq.s      IL_01cb
 
-      IL_01c5:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_01c5:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_01ca:  throw
 
       IL_01cb:  ldloc.2
@@ -271,7 +271,7 @@
       IL_01ef:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_01f4:  beq.s      IL_01fc
 
-      IL_01f6:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_01f6:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_01fb:  throw
 
       IL_01fc:  ldloc.2
@@ -295,7 +295,7 @@
       IL_022a:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_022f:  beq.s      IL_0237
 
-      IL_0231:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0231:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0236:  throw
 
       IL_0237:  ldloc.2
@@ -314,7 +314,7 @@
       IL_025b:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0260:  beq.s      IL_0268
 
-      IL_0262:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0262:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0267:  throw
 
       IL_0268:  ldloc.2
@@ -331,7 +331,7 @@
       IL_0286:  ldind.i1
       IL_0287:  brfalse.s  IL_028f
 
-      IL_0289:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0289:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_028e:  throw
 
       IL_028f:  ldarg.1
@@ -341,7 +341,7 @@
       IL_029c:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_02a1:  beq.s      IL_02a9
 
-      IL_02a3:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02a3:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02a8:  throw
 
       IL_02a9:  ldloc.2
@@ -366,7 +366,7 @@
       IL_02d3:  ldind.i1
       IL_02d4:  brfalse.s  IL_02dc
 
-      IL_02d6:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02d6:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02db:  throw
 
       IL_02dc:  ldarg.1
@@ -376,7 +376,7 @@
       IL_02e9:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_02ee:  beq.s      IL_02f6
 
-      IL_02f0:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_02f0:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_02f5:  throw
 
       IL_02f6:  ldloc.2
@@ -393,7 +393,7 @@
       IL_0314:  ldind.i1
       IL_0315:  brfalse.s  IL_031d
 
-      IL_0317:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0317:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_031c:  throw
 
       IL_031d:  ldarg.1
@@ -403,7 +403,7 @@
       IL_032a:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_032f:  beq.s      IL_0337
 
-      IL_0331:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0331:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0336:  throw
 
       IL_0337:  ldloc.2
@@ -422,7 +422,7 @@
       IL_0357:  ldind.i1
       IL_0358:  brfalse.s  IL_0360
 
-      IL_035a:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_035a:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_035f:  throw
 
       IL_0360:  ldarg.1
@@ -432,7 +432,7 @@
       IL_036d:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(value class [mscorlib]System.RuntimeTypeHandle)
       IL_0372:  beq.s      IL_037a
 
-      IL_0374:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0374:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_0379:  throw
 
       IL_037a:  ldarg.1
@@ -467,10 +467,10 @@
       IL_03bf:  stloc.2
       IL_03c0:  br.s       IL_03ce
 
-      IL_03c2:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_03c2:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_03c7:  throw
 
-      IL_03c8:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_03c8:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_03cd:  throw
 
       IL_03ce:  ldloc.s    V_4
@@ -531,7 +531,7 @@
       IL_003e:  ldloc.1
       IL_003f:  call       string [mscorlib]System.String::Concat(string[])
       IL_0044:  call       void [System.Console]System.Console::WriteLine(string)
-      IL_0049:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+      IL_0049:  newobj     instance void [mscorlib]System.Exception::.ctor()
       IL_004e:  throw
 
       IL_004f:  ret

--- a/tests/src/JIT/Methodical/varargs/seh/fault.il
+++ b/tests/src/JIT/Methodical/varargs/seh/fault.il
@@ -15,14 +15,14 @@
 }
 .namespace VATestLib
 {
-  .class public auto ansi FormatSpecException extends [mscorlib]System.ApplicationException
+  .class public auto ansi FormatSpecException extends [mscorlib]System.Exception
   {
     .method public specialname rtspecialname instance void .ctor() il managed
     {
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldstr      "Invalid format spec"
-      IL_0006:  call       instance void [mscorlib]System.ApplicationException::.ctor(class System.String)
+      IL_0006:  call       instance void [mscorlib]System.Exception::.ctor(class System.String)
       IL_000b:  ret
     } 
 

--- a/tests/src/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b47392/b47392.il
+++ b/tests/src/JIT/Regression/CLR-x86-EJIT/V1-M12-Beta2/b47392/b47392.il
@@ -24,7 +24,7 @@
 	again:
 		ldloc i
 		switch (case1,case2,case3,stop)
-		newobj instance void [mscorlib]System.ApplicationException::.ctor()
+		newobj instance void [mscorlib]System.Exception::.ctor()
 		throw
 	case1:
 		ldloca i

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324a.il
@@ -13,14 +13,14 @@
 }
 .namespace Test
 {
-  .class public auto ansi FormatSpecException extends [mscorlib]System.ApplicationException
+  .class public auto ansi FormatSpecException extends [mscorlib]System.Exception
   {
     .method public specialname rtspecialname instance void .ctor() il managed
     {
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldstr      "Invalid format spec"
-      IL_0006:  call       instance void [mscorlib]System.ApplicationException::.ctor(class [mscorlib]System.String)
+      IL_0006:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.String)
       IL_000b:  ret
     } 
 

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M09.5-PDC/b26324/b26324b.il
@@ -13,14 +13,14 @@
 }
 .namespace Test
 {
-  .class public auto ansi FormatSpecException extends [mscorlib]System.ApplicationException
+  .class public auto ansi FormatSpecException extends [mscorlib]System.Exception
   {
     .method public specialname rtspecialname instance void .ctor() il managed
     {
       .maxstack  8
       IL_0000:  ldarg.0
       IL_0001:  ldstr      "Invalid format spec"
-      IL_0006:  call       instance void [mscorlib]System.ApplicationException::.ctor(class [mscorlib]System.String)
+      IL_0006:  call       instance void [mscorlib]System.Exception::.ctor(class [mscorlib]System.String)
       IL_000b:  ret
     } 
 

--- a/tests/src/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b92289/b92289.il
+++ b/tests/src/JIT/Regression/CLR-x86-JIT/V1-M13-RTM/b92289/b92289.il
@@ -57,7 +57,7 @@
 	start_try1: 
 		call void EHTest::f3()
 	try1_out:
-	newobj instance void [mscorlib]System.ApplicationException::.ctor()
+	newobj instance void [mscorlib]System.Exception::.ctor()
 	throw
 	end_try1: 
 	OUT: ret

--- a/tests/src/JIT/Regression/VS-ia64-JIT/M00/b112348/length0.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/M00/b112348/length0.il
@@ -62,7 +62,7 @@
 
         IL_0025:  ldstr      "READ-WRITE FAILED"
         IL_002a:  call       void [System.Console]System.Console::WriteLine(string)
-        IL_002f:  newobj     instance void [mscorlib]System.ApplicationException::.ctor()
+        IL_002f:  newobj     instance void [mscorlib]System.Exception::.ctor()
         IL_0034:  throw
 
         IL_0035:  ldstr      ": OK"

--- a/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b410474/b410474.il
+++ b/tests/src/JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b410474/b410474.il
@@ -10,31 +10,31 @@
 ldsfld int8 [b410474]A::a0100
 ldc.i4 0
 beq a0101
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0101:
 ldsfld int8 [b410474]A::a0101
 ldc.i4 1
 beq a0102
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0102:
 ldsfld float32 [b410474]A::a0102
 ldc.r4 2.0
 beq a0103
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0103:
 ldsfld int16 [b410474]A::a0103
 ldc.i4 3
 beq a0104
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0104:
 ldsfld float32 [b410474]A::a0104
 ldc.r4 4.0
 beq a0105
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0105:
 ret}
@@ -43,35 +43,35 @@ ldsflda int8 [b410474]A::a0100
 ldind.i1
 ldc.i4 0
 beq a0100
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0100:
 ldsflda int8 [b410474]A::a0101
 ldind.i1
 ldc.i4 1
 beq a0101
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0101:
 ldsflda float32 [b410474]A::a0102
 ldind.r4
 ldc.r4 2.0
 beq a0102
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0102:
 ldsflda int16 [b410474]A::a0103
 ldind.i2
 ldc.i4 3
 beq a0103
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0103:
 ldsflda float32 [b410474]A::a0104
 ldind.r4
 ldc.r4 4.0
 beq a0104
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0104:
 ret}
@@ -79,31 +79,31 @@ ret}
 ldsfld float32 [b410474]A::a0102
 ldc.r4 2.0
 beq a0106
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0106:
 ldsfld int8 [b410474]A::a0101
 ldc.i4 1
 beq a0107
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0107:
 ldsfld float32 [b410474]A::a0104
 ldc.r4 4.0
 beq a0108
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0108:
 ldsfld int16 [b410474]A::a0103
 ldc.i4 3
 beq a0109
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0109:
 ldsfld int16 [b410474]A::a0103
 ldc.i4 3
 beq a01010
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a01010:
 ret}
@@ -124,7 +124,7 @@ ldind.i1
 ldc.i4 0
 beq a0100
 ldstr "a0100"
-newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+newobj instance void [mscorlib]System.Exception::.ctor(string)
 throw
 a0100:
 ldsflda int8 [b410474]A::a0101
@@ -139,7 +139,7 @@ ldind.i1
 ldc.i4 1
 beq a0101
 ldstr "a0101"
-newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+newobj instance void [mscorlib]System.Exception::.ctor(string)
 throw
 a0101:
 ldsflda float32 [b410474]A::a0102
@@ -153,7 +153,7 @@ ldind.r4
 ldc.r4 2.0
 beq a0102
 ldstr "a0102"
-newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+newobj instance void [mscorlib]System.Exception::.ctor(string)
 throw
 a0102:
 ldsflda int16 [b410474]A::a0103
@@ -168,7 +168,7 @@ ldind.i2
 ldc.i4 3
 beq a0103
 ldstr "a0103"
-newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+newobj instance void [mscorlib]System.Exception::.ctor(string)
 throw
 a0103:
 ldsflda float32 [b410474]A::a0104
@@ -182,7 +182,7 @@ ldind.r4
 ldc.r4 4.0
 beq a0104
 ldstr "a0104"
-newobj instance void [mscorlib]System.ApplicationException::.ctor(string)
+newobj instance void [mscorlib]System.Exception::.ctor(string)
 throw
 a0104:
 ret}
@@ -194,7 +194,7 @@ stsfld int8 [b410474]A::a0100
 ldsfld int8 [b410474]A::a0100
 ldc.i4 1
 beq a0100
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0100:
 ldsfld int8 [b410474]A::a0101
@@ -204,7 +204,7 @@ stsfld int8 [b410474]A::a0101
 ldsfld int8 [b410474]A::a0101
 ldc.i4 2
 beq a0101
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0101:
 ldsfld float32 [b410474]A::a0102
@@ -214,7 +214,7 @@ stsfld float32 [b410474]A::a0102
 ldsfld float32 [b410474]A::a0102
 ldc.r4 3.0
 beq a0102
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0102:
 ldsfld int16 [b410474]A::a0103
@@ -224,7 +224,7 @@ stsfld int16 [b410474]A::a0103
 ldsfld int16 [b410474]A::a0103
 ldc.i4 4
 beq a0103
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0103:
 ldsfld float32 [b410474]A::a0104
@@ -234,7 +234,7 @@ stsfld float32 [b410474]A::a0104
 ldsfld float32 [b410474]A::a0104
 ldc.r4 5.0
 beq a0104
-newobj instance void [mscorlib]System.ApplicationException::.ctor()
+newobj instance void [mscorlib]System.Exception::.ctor()
 throw
 a0104:
 ret}

--- a/tests/src/JIT/jit64/mcc/common/common.il
+++ b/tests/src/JIT/jit64/mcc/common/common.il
@@ -63,7 +63,7 @@
 } // end of class MCCTest.FormatUtils
 
 .class public auto ansi beforefieldinit MCCTest.ResultVerificationException
-       extends [mscorlib]System.ApplicationException
+       extends [mscorlib]System.Exception
 {
   .method public hidebysig specialname rtspecialname 
           instance void  .ctor(string fieldName,
@@ -163,7 +163,7 @@
     IL_0000:  ldarg.0
     IL_0001:  ldarg.1
     IL_0002:  ldarg.2
-    IL_0003:  call       instance void [mscorlib]System.ApplicationException::.ctor(string,
+    IL_0003:  call       instance void [mscorlib]System.Exception::.ctor(string,
                                                                                     class [mscorlib]System.Exception)
     IL_0008:  nop
     IL_0009:  nop


### PR DESCRIPTION
ApplicationException is not in the .NET Core profile. Most of these
tests only use it to crash the test with an unhandled exception and it
doesn't matter what exception type it is.

Most of these are blind replacements with Exception, but for some, I made them throw ArgumentException mostly because there was a catch block and the test was expecting a "good" exception and ApplicationException played the role of a "bad" exception and this made them different enough just to be sure. These were special:

```
tests/src/JIT/Directed/ExcepFilters/mixed3/mixed3.il 
tests/src/JIT/Methodical/Boxing/boxunbox/huge_filter.il
tests/src/JIT/Methodical/casts/SEH/castclass_catch_neg.il
tests/src/JIT/Methodical/casts/SEH/isinst_catch_neg.il
tests/src/JIT/Methodical/int64/signed/s_addsub.il
tests/src/JIT/Methodical/nonvirtualcall/classic.il
tests/src/JIT/Methodical/nonvirtualcall/delegate.il
tests/src/JIT/Methodical/nonvirtualcall/generics.il 
```

Fixes #2131.