### PR TITLE
ARM: fix build warning for unw usage

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -88,6 +88,9 @@ elseif(PAL_CMAKE_PLATFORM_ARCH_ARM64)
   )
 endif()
 
+if(CLR_CMAKE_PLATFORM_UNIX_TARGET_ARM)
+set_source_files_properties(exception/seh.cpp PROPERTIES COMPILE_FLAGS -Wno-error=inline-asm)
+endif(CLR_CMAKE_PLATFORM_UNIX_TARGET_ARM)
 set(SOURCES
   cruntime/file.cpp
   cruntime/filecrt.cpp


### PR DESCRIPTION
Unw uses SP/PC registers, which clang complains.

fix #4259

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>