### PR TITLE
ByValArray marshaling support is implemented in OleVariant.cpp (which…

### DIFF
--- a/src/vm/olevariant.cpp
+++ b/src/vm/olevariant.cpp
@@ -995,8 +995,8 @@ VariantArray:
             ClearLPWSTRArray
         );
 
-#ifdef FEATURE_CLASSIC_COMINTEROP
     case VT_RECORD:
+#ifdef FEATURE_CLASSIC_COMINTEROP
         RETURN_MARSHALER(
             MarshalRecordVariantOleToCom,
             MarshalRecordVariantComToOle,
@@ -1005,7 +1005,14 @@ VariantArray:
             MarshalRecordArrayComToOle,
             ClearRecordArray
         );
-#endif
+#else
+        RETURN_MARSHALER(
+            NULL, NULL, NULL,
+            MarshalRecordArrayOleToCom,
+            MarshalRecordArrayComToOle,
+            ClearRecordArray
+        );
+#endif // FEATURE_CLASSIC_COMINTEROP
 
     case VT_CARRAY:
     case VT_USERDEFINED:

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -171,7 +171,6 @@ JIT/Regression/Dev11/External/dev11_145295/CSharpPart/CSharpPart.sh
 Interop/SimpleStruct/SimpleStruct/SimpleStruct.sh
 Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/MarshalStructAsLayoutExp.sh
 Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq/MarshalStructAsLayoutSeq.sh
-Interop/ArrayMarshalling/ByValArray/MarshalArrayByValTest/MarshalArrayByValTest.sh
 GC/LargeMemory/Allocation/finalizertest/finalizertest.sh
 GC/LargeMemory/API/gc/reregisterforfinalize/reregisterforfinalize.sh
 GC/LargeMemory/API/gc/collect/collect.sh


### PR DESCRIPTION
… actually implements both regular array marshalling and variant marshalling) and is incorrectly #ifdef-ed out under x-plat. Fix by only #ifdef the COM interop VARIANT part.