### PR TITLE
Inliner: initial version of a model-based policy

### DIFF
--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -84,6 +84,7 @@ INLINE_OBSERVATION(IS_DISCRETIONARY_INLINE,   bool,   "can inline, check heurist
 INLINE_OBSERVATION(IS_FORCE_INLINE,           bool,   "aggressive inline attribute",   INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_INSTANCE_CTOR,          bool,   "instance constructor",          INFORMATION, CALLEE)
 INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLEE)
+INLINE_OBSERVATION(IS_SIZE_DECREASING_INLINE, bool,   "size decreasing inline",        INFORMATION, CALLEE)
 INLINE_OBSERVATION(LOOKS_LIKE_WRAPPER,        bool,   "thin wrapper around a call",    INFORMATION, CALLEE)
 INLINE_OBSERVATION(MAXSTACK,                  int,    "maxstack",                      INFORMATION, CALLEE)
 INLINE_OBSERVATION(OPCODE,                    int,    "next opcode in IL stream",      INFORMATION, CALLEE)
@@ -153,6 +154,7 @@ INLINE_OBSERVATION(CONSTANT_ARG_FEEDS_TEST,   bool,   "constant argument feeds t
 INLINE_OBSERVATION(DEPTH,                     int,    "depth",                         INFORMATION, CALLSITE)
 INLINE_OBSERVATION(FREQUENCY,                 int,    "execution frequency",           INFORMATION, CALLSITE)
 INLINE_OBSERVATION(IS_PROFITABLE_INLINE,      bool,   "profitable inline",             INFORMATION, CALLSITE)
+INLINE_OBSERVATION(IS_SIZE_DECREASING_INLINE, bool,   "size decreasing inline",        INFORMATION, CALLSITE)
 INLINE_OBSERVATION(RANDOM_ACCEPT,             bool,   "random accept",                 INFORMATION, CALLSITE)
 
 // ------ Final Sentinel ------- 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -193,6 +193,7 @@ CONFIG_STRING(TailCallOpt, W("TailCallOpt"))
 CONFIG_INTEGER(JitInlineDumpData, W("JitInlineDumpData"), 0)
 CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
+CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
 #undef CONFIG_INTEGER


### PR DESCRIPTION
Add a model-based size predictor to the `DiscretionaryPolicy` and
dump its data along with observations. This can be used to assess
the performance of the model. Currently using a linear model that
can explain about 55% of the variability in code size impact for
mscorlib. Whether this holds up for other situations is still to
be determined.

Create a `ModelPolicy` that relies on this code size model to make
inlining decisions. This is very much a work in progress as the code
size models are still not well vetted and there is no real code
quality model yet.