### PR TITLE
Add missing arch-specifc strings in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -265,9 +265,18 @@ Temporary Items
 !src/debug
 
 # Ignore folders created by the test build
-TestWrappers_x64_debug
-TestWrappers_x64_checked
-TestWrappers_x64_release
+TestWrappers_x64_[d|D]ebug
+TestWrappers_x64_[c|C]hecked
+TestWrappers_x64_[r|R]elease
+TestWrappers_x86_[d|D]ebug
+TestWrappers_x86_[c|C]hecked
+TestWrappers_x86_[r|R]elease
+TestWrappers_arm_[d|D]ebug
+TestWrappers_arm_[c|C]hecked
+TestWrappers_arm_[r|R]elease
+TestWrappers_arm64_[d|D]ebug
+TestWrappers_arm64_[c|C]hecked
+TestWrappers_arm64_[r|R]elease
 tests/src/common/test_runtime/project.json
 
 Vagrantfile


### PR DESCRIPTION
I would prefer that the test build not drop cruft outside of designated
folders like bin, but unless/until that happens we should at least make
the architectures' builds consistent.