### PR TITLE
Make it possible to build JIT32 in the OSS tree.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -691,6 +691,12 @@ endif()
 
 # End of projects that require usage of platform include files
 
+if(WIN32 AND CLR_CMAKE_PLATFORM_ARCH_I386 AND BUILD_JIT32)
+  set(CLR_BUILD_JIT32 1)
+else()
+  set(CLR_BUILD_JIT32 0)
+endif()
+
 # Enable for UNIX altjit on Windows - set(CLR_CMAKE_PLATFORM_UNIX_TARGET_AMD64 1)
 # Enable for UNIX altjit on Windows - add_definitions(-DCLR_CMAKE_PLATFORM_UNIX=1)
 

--- a/build.cmd
+++ b/build.cmd
@@ -68,6 +68,7 @@ set __BuildTypeDebug=0
 set __BuildTypeChecked=0
 set __BuildTypeRelease=0
 set __GCStressLevel=0
+set __BuildJit32="-DBUILD_JIT32=0"
 
 REM __PassThroughArgs is a set of things that will be passed through to nested calls to build.cmd
 REM when using "all".
@@ -117,6 +118,7 @@ if /i "%1" == "sequential"          (set __BuildSequential=1&shift&goto Arg_Loop
 if /i "%1" == "disableoss"          (set __SignTypeReal="/p:SignType=real"&shift&goto Arg_Loop)
 if /i "%1" == "priority"            (set __TestPriority=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
 if /i "%1" == "gcstresslevel"       (set __GCStressLevel=%2&set __PassThroughArgs=%__PassThroughArgs% %2&shift&shift&goto Arg_Loop)
+if /i "%1" == "buildjit32"          (set __BuildJit32="-DBUILD_JIT32=1"&shift&goto Arg_Loop)
 
 @REM For backwards compatibility, continue accepting "skiptestbuild", which was the original name of the option.
 if /i "%1" == "skiptestbuild"       (set __SkipTestBuild=1&shift&goto Arg_Loop)
@@ -308,7 +310,7 @@ if defined __SkipConfigure goto SkipConfigure
 echo %__MsgPrefix%Regenerating the Visual Studio solution
 
 pushd "%__IntermediatesDir%"
-call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion% %__BuildArch%
+call "%__SourceDir%\pal\tools\gen-buildsys-win.bat" "%__ProjectDir%" %__VSVersion% %__BuildArch% %__BuildJit32%
 @if defined __echo @echo on
 popd
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,11 @@ add_subdirectory(utilcode)
 add_subdirectory(gcinfo)
 add_subdirectory(coreclr)
 add_subdirectory(jit)
+
+if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/jit32")
+  add_subdirectory(jit32)
+endif()
+
 add_subdirectory(vm)
 add_subdirectory(md)
 add_subdirectory(debug)

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -59,6 +59,11 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     set(LIB_UNWINDER unwinder_wks)
 endif (CLR_CMAKE_PLATFORM_UNIX)
 
+set(LIB_JIT ClrJit)
+if (CLR_BUILD_JIT32)
+    set(LIB_JIT ClrJit32)
+endif()
+
 # IMPORTANT! Please do not rearrange the order of the libraries. The linker on Linux is
 # order dependent and changing the order can result in undefined symbols in the shared 
 # library.
@@ -76,7 +81,7 @@ set(CORECLR_LIBRARIES
     mdhotdata_full
     bcltype
     ceefgen
-    ClrJit
+    ${LIB_JIT}
     comfloat_wks
     corguids
     gcinfo # Condition="'$(TargetCpu)'=='amd64' or '$(TargetCpu)' == 'arm' or '$(TargetCpu)' == 'arm64'"

--- a/src/pal/tools/gen-buildsys-win.bat
+++ b/src/pal/tools/gen-buildsys-win.bat
@@ -5,7 +5,7 @@ rem This file invokes cmake and generates the build system for windows.
 set argC=0
 for %%x in (%*) do Set /A argC+=1
 
-if NOT %argC%==3 GOTO :USAGE
+if NOT %argC%==3 if NOT %argC%==4 GOTO :USAGE
 if %1=="/?" GOTO :USAGE
 
 setlocal
@@ -16,11 +16,12 @@ set "basePath=%basePath:"=%"
 if %basePath:~-1%==\ set "basePath=%basePath:~0,-1%"
 
 set __VSString=12 2013
+set __UseVS=1
 if /i "%2" == "vs2015" (set __VSString=14 2015)
 if /i "%3" == "x64" (set __VSString=%__VSString% Win64)
-if /i "%3" == "arm64" (
-    set USE_VS=0
-)
+if /i "%3" == "arm64" (set UseVS=0)
+
+set __BuildJit32=%4
 
 if defined CMakePath goto DoGen
 
@@ -28,10 +29,10 @@ if defined CMakePath goto DoGen
 for /f "delims=" %%a in ('powershell -NoProfile -ExecutionPolicy RemoteSigned "& .\probe-win.ps1"') do %%a
 
 :DoGen
-if "%USE_VS%" == "0" (
+if "%UseVS%" == "0" (
     "%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" "-DCLR_CMAKE_TARGET_ARCH=%3" -G "Visual Studio %__VSString% Win64" %1
 ) else (
-    "%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" "-DCLR_CMAKE_TARGET_ARCH=%3" -G "Visual Studio %__VSString%" %1
+    "%CMakePath%" "-DCMAKE_USER_MAKE_RULES_OVERRIDE=%basePath%\windows-compiler-override.txt" "-DCLR_CMAKE_TARGET_ARCH=%3" %__BuildJit32% -G "Visual Studio %__VSString%" %1
 )
 endlocal
 GOTO :DONE

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -24,6 +24,11 @@ add_executable_clr(crossgen
   ${crossgen_RESOURCES}
 )
 
+set(LIB_JIT jit_crossgen)
+if (CLR_BUILD_JIT32)
+    set(LIB_JIT jit32_crossgen)
+endif()
+
 target_link_libraries(crossgen
     cee_crossgen
     mdcompiler_crossgen
@@ -31,7 +36,7 @@ target_link_libraries(crossgen
     mdruntimerw_crossgen
     mdhotdata_crossgen
     corguids
-    jit_crossgen
+    ${LIB_JIT}
     gcinfo_crossgen
     corzap_crossgen
     mscorlib_crossgen


### PR DESCRIPTION
This change adds a new argument to build.cmd, buildjit32, that configures
the build to build and link JIT32 instead of RyuJIT if the sources are
available in `src/jit32`.