### PR TITLE
Port arglist tests for x86 and ARM

### DIFF
--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.il
@@ -23,44 +23,34 @@ arg1==arg4, arg2==arg5, arg3==arg6.
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
 
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
-
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
 .maxstack 10
 .try{
-	ldc.i4		2
+	ldc.i4		1
 	stloc		currentindex
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x1
 	ldind.i4
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x1
 	ldind.i4
 	ceq
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
-	add
 	beq		EXITWITHPASS
 	ldc.i4		1
 	ldloc		currentindex

--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
@@ -29,7 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist64.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist64.il
@@ -19,11 +19,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 */
 
 .assembly extern legacy library mscorlib {}
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }

--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/arglistARM.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/arglistARM.il
@@ -16,20 +16,21 @@ another.
 
 ie. in this case CompareArgs checks that
 arg1==arg4, arg2==arg5, arg3==arg6.
+
+The vararg cookie in the case of x86 and ARM 
+is after/before the declared arguments respectively:
+(from Compiler::lvaInitTypeRef() in lclvars.cpp)
+x86 args look something like this:
+[this ptr] [hidden return buffer] [declared arguments]* [generic context] [var arg cookie]
+ARM is closer to the native ABI:
+[hidden return buffer] [this ptr] [generic context] [var arg cookie] [declared arguments]*
+
 */
 
 .assembly extern legacy library mscorlib {}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
-
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
 
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
@@ -40,20 +41,20 @@ arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x1
 	ldind.i4
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x1
 	ldind.i4
 	ceq
 	brfalse		EXITWITHFAIL

--- a/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.il
@@ -23,44 +23,34 @@ arg1==arg4, arg2==arg5, arg3==arg6.
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
 
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
-
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
 .maxstack 10
 .try{
-	ldc.i4		2
+	ldc.i4		1
 	stloc		currentindex
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x2
 	ldind.i4
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x2
 	ldind.i4
 	ceq
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
-	add
 	beq		EXITWITHPASS
 	ldc.i4		1
 	ldloc		currentindex
@@ -74,6 +64,7 @@ LOOP:	ldloc		currentindex
 }catch [mscorlib]System.NullReferenceException{
 	pop
 	leave FAIL
+
 }
 SUCCESS:
 	ldc.i4		0x64

--- a/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
@@ -29,7 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist64.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist64.il
@@ -19,11 +19,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 */
 
 .assembly extern legacy library mscorlib {}
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }

--- a/tests/src/JIT/Directed/PREFIX/unaligned/2/arglistARM.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/2/arglistARM.il
@@ -16,20 +16,20 @@ another.
 
 ie. in this case CompareArgs checks that
 arg1==arg4, arg2==arg5, arg3==arg6.
+
+The vararg cookie in the case of x86 and ARM 
+is after/before the declared arguments respectively:
+(from Compiler::lvaInitTypeRef() in lclvars.cpp)
+x86 args look something like this:
+[this ptr] [hidden return buffer] [declared arguments]* [generic context] [var arg cookie]
+ARM is closer to the native ABI:
+[hidden return buffer] [this ptr] [generic context] [var arg cookie] [declared arguments]*
 */
 
 .assembly extern legacy library mscorlib {}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
-
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
 
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
@@ -40,26 +40,26 @@ arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x2
 	ldind.i4
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	unaligned. 0x2
 	ldind.i4
 	ceq
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
+	ldc.i4 1
 	add
 	beq		EXITWITHPASS
 	ldc.i4		1
@@ -74,6 +74,7 @@ LOOP:	ldloc		currentindex
 }catch [mscorlib]System.NullReferenceException{
 	pop
 	leave FAIL
+
 }
 SUCCESS:
 	ldc.i4		0x64

