### PR TITLE
Cleanup some minor JIT issues.

### DIFF
--- a/src/jit/codegen.h
+++ b/src/jit/codegen.h
@@ -182,11 +182,11 @@ private:
     // to be the sizes of the prolog and epilog, respectively.  In DEBUG, makes a check involving the
     // "codePtr", assumed to be a pointer to the start of the generated code.
 #ifdef JIT32_GCENCODER
-    void*               genCreateAndStoreGCInfo     (unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr));
-    void*               genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr));
+    void*               genCreateAndStoreGCInfo     (unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr));
+    void*               genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr));
 #else // !JIT32_GCENCODER
-    void                genCreateAndStoreGCInfo     (unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr));
-    void                genCreateAndStoreGCInfoX64  (unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr));
+    void                genCreateAndStoreGCInfo     (unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr));
+    void                genCreateAndStoreGCInfoX64  (unsigned codeSize, unsigned prologSize DEBUGARG(void* codePtr));
 #endif // !JIT32_GCENCODER
 
     /**************************************************************************

--- a/src/jit/codegenarm.cpp
+++ b/src/jit/codegenarm.cpp
@@ -342,8 +342,8 @@ void                CodeGen::genCodeForBBlist()
         }
 
         regSet.rsMaskVars = newLiveRegSet;
-        gcInfo.gcMarkRegSetGCref(newRegGCrefSet DEBUG_ARG(true));
-        gcInfo.gcMarkRegSetByref(newRegByrefSet DEBUG_ARG(true));
+        gcInfo.gcMarkRegSetGCref(newRegGCrefSet DEBUGARG(true));
+        gcInfo.gcMarkRegSetByref(newRegByrefSet DEBUGARG(true));
 
         /* Blocks with handlerGetsXcptnObj()==true use GT_CATCH_ARG to
            represent the exception object (TYP_REF).
@@ -2076,18 +2076,18 @@ void*
 #else
 void
 #endif
-CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr))
+CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr))
 {
 #ifdef JIT32_GCENCODER
-    return genCreateAndStoreGCInfoJIT32(codeSize, prologSize, epilogSize DEBUG_ARG(codePtr));
+    return genCreateAndStoreGCInfoJIT32(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 #else
-    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUG_ARG(codePtr));
+    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUGARG(codePtr));
 #endif
 }
 
 // TODO-ARM-Cleanup: It seems that the ARM JIT (classic and otherwise) uses this method, so it seems to be inappropriately named?
 
-void                CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
+void                CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUGARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
     GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1601,8 +1601,8 @@ void                CodeGen::genCodeForBBlist()
         }
 #endif // DEBUG
 
-        gcInfo.gcMarkRegSetGCref(newRegGCrefSet DEBUG_ARG(true));
-        gcInfo.gcMarkRegSetByref(newRegByrefSet DEBUG_ARG(true));
+        gcInfo.gcMarkRegSetGCref(newRegGCrefSet DEBUGARG(true));
+        gcInfo.gcMarkRegSetByref(newRegByrefSet DEBUGARG(true));
 
         /* Blocks with handlerGetsXcptnObj()==true use GT_CATCH_ARG to
            represent the exception object (TYP_REF).
@@ -6699,13 +6699,13 @@ void CodeGen::genCodeForObj(GenTreeObj* objNode)
  *  Create and record GC Info for the function.
  */
 void
-CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr))
+CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr))
 {
-    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUG_ARG(codePtr));
+    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUGARG(codePtr));
 }
 
 void
-CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
+CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUGARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
     GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3189,7 +3189,7 @@ void                CodeGen::genGenerateCode(void * * codePtr,
     void* infoPtr = 
 #endif // DEBUG    
 #endif
-        genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUG_ARG(codePtr));
+        genCreateAndStoreGCInfo(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 
 #ifdef  DEBUG
     FILE* dmpf = stdout;

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -20800,17 +20800,17 @@ void*
 #else
 void
 #endif
-CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr))
+CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr))
 {
 #ifdef JIT32_GCENCODER
-    return genCreateAndStoreGCInfoJIT32(codeSize, prologSize, epilogSize DEBUG_ARG(codePtr));
+    return genCreateAndStoreGCInfoJIT32(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 #else
-    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUG_ARG(codePtr));
+    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUGARG(codePtr));
 #endif
 }
 
 #ifdef JIT32_GCENCODER
-void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr))
+void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr))
 {
     BYTE            headerBuf[64];
     InfoHdr         header;
@@ -20966,7 +20966,7 @@ void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologS
 
 #else // JIT32_GCENCODER
 
-void                CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
+void                CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUGARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
     GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -17655,7 +17655,7 @@ bool CodeGen::genFillSlotFromPromotedStruct(GenTreePtr        arg,
             noway_assert((curRegNum % 2) == 0);
             // We leave the fieldSize as EA_4BYTE; but we must do 2 reg moves.
             break;
-        default: _ASSERTE(fieldVarDsc->lvExactSize == 4); break;
+        default: assert(fieldVarDsc->lvExactSize == 4); break;
         }
     }
     else

--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -513,8 +513,8 @@ void                CodeGen::genCodeForBBlist()
         }
 #endif // DEBUG
 
-        gcInfo.gcMarkRegSetGCref(newRegGCrefSet DEBUG_ARG(true));
-        gcInfo.gcMarkRegSetByref(newRegByrefSet DEBUG_ARG(true));
+        gcInfo.gcMarkRegSetGCref(newRegGCrefSet DEBUGARG(true));
+        gcInfo.gcMarkRegSetByref(newRegByrefSet DEBUGARG(true));
 
         /* Blocks with handlerGetsXcptnObj()==true use GT_CATCH_ARG to
            represent the exception object (TYP_REF).
@@ -8179,17 +8179,17 @@ void
 #else // !_TARGET_AMD64_
 void*
 #endif // !_TARGET_AMD64_
-CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr))
+CodeGen::genCreateAndStoreGCInfo(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr))
 {
 #ifdef JIT32_GCENCODER
-    return genCreateAndStoreGCInfoJIT32(codeSize, prologSize, epilogSize DEBUG_ARG(codePtr));
+    return genCreateAndStoreGCInfoJIT32(codeSize, prologSize, epilogSize DEBUGARG(codePtr));
 #else // !JIT32_GCENCODER
-    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUG_ARG(codePtr));
+    genCreateAndStoreGCInfoX64(codeSize, prologSize DEBUGARG(codePtr));
 #endif // !JIT32_GCENCODER
 }
 
 #ifdef JIT32_GCENCODER
-void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUG_ARG(void* codePtr))
+void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologSize, unsigned epilogSize DEBUGARG(void* codePtr))
 {
     BYTE            headerBuf[64];
     InfoHdr         header;
@@ -8345,7 +8345,7 @@ void*  CodeGen::genCreateAndStoreGCInfoJIT32(unsigned codeSize, unsigned prologS
 
 #else // !JIT32_GCENCODER
 void
-CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUG_ARG(void* codePtr))
+CodeGen::genCreateAndStoreGCInfoX64(unsigned codeSize, unsigned prologSize DEBUGARG(void* codePtr))
 {
     IAllocator* allowZeroAlloc = new (compiler, CMK_GC) AllowZeroAllocator(compiler->getAllocatorGC());
     GcInfoEncoder* gcInfoEncoder = new (compiler, CMK_GC) GcInfoEncoder(compiler->info.compCompHnd, compiler->info.compMethodInfo, allowZeroAlloc, NOMEM);

--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -5469,7 +5469,7 @@ START:
 #if defined(_PREFAST_) || defined(_PREFIX_)             
             PREFIX_ASSUME(pParam->pComp != NULL);
 #else
-            _ASSERTE(pParam->pComp != NULL);
+            assert(pParam->pComp != NULL);
 #endif
             
             pParam->pComp->compInit(pParam->pAlloc, pParam->inlineInfo);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1844,7 +1844,7 @@ public:
 
     GenTreePtr              gtNewAssignNode (GenTreePtr     dst,
                                              GenTreePtr     src
-                                             DEBUG_ARG(bool isPhiDefn = false));
+                                             DEBUGARG(bool isPhiDefn = false));
 
     GenTreePtr              gtNewTempAssign (unsigned       tmp,
                                              GenTreePtr     val);
@@ -2200,7 +2200,7 @@ public :
 #endif
     };
 #endif
-    void                lvaSetVarDoNotEnregister(unsigned varNum DEBUG_ARG(DoNotEnregisterReason reason));     
+    void                lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregisterReason reason));     
 
     unsigned            lvaVarargsHandleArg;
 #ifdef _TARGET_X86_
@@ -4558,7 +4558,7 @@ private:
 #endif
     void                fgMorphTreeDone     (GenTreePtr     tree,
                                              GenTreePtr     oldTree = NULL
-                                             DEBUG_ARG(int morphNum = 0));
+                                             DEBUGARG(int morphNum = 0));
 
     GenTreePtr          fgMorphStmt;
     

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -839,7 +839,7 @@ void* GenTree::operator new(size_t sz, Compiler* comp, genTreeOps oper)
 
 // GenTree constructor
 inline
-GenTree::GenTree(genTreeOps oper, var_types type DEBUG_ARG(bool largeNode))
+GenTree::GenTree(genTreeOps oper, var_types type DEBUGARG(bool largeNode))
 {
     gtOper     = oper;
     gtType     = type;
@@ -984,7 +984,7 @@ GenTreePtr          Compiler::gtNewLargeOperNode(genTreeOps     oper,
 
     assert(GenTree::s_gtNodeSizes[oper   ] == TREE_NODE_SZ_SMALL);
 
-    GenTreePtr node = new(this, LargeOpOpcode()) GenTreeOp(oper, type, op1, op2 DEBUG_ARG(/*largeNode*/true));
+    GenTreePtr node = new(this, LargeOpOpcode()) GenTreeOp(oper, type, op1, op2 DEBUGARG(/*largeNode*/true));
 #else
     GenTreePtr node = new(this, oper) GenTreeOp(oper, type, op1, op2);
 #endif
