### PR TITLE
Fix brick table issue on Unix

### DIFF
--- a/src/gc/gc.cpp
+++ b/src/gc/gc.cpp
@@ -11177,7 +11177,7 @@ void gc_heap::adjust_limit_clr (uint8_t* start, size_t limit_size,
             b++;
             dprintf (3, ("Allocation Clearing bricks [%Ix, %Ix[",
                          b, brick_of (align_on_brick (start + limit_size))));
-            short* x = &brick_table [b];
+            volatile short* x = &brick_table [b];
             short* end_x = &brick_table [brick_of (align_on_brick (start + limit_size))];
 
             for (;x < end_x;x++)


### PR DESCRIPTION
There is a problem with Clang compiling a loop that sets a range of brick
table entries that are "shorts" as a memset. That causes it to be written
by bytes in some cases on OSX (and it is a mere chance that the memset on
Linux is implemented so that it doesn't use byte access).
This was causing corruption of the brick table on OSX.
The fix is to mark the pointer that iterates over the brick table as volatile
to prevent the compiler from using the memset.