### PR TITLE
Add support for ready to run to NGEN rundown

### DIFF
--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -111,6 +111,7 @@ public:
         BOOL Next();
 
         MethodDesc * GetMethodDesc();
+        MethodDesc * GetMethodDesc_NoRestore();
         PCODE GetMethodStartAddress();
     };
 


### PR DESCRIPTION
Tracing tools such as PerfView cannot resolve symbols for ready to run images because native PDBs are not created for these images.

This change enables NGEN rundown to log pre-compiled methods in ready to run images to ensure that PerfView can resolve symbols for these methods.

The goal is to use NGEN rundown while we look into how we can support symbol resolution using PDBs without rundown.