@@ -1013,7 +1013,7 @@ GenTreePtr          Compiler::gtNewIconHandleNode(size_t        value,
         fields = FieldSeqStore::NotAField();
 
 #if defined(LATE_DISASM)
-    node = new (this, LargeOpOpcode()) GenTreeIntCon(TYP_I_IMPL, value, fields DEBUG_ARG(/*largeNode*/true));
+    node = new (this, LargeOpOpcode()) GenTreeIntCon(TYP_I_IMPL, value, fields DEBUGARG(/*largeNode*/true));
 
     node->gtIntCon.gtIconHdl.gtIconHdl1 = handle1;
     node->gtIntCon.gtIconHdl.gtIconHdl2 = handle2;
@@ -1395,7 +1395,7 @@ GenTreePtr          Compiler::gtNewCastNodeL(var_types typ, GenTreePtr op1,
 
     /* Make a big node first and then change it to be GT_CAST */
 
-    GenTreePtr res = new (this, LargeOpOpcode()) GenTreeCast(typ, op1, castType DEBUG_ARG(/*largeNode*/true));
+    GenTreePtr res = new (this, LargeOpOpcode()) GenTreeCast(typ, op1, castType DEBUGARG(/*largeNode*/true));
     return res;
 
 }

--- a/src/jit/disasm.h
+++ b/src/jit/disasm.h
@@ -27,7 +27,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 // free() is redefined to cause a runtime error instead of a compile time error.
 #undef free
 #ifdef DEBUG
-#define free(x) _ASSERTE(false && "Must not call free(). Use a ClrXXX function instead.")
+#define free(x) assert(false && "Must not call free(). Use a ClrXXX function instead.")
 #endif
 
 #if CHECK_STRUCT_PADDING

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -22766,6 +22766,6 @@ void Compiler::fgLclFldAssign(unsigned lclNum)
     assert(varTypeIsStruct(lvaTable[lclNum].lvType));
     if (lvaTable[lclNum].lvPromoted && lvaTable[lclNum].lvFieldCnt > 1)
     {
-        lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_LocalField));
+        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
     }
 }

