### PR TITLE
Don't allocate in NullStream.CopyToAsync

### DIFF
--- a/src/mscorlib/model.xml
+++ b/src/mscorlib/model.xml
@@ -8057,7 +8057,6 @@
       <Member Name="get_Position" />
       <Member Name="get_ReadTimeout" />
       <Member Name="get_WriteTimeout" />
-      <Member Status="ImplRoot" Name="InternalCopyTo(System.IO.Stream,System.Int32)" />
       <Member Name="Read(System.Byte[],System.Int32,System.Int32)" />
       <Member Name="ReadByte" />
       <Member Name="ReadAsync(System.Byte[],System.Int32,System.Int32)"  />


### PR DESCRIPTION
This is basically a port of the changes in dotnet/corefx#7782 to CoreCLR. Here are the changes:

- A `TaskCache` class has been introduced to hold cached tasks for the values 0, null, and the empty string.

- A few classes have been optimized in their `Read` methods to return the task holding 0 in `TaskCache`, instead of allocating a new `Task` every time.

- Methods on the null-object readers/writers (e.g. `Stream.Null`, `StreamReader.Null`) have been overridden to more efficiently noop/return a completed Task, since reading/writing from them isn't supposed to do anything.

cc @jkotas @justinvp 