### PR TITLE
Add clang-3.8 into build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -495,6 +495,11 @@ while :; do
             __ClangMinorVersion=7
             ;;
 
+        clang3.8)
+            __ClangMajorVersion=3
+            __ClangMinorVersion=8
+            ;;
+
         ninja)
             __UseNinja=1
             ;;


### PR DESCRIPTION
According to the official release note, clang 3.8 is also stable version.
http://llvm.org/releases/download.html
Let's add version 3.8 of clang into build.sh script.

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>