--- a/src/jit/gcencode.cpp
+++ b/src/jit/gcencode.cpp
@@ -1171,7 +1171,7 @@ size_t              GCInfo::gcInfoBlockHdrSave(BYTE*      dest,
     header->gsCookieOffset = INVALID_GS_COOKIE_OFFSET;
     if (compiler->getNeedsGSSecurityCookie())
     {
-        _ASSERTE(compiler->lvaGSSecurityCookie != BAD_VAR_NUM);
+        assert(compiler->lvaGSSecurityCookie != BAD_VAR_NUM);
         int stkOffs = compiler->lvaTable[compiler->lvaGSSecurityCookie].lvStkOffs;
         header->gsCookieOffset = compiler->isFramePointerUsed() ? -stkOffs : stkOffs;
         assert(header->gsCookieOffset != INVALID_GS_COOKIE_OFFSET);

--- a/src/jit/gcinfo.cpp
+++ b/src/jit/gcinfo.cpp
@@ -86,7 +86,7 @@ void                GCInfo::gcResetForBB()
  *  Print the changes in the gcRegGCrefSetCur sets.
  */
 
-void                GCInfo::gcDspGCrefSetChanges(regMaskTP gcRegGCrefSetNew DEBUG_ARG(bool forceOutput))
+void                GCInfo::gcDspGCrefSetChanges(regMaskTP gcRegGCrefSetNew DEBUGARG(bool forceOutput))
 {
     if (compiler->verbose)
     {
@@ -115,7 +115,7 @@ void                GCInfo::gcDspGCrefSetChanges(regMaskTP gcRegGCrefSetNew DEBU
  *  Print the changes in the gcRegByrefSetCur sets.
  */
 
-void                GCInfo::gcDspByrefSetChanges(regMaskTP gcRegByrefSetNew DEBUG_ARG(bool forceOutput))
+void                GCInfo::gcDspByrefSetChanges(regMaskTP gcRegByrefSetNew DEBUGARG(bool forceOutput))
 {
     if (compiler->verbose)
     {
@@ -147,7 +147,7 @@ void                GCInfo::gcDspByrefSetChanges(regMaskTP gcRegByrefSetNew DEBU
  *  GCref pointer values.
  */
 
-void                GCInfo::gcMarkRegSetGCref(regMaskTP regMask DEBUG_ARG(bool forceOutput))
+void                GCInfo::gcMarkRegSetGCref(regMaskTP regMask DEBUGARG(bool forceOutput))
 {
 #ifdef DEBUG    
     if (compiler->compRegSetCheckLevel == 0)
@@ -174,7 +174,7 @@ void                GCInfo::gcMarkRegSetGCref(regMaskTP regMask DEBUG_ARG(bool f
  *  Byref pointer values.
  */
 
-void                GCInfo::gcMarkRegSetByref(regMaskTP regMask DEBUG_ARG(bool forceOutput))
+void                GCInfo::gcMarkRegSetByref(regMaskTP regMask DEBUGARG(bool forceOutput))
 {
     regMaskTP gcRegByrefSetNew = gcRegByrefSetCur | regMask;   // Set it in Byref mask
     regMaskTP gcRegGCrefSetNew = gcRegGCrefSetCur & ~regMask;  // Clear it if set in GCref mask
@@ -192,7 +192,7 @@ void                GCInfo::gcMarkRegSetByref(regMaskTP regMask DEBUG_ARG(bool f
  *  non-pointer values.
  */
 
-void                GCInfo::gcMarkRegSetNpt(regMaskTP regMask DEBUG_ARG(bool forceOutput))
+void                GCInfo::gcMarkRegSetNpt(regMaskTP regMask DEBUGARG(bool forceOutput))
 {
     /* NOTE: don't unmark any live register variables */
 

--- a/src/jit/gentree.cpp
+++ b/src/jit/gentree.cpp
@@ -5008,10 +5008,10 @@ GenTreePtr          Compiler::gtNewSconNode(int CPX, CORINFO_MODULE_HANDLE scpHa
     assert(GenTree::s_gtNodeSizes[GT_CALL] > GenTree::s_gtNodeSizes[GT_CNS_STR]);
 
     GenTreePtr      node = new(this, GT_CALL) GenTreeStrCon(CPX, scpHandle 
-                                                            DEBUG_ARG(/*largeNode*/true));
+                                                            DEBUGARG(/*largeNode*/true));
 #else
     GenTreePtr      node = new(this, GT_CNS_STR) GenTreeStrCon(CPX, scpHandle
-                                                               DEBUG_ARG(/*largeNode*/true));
+                                                               DEBUGARG(/*largeNode*/true));
 #endif
 
     return node;
@@ -5203,10 +5203,10 @@ GenTreePtr          Compiler::gtNewLclLNode(unsigned   lnum,
 //    assert(GenTree::s_gtNodeSizes[GT_CALL] > GenTree::s_gtNodeSizes[GT_LCL_VAR]);
 
     GenTreePtr node = new(this, GT_CALL) GenTreeLclVar(type, lnum, ILoffs
-                                                       DEBUG_ARG(/*largeNode*/true));
+                                                       DEBUGARG(/*largeNode*/true));
 #else
     GenTreePtr node = new(this, GT_LCL_VAR) GenTreeLclVar(type, lnum, ILoffs
-                                                          DEBUG_ARG(/*largeNode*/true));
+                                                          DEBUGARG(/*largeNode*/true));
 #endif
 
     return node;
@@ -5391,7 +5391,7 @@ bool  Compiler::gtArgIsThisPtr(fgArgTabEntryPtr argEntry)
  *  Create a node that will assign 'src' to 'dst'.
  */
 
-GenTreePtr          Compiler::gtNewAssignNode(GenTreePtr dst, GenTreePtr src DEBUG_ARG(bool isPhiDefn))
+GenTreePtr          Compiler::gtNewAssignNode(GenTreePtr dst, GenTreePtr src DEBUGARG(bool isPhiDefn))
 {
     var_types type = dst->TypeGet();
 
@@ -6007,7 +6007,7 @@ GenTreePtr          Compiler::gtCloneExpr(GenTree * tree,
 
         case GT_CAST:
             copy = new (this, LargeOpOpcode()) GenTreeCast(tree->TypeGet(), tree->gtCast.CastOp(), tree->gtCast.gtCastType
-                                                           DEBUG_ARG(/*largeNode*/TRUE));
+                                                           DEBUGARG(/*largeNode*/TRUE));
             break;
 
             // The nodes below this are not bashed, so they can be allocated at their individual sizes.

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1654,7 +1654,7 @@ public:
 #ifdef DEBUG
   private:
     GenTree& operator=(const GenTree& gt) {
-        _ASSERTE(!"Don't copy");
+        assert(!"Don't copy");
         return *this;
     }
 #endif // DEBUG

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -1676,7 +1676,7 @@ public:
     inline void* operator new(size_t sz, class Compiler*, genTreeOps oper);
 
     inline GenTree(genTreeOps oper, var_types type
-                   DEBUG_ARG(bool largeNode = false));
+                   DEBUGARG(bool largeNode = false));
 };
 
 
@@ -1692,16 +1692,16 @@ struct GenTreeUnOp: public GenTree
 
 protected:
     GenTreeUnOp(genTreeOps oper, var_types type 
-                DEBUG_ARG(bool largeNode = false)) : 
+                DEBUGARG(bool largeNode = false)) : 
         GenTree(oper, type 
-                DEBUG_ARG(largeNode)),
+                DEBUGARG(largeNode)),
         gtOp1(nullptr)
         {}
 
     GenTreeUnOp(genTreeOps oper, var_types type, GenTreePtr op1 
-                DEBUG_ARG(bool largeNode = false)) : 
+                DEBUGARG(bool largeNode = false)) : 
         GenTree(oper, type 
-                DEBUG_ARG(largeNode)), 
+                DEBUGARG(largeNode)), 
         gtOp1(op1)
         {
             assert(op1 != nullptr || NullOp1Legal());
@@ -1719,9 +1719,9 @@ struct GenTreeOp: public GenTreeUnOp
     GenTreePtr      gtOp2;
 
     GenTreeOp(genTreeOps oper, var_types type, GenTreePtr op1, GenTreePtr op2 
-              DEBUG_ARG(bool largeNode = false)) : 
+              DEBUGARG(bool largeNode = false)) : 
         GenTreeUnOp(oper, type, op1 
-                    DEBUG_ARG(largeNode)), 
+                    DEBUGARG(largeNode)), 
         gtOp2(op2) 
         {
             // comparisons are always integral types
@@ -1741,9 +1741,9 @@ struct GenTreeOp: public GenTreeUnOp
     // A small set of types are unary operators with optional arguments.  We use
     // this constructor to build those.
     GenTreeOp(genTreeOps oper, var_types type 
-              DEBUG_ARG(bool largeNode = false)) : 
+              DEBUGARG(bool largeNode = false)) : 
         GenTreeUnOp(oper, type 
-                    DEBUG_ARG(largeNode)),
+                    DEBUGARG(largeNode)),
         gtOp2(nullptr)
         {
             // Unary operators with optional arguments:
@@ -1780,9 +1780,9 @@ struct GenTreeIntConCommon: public GenTree
     inline void SetIconValue(ssize_t val);
     
     GenTreeIntConCommon(genTreeOps oper, var_types type
-                        DEBUG_ARG(bool largeNode = false)) : 
+                        DEBUGARG(bool largeNode = false)) : 
         GenTree(oper, type 
-                DEBUG_ARG(largeNode))
+                DEBUGARG(largeNode))
         {}
 
         bool FitsInI32() 
@@ -1839,9 +1839,9 @@ struct GenTreeJumpTable : public GenTreeIntConCommon
     ssize_t        gtJumpTableAddr;
 
     GenTreeJumpTable(var_types type
-                  DEBUG_ARG(bool largeNode = false)) : 
+                  DEBUGARG(bool largeNode = false)) : 
         GenTreeIntConCommon(GT_JMPTABLE, type 
-                            DEBUG_ARG(largeNode)) 
+                            DEBUGARG(largeNode)) 
         {}
 #if DEBUGGABLE_GENTREE
     GenTreeJumpTable() : GenTreeIntConCommon() {}
@@ -1910,18 +1910,18 @@ struct GenTreeIntCon: public GenTreeIntConCommon
 #endif
 
     GenTreeIntCon(var_types type, ssize_t value
-                  DEBUG_ARG(bool largeNode = false)) : 
+                  DEBUGARG(bool largeNode = false)) : 
         GenTreeIntConCommon(GT_CNS_INT, type 
-                            DEBUG_ARG(largeNode)),
+                            DEBUGARG(largeNode)),
         gtIconVal(value),
         gtCompileTimeHandle(0),
         gtFieldSeq(FieldSeqStore::NotAField())
         {}
 
     GenTreeIntCon(var_types type, ssize_t value, FieldSeqNode* fields
-                  DEBUG_ARG(bool largeNode = false)) : 
+                  DEBUGARG(bool largeNode = false)) : 
         GenTreeIntConCommon(GT_CNS_INT, type 
-                            DEBUG_ARG(largeNode)),
+                            DEBUGARG(largeNode)),
         gtIconVal(value),
         gtCompileTimeHandle(0),
         gtFieldSeq(fields)
