### PR TITLE
Use _lwp_self() in THREADSilentGetCurrentThreadId() for NetBSD

### DIFF
--- a/src/pal/src/include/pal/thread.hpp
+++ b/src/pal/src/include/pal/thread.hpp
@@ -828,6 +828,9 @@ inline SIZE_T THREADSilentGetCurrentThreadId() {
     pthread_threadid_np(pthread_self(), &tid);
     return (SIZE_T)tid;
 }
+#elif defined(__NetBSD__)
+#include <lwp.h>
+#define THREADSilentGetCurrentThreadId() (SIZE_T)_lwp_self()
 #else
 #define THREADSilentGetCurrentThreadId() (SIZE_T)pthread_self()
 #endif


### PR DESCRIPTION
The `_lwp_self()` call returns the LWP ID of the calling LWP.
It requires `<lwp.h>` on NetBSD.