### PR TITLE
Fix output casing of prefix dir

### DIFF
--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_d.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_d.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv1.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_do.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_do.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv1.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_r.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_r.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv1.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_ro.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv1_cs_ro.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv1.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_d.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_d.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv2.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_do.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_do.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv2.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_r.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_r.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv2.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_ro.csproj
+++ b/tests/src/JIT/Directed/perffix/primitivevt/callconv2_cs_ro.csproj
@@ -35,7 +35,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="callconv2.cs" />
-    <ProjectReference Include="..\..\prefix\primitivevt\helper.csproj" />
+    <ProjectReference Include="..\..\PREFIX\primitivevt\helper.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -138,10 +138,6 @@ JIT/Regression/VS-ia64-JIT/V1.2-M02/b22545/b22545/b22545.sh
 JIT/Regression/VS-ia64-JIT/V1.2-M02/b22591/b22591/b22591.sh
 JIT/Regression/VS-ia64-JIT/V2.0-Beta2/b416776/b416776/b416776.sh
 JIT/Regression/CLR-x86-JIT/V1-M09/b13621/b13621/b13621.sh
-JIT/Directed/prefix/unaligned/1/arglist/arglist.sh
-JIT/Directed/prefix/unaligned/2/arglist/arglist.sh
-JIT/Directed/prefix/unaligned/4/arglist/arglist.sh
-JIT/Directed/prefix/volatile/1/arglist/arglist.sh
 JIT/jit64/localloc/eh/eh01_dynamic/eh01_dynamic.sh
 JIT/jit64/localloc/eh/eh01_large/eh01_large.sh
 JIT/jit64/localloc/eh/eh01_small/eh01_small.sh


### PR DESCRIPTION
The PREFIX dir is upper case, should be refered to as such.  Blocker for building on Linux