@@ -2042,9 +2042,9 @@ struct GenTreeStrCon: public GenTree
     // Because this node can come from an inlined method we need to
     // have the scope handle, since it will become a helper call.
     GenTreeStrCon(unsigned sconCPX, CORINFO_MODULE_HANDLE mod
-                  DEBUG_ARG(bool largeNode = false)) : 
+                  DEBUGARG(bool largeNode = false)) : 
         GenTree(GT_CNS_STR, TYP_REF 
-                DEBUG_ARG(largeNode)),
+                DEBUGARG(largeNode)),
         gtSconCPX(sconCPX), gtScpHnd(mod)
         {}
 #if DEBUGGABLE_GENTREE
@@ -2062,9 +2062,9 @@ private:
 
 public:
     GenTreeLclVarCommon(genTreeOps oper, var_types type, unsigned lclNum
-                        DEBUG_ARG(bool largeNode = false)) : 
+                        DEBUGARG(bool largeNode = false)) : 
         GenTreeUnOp(oper, type 
-                DEBUG_ARG(largeNode))
+                DEBUGARG(largeNode))
     {
         SetLclNum(lclNum);
     }
@@ -2109,16 +2109,16 @@ struct GenTreeLclVar: public GenTreeLclVarCommon
     IL_OFFSET       gtLclILoffs;    // instr offset of ref (only for debug info)
 
     GenTreeLclVar(var_types type, unsigned lclNum, IL_OFFSET ilOffs
-                  DEBUG_ARG(bool largeNode = false)) : 
+                  DEBUGARG(bool largeNode = false)) : 
         GenTreeLclVarCommon(GT_LCL_VAR, type, lclNum
-                            DEBUG_ARG(largeNode)),
+                            DEBUGARG(largeNode)),
             gtLclILoffs(ilOffs)
             {}
     
     GenTreeLclVar(genTreeOps oper, var_types type, unsigned lclNum, IL_OFFSET ilOffs
-              DEBUG_ARG(bool largeNode = false)) : 
+              DEBUGARG(bool largeNode = false)) : 
         GenTreeLclVarCommon(oper, type, lclNum
-                            DEBUG_ARG(largeNode)),
+                            DEBUGARG(largeNode)),
             gtLclILoffs(ilOffs)
             {
                 assert(OperIsLocal(oper) || OperIsLocalAddr(oper));
@@ -2228,9 +2228,9 @@ struct GenTreeCast: public GenTreeOp
     var_types       gtCastType;
 
     GenTreeCast(var_types type, GenTreePtr op, var_types castType 
-                DEBUG_ARG(bool largeNode = false)) : 
+                DEBUGARG(bool largeNode = false)) : 
         GenTreeOp(GT_CAST, type, op, nullptr
-                    DEBUG_ARG(largeNode)), 
+                    DEBUGARG(largeNode)), 
         gtCastType(castType) 
         {}
 #if DEBUGGABLE_GENTREE
@@ -2737,7 +2737,7 @@ struct GenTreeQmark : public GenTreeOp
     VARSET_TP       gtThenLiveSet;
     VARSET_TP       gtElseLiveSet;
     
-    // The "Compiler*" argument is not a DEBUG_ARG here because we use it to keep track of the set of
+    // The "Compiler*" argument is not a DEBUGARG here because we use it to keep track of the set of
     // (possible) QMark nodes.
     GenTreeQmark(var_types type, GenTreePtr cond, GenTreePtr colonOp, class Compiler* comp);
 
@@ -3026,7 +3026,7 @@ public:
     bool gtBlkOpGcUnsafe; 
 
     GenTreeBlkOp(genTreeOps oper) :
-        GenTreeOp(oper, TYP_VOID DEBUG_ARG(true)),
+        GenTreeOp(oper, TYP_VOID DEBUGARG(true)),
             gtBlkOpKind(BlkOpKindInvalid),
             gtBlkOpGcUnsafe(false)
     {
@@ -3555,10 +3555,10 @@ struct GenTreePutArgStk: public GenTreeUnOp
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(unsigned numSlots)
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(bool isStruct),
             bool _putInIncomingArgArea = false
-            DEBUG_ARG(GenTreePtr callNode = NULL)
-            DEBUG_ARG(bool largeNode = false))
+            DEBUGARG(GenTreePtr callNode = NULL)
+            DEBUGARG(bool largeNode = false))
         : 
-        GenTreeUnOp(oper, type DEBUG_ARG(largeNode)),
+        GenTreeUnOp(oper, type DEBUGARG(largeNode)),
         gtSlotNum(slotNum),
         putInIncomingArgArea(_putInIncomingArgArea)
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
@@ -3583,10 +3583,10 @@ struct GenTreePutArgStk: public GenTreeUnOp
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(unsigned numSlots)
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(bool isStruct),
             bool _putInIncomingArgArea = false
-            DEBUG_ARG(GenTreePtr callNode = NULL)
-            DEBUG_ARG(bool largeNode = false))
+            DEBUGARG(GenTreePtr callNode = NULL)
+            DEBUGARG(bool largeNode = false))
         :
-        GenTreeUnOp(oper, type, op1 DEBUG_ARG(largeNode)), 
+        GenTreeUnOp(oper, type, op1 DEBUGARG(largeNode)), 
         gtSlotNum(slotNum),
         putInIncomingArgArea(_putInIncomingArgArea)
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
@@ -3610,10 +3610,10 @@ struct GenTreePutArgStk: public GenTreeUnOp
             unsigned slotNum
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(unsigned numSlots)
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(bool isStruct)
-            DEBUG_ARG(GenTreePtr callNode = NULL)
-            DEBUG_ARG(bool largeNode = false))
+            DEBUGARG(GenTreePtr callNode = NULL)
+            DEBUGARG(bool largeNode = false))
         :
-        GenTreeUnOp(oper, type DEBUG_ARG(largeNode)),
+        GenTreeUnOp(oper, type DEBUGARG(largeNode)),
         gtSlotNum(slotNum)
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
         , gtPutArgStkKind(PutArgStkKindInvalid),
@@ -3636,10 +3636,10 @@ struct GenTreePutArgStk: public GenTreeUnOp
             unsigned slotNum
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(unsigned numSlots)
             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(bool isStruct)
-            DEBUG_ARG(GenTreePtr callNode = NULL)
-            DEBUG_ARG(bool largeNode = false))
+            DEBUGARG(GenTreePtr callNode = NULL)
+            DEBUGARG(bool largeNode = false))
         :
