### PR TITLE
Cleanup VCRuntime140.dll dependency from native components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,15 @@ if (WIN32)
   add_compile_options($<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/GL>)
   add_compile_options($<$<OR:$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>,$<CONFIG:Checked>>:/O1>)
 
+  # Statically linked CRT (libcmt[d].lib, libvcruntime[d].lib and libucrt[d].lib) by default. This is done to avoid
+  # linking in VCRUNTIME140.DLL for a simplified xcopy experience by reducing the dependency on VC REDIST.
+  #
+  # For Release builds, we shall dynamically link into uCRT [ucrtbase.dll] (which is pushed down as a Windows Update on downlevel OS) but
+  # wont do the same for debug/checked builds since ucrtbased.dll is not redistributable and Debug/Checked builds are not
+  # production-time scenarios.
+  add_compile_options($<$<OR:$<CONFIG:Release>,$<CONFIG:Relwithdebinfo>>:/MT>)
+  add_compile_options($<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:/MTd>)
+
   if (CLR_CMAKE_PLATFORM_ARCH_AMD64)
   # The generator expression in the following command means that the /homeparams option is added only for debug builds
   add_compile_options($<$<CONFIG:Debug>:/homeparams>) # Force parameters passed in registers to be written to the stack
@@ -573,16 +582,24 @@ if (WIN32)
   set(CMAKE_SHARED_LINKER_FLAGS_CHECKED "${CMAKE_SHARED_LINKER_FLAGS_CHECKED} /OPT:REF /OPT:NOICF /NOVCFEATURE ${NO_INCREMENTAL_LINKER_FLAGS}")
   set(CMAKE_STATIC_LINKER_FLAGS_CHECKED "${CMAKE_STATIC_LINKER_FLAGS_CHECKED}")
   set(CMAKE_EXE_LINKER_FLAGS_CHECKED "${CMAKE_EXE_LINKER_FLAGS_CHECKED} /OPT:REF /OPT:NOICF ${NO_INCREMENTAL_LINKER_FLAGS}")
-
+  
   # Release build specific flags
   set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
   set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} /LTCG")
   set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
-
+  
+  # Force uCRT to be dynamically linked for Release build
+  set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+  set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+  
   # ReleaseWithDebugInfo build specific flags
   set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
   set(CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_STATIC_LINKER_FLAGS_RELWITHDEBINFO} /LTCG")
   set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /LTCG /OPT:REF /OPT:ICF ${NO_INCREMENTAL_LINKER_FLAGS}")
+  
+  # Force uCRT to be dynamically linked for Release build
+  set(CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_SHARED_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
+  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /NODEFAULTLIB:libucrt.lib /DEFAULTLIB:ucrt.lib")
 
 # Temporary until cmake has VS generators for arm64
 if(CLR_CMAKE_PLATFORM_ARCH_ARM64)
@@ -727,7 +744,8 @@ if (WIN32)
     # ARM64_TODO: Enable this for Windows Arm64
     if (NOT CLR_CMAKE_PLATFORM_ARCH_ARM64)
       # Define the uCRT lib reference
-      set(STATIC_MT_UCRT_LIB  "libucrt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
+      set(STATIC_UCRT_LIB  "libucrt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
+      set(DYNAMIC_UCRT_LIB  "ucrt$<$<OR:$<CONFIG:Debug>,$<CONFIG:Checked>>:d>.lib")
     endif()
 
 endif(WIN32)

--- a/src/coreclr/hosts/coreconsole/CMakeLists.txt
+++ b/src/coreclr/hosts/coreconsole/CMakeLists.txt
@@ -23,7 +23,8 @@ else()
     )
 
     target_link_libraries(CoreConsole
-        msvcrt.lib
+        ${STATIC_MT_CRT_LIB}
+        ${STATIC_MT_VCRT_LIB}
     )
 
     # Can't compile on linux yet so only add for windows

--- a/src/coreclr/hosts/corerun/CMakeLists.txt
+++ b/src/coreclr/hosts/corerun/CMakeLists.txt
@@ -28,7 +28,8 @@ else()
         oleaut32.lib
         uuid.lib
         user32.lib
-        msvcrt.lib
+        ${STATIC_MT_CRT_LIB}
+        ${STATIC_MT_VCRT_LIB}
     )
 
     # Can't compile on linux yet so only add for windows

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -99,9 +99,10 @@ set(CORECLR_LIBRARIES
 
 if(WIN32)
     list(APPEND CORECLR_LIBRARIES
+        ${STATIC_MT_CRT_LIB}
+        ${STATIC_MT_VCRT_LIB}
         mdwinmd_wks
         comnls_wks
-        msvcrt.lib
         kernel32.lib
         advapi32.lib
         ole32.lib

--- a/src/ilasm/CMakeLists.txt
+++ b/src/ilasm/CMakeLists.txt
@@ -70,7 +70,6 @@ else()
   target_link_libraries(ilasm
     ${ILASM_LINK_LIBRARIES}
     coreclr
-    msvcrt
     ole32
     oleaut32
     shell32

--- a/src/ildasm/exe/CMakeLists.txt
+++ b/src/ildasm/exe/CMakeLists.txt
@@ -64,7 +64,6 @@ else()
     target_link_libraries(ildasm
         ${ILDASM_LINK_LIBRARIES}
         coreclr
-        msvcrt
         ole32
         oleaut32
         shell32

--- a/src/ildasm/rcdll/CMakeLists.txt
+++ b/src/ildasm/rcdll/CMakeLists.txt
@@ -18,7 +18,8 @@ add_library_clr(ildasmrc
 )
 
 target_link_libraries(ildasmrc
-     msvcrt
+	${STATIC_MT_CRT_LIB}
+	${STATIC_MT_VCRT_LIB}
 )
 
 # We will generate PDB only for the debug configuration

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -27,7 +27,8 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     )
 else()
     list(APPEND RYUJIT_LINK_LIBRARIES
-       msvcrt.lib
+       ${STATIC_MT_CRT_LIB}
+       ${STATIC_MT_VCRT_LIB}
        kernel32.lib
        advapi32.lib
        ole32.lib

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -62,7 +62,8 @@ else()
         shlwapi
         bcrypt
         mdwinmd_crossgen
-        msvcrt
+        ${STATIC_MT_CRT_LIB}
+        ${STATIC_MT_VCRT_LIB}
     )
 
 endif(CLR_CMAKE_PLATFORM_UNIX)


### PR DESCRIPTION
This removes the dependency on VCRuntime140.dll from the native components built in CoreCLR repo. By default, we static link all CRT pieces. However, for the Release build, we link into uCRT DLL while continuing to static link the CRT pieces corresponding to vcruntime140.dll. I have confirmed that the Release binaries only have dependency on the uCRT APISets that will be pushed down via WU.

Fixes https://github.com/dotnet/coreclr/issues/4334. 

@jkotas @russellhadley PTAL

@weshaggard @ericstj - FYI
