### PR TITLE
Set the lvIsMultiRegArgOrRet for a variable containing the result of in-lined multi-register return call.

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -2663,9 +2663,8 @@ CodeGen::genMultiRegCallStoreToLocal(GenTreePtr treeNode)
     // var in 'var = call' is flagged as lvIsMultiRegArgOrRet to prevent it from
     // being struct poromoted.  
     //
-    // TODO-BUG: Crossgen of mscorlib fires the below assert.
-    // A git issue is opened for investigating this.
-    // noway_assert(varDsc->lvIsMultiRegArgOrRet);
+
+    noway_assert(varDsc->lvIsMultiRegArgOrRet);
 
     getEmitter()->emitIns_S_R(ins_Store(type0), emitTypeSize(type0), reg0, lclNum, 0);
     getEmitter()->emitIns_S_R(ins_Store(type1), emitTypeSize(type1), reg1, lclNum, 8);

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21674,6 +21674,13 @@ GenTreePtr Compiler::fgAssignStructInlineeToVar(GenTreePtr child, CORINFO_CLASS_
         // If inlinee was just a call, new inlinee is v05 = call()
         newInlinee = gtNewAssignNode(dst, src);
 
+        // When returning a multi-register value in a local var, make sure the variable is
+        // marked as lvIsMultiRegArgOrRet, so it does not get promoted.
+        if (src->AsCall()->HasMultiRegRetVal())
+        {
+            lvaTable[tmpNum].lvIsMultiRegArgOrRet = true;
+        }
+
         // If inlinee was comma, but a deeper call, new inlinee is (, , , v05 = call())
         if (child->gtOper == GT_COMMA)
         {


### PR DESCRIPTION
This change makes sure the lvIsMultiRegArgOrRet on a variable used to
store the result of inlined multi-register return function is set.
The way the code works today, this is not an issue since the code in
fgAttachStructInlineeToAsg always uses a CopyObj/Blk to asign the return
value from the registers to the var on stack. The CopyBlock/Obj gets the
address of the variable making it address-exposed and that prevents struct
promotion.
In the future (when CopyObj/Blk is not used) not having
lvIsMultiRegArgOrRet set could cause a problem.

Fixes issue 4276.