-        GenTreeUnOp(oper, type, op1 DEBUG_ARG(largeNode)), 
+        GenTreeUnOp(oper, type, op1 DEBUGARG(largeNode)), 
         gtSlotNum(slotNum)
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING
         , gtPutArgStkKind(PutArgStkKindInvalid),

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -1597,7 +1597,7 @@ GenTreePtr          Compiler::impLookupToTree(CORINFO_LOOKUP *pLookup, unsigned 
 
         CORINFO_GENERIC_HANDLE handle = 0;
         void *pIndirection = 0;
-        _ASSERTE(pLookup->constLookup.accessType != IAT_PPVALUE);
+        assert(pLookup->constLookup.accessType != IAT_PPVALUE);
 
         if (pLookup->constLookup.accessType == IAT_VALUE)
             handle = pLookup->constLookup.handle;
@@ -1821,7 +1821,7 @@ GenTreePtr          Compiler::impRuntimeLookupToTree(CORINFO_RUNTIME_LOOKUP_KIND
         return gtNewLclvNode(tmp, TYP_I_IMPL);
     }
 
-    _ASSERTE(pLookup->indirections != 0);
+    assert(pLookup->indirections != 0);
 
     impSpillSideEffects(true, CHECK_SPILL_ALL DEBUGARG("bubbling QMark1"));  
     
@@ -3274,7 +3274,7 @@ GenTreePtr      Compiler::impArrayAccessIntrinsic(CORINFO_CLASS_HANDLE  clsHnd,
         }
         else
         {
-            _ASSERTE(intrinsicID == CORINFO_INTRINSIC_Array_Address);
+            assert(intrinsicID == CORINFO_INTRINSIC_Array_Address);
 
             // Fetch the return type
             typeInfo retInfo = verMakeTypeInfo(LocalSig.retType, LocalSig.retTypeClass);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -10067,7 +10067,7 @@ MATH_OP2_FLAGS: // If 'ovfl' and 'callNode' have already been set
                 // That said, as of now it *is* a large node, so we'll do this with an assert rather
                 // than an "if".
                 assert(GenTree::s_gtNodeSizes[GT_CALL] == TREE_NODE_SZ_LARGE);
-                op1 = new (this, GT_CALL) GenTreeOp(oper, type, op1, op2 DEBUG_ARG(/*largeNode*/true));
+                op1 = new (this, GT_CALL) GenTreeOp(oper, type, op1, op2 DEBUGARG(/*largeNode*/true));
             }
             else
 #endif // SMALL_TREE_NODES

--- a/src/jit/jitconfig.cpp
+++ b/src/jit/jitconfig.cpp
@@ -13,7 +13,7 @@ JitConfigValues JitConfig;
 
 void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* host)
 {
-    _ASSERTE(m_list == nullptr);
+    assert(m_list == nullptr);
 
     enum State { NO_NAME, CLS_NAME, FUNC_NAME, ARG_LIST }; // parsing state machine
 
@@ -122,7 +122,7 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
             if (m_list[i] == '\0' || m_list[i] == SEP_CHAR || m_list[i] == '(')
             {
             DONE_FUNC_NAME:
-                _ASSERTE(m_list[i] == '\0' || m_list[i] == SEP_CHAR || m_list[i] == '(');
+                assert(m_list[i] == '\0' || m_list[i] == SEP_CHAR || m_list[i] == '(');
 
                 if (m_list[nameStart] == '*' && !isQuoted)
                 {
@@ -150,7 +150,7 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
                 }
                 else
                 {
-                    _ASSERTE(m_list[i] == '(');
+                    assert(m_list[i] == '(');
                     currentName.m_numArgs = -1;
                     state = ARG_LIST;
                 }
@@ -166,13 +166,13 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
                 }
 
             DONE_ARG_LIST:
-                _ASSERTE(m_list[i] == '\0' || m_list[i] == SEP_CHAR || m_list[i] == ')');
+                assert(m_list[i] == '\0' || m_list[i] == SEP_CHAR || m_list[i] == ')');
 
                 // We have parsed an entire method name; create a new entry in the list for it.
                 MethodName* name = (MethodName*)host->allocateMemory(sizeof(MethodName));
                 *name = currentName;
 
-                _ASSERTE(name->m_next == nullptr);
+                assert(name->m_next == nullptr);
                 *lastName = name;
                 lastName = &name->m_next;
 
@@ -204,7 +204,7 @@ void JitConfigValues::MethodSet::initialize(const wchar_t* list, ICorJitHost* ho
             break;
 
         default:
-            _ASSERTE(!"Bad state");
+            assert(!"Bad state");
             break;
         }
     }
@@ -298,7 +298,7 @@ bool JitConfigValues::MethodSet::contains(const char* methodName, const char* cl
 
 void JitConfigValues::initialize(ICorJitHost* host)
 {
-    _ASSERTE(!m_isInitialized);
+    assert(!m_isInitialized);
 
 #define CONFIG_INTEGER(name, key, defaultValue) m_##name = host->getIntConfigValue(key, defaultValue);
 #define CONFIG_STRING(name, key) m_##name = host->getStringConfigValue(key);

--- a/src/jit/jitgcinfo.h
+++ b/src/jit/jitgcinfo.h
@@ -80,15 +80,15 @@ public :
 
     void                gcResetForBB        ();
 
-    void                gcMarkRegSetGCref   (regMaskTP  regMask DEBUG_ARG(bool forceOutput = false));
-    void                gcMarkRegSetByref   (regMaskTP  regMask DEBUG_ARG(bool forceOutput = false));
-    void                gcMarkRegSetNpt     (regMaskTP  regMask DEBUG_ARG(bool forceOutput = false));
+    void                gcMarkRegSetGCref   (regMaskTP  regMask DEBUGARG(bool forceOutput = false));
+    void                gcMarkRegSetByref   (regMaskTP  regMask DEBUGARG(bool forceOutput = false));
+    void                gcMarkRegSetNpt     (regMaskTP  regMask DEBUGARG(bool forceOutput = false));
     void                gcMarkRegPtrVal     (regNumber  reg, var_types type);
     void                gcMarkRegPtrVal     (GenTreePtr tree);
 
 #ifdef DEBUG    
-    void                gcDspGCrefSetChanges(regMaskTP gcRegGCrefSetNew DEBUG_ARG(bool forceOutput = false));
-    void                gcDspByrefSetChanges(regMaskTP gcRegByrefSetNew DEBUG_ARG(bool forceOutput = false));
+    void                gcDspGCrefSetChanges(regMaskTP gcRegGCrefSetNew DEBUGARG(bool forceOutput = false));
+    void                gcDspByrefSetChanges(regMaskTP gcRegByrefSetNew DEBUGARG(bool forceOutput = false));
 #endif // DEBUG    
 
 /*****************************************************************************/

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1025,7 +1025,7 @@ void                Compiler::lvaInitVarArgsHandle(InitVarDscInfo * varDscInfo)
         varDsc->lvIsParam   = 1;
         // Make sure this lives in the stack -- address may be reported to the VM.
         // TODO-CQ: This should probably be:
-        //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUG_ARG(DNER_VMNeedsStackAddr));
+        //   lvaSetVarDoNotEnregister(varDscInfo->varNum DEBUGARG(DNER_VMNeedsStackAddr));
         // But that causes problems, so, for expedience, I switched back to this heavyweight
         // hammer.  But I think it should be possible to switch; it may just work now
         // that other problems are fixed.
@@ -1848,11 +1848,11 @@ void               Compiler::lvaSetVarAddrExposed(unsigned varNum)
         {        
             noway_assert(lvaTable[i].lvIsStructField);            
             lvaTable[i].lvAddrExposed = 1;   // Make field local as address-exposed.
-            lvaSetVarDoNotEnregister(i DEBUG_ARG(DNER_AddrExposed));
+            lvaSetVarDoNotEnregister(i DEBUGARG(DNER_AddrExposed));
         }
     }
 
-    lvaSetVarDoNotEnregister(varNum DEBUG_ARG(DNER_AddrExposed));
+    lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_AddrExposed));
 }
 
 
