### PR TITLE
Add a CMake variable to support build for platforms other than Ubuntu/Debian

### DIFF
--- a/cross/arm-softfp/toolchain.cmake
+++ b/cross/arm-softfp/toolchain.cmake
@@ -1,4 +1,6 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
+set(EXTRA_CROSS_COMPILE_FLAGS $ENV{EXTRA_CROSS_COMPILE_FLAGS})
+separate_arguments(EXTRA_CROSS_COMPILE_FLAGS)
 
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
@@ -8,6 +10,7 @@ add_compile_options(-target armv7-linux-gnueabi)
 add_compile_options(-mthumb)
 add_compile_options(-mfpu=vfpv3)
 add_compile_options(--sysroot=${CROSS_ROOTFS})
+add_compile_options(${EXTRA_CROSS_COMPILE_FLAGS})
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target arm-linux-gnueabi")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B${CROSS_ROOTFS}/usr/lib/arm-linux-gnueabi")

--- a/cross/arm/toolchain.cmake
+++ b/cross/arm/toolchain.cmake
@@ -1,4 +1,6 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
+set(EXTRA_CROSS_COMPILE_FLAGS $ENV{EXTRA_CROSS_COMPILE_FLAGS})
+separate_arguments(EXTRA_CROSS_COMPILE_FLAGS)
 
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
@@ -18,6 +20,7 @@ add_compile_options(-target armv7-linux-gnueabihf)
 add_compile_options(-mthumb)
 add_compile_options(-mfpu=vfpv3)
 add_compile_options(--sysroot=${CROSS_ROOTFS})
+add_compile_options(${EXTRA_CROSS_COMPILE_FLAGS})
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")

--- a/cross/arm64/toolchain.cmake
+++ b/cross/arm64/toolchain.cmake
@@ -1,4 +1,6 @@
 set(CROSS_ROOTFS $ENV{ROOTFS_DIR})
+set(EXTRA_CROSS_COMPILE_FLAGS $ENV{EXTRA_CROSS_COMPILE_FLAGS})
+separate_arguments(EXTRA_CROSS_COMPILE_FLAGS)
 
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_VERSION 1)
@@ -16,6 +18,7 @@ set(TOOLCHAIN_PREFIX ${TOOLCHAIN}-)
 
 add_compile_options(-target ${TOOLCHAIN})
 add_compile_options(--sysroot=${CROSS_ROOTFS})
+add_compile_options(${EXTRA_CROSS_COMPILE_FLAGS})
 
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -target ${TOOLCHAIN}")
 set(CROSS_LINK_FLAGS "${CROSS_LINK_FLAGS} -B ${CROSS_ROOTFS}/usr/lib/gcc/${TOOLCHAIN}")


### PR DESCRIPTION
We want to use coreclr's cross compilation procedure to build coreclr for platforms other than Ubuntu/Debian, provided we already have our own rootfs. This PR adds an environment variable that holds extra compilation flags (paths to headers/libs, etc) and adds its contents along with other cross-compilation-specific flags.