--- a/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.il
@@ -23,24 +23,16 @@ arg1==arg4, arg2==arg5, arg3==arg6.
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
 
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
-
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
 .maxstack 10
 .try{
-	ldc.i4		2
+	ldc.i4		1
 	stloc		currentindex
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
@@ -49,7 +41,7 @@ LOOP:	ldloc		currentindex
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
@@ -59,8 +51,6 @@ LOOP:	ldloc		currentindex
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
-	add
 	beq		EXITWITHPASS
 	ldc.i4		1
 	ldloc		currentindex

--- a/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
@@ -29,7 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/4/arglistARM.il
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/4/arglistARM.il
@@ -16,20 +16,20 @@ another.
 
 ie. in this case CompareArgs checks that
 arg1==arg4, arg2==arg5, arg3==arg6.
+
+The vararg cookie in the case of x86 and ARM 
+is after/before the declared arguments respectively:
+(from Compiler::lvaInitTypeRef() in lclvars.cpp)
+x86 args look something like this:
+[this ptr] [hidden return buffer] [declared arguments]* [generic context] [var arg cookie]
+ARM is closer to the native ABI:
+[hidden return buffer] [this ptr] [generic context] [var arg cookie] [declared arguments]*
 */
 
 .assembly extern legacy library mscorlib {}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
-
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
 
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
@@ -40,7 +40,7 @@ arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
@@ -49,7 +49,7 @@ LOOP:	ldloc		currentindex
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
@@ -59,7 +59,7 @@ LOOP:	ldloc		currentindex
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
+	ldc.i4 1
 	add
 	beq		EXITWITHPASS
 	ldc.i4		1

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.il
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.il
@@ -23,44 +23,36 @@ arg1==arg4, arg2==arg5, arg3==arg6.
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
 
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
-
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
 .maxstack 10
 .try{
-	ldc.i4		2
+	ldc.i4		1
 	stloc		currentindex
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	volatile.
+	unaligned. 0x1
 	ldind.i4
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	volatile.
+	unaligned. 0x1
 	ldind.i4
 	ceq
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
-	add
 	beq		EXITWITHPASS
 	ldc.i4		1
 	ldloc		currentindex

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
@@ -29,7 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/arglist64.il
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/arglist64.il
@@ -19,11 +19,6 @@ arg1==arg4, arg2==arg5, arg3==arg6.
 */
 
 .assembly extern legacy library mscorlib {}
-.assembly extern System.Console
-{
-  .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A )
-  .ver 4:0:0:0
-}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/arglistARM.il
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/arglistARM.il
@@ -16,20 +16,20 @@ another.
 
 ie. in this case CompareArgs checks that
 arg1==arg4, arg2==arg5, arg3==arg6.
+
+The vararg cookie in the case of x86 and ARM 
+is after/before the declared arguments respectively:
+(from Compiler::lvaInitTypeRef() in lclvars.cpp)
+x86 args look something like this:
+[this ptr] [hidden return buffer] [declared arguments]* [generic context] [var arg cookie]
+ARM is closer to the native ABI:
+[hidden return buffer] [this ptr] [generic context] [var arg cookie] [declared arguments]*
 */
 
 .assembly extern legacy library mscorlib {}
 .assembly arglist.exe{ //This byte field requests that this assembly not be verified at run time and corresponds to this C# declaration:
   //[assembly:System.Security.Permissions.SecurityPermissionAttribute( [mscorlib]System.Security.Permissions.SecurityAction.RequestMinimum, Flags=System.Security.Permissions.SecurityPermissionFlag.SkipVerification )]
                         }
-
-/*
-CompareArgs(5,1,2,3,4,5,1,2,3,4,5)
-arglist on x86: 5,4,3,2,1,5,4,3,2,1,5
-                ^ index 1
-arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
-                 ^ index 1
-*/
 
 .method static vararg int32 CompareArgs(int32){
 .locals(int32 currentindex, int32 loopconstant)
@@ -40,26 +40,28 @@ arglist on ia64: 5,1,2,3,4,5,1,2,3,4,5
 	ldarg		0
 	stloc		loopconstant
 LOOP:	ldloc		currentindex
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	volatile.
+	unaligned. 0x1
 	ldind.i4
 	ldloc		currentindex
 	ldloc		loopconstant
 	add
-	ldc.i4		8
+	ldc.i4		4
 	mul
 	arglist
 	add
-	unaligned. 0x4
+	volatile.
+	unaligned. 0x1
 	ldind.i4
 	ceq
 	brfalse		EXITWITHFAIL
 	ldloc		currentindex
 	ldloc		loopconstant
-	ldc.i4		1
+	ldc.i4 1
 	add
 	beq		EXITWITHPASS
 	ldc.i4		1

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -31,9 +31,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\filter_il_r\filter_il_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\prefix\unaligned\2\arglist\arglist.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\rvastatics\rvastatic1\rvastatic1.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -73,9 +70,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_il_il\_dbgsin_il_il.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\prefix\unaligned\1\arglist\arglist.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u8div_cs_ro\u8div_cs_ro.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
@@ -113,9 +107,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\overlap\overlap.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\prefix\unaligned\4\arglist\arglist.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\badldsfld_il_r\badldsfld_il_r.cmd">
@@ -320,9 +311,6 @@
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102754\test1\test1.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\prefix\volatile\1\arglist\arglist.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_il_il\_orelsin_il_il.cmd">


### PR DESCRIPTION
Arglist tests, which are only valid on Windows, have non-x64 versions that
needed to be ported.  I also removed unnecessary System.Console references from the existing arglist64.il files.

These will continue to fail for ARM64, and I'm intentionally deferring the decision on how to deal with that.