### PR TITLE
Fix assertion failure on ARM

### DIFF
--- a/src/gc/gcpriv.h
+++ b/src/gc/gcpriv.h
@@ -1663,7 +1663,7 @@ protected:
     PER_HEAP
     void reset_write_watch (BOOL concurrent_p);
     PER_HEAP
-    void adjust_ephemeral_limits ();
+    void adjust_ephemeral_limits (bool is_runtime_suspended);
     PER_HEAP
     void make_generation (generation& gen, heap_segment* seg,
                           uint8_t* start, uint8_t* pointer);


### PR DESCRIPTION
StompWriteBarrierEphemeral may be called on the init path, where the runtime is technically not suspended, but has not started yet. Added a check for g_fEEInit in the call.

Fixes #4344