### PR TITLE
Remove unnecessary compat check in Dictionary

### DIFF
--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -110,10 +110,8 @@ namespace System.Collections.Generic {
 
             // It is likely that the passed-in dictionary is Dictionary<TKey,TValue>. When this is the case,
             // avoid the enumerator allocation and overhead by looping through the entries array directly.
-            // We only do this when dictionary is Dictionary<TKey,TValue> and not a subclass, to maintain
-            // back-compat with subclasses that may have overridden the enumerator behavior.
-            if (dictionary.GetType() == typeof(Dictionary<TKey,TValue>)) {
-                Dictionary<TKey,TValue> d = (Dictionary<TKey,TValue>)dictionary;
+            var d = dictionary as Dictionary<TKey, TValue>;
+            if (d != null) {
                 int count = d.count;
                 Entry[] entries = d.entries;
                 for (int i = 0; i < count; i++) {


### PR DESCRIPTION
The optimization in Dictionary's constructor should still apply to subclasses, since:

- Neither `GetEnumerator`, or its explicitly-implemented counterpart, are virtual (and thus cannot be overridden)
- In the case where the subclass defines something silly like this (which will be picked up by `foreach`):

```cs
public struct BadBehaviorEnumerator
{
    public bool MoveNext() => throw new OutOfMemoryException();
}

public class BadBehaviorDictionary<TKey, TValue> : Dictionary<TKey, TValue>
{
    // `foreach` is duck-typed, so Roslyn will generate the code calling this GetEnumerator
    public new BadBehaviorEnumerator GetEnumerator() => new BadBehaviorEnumerator();
}
```

this still doesn't change any behavior, since when `BadBehaviorDictionary` is passed into the constructor with the current implementation, it is converted to an `IDictionary`. Which means that when we call `foreach` on it, it will call the explicitly-implemented `IDictionary.GetEnumerator` method which we define and we're in control of (since as mentioned it cannot be overridden).

This PR simply removes the `GetType` check and the associated comment from the constructor, and replaces it with an `as` statement.

cc @AlexGhiondea