### PR TITLE
Build break: Replace $(Platform) with $(BuildArch) in arch-specific IL projects

### DIFF
--- a/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/1/arglist.ilproj
@@ -29,10 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
-    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
-    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/2/arglist.ilproj
@@ -29,10 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
-    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
-    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/unaligned/4/arglist.ilproj
@@ -29,10 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
-    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
-    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
+++ b/tests/src/JIT/Directed/PREFIX/volatile/1/arglist.ilproj
@@ -29,10 +29,10 @@
     
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="arglist.il" />
-    <Compile Condition="'$(Platform)' == 'x64'" Include="arglist64.il" />
-    <Compile Condition="'$(Platform)' == 'arm'" Include="arglistARM.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="arglist.il" />
+    <Compile Condition="'$(BuildArch)' == 'x64'" Include="arglist64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm'" Include="arglistARM.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="arglist64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgi_array_merge.ilproj
@@ -30,10 +30,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="i_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="i_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="i_array_merge-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x86'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'arm'" Include="i_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgsizeof.ilproj
@@ -29,10 +29,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x64'" Include="sizeof-ia64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="sizeof-ia64.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x86'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'arm'" Include="sizeof-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_dbgu_array_merge.ilproj
@@ -30,10 +30,10 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="u_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="u_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="u_array_merge-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x86'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'arm'" Include="u_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_reli_array_merge.ilproj
@@ -30,10 +30,10 @@
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="i_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="i_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="i_array_merge-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="i_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x86'" Include="i_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'arm'" Include="i_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relsizeof.ilproj
@@ -29,10 +29,10 @@
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="sizeof-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="sizeof-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x64'" Include="sizeof-ia64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="sizeof-ia64.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x86'" Include="sizeof-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'arm'" Include="sizeof-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
+++ b/tests/src/JIT/Methodical/ELEMENT_TYPE_IU/_il_relu_array_merge.ilproj
@@ -30,10 +30,10 @@
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' ==   'x64'" Include="u_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' == 'arm64'" Include="u_array_merge-ia64.il" />
-    <Compile Condition="'$(Platform)' ==   'x86'" Include="u_array_merge-i386.il" />
-    <Compile Condition="'$(Platform)' ==   'arm'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' == 'arm64'" Include="u_array_merge-ia64.il" />
+    <Compile Condition="'$(BuildArch)' ==   'x86'" Include="u_array_merge-i386.il" />
+    <Compile Condition="'$(BuildArch)' ==   'arm'" Include="u_array_merge-i386.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof.ilproj
@@ -30,8 +30,8 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof.il" />
-    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="sizeof.il" />
+    <Compile Condition="'$(BuildArch)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof32.ilproj
@@ -30,8 +30,8 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof32.il" />
-    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof32.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="sizeof32.il" />
+    <Compile Condition="'$(BuildArch)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_dbgsizeof64.ilproj
@@ -30,8 +30,8 @@
     <DebugType>Full</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof64.il" />
-    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof64.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="sizeof64.il" />
+    <Compile Condition="'$(BuildArch)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof.ilproj
@@ -30,8 +30,8 @@
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof.il" />
-    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="sizeof.il" />
+    <Compile Condition="'$(BuildArch)' != 'x86'" Include="64sizeof.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof32.ilproj
@@ -30,8 +30,8 @@
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof32.il" />
-    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof32.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="sizeof32.il" />
+    <Compile Condition="'$(BuildArch)' != 'x86'" Include="64sizeof32.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />

--- a/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
+++ b/tests/src/JIT/Methodical/xxobj/sizeof/_il_relsizeof64.ilproj
@@ -30,8 +30,8 @@
     <DebugType>PdbOnly</DebugType>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Condition="'$(Platform)' == 'x86'" Include="sizeof64.il" />
-    <Compile Condition="'$(Platform)' != 'x86'" Include="64sizeof64.il" />
+    <Compile Condition="'$(BuildArch)' == 'x86'" Include="sizeof64.il" />
+    <Compile Condition="'$(BuildArch)' != 'x86'" Include="64sizeof64.il" />
   </ItemGroup>
   <ItemGroup>
     <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />


### PR DESCRIPTION
I recently fixed some IL projects for non-x64 architectures, but I tested the wrong property.  It appears that $(Platform) is set to AnyCpu in some circumstances, and $(BuildArch) is what I want.