### PR TITLE
Detect if powershell version is suitable for restoring build tools

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -36,6 +36,9 @@ PowerShell
 ----------
 PowerShell is used in the build system. Ensure that it is accessible via the PATH environment variable. Typically this is %SYSTEMROOT%\System32\WindowsPowerShell\v1.0\.
 
+Powershell version must be 3.0 or higher. This should be the case for Windows 8 and later builds.
+- Windows 7 SP1 can install Powershell version 4 [here](https://www.microsoft.com/en-us/download/details.aspx?id=40855).
+
 Git Setup
 ---------
 


### PR DESCRIPTION
Powershell v3 or higher is required to decompress the build tools
bundle. Windows 7 typically has v2 installed.

Detect earlier versions and fail with a pointer to the
build prerequisites and a download link for an updated version.

Also propagate failures out of init-tools.cmd.

See #3510.