### PR TITLE
Collect the JIT's TLS variables in a single type.

### DIFF
--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -45,7 +45,7 @@ unsigned SsaStressHashHelper()
     }
     if (hash == 1)
     {
-        return GetTlsCompiler()->info.compMethodHash();
+        return JitTls::GetCompiler()->info.compMethodHash();
     }
     return ((hash >> 16) == 0) ? ((hash << 16) | hash) : hash;
 }

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -885,7 +885,7 @@ GenTree::GenTree(genTreeOps oper, var_types type DEBUG_ARG(bool largeNode))
 
 #ifdef DEBUG
     gtSeqNum   = 0;
-    gtTreeID   = GetTlsCompiler()->compGenTreeID++;
+    gtTreeID   = JitTls::GetCompiler()->compGenTreeID++;
     gtVNPair.SetBoth(ValueNumStore::NoVN);
     gtRegTag   = GT_REGTAG_NONE;
     gtOperSave = GT_NONE;

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -477,7 +477,7 @@ bool Compiler::fgBlockContainsStatementBounded(BasicBlock* block, GenTree* stmt,
 
     assert(stmt->gtOper == GT_STMT);
 
-    __int64 *numTraversed = &GetTlsCompiler()->compNumStatementLinksTraversed;
+    __int64 *numTraversed = &JitTls::GetCompiler()->compNumStatementLinksTraversed;
 
     if (*numTraversed > maxLinks)
         return answerOnBoundExceeded;

--- a/src/jit/host.h
+++ b/src/jit/host.h
@@ -10,19 +10,14 @@
 #endif
 
 class Compiler;
-class LogEnv {
+class LogEnv
+{
 public:
     LogEnv(ICorJitInfo* aCompHnd);
-    ~LogEnv();
-    static LogEnv* cur();           // get current logging environement
-    static void cleanup();          // clean up cached information (TLS ID)
     void setCompiler(Compiler* val) { const_cast<Compiler*&>(compiler) = val; }
 
     ICorJitInfo* const compHnd;
     Compiler* const compiler;
-private:
-    static int tlsID;
-    LogEnv* next;
 };
 
 BOOL vlogf(unsigned level, const char* fmt, va_list args);

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -9044,7 +9044,7 @@ LinearScan::lsraGetOperandString(GenTreePtr tree, LsraTupleDumpMode mode, char *
         break;
     case LinearScan::LSRA_DUMP_POST:
         {
-            Compiler *compiler = GetTlsCompiler();
+            Compiler *compiler = JitTls::GetCompiler();
 
             if (!tree->gtHasReg())
             {
@@ -9064,7 +9064,7 @@ LinearScan::lsraGetOperandString(GenTreePtr tree, LsraTupleDumpMode mode, char *
 void
 LinearScan::lsraDispNode(GenTreePtr tree, LsraTupleDumpMode mode, bool hasDest)
 {
-    Compiler*         compiler = GetTlsCompiler();
+    Compiler*         compiler = JitTls::GetCompiler();
     const unsigned    operandStringLength = 16;
     char              operandString[operandStringLength];
     const char*       emptyDestOperand = "               ";

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -16,7 +16,7 @@
 void dumpMethod()
 {
     if (VERBOSE)
-        GetTlsCompiler()->fgDispBasicBlocks(true);
+        JitTls::GetCompiler()->fgDispBasicBlocks(true);
 }
 
 void dumpTreeStack(Compiler *comp, ArrayStack<GenTree *> *stack)
@@ -939,7 +939,7 @@ void Compiler::fgFixupIfCallArg(ArrayStack<GenTree *> *parentStack,
     GenTree *parentCall = isNodeCallArg(parentStack);
     if (!parentCall) 
     {
-        DBEXEC(VERBOSE, dumpTreeStack(GetTlsCompiler(), parentStack));
+        DBEXEC(VERBOSE, dumpTreeStack(JitTls::GetCompiler(), parentStack));
         return;
     }
      
@@ -2160,7 +2160,7 @@ void Rationalizer::ValidateStatement(Location loc)
 void Rationalizer::ValidateStatement(GenTree *tree, BasicBlock *block)
 {
     assert(tree->gtOper == GT_STMT);
-    DBEXEC(TRUE, GetTlsCompiler()->fgDebugCheckNodeLinks(block, tree));
+    DBEXEC(TRUE, JitTls::GetCompiler()->fgDebugCheckNodeLinks(block, tree));
 }
 
 // sanity checks that apply to all kinds of IR

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -922,7 +922,7 @@ void SsaBuilder::TreeRenameVariables(GenTree* tree, BasicBlock* block, SsaRename
                     pRenameState->PushHeap(block, count);
                     m_pCompiler->GetHeapSsaMap()->Set(tree, count);
 #ifdef DEBUG
-                    if (GetTlsCompiler()->verboseSsa) 
+                    if (JitTls::GetCompiler()->verboseSsa) 
                     {
                         printf("Node ");
                         Compiler::printTreeID(tree);

--- a/src/jit/ssaconfig.h
+++ b/src/jit/ssaconfig.h
@@ -23,7 +23,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 
 #ifdef DEBUG
-    #define DBG_SSA_JITDUMP(...) if (GetTlsCompiler()->verboseSsa) JitDump(__VA_ARGS__)
+    #define DBG_SSA_JITDUMP(...) if (JitTls::GetCompiler()->verboseSsa) JitDump(__VA_ARGS__)
 #else
     #define DBG_SSA_JITDUMP(...)
 #endif

--- a/src/jit/ssarenamestate.cpp
+++ b/src/jit/ssarenamestate.cpp
@@ -155,7 +155,7 @@ void SsaRenameState::Push(BasicBlock* bb, unsigned lclNum, unsigned count)
     }
 
 #ifdef DEBUG
-    if (GetTlsCompiler()->verboseSsa)
+    if (JitTls::GetCompiler()->verboseSsa)
     {
         printf("\tContents of the stack: [");
         for (Stack::iterator iter2 = stack->begin(); iter2 != stack->end(); iter2++)
@@ -194,7 +194,7 @@ void SsaRenameState::PopBlockStacks(BasicBlock* block)
             assert(stacks[i]->back().m_bb != block);
         }
     }
-    if (GetTlsCompiler()->verboseSsa)
+    if (JitTls::GetCompiler()->verboseSsa)
     {
         DumpStacks();
     }

--- a/src/vm/crossgencompile.cpp
+++ b/src/vm/crossgencompile.cpp
@@ -78,18 +78,23 @@ BOOL Debug_IsLockedViaThreadSuspension()
 #endif // _DEBUG
 
 #if defined(FEATURE_MERGE_JIT_AND_ENGINE) && defined(FEATURE_IMPLICIT_TLS)
-Compiler* theTlsCompiler;
+void* theJitTls;
 
-Compiler* GetTlsCompiler()
+extern "C"
+{
+
+void* GetJitTls()
 {
     LIMITED_METHOD_CONTRACT
 
-    return theTlsCompiler;
+    return theJitTls;
 }
-void SetTlsCompiler(Compiler* c)
+void SetJitTls(void* v)
 {
     LIMITED_METHOD_CONTRACT
-    theTlsCompiler = c;
+    theJitTls = v;
+}
+
 }
 #endif
 

--- a/src/vm/threads.cpp
+++ b/src/vm/threads.cpp
@@ -344,16 +344,22 @@ BOOL SetAppDomain(AppDomain* ad)
 }
 
 #if defined(FEATURE_MERGE_JIT_AND_ENGINE)
-Compiler* GetTlsCompiler()
+extern "C"
+{
+
+void* GetJitTls()
 {
     LIMITED_METHOD_CONTRACT
 
-    return gCurrentThreadInfo.m_pCompiler;
+    return gCurrentThreadInfo.m_pJitTls;
 }
-void SetTlsCompiler(Compiler* c)
+
+void SetJitTls(void* v)
 {
     LIMITED_METHOD_CONTRACT
-    gCurrentThreadInfo.m_pCompiler = c;
+    gCurrentThreadInfo.m_pJitTls = v;
+}
+
 }
 #endif // defined(FEATURE_MERGE_JIT_AND_ENGINE)
 

--- a/src/vm/threads.h
+++ b/src/vm/threads.h
@@ -7764,7 +7764,7 @@ struct ThreadLocalInfo
     AppDomain* m_pAppDomain;
     void** m_EETlsData; // ClrTlsInfo::data
 #ifdef FEATURE_MERGE_JIT_AND_ENGINE
-    Compiler* m_pCompiler;
+    void* m_pJitTls;
 #endif
 };
 #endif // FEATURE_IMPLICIT_TLS


### PR DESCRIPTION
Instead of storing pointers to the thread-local compiler instance
and the current logging environment in separate TLS slots, wrap
these values in a struct and store a pointer to the struct in a
single TLS slot. This simplifies and standardizes the JIT's interface
to its TLS storage, especially when it is being statically linked
into another program or library that cannot use standard TLS.

Note that for release builds, the logging environment is not used
and a pointer to the current compiler instance is stored directly
into the JIT's TLS slot as an implementation detail of the TLS
wrapper type.