@@ -1861,7 +1861,7 @@ void               Compiler::lvaSetVarAddrExposed(unsigned varNum)
  *  Record that the local var "varNum" should not be enregistered (for one of several reasons.)
  */
 
-void               Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUG_ARG(DoNotEnregisterReason reason))
+void               Compiler::lvaSetVarDoNotEnregister(unsigned varNum DEBUGARG(DoNotEnregisterReason reason))
 {              
     noway_assert(varNum < lvaCount);
     LclVarDsc   *   varDsc = &lvaTable[varNum];
@@ -2642,7 +2642,7 @@ void                Compiler::lvaSortByRefCount()
             }
             else if ((varDsc->lvType == TYP_STRUCT) && !varDsc->lvRegStruct)
             {
-                lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_IsStruct));
+                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_IsStruct));
             }
         }
         else if (varDsc->lvIsStructField &&
@@ -2662,7 +2662,7 @@ void                Compiler::lvaSortByRefCount()
         {
             varDsc->lvTracked = 0;
 #ifdef JIT32_GCENCODER
-            lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_PinningRef));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_PinningRef));
 #endif
         }
 
@@ -2671,7 +2671,7 @@ void                Compiler::lvaSortByRefCount()
         //
         if  (opts.MinOpts() && compHndBBtabCount > 0)
         {
-            lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_LiveInOutOfHandler));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LiveInOutOfHandler));
             continue;
         }
 

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1847,7 +1847,7 @@ SKIP_QMARK:
                         // If it is a GC-ref type then mark it DoNotEnregister.
                         if (varTypeIsGC(varDsc->TypeGet()))
                         {
-                            lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_LiveAcrossUnmanagedCall));
+                            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LiveAcrossUnmanagedCall));
                         }
                     }
                 }
@@ -2687,7 +2687,7 @@ void                Compiler::fgInterBlockLocalVarLiveness()
              VarSetOps::IsMember(this, filterVars, varDsc->lvVarIndex))
         {
             /* Mark the variable appropriately */
-            lvaSetVarDoNotEnregister(varNum DEBUG_ARG(DNER_LiveInOutOfHandler));
+            lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LiveInOutOfHandler));
         }
 
         /* Mark all pointer variables live on exit from a 'finally'
@@ -2696,7 +2696,7 @@ void                Compiler::fgInterBlockLocalVarLiveness()
 
         if  (VarSetOps::IsMember(this, finallyVars, varDsc->lvVarIndex))
         {
-            lvaSetVarDoNotEnregister(varNum DEBUG_ARG(DNER_LiveInOutOfHandler));
+            lvaSetVarDoNotEnregister(varNum DEBUGARG(DNER_LiveInOutOfHandler));
 
             /* Don't set lvMustInit unless we have a non-arg, GC pointer */
 

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -1290,7 +1290,7 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                                                             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(info->numSlots)
                                                             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(info->isStruct),
                                                             call->IsFastTailCall() 
-                                                            DEBUG_ARG(call));
+                                                            DEBUGARG(call));
 #else
         putArg = new (comp, GT_PUTARG_STK) GenTreePutArgStk(GT_PUTARG_STK,
                                                             type, 
@@ -1298,7 +1298,7 @@ GenTreePtr Lowering::NewPutArg(GenTreeCall* call, GenTreePtr arg, fgArgTabEntryP
                                                             info->slotNum
                                                             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(info->numSlots)
                                                             FEATURE_UNIX_AMD64_STRUCT_PASSING_ONLY_ARG(info->isStruct)
-                                                            DEBUG_ARG(call));
+                                                            DEBUGARG(call));
 #endif
 
 #ifdef FEATURE_UNIX_AMD64_STRUCT_PASSING

--- a/src/jit/lsra.cpp
+++ b/src/jit/lsra.cpp
@@ -1685,7 +1685,7 @@ LinearScan::identifyCandidatesExceptionDataflow()
         unsigned varNum = compiler->lvaTrackedToVarNum[varIndex];
         LclVarDsc* varDsc = compiler->lvaTable + varNum;
 
-        compiler->lvaSetVarDoNotEnregister(varNum DEBUG_ARG(Compiler::DNER_LiveInOutOfHandler));
+        compiler->lvaSetVarDoNotEnregister(varNum DEBUGARG(Compiler::DNER_LiveInOutOfHandler));
 
         if (varTypeIsGC(varDsc))
         {
@@ -1841,13 +1841,13 @@ void LinearScan::identifyCandidates()
                 dner = Compiler::DNER_IsStruct;
             }
 #endif // DEBUG
-            compiler->lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(dner));
+            compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(dner));
         }
         else if (varDsc->lvPinned)
         {
             varDsc->lvTracked  = 0;
 #ifdef JIT32_GCENCODER
-            compiler->lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(Compiler::DNER_PinningRef));
+            compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_PinningRef));
 #endif // JIT32_GCENCODER
         }
 
@@ -1857,7 +1857,7 @@ void LinearScan::identifyCandidates()
         //
         if  (compiler->opts.MinOpts() && compiler->compHndBBtabCount > 0)
         {
-            compiler->lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(Compiler::DNER_LiveInOutOfHandler));
+            compiler->lvaSetVarDoNotEnregister(lclNum DEBUGARG(Compiler::DNER_LiveInOutOfHandler));
             varDsc->lvLRACandidate = 0;
             continue;
         }
