### PR TITLE
Stop including utilcode.h in the GC info encoder.

### DIFF
--- a/src/gcinfo/gcinfoencoder.cpp
+++ b/src/gcinfo/gcinfoencoder.cpp
@@ -220,6 +220,11 @@ public:
     }    
 #endif
 
+    static void* operator new(size_t size, IAllocator* allocator)
+    {
+        return allocator->Alloc(size);
+    }
+
 private:
     size_t * m_pData;
     size_t * m_pEndData;
@@ -1836,7 +1841,7 @@ void GcInfoEncoder::Build()
                     UINT32 liveStateOffset = 0;
                     if (!hashMap.Lookup(&liveState, &liveStateOffset))
                     {
-                        BitArray * newLiveState = new (m_pAllocator->Alloc(sizeof(BitArray))) BitArray(m_pAllocator, size_tCount);
+                        BitArray * newLiveState = new (m_pAllocator) BitArray(m_pAllocator, size_tCount);
                         *newLiveState = liveState;
                         hashMap.Set(newLiveState, (UINT32)(-1));
                     }
@@ -1864,7 +1869,7 @@ void GcInfoEncoder::Build()
                 UINT32 liveStateOffset = 0;
                 if (!hashMap.Lookup(&liveState, &liveStateOffset))
                 {
-                    BitArray * newLiveState = new (m_pAllocator->Alloc(sizeof(BitArray))) BitArray(m_pAllocator, size_tCount);
+                    BitArray * newLiveState = new (m_pAllocator) BitArray(m_pAllocator, size_tCount);
                     *newLiveState = liveState;
                     hashMap.Set(newLiveState, (UINT32)(-1));
                 }

--- a/src/inc/dbggcinfoencoder.h
+++ b/src/inc/dbggcinfoencoder.h
@@ -21,7 +21,6 @@
 #include <wchar.h>
 #include <stdio.h>
 
-#include "utilcode.h"
 #include "corjit.h"
 #include "iallocator.h"
 #include "gcinfoarraylist.h"

--- a/src/inc/gcinfoencoder.h
+++ b/src/inc/gcinfoencoder.h
@@ -78,7 +78,6 @@
 #include <windows.h>
 #include <wchar.h>
 #include <stdio.h>
-#include "utilcode.h"
 #include "corjit.h"
 #include "iallocator.h"
 #include "gcinfoarraylist.h"
@@ -318,6 +317,8 @@ enum GENERIC_CONTEXTPARAM_TYPE
     GENERIC_CONTEXTPARAM_THIS = 3,
 };
 
+extern void DECLSPEC_NORETURN ThrowOutOfMemory();
+
 class GcInfoEncoder
 {
 public:
@@ -327,7 +328,7 @@ public:
             ICorJitInfo*                pCorJitInfo,
             CORINFO_METHOD_INFO*        pMethodInfo,
             IAllocator*                 pJitAllocator,
-            NoMemoryFunction            pNoMem = ThrowOutOfMemory
+            NoMemoryFunction            pNoMem = ::ThrowOutOfMemory
             );
 
     struct LifetimeTransition


### PR DESCRIPTION
This required two other minor changes:
- A prototype for `ThrowOutOfMemory` is now defined in gcinfoencoder.h
- `BitArray` now defines an overload of `operator new` that accepts an
  `IAllocator`.