### PR TITLE
NetBSD: Add support for PAL_IsDebuggerPresent()

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -271,13 +271,16 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
 endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 if(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
+  add_definitions(-D_KMEMUSER)
   find_library(UNWIND unwind)
   find_library(INTL intl)
+  find_library(KVM kvm)
   target_link_libraries(coreclrpal
     pthread
     rt
     ${UNWIND}
     ${INTL}
+    ${KVM}
   )
 endif(CMAKE_SYSTEM_NAME STREQUAL NetBSD)
 


### PR DESCRIPTION
Reuse the `kvm`(3) interface to grab `struct kinfo_proc`.

```
NAME
     kvm - kernel memory interface

LIBRARY
     Kernel Data Access Library (libkvm, -lkvm)

DESCRIPTION
     The kvm library provides a uniform interface for accessing kernel virtual
     memory images, including live systems and crash dumps.  Access to live
     systems is via /dev/mem while crash dumps can be examined via the core
     file generated by savecore(8).  The interface behaves identically in both
     cases.  Memory can be read and written, kernel symbol addresses can be
     looked up efficiently, and information about user processes can be
     gathered.

     kvm_open() is first called to obtain a descriptor for all subsequent
     calls
```