@@ -2612,7 +2612,7 @@ LinearScan::buildKillPositionsForNode(GenTree*     tree,
         // CORINFO_HELP_ASSIGN_BYREF helper, which kills callee-saved RSI and RDI, if
         // LSRA doesn't assign RSI/RDI, they wouldn't get marked as modified until codegen,
         // which is too late.
-        compiler->codeGen->regSet.rsSetRegsModified(killMask DEBUG_ARG(dumpTerse));
+        compiler->codeGen->regSet.rsSetRegsModified(killMask DEBUGARG(dumpTerse));
 
         addRefsForPhysRegMask(killMask, currentLoc, RefTypeKill, true);
 
@@ -3483,7 +3483,7 @@ LinearScan::updateRegStateForArg(LclVarDsc* argDsc)
 //                                    the register locations will be "rotated" to stress the resolution and allocation code.
 
 BasicBlock*
-LinearScan::findPredBlockForLiveIn(BasicBlock* block, BasicBlock* prevBlock DEBUG_ARG(bool* pPredBlockIsAllocated))
+LinearScan::findPredBlockForLiveIn(BasicBlock* block, BasicBlock* prevBlock DEBUGARG(bool* pPredBlockIsAllocated))
 {
     BasicBlock* predBlock = nullptr;
 #ifdef DEBUG
@@ -3729,7 +3729,7 @@ LinearScan::buildIntervals()
         JITDUMP("\nNEW BLOCK BB%02u\n", block->bbNum);
 
         bool predBlockIsAllocated = false;
-        predBlock = findPredBlockForLiveIn(block, prevBlock DEBUG_ARG(&predBlockIsAllocated));
+        predBlock = findPredBlockForLiveIn(block, prevBlock DEBUGARG(&predBlockIsAllocated));
 
         if (block == compiler->fgFirstBB)
         {
@@ -5101,7 +5101,7 @@ void LinearScan::checkAndAssignInterval( RegRecord * regRec, Interval * interval
 void LinearScan::assignPhysReg( RegRecord * regRec, Interval * interval)
 {
     regMaskTP assignedRegMask = genRegMask(regRec->regNum);
-    compiler->codeGen->regSet.rsSetRegsModified(assignedRegMask DEBUG_ARG(dumpTerse));
+    compiler->codeGen->regSet.rsSetRegsModified(assignedRegMask DEBUGARG(dumpTerse));
 
     checkAndAssignInterval(regRec, interval);
     interval->assignedReg = regRec;
@@ -8771,7 +8771,7 @@ LinearScan::resolveEdge(BasicBlock*      fromBlock,
                 }
                 else
                 {
-                    compiler->codeGen->regSet.rsSetRegsModified(genRegMask(tempReg) DEBUG_ARG(dumpTerse));
+                    compiler->codeGen->regSet.rsSetRegsModified(genRegMask(tempReg) DEBUGARG(dumpTerse));
                     assert(sourceIntervals[targetReg] != nullptr);
                     addResolution(block, insertionPoint, sourceIntervals[targetReg], tempReg, targetReg);
                     JITDUMP(" (%s)\n", resolveTypeName[resolveType]);

--- a/src/jit/lsra.h
+++ b/src/jit/lsra.h
@@ -972,7 +972,7 @@ private:
 
     // A map from bbNum to the block information used during register allocation.
     LsraBlockInfo*              blockInfo;
-    BasicBlock*                 findPredBlockForLiveIn(BasicBlock* block, BasicBlock* prevBlock DEBUG_ARG(bool* pPredBlockIsAllocated));
+    BasicBlock*                 findPredBlockForLiveIn(BasicBlock* block, BasicBlock* prevBlock DEBUGARG(bool* pPredBlockIsAllocated));
 
     // The order in which the blocks will be allocated.
     // This is any array of BasicBlock*, in the order in which they should be traversed.

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -3330,7 +3330,7 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
                                     else
                                     {
                                         // use GT_LCL_FLD to swizzle the single field struct to a new type
-                                        lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_LocalField));
+                                        lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                                         argObj->ChangeOper(GT_LCL_FLD);
                                         argObj->gtType = structBaseType;
                                     }
@@ -4257,7 +4257,7 @@ Compiler::fgMakeOutgoingStructArgCopy(GenTreeCall* call,
     // allocated on stack and address of it needs to be passed.
     if (lclVarIsSIMDType(tmp))
     {
-        lvaSetVarDoNotEnregister(tmp DEBUG_ARG(DNER_IsStruct));
+        lvaSetVarDoNotEnregister(tmp DEBUGARG(DNER_IsStruct));
     }
 
     // Create a reference to the temp
@@ -7416,7 +7416,7 @@ ONE_SIMPLE_ASG:
             {
                 // Could be a non-promoted struct, or a floating point type local, or
                 // an int subject to a partial write.  Don't enregister.
-                lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_LocalField));
+                lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
                 // Fall through to indirect the dest node.
             }
             // Mark the local var tree as a definition point of the local.
@@ -7487,10 +7487,10 @@ _DoneDest:;
                     // we don't delete it as a dead store later on.
                     unsigned lclVarNum = lclVarTree->gtLclVarCommon.gtLclNum;
                     lvaTable[lclVarNum].lvAddrExposed = true;
-                    lvaSetVarDoNotEnregister(lclVarNum DEBUG_ARG(DNER_AddrExposed));
+                    lvaSetVarDoNotEnregister(lclVarNum DEBUGARG(DNER_AddrExposed));
 
 #else // LEGACY_BACKEND
-                    lvaSetVarDoNotEnregister(lclVarTree->gtLclVarCommon.gtLclNum DEBUG_ARG(DNER_LocalField));
+                    lvaSetVarDoNotEnregister(lclVarTree->gtLclVarCommon.gtLclNum DEBUGARG(DNER_LocalField));
 #endif // LEGACY_BACKEND
 
                     // Fall through to indirect the src node.
@@ -7664,7 +7664,7 @@ GenTreePtr          Compiler::fgMorphInitBlock(GenTreePtr tree)
             if (!destLclVar->lvRegStruct)
             {
                 // Mark it as DoNotEnregister.
-                lvaSetVarDoNotEnregister(destLclNum DEBUG_ARG(DNER_BlockOp));
+                lvaSetVarDoNotEnregister(destLclNum DEBUGARG(DNER_BlockOp));
             }
         }
 
@@ -8048,7 +8048,7 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
             if (!destLclVar->lvRegStruct)
             {
                 // Mark it as DoNotEnregister.
-                lvaSetVarDoNotEnregister(destLclNum DEBUG_ARG(DNER_BlockOp));
+                lvaSetVarDoNotEnregister(destLclNum DEBUGARG(DNER_BlockOp));
             }
         }
 
@@ -8056,7 +8056,7 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
         {
             if (!srcLclVar->lvRegStruct)
             {
-                lvaSetVarDoNotEnregister(srcLclNum DEBUG_ARG(DNER_BlockOp));
+                lvaSetVarDoNotEnregister(srcLclNum DEBUGARG(DNER_BlockOp));
             }
         }
 
@@ -8233,7 +8233,7 @@ GenTreePtr          Compiler::fgMorphCopyBlock(GenTreePtr tree)
                 {
                     unsigned lclVarNum = addrOp->gtLclVarCommon.gtLclNum;
                     lvaTable[lclVarNum].lvAddrExposed = true;
-                    lvaSetVarDoNotEnregister(lclVarNum DEBUG_ARG(DNER_AddrExposed));
+                    lvaSetVarDoNotEnregister(lclVarNum DEBUGARG(DNER_AddrExposed));
                 }
             }
 #endif // !LEGACY_BACKEND
@@ -11039,7 +11039,7 @@ CM_ADD_OP:
                 }
                 else
                 {
-                    lvaSetVarDoNotEnregister(temp->gtLclVarCommon.gtLclNum DEBUG_ARG(DNER_LocalField));
+                    lvaSetVarDoNotEnregister(temp->gtLclVarCommon.gtLclNum DEBUGARG(DNER_LocalField));
                 }
 
                 // We will turn a GT_LCL_VAR into a GT_LCL_FLD with an gtLclOffs of 'ival'
@@ -13020,7 +13020,7 @@ GenTreePtr          Compiler::fgMorphTree(GenTreePtr tree, MorphAddrContext* mac
     }
 DONE:
 
-    fgMorphTreeDone(tree, oldTree DEBUG_ARG(thisMorphNum));
+    fgMorphTreeDone(tree, oldTree DEBUGARG(thisMorphNum));
 
     return tree;
 }
