### PR TITLE
Add support for handling SIGTERM gracefully [WIP]

### DIFF
--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -6490,6 +6490,7 @@ public:
 
 typedef VOID (PALAPI *PHARDWARE_EXCEPTION_HANDLER)(PAL_SEHException* ex);
 typedef BOOL (PALAPI *PHARDWARE_EXCEPTION_SAFETY_CHECK_FUNCTION)(PCONTEXT contextRecord, PEXCEPTION_RECORD exceptionRecord);
+typedef VOID (PALAPI *PTERMINATION_REQUEST_HANDLER)();
 typedef DWORD (PALAPI *PGET_GCMARKER_EXCEPTION_CODE)(LPVOID ip);
 
 PALIMPORT
@@ -6511,6 +6512,12 @@ PALAPI
 PAL_ThrowExceptionFromContext(
     IN CONTEXT* context,
     IN PAL_SEHException* ex);
+
+PALIMPORT
+VOID
+PALAPI
+PAL_SetTerminationRequestHandler(
+    IN PTERMINATION_REQUEST_HANDLER terminationRequestHandler);
 
 //
 // This holder is used to indicate that a hardware

--- a/src/pal/src/include/pal/corunix.hpp
+++ b/src/pal/src/include/pal/corunix.hpp
@@ -1124,6 +1124,10 @@ namespace CorUnix
             CPalThread *pThread
             ) = 0;
 
+        virtual
+        PAL_ERROR
+        SendTerminationRequestToWorkerThread() = 0;
+
         //
         // This routine is primarily meant for use by WaitForMultipleObjects[Ex].
         // The caller must individually release each of the returned controller

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -529,6 +529,7 @@ namespace CorUnix
             SynchWorkerCmdRemoteSignal,
             SynchWorkerCmdDelegatedObjectSignaling,
             SynchWorkerCmdShutdown,
+            SynchWorkerCmdTerminationRequest,
             SynchWorkerCmdLast
         };
 
@@ -621,7 +622,7 @@ namespace CorUnix
             // initialization code.
             return s_pObjSynchMgr; 
         }
-        
+
         //
         // Inline utility methods
         //
@@ -876,6 +877,8 @@ namespace CorUnix
             CPalThread *pthrTarget,
             PAPCFUNC pfnAPC,
             ULONG_PTR uptrData);
+
+        virtual PAL_ERROR SendTerminationRequestToWorkerThread();
 
         virtual bool AreAPCsPending(CPalThread * pthrTarget);
 

--- a/src/vm/exceptionhandling.cpp
+++ b/src/vm/exceptionhandling.cpp
@@ -140,6 +140,11 @@ static inline void UpdatePerformanceMetrics(CrawlFrame *pcfThisFrame, BOOL bIsRe
     ETW::ExceptionLog::ExceptionThrown(pcfThisFrame, bIsRethrownException, bIsNewException);
 }
 
+void ShutdownEEAndExitProcess()
+{
+    ForceEEShutdown(SCA_ExitProcessWhenShutdownComplete);
+}
+
 void InitializeExceptionHandling()
 {
     EH_LOG((LL_INFO100, "InitializeExceptionHandling(): ExceptionTracker size: 0x%x bytes\n", sizeof(ExceptionTracker)));
@@ -159,6 +164,9 @@ void InitializeExceptionHandling()
 
     // Register handler for determining whether the specified IP has code that is a GC marker for GCCover
     PAL_SetGetGcMarkerExceptionCode(GetGcMarkerExceptionCode);
+
+    // Register handler for termination requests (e.g. SIGTERM)
+    PAL_SetTerminationRequestHandler(ShutdownEEAndExitProcess);
 #endif // FEATURE_PAL
 }
 


### PR DESCRIPTION
Today, our signal handling logic doesn't handle SIGTERM, so it just terminates the process abruptly. This change improves on that behavior by allowing us to treat SIGTERM similar to how we treat `Environment.Exit()` (so that the system is shutdown gracefully).

This change brings back the logic we had in place before for handling things like SIGINT, where we have a thread waiting to receive notifications about signals through a pipe. Doing so allows us to handle the signals outside of the context of the signal handler.

Addresses #2688
 
cc: @janvorli 