### PR TITLE
Inliner: introducing InlineStrategy

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -34,24 +34,9 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 #define COLUMN_FLAGS    (COLUMN_KINDS + 32)
 #endif
 
-#if defined(DEBUG) || MEASURE_INLINING
+#if defined(DEBUG)
 unsigned Compiler::jitTotalMethodCompiled = 0;
-unsigned Compiler::jitTotalMethodInlined  = 0;
-unsigned Compiler::jitTotalInlineCandidates = 0;
-unsigned Compiler::jitTotalInlineCandidatesWithNonNullReturn = 0;
-unsigned Compiler::jitTotalNumLocals = 0;
-unsigned Compiler::jitTotalInlineReturnFromALocal = 0;
-unsigned Compiler::jitInlineInitVarsFailureCount = 0;
-unsigned Compiler::jitCheckCanInlineCallCount = 0;
-unsigned Compiler::jitCheckCanInlineFailureCount = 0;
-
-unsigned Compiler::jitInlineGetMethodInfoCallCount = 0;
-unsigned Compiler::jitInlineInitClassCallCount = 0;
-unsigned Compiler::jitInlineCanInlineCallCount = 0;
-
-unsigned Compiler::jitIciStmtIsTheLastInBB = 0;
-unsigned Compiler::jitInlineeContainsOnlyOneBB = 0;
-#endif  // defined(DEBUG) || MEASURE_INLINING
+#endif  // defined(DEBUG)
 
 #if defined(DEBUG)
 LONG     Compiler::jitNestingLevel = 0;
@@ -645,10 +630,6 @@ unsigned            Compiler::s_compMethodsCount = 0; // to produce unique label
 bool                Compiler::s_dspMemStats = false;
 #endif
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-bool                Compiler::s_inlDumpDataHeader = false;
-#endif // if defined(DEBUG) || defined(INLINE_DATA)
-
 #ifndef DEBUGGING_SUPPORT
 /* static */
 const bool          Compiler::Options::compDbgCode = false;
@@ -746,54 +727,6 @@ void                Compiler::compShutdown()
         compJitFuncInfoFile = NULL;
     }
 #endif // FUNC_INFO_LOGGING
-    
-#if defined(DEBUG) || MEASURE_INLINING
-
-#ifdef DEBUG
-    if ((unsigned)JitConfig.JitInlinePrintStats() == 1)
-#endif // DEBUG
-    {
-        fprintf(fout, "\n");
-        fprintf(fout, "--------------------------------------\n");
-        fprintf(fout, "Inlining stats\n");
-        fprintf(fout, "--------------------------------------\n");
-
-        fprintf(fout,
-               "jitTotalMethodCompiled = %d\n"
-               "jitTotalMethodInlined = %d\n"
-               "jitTotalInlineCandidates = %d\n"
-               "jitTotalInlineCandidatesWithNonNullReturn = %d\n"
-               "jitTotalNumLocals = %d\n"
-               "jitTotalInlineReturnFromALocal = %d\n"
-               "jitInlineInitVarsFailureCount = %d\n"
-               "jitCheckCanInlineCallCount = %d\n"
-               "jitCheckCanInlineFailureCount = %d\n"
-               "jitInlineGetMethodInfoCallCount = %d\n"
-               "jitInlineInitClassCallCount = %d\n"
-               "jitInlineCanInlineCallCount = %d\n"
-               "jitIciStmtIsTheLastInBB = %d\n"
-               "jitInlineeContainsOnlyOneBB = %d\n",
-        
-               jitTotalMethodCompiled,
-               jitTotalMethodInlined,
-               jitTotalInlineCandidates,
-               jitTotalInlineCandidatesWithNonNullReturn,
-               jitTotalNumLocals,
-               jitTotalInlineReturnFromALocal,
-               jitInlineInitVarsFailureCount,
-               jitCheckCanInlineCallCount,
-               jitCheckCanInlineFailureCount,
-
-               jitInlineGetMethodInfoCallCount,
-               jitInlineInitClassCallCount,
-               jitInlineCanInlineCallCount,
-
-               jitIciStmtIsTheLastInBB,
-               jitInlineeContainsOnlyOneBB
-               );                         
-    }
-    
-#endif // defined(DEBUG) || MEASURE_INLINING
 
 #if COUNT_RANGECHECKS
     if  (optRangeChkAll > 0)