@@ -13104,7 +13104,7 @@ void                Compiler::fgKillDependentAssertions(unsigned lclNum
 
 void                Compiler::fgMorphTreeDone(GenTreePtr tree,
                                               GenTreePtr oldTree /* == NULL */
-                                              DEBUG_ARG(int morphNum))
+                                              DEBUGARG(int morphNum))
 {
 #ifdef DEBUG
     if (verbose && treesBeforeAfterMorph)
@@ -15465,7 +15465,7 @@ Compiler::fgWalkResult      Compiler::fgMorphLocalField(GenTreePtr tree, fgWalkD
         {
             // There is no existing field that has all the parts that we need
             // So we must ensure that the struct lives in memory.
-            lvaSetVarDoNotEnregister(lclNum DEBUG_ARG(DNER_LocalField));
+            lvaSetVarDoNotEnregister(lclNum DEBUGARG(DNER_LocalField));
 
 #ifdef DEBUG
             // We can't convert this guy to a float because he really does have his

--- a/src/jit/regset.cpp
+++ b/src/jit/regset.cpp
@@ -72,7 +72,7 @@ void                RegSet::rsClearRegsModified()
     rsModifiedRegsMask = RBM_NONE;
 }
 
-void                RegSet::rsSetRegsModified(regMaskTP mask DEBUG_ARG(bool suppressDump))
+void                RegSet::rsSetRegsModified(regMaskTP mask DEBUGARG(bool suppressDump))
 {
     assert(mask != RBM_NONE);
     assert(rsModifiedRegsMaskInitialized);

--- a/src/jit/regset.h
+++ b/src/jit/regset.h
@@ -139,7 +139,7 @@ public:
 
     void                rsClearRegsModified();
 
-    void                rsSetRegsModified(regMaskTP mask DEBUG_ARG(bool suppressDump = false));
+    void                rsSetRegsModified(regMaskTP mask DEBUGARG(bool suppressDump = false));
 
     void                rsRemoveRegsModified(regMaskTP mask);
 

--- a/src/jit/ssabuilder.cpp
+++ b/src/jit/ssabuilder.cpp
@@ -761,7 +761,7 @@ void SsaBuilder::InsertPhiFunctions(BasicBlock** postOrder, int count)
                     //
                     GenTreePtr phiRhs = m_pCompiler->gtNewOperNode(GT_PHI, m_pCompiler->lvaTable[lclNum].TypeGet(), nullptr);
 
-                    GenTreePtr phiAsg = m_pCompiler->gtNewAssignNode(phiLhs, phiRhs  DEBUG_ARG(/*isPhiDefn*/true));
+                    GenTreePtr phiAsg = m_pCompiler->gtNewAssignNode(phiLhs, phiRhs  DEBUGARG(/*isPhiDefn*/true));
 
                     GenTreePtr stmt = m_pCompiler->fgInsertStmtAtBeg(bbInDomFront, phiAsg);
                     m_pCompiler->gtSetStmtInfo(stmt);

--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -1468,7 +1468,7 @@ AssemblyNamesList2::~AssemblyNamesList2()
     }
 }
 
-bool AssemblyNamesList2::IsInList(LPCUTF8 assemblyName)
+bool AssemblyNamesList2::IsInList(const char* assemblyName)
 {
     for (AssemblyName* pName = m_pNames; pName != nullptr; pName = pName->m_next)
     {

--- a/src/jit/utils.cpp
+++ b/src/jit/utils.cpp
@@ -724,7 +724,7 @@ bool ConfigMethodRange::contains(ICorJitInfo* info, CORINFO_METHOD_HANDLE method
 void ConfigMethodRange::initRanges(const wchar_t* rangeStr)
 {
     // make sure that the memory was zero initialized
-    _ASSERTE(m_inited == 0 || m_inited == 1);
+    assert(m_inited == 0 || m_inited == 1);
 
     if (rangeStr == nullptr)
     {
@@ -1052,10 +1052,10 @@ int SimpleSprintf_s(__in_ecount(cbBufSize - (pWriteStart- pBufStart)) char * pWr
                     __in_ecount(cbBufSize) char * pBufStart, size_t cbBufSize,
                     __in_z const char * fmt, ...)
 {
-    _ASSERTE(fmt);
-    _ASSERTE(pBufStart);
-    _ASSERTE(pWriteStart);
-    _ASSERTE((size_t)pBufStart <= (size_t)pWriteStart);
+    assert(fmt);
+    assert(pBufStart);
+    assert(pWriteStart);
+    assert((size_t)pBufStart <= (size_t)pWriteStart);
     int ret;
 
     //compute the space left in the buffer.

--- a/src/jit/utils.h
+++ b/src/jit/utils.h
@@ -432,7 +432,7 @@ class AssemblyNamesList2
 {
     struct AssemblyName
     {
-        LPUTF8          m_assemblyName;
+        char*           m_assemblyName;
         AssemblyName*   m_next;
     };
 
@@ -447,7 +447,7 @@ public:
     ~AssemblyNamesList2();
 
     // Return 'true' if 'assemblyName' (in UTF-8 format) is in the stored list of assembly names.
-    bool IsInList(LPCUTF8 assemblyName);
+    bool IsInList(const char* assemblyName);
 
     // Return 'true' if the assembly name list is empty.
     bool IsEmpty()

--- a/src/jit/utils.h
+++ b/src/jit/utils.h
@@ -97,12 +97,12 @@ public:
     inline void ensureInit(const wchar_t* rangeStr)
     {
         // make sure that the memory was zero initialized
-        _ASSERTE(m_inited == 0 || m_inited == 1);
+        assert(m_inited == 0 || m_inited == 1);
 
         if (!m_inited)
         {
             initRanges(rangeStr);
-            _ASSERTE(m_inited == 1);
+            assert(m_inited == 1);
         }
     }
 

--- a/src/jit/valuenum.cpp
+++ b/src/jit/valuenum.cpp
@@ -437,7 +437,7 @@ ValueNumPair ValueNumStore::VNPExcSetSingleton(ValueNumPair xp)
                         VNExcSetSingleton(xp.GetConservative()));
 }
 
-ValueNum ValueNumStore::VNExcSetUnion(ValueNum xs0, ValueNum xs1 DEBUG_ARG(bool topLevel))
+ValueNum ValueNumStore::VNExcSetUnion(ValueNum xs0, ValueNum xs1 DEBUGARG(bool topLevel))
 {
     if (xs0 == VNForEmptyExcSet())
         return xs1;
@@ -456,7 +456,7 @@ ValueNum ValueNumStore::VNExcSetUnion(ValueNum xs0, ValueNum xs1 DEBUG_ARG(bool 
         {
             res = VNForFunc(TYP_REF, VNF_ExcSetCons, 
                             funcXs0.m_args[0],
-                            VNExcSetUnion(funcXs0.m_args[1], xs1 DEBUG_ARG(false)));
+                            VNExcSetUnion(funcXs0.m_args[1], xs1 DEBUGARG(false)));
         } 
         else if (funcXs0.m_args[0] == funcXs1.m_args[0])
         {
@@ -468,7 +468,7 @@ ValueNum ValueNumStore::VNExcSetUnion(ValueNum xs0, ValueNum xs1 DEBUG_ARG(bool 
             assert(funcXs0.m_args[0] > funcXs1.m_args[0]);
             res = VNForFunc(TYP_REF, VNF_ExcSetCons, 
                             funcXs1.m_args[0],
-                            VNExcSetUnion(xs0, funcXs1.m_args[1] DEBUG_ARG(false)));
+                            VNExcSetUnion(xs0, funcXs1.m_args[1] DEBUGARG(false)));
         }
 
         return res;
@@ -5494,7 +5494,7 @@ void Compiler::fgValueNumberTree(GenTreePtr tree, bool evalAsgLhsInd)
                             arg->ParseArrayAddress(this, &arrInfo, &arr, &inxVN, &fldSeq);
                             if (arr == nullptr)
                             {
-                                fgMutateHeap(tree DEBUG_ARG("assignment to unparseable array expression"));
+                                fgMutateHeap(tree DEBUGARG("assignment to unparseable array expression"));
                                 return;
                             }
                             // Otherwise, parsing succeeded.

--- a/src/jit/valuenum.h
+++ b/src/jit/valuenum.h
@@ -340,7 +340,7 @@ public:
     // Returns the VN representing the union of the two exception sets "xs0" and "xs1".
     // These must be VNForEmtpyExcSet() or applications of VNF_ExcSetCons, obeying
     // the ascending order invariant (which is preserved in the result.)
-    ValueNum VNExcSetUnion(ValueNum xs0, ValueNum xs1 DEBUG_ARG(bool topLevel = true));
+    ValueNum VNExcSetUnion(ValueNum xs0, ValueNum xs1 DEBUGARG(bool topLevel = true));
 
     ValueNumPair VNPExcSetUnion(ValueNumPair xs0vnp, ValueNumPair xs1vnp);
 


### PR DESCRIPTION
These changes replace uses of some type and macro
definitions from `utilcode.h` with uses of equivalent
definitions that are internal to the JIT.