### PR TITLE
Replace `SList` in the GC info encoders.

### DIFF
--- a/src/inc/dbggcinfoencoder.h
+++ b/src/inc/dbggcinfoencoder.h
@@ -121,23 +121,42 @@ public:
 
 private:
 
-    class MemoryBlockDesc
+    class MemoryBlockList;
+    class MemoryBlock
     {
-    public:
-        size_t* StartAddress;
-        MemoryBlockDesc* m_Next;
+        friend class MemoryBlockList;
+        MemoryBlock* m_next;
 
-        inline void Init()
+    public:
+        size_t Contents[];
+
+        inline MemoryBlock* Next()
         {
-            m_Next = NULL;
+            return m_next;
         }
+    };
+
+    class MemoryBlockList
+    {
+        MemoryBlock* m_head;
+        MemoryBlock* m_tail;
+
+    public:
+        MemoryBlockList();
+
+        inline MemoryBlock* Head()
+        {
+            return m_head;
+        }
+
+        MemoryBlock* AppendNew(IAllocator* allocator, size_t bytes);
+        void Dispose(IAllocator* allocator);
     };
 
     IJitAllocator* m_pAllocator;
     size_t m_BitCount;
     int m_FreeBitsInCurrentSlot;
-    MemoryBlockDesc* m_MemoryBlocksHead;
-    MemoryBlockDesc* m_MemoryBlocksTail;
+    MemoryBlockList m_MemoryBlocks;
     const static int m_MemoryBlockSize = 512;    // must be a multiple of the pointer size
     size_t* m_pCurrentSlot;            // bits are written through this pointer
     size_t* m_OutOfBlockSlot;        // sentinel value to determine when the block is full

--- a/src/inc/dbggcinfoencoder.h
+++ b/src/inc/dbggcinfoencoder.h
@@ -23,7 +23,6 @@
 
 #include "utilcode.h"
 #include "corjit.h"
-#include "list.h"     // for SList
 #include "iallocator.h"
 #include "gcinfoarraylist.h"
 
@@ -126,18 +125,19 @@ private:
     {
     public:
         size_t* StartAddress;
-        SLink m_Link;
+        MemoryBlockDesc* m_Next;
 
         inline void Init()
         {
-            m_Link.m_pNext = NULL;
+            m_Next = NULL;
         }
     };
 
     IJitAllocator* m_pAllocator;
     size_t m_BitCount;
     int m_FreeBitsInCurrentSlot;
-    SList<MemoryBlockDesc> m_MemoryBlocks;
+    MemoryBlockDesc* m_MemoryBlocksHead;
+    MemoryBlockDesc* m_MemoryBlocksTail;
     const static int m_MemoryBlockSize = 512;    // must be a multiple of the pointer size
     size_t* m_pCurrentSlot;            // bits are written through this pointer
     size_t* m_OutOfBlockSlot;        // sentinel value to determine when the block is full


### PR DESCRIPTION
Instead of using `SList`, manage the links manually. There are only
a few list manipulations in the encoders, so this is not too onerous.