### PR TITLE
Fix LPTSTRTest failure - it has a incorrect constant

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -310,12 +310,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_cs_il\_orelsin_cs_il.cmd" >
              <Issue>3216</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\Interop\StringMarshalling\LPSTR\LPSTRTest\LPSTRTest.cmd" >
-             <Issue>3572</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\Interop\StringMarshalling\LPTSTR\LPTSTRTest\LPTSTRTest.cmd" >
-             <Issue>3571</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\Interop\BestFitMapping\BestFitMapping\BestFitMapping.cmd" >
              <Issue>3571</Issue>
 	</ExcludeList>

--- a/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTestNative.cpp
+++ b/tests/src/Interop/StringMarshalling/LPTSTR/LPTSTRTestNative.cpp
@@ -11,7 +11,7 @@ const WCHAR* strReturn = W("a\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
 
 const WCHAR* strErrReturn = W("Error");
 
-const WCHAR* strNative = W("Native\0String\0");
+const WCHAR* strNative = W(" Native\0String\0");
 size_t lenstrNative = 7; //the len of strNative
 
 extern "C" LPWSTR ReturnString()

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -172,7 +172,6 @@ Interop/SimpleStruct/SimpleStruct/SimpleStruct.sh
 Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/MarshalStructAsLayoutExp.sh
 Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq/MarshalStructAsLayoutSeq.sh
 Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest/MarshalArrayByValTest.sh
-Interop/StringMarshalling/LPTSTR/LPTSTRTest/LPTSTRTest.sh
 GC/LargeMemory/Allocation/finalizertest/finalizertest.sh
 GC/LargeMemory/API/gc/reregisterforfinalize/reregisterforfinalize.sh
 GC/LargeMemory/API/gc/collect/collect.sh


### PR DESCRIPTION
Fix #4197. Probably from bad merging. 