### PR TITLE
Change Marshal.SizeOf to sizeof because Marshal.Copy copies managed c…

### DIFF
--- a/tests/src/Interop/MarshalAPI/Copy/CopyByteArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyByteArray.cs
@@ -96,7 +96,7 @@ public class CopyByteArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(byte) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -153,7 +153,7 @@ public class CopyByteArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(byte) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopyCharArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyCharArray.cs
@@ -86,7 +86,7 @@ public class CopyCharArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(char) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -141,7 +141,7 @@ public class CopyCharArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(char) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopyDoubleArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyDoubleArray.cs
@@ -87,7 +87,7 @@ public class CopyDoubleArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(double) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -142,7 +142,7 @@ public class CopyDoubleArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(double) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopyInt16Array.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyInt16Array.cs
@@ -88,7 +88,7 @@ public class CopyInt16ArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(short) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -142,7 +142,7 @@ public class CopyInt16ArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(short) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopyInt32Array.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyInt32Array.cs
@@ -90,7 +90,7 @@ public class CopyInt32ArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(int) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -145,7 +145,7 @@ public class CopyInt32ArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(int) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopyInt64Array.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyInt64Array.cs
@@ -90,7 +90,7 @@ public class CopyInt64ArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(long) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -144,7 +144,7 @@ public class CopyInt64ArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(long) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopyIntPtrArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopyIntPtrArray.cs
@@ -89,7 +89,7 @@ public class CopyIntPtrArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = IntPtr.Size * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -147,7 +147,7 @@ public class CopyIntPtrArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = IntPtr.Size * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 

--- a/tests/src/Interop/MarshalAPI/Copy/CopySingleArray.cs
+++ b/tests/src/Interop/MarshalAPI/Copy/CopySingleArray.cs
@@ -91,7 +91,7 @@ public class CopySingleArrayTest
 
     private void OutOfRangeTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(float) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 
@@ -144,7 +144,7 @@ public class CopySingleArrayTest
 
     private void CopyRoundTripTests()
     {
-        int sizeOfArray = Marshal.SizeOf(TestArray[0]) * TestArray.Length;
+        int sizeOfArray = sizeof(float) * TestArray.Length;
 
         IntPtr ptr = Marshal.AllocCoTaskMem(sizeOfArray);
 


### PR DESCRIPTION
…ontents and does not do marshalling.

Fix issue #4254 