@@ -1269,16 +1202,13 @@ void                Compiler::compInit(ArenaAllocator * pAlloc, InlineInfo * inl
     // Set the inline info.
     impInlineInfo    = inlineInfo;
 
-#if defined(DEBUG) || defined(INLINE_DATA)
-    inlLastSuccessfulPolicy = nullptr;
-#endif // defined(DEBUG) || defined(INLINE_DATA)
-
     eeInfoInitialized = false;
 
     compDoAggressiveInlining = false;
 
     if (compIsForInlining())
     {
+        m_inlineStrategy            = nullptr;
         compInlineResult            = inlineInfo->inlineResult;
         compAsIAllocator            = nullptr;  // We shouldn't be using the compAsIAllocator for other than the root compiler.
 #if MEASURE_MEM_ALLOC
@@ -1294,6 +1224,7 @@ void                Compiler::compInit(ArenaAllocator * pAlloc, InlineInfo * inl
     }
     else
     {
+        m_inlineStrategy            = new (this, CMK_Inlining) InlineStrategy(this);
         compInlineResult            = nullptr;
         compAsIAllocator            = new (this, CMK_Unknown) CompAllocator(this, CMK_AsIAllocator);
 #if MEASURE_MEM_ALLOC
@@ -3969,10 +3900,9 @@ void                 Compiler::compCompile(void * * methodCodePtr,
     compJitTelemetry.NotifyEndOfCompilation();
 #endif
 
-#if defined(DEBUG) || MEASURE_INLINING
+#if defined(DEBUG)
     ++Compiler::jitTotalMethodCompiled;
-    Compiler::jitTotalNumLocals += lvaCount; 
-#endif // defined(DEBUG) || MEASURE_INLINING
+#endif // defined(DEBUG)
 
 #ifdef DEBUG
     LONG newJitNestingLevel = InterlockedDecrement(&Compiler::jitNestingLevel);
@@ -4462,76 +4392,9 @@ void Compiler::compCompileFinish()
 
 #if defined(DEBUG) || defined(INLINE_DATA)
 
-    // Inliner data display
-    if (JitConfig.JitInlineDumpData() != 0)
-    {
-        // Don't dump anything if limiting is on and we didn't reach
-        // the limit while inlining.
-        //
-        // This serves to filter out duplicate data.
-        const int limit = JitConfig.JitInlineLimit();
+    m_inlineStrategy->DumpData();
 
-        if ((limit < 0) || (fgInlinedCount == static_cast<unsigned>(limit)))
-        {
-            // If there weren't any successful inlines (no limit, or
-            // limit=0 case), we won't have a successful policy, so
-            // fake one up.
-            if (inlLastSuccessfulPolicy == nullptr)
-            {
-                assert(limit <= 0);
-                const bool isPrejitRoot = (opts.eeFlags & CORJIT_FLG_PREJIT) != 0;
-                inlLastSuccessfulPolicy = InlinePolicy::GetPolicy(this, isPrejitRoot);
-
-                // Add in a bit of data....
-                const bool isForceInline = (info.compFlags & CORINFO_FLG_FORCEINLINE) != 0;
-                inlLastSuccessfulPolicy->NoteBool(InlineObservation::CALLEE_IS_FORCE_INLINE, isForceInline);
-                inlLastSuccessfulPolicy->NoteInt(InlineObservation::CALLEE_IL_CODE_SIZE, info.compMethodInfo->ILCodeSize);
-            }
-
-            if (!s_inlDumpDataHeader)
-            {
-                if (limit == 0)
-                {
-                    fprintf(stderr, "*** Inline Data: Policy=%s JitInlineLimit=%d ***\n",
-                                inlLastSuccessfulPolicy->GetName(),
-                                limit);
-                    fprintf(stderr, "Method,Version,HotSize,ColdSize,JitTime");
-                    inlLastSuccessfulPolicy->DumpSchema(stderr);
-                    fprintf(stderr, "\n");
-                }
-
-                s_inlDumpDataHeader = true;
-            }
-
-            // We'd really like the method identifier to be unique and
-            // durable across crossgen invocations. Not clear how to
-            // accomplish this, so we'll use the token for now.
-            //
-            // Post processing will have to filter out all data from
-            // methods where the root entry appears multiple times.
-            mdMethodDef currentMethodToken = info.compCompHnd->getMethodDefFromMethod(info.compMethodHnd);
-
-            // Convert time spent jitting into milliseconds
-            unsigned microsecondsSpentJitting = 0;
-            if (m_compCycles > 0)
-            {
-                double countsPerSec = CycleTimer::CyclesPerSecond();
-                double counts = (double) m_compCycles;
-                microsecondsSpentJitting = (unsigned) ((counts / countsPerSec) * 1000 * 1000);
-            }
-
-            fprintf(stderr, "%08X,%u,%u,%u,%u",
-                        currentMethodToken,
-                        fgInlinedCount,
-                        info.compTotalHotCodeSize,
-                        info.compTotalColdCodeSize,
-                        microsecondsSpentJitting);
-            inlLastSuccessfulPolicy->DumpData(stderr);
-            fprintf(stderr, "\n");
-        }
-    }
-
-#endif // defined(DEBUG) || defined(INLINE_DATA)
+#endif
 
 #ifdef DEBUG
     if (opts.dspOrder)

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2521,15 +2521,10 @@ public :
 #endif
 
     InlineInfo*          impInlineInfo;
+    InlineStrategy*      m_inlineStrategy;
 
     // Get the maximum IL size allowed for an inline
     unsigned             getImpInlineSize() const { return impInlineSize; }
-
-#if defined(DEBUG) || defined(INLINE_DATA)
-    unsigned             fgInlinedCount; // Number of successful inline expansion of this method.
-    InlinePolicy*        inlLastSuccessfulPolicy; // Policy used in last successful inline.
-    static bool          s_inlDumpDataHeader;  // Print header schema for inline data
-#endif // defined(DEBUG) || defined(INLINE_DATA)
 
     // The Compiler* that is the root of the inlining tree of which "this" is a member.
     Compiler*            impInlineRoot();
@@ -3082,27 +3077,10 @@ private:
     regNumber           getCallArgIntRegister       (regNumber floatReg);
     regNumber           getCallArgFloatRegister     (regNumber intReg);
 #endif // FEATURE_VARARG
-    //--------------------------- Inlining-------------------------------------
 
-#if defined(DEBUG) || MEASURE_INLINING
+#if defined(DEBUG)
     static unsigned jitTotalMethodCompiled;
-    static unsigned jitTotalMethodInlined;
-    static unsigned jitTotalInlineCandidates;
-    static unsigned jitTotalInlineCandidatesWithNonNullReturn;
-    static unsigned jitTotalNumLocals;
-    static unsigned jitTotalInlineReturnFromALocal;
-    static unsigned jitInlineInitVarsFailureCount;
-    static unsigned jitCheckCanInlineCallCount;
-    static unsigned jitCheckCanInlineFailureCount;
-
-    static unsigned jitInlineGetMethodInfoCallCount;
-    static unsigned jitInlineInitClassCallCount;
-    static unsigned jitInlineCanInlineCallCount;
-
-    static unsigned jitIciStmtIsTheLastInBB;
-    static unsigned jitInlineeContainsOnlyOneBB;
-
-#endif // defined(DEBUG) || MEASURE_INLINING
+#endif
 
 #ifdef DEBUG
     static LONG     jitNestingLevel;

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -1391,10 +1391,11 @@ void DiscretionaryPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo
 {
     // Punt if we're inlining and we've reached the acceptance limit.
     int limit = JitConfig.JitInlineLimit();
+    unsigned current = m_RootCompiler->m_inlineStrategy->GetInlineCount();
 
     if (!m_IsPrejitRoot &&
         (limit >= 0) &&
-        (m_RootCompiler->fgInlinedCount >= static_cast<unsigned>(limit)))
+        (current >= static_cast<unsigned>(limit)))
     {
         SetFailure(InlineObservation::CALLSITE_OVER_INLINE_LIMIT);
         return;

--- a/src/jit/jit.h
+++ b/src/jit/jit.h
@@ -435,7 +435,6 @@ typedef ptrdiff_t   ssize_t;
 #define DISPLAY_SIZES       0   // Display generated code, data, and GC information sizes.
 #define MEASURE_BLOCK_SIZE  0   // Collect stats about basic block and flowList node sizes and memory allocations.
 #define MEASURE_FATAL       0   // Count the number of calls to fatal(), including NYIs and noway_asserts.
-#define MEASURE_INLINING    0   // Collect various stats about inlining.
 #define MEASURE_NODE_SIZE   0   // Collect stats about GenTree node allocations.
 #define MEASURE_PTRTAB_SIZE 0   // Collect stats about GC pointer table allocations.
 #define EMITTER_STATS       0   // Collect stats on the emitter.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -5616,7 +5616,7 @@ void        Compiler::fgMorphCallInline(GenTreeCall* call, InlineResult* inlineR
 
         // Before we do any cleanup, create a failing InlineContext to
         // capture details of the inlining attempt.
-        InlineContext::NewFailure(this, fgMorphStmt, inlineResult);
+        m_inlineStrategy->NewFailure(fgMorphStmt, inlineResult);
 
 #endif
 
@@ -5737,11 +5737,6 @@ void Compiler::fgMorphCallInlineHelper(GenTreeCall* call, InlineResult* result)
     {
        // printf("After inlining lvaCount=%d.\n", lvaCount);
     }
-#endif
-
-
-#if defined(DEBUG) || MEASURE_INLINING
-    ++Compiler::jitTotalMethodInlined;
 #endif
 }
 


### PR DESCRIPTION
Create the `InlineStrategy` class to hold inline-relevant data that
spans multiple inlines. It tracks the number of inline candidates,
attempts, successes, last successful policy, and holds onto the root
context, and so on. The strategy is responsible for creating contexts
and reporting overall results for a method (either tree-based or
data-based).

The strategy also includes a simple jit time estimate. From various
observations, post-inline jit time can be modelled acceptably by simple
linear relationships on the input IL size. The strategy uses these models
to estimate the initial and current jit time. Estimate units are roughly
microseconds.

The strategy creates a time budget to flag cases where the estimated
jit time increase due to inlining is unreasonbly large. The budget
is initially based on the root method size, and may increase if there
are non-discretionary force inlines.

Once we have a bit more vetting of the budgeting mechanism, policies
will use it to limit inlining in a small number of runaway inlining cases
(see for example #2472).

Remove code under MEASURE_INLINING since the strategy plus the context
tree (optionally extended via policies) contains all that data and more.
Likewise, consolidate a number of the compiler's inlining-related member
variables into the strategy.