### PR TITLE
Reenable tests per #3664

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -4,9 +4,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\lifetime\lifetime2\lifetime2.cmd" >
              <Issue>1037</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M09.5-PDC\b14426\b14426\*" >
-            <Issue>2235</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b13621\b13621\*" >
             <Issue>2235</Issue>
         </ExcludeList>

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -183,5 +183,3 @@ GC/Features/SustainedLowLatency/sustainedlowlatency_race_reverse/sustainedlowlat
 GC/Features/SustainedLowLatency/scenario/scenario.sh
 GC/Features/SustainedLowLatency/sustainedlowlatency_race/sustainedlowlatency_race.sh
 GC/Regressions/dev10bugs/536168/536168/536168.sh
-JIT/Regression/CLR-x86-EJIT/V1-M09.5-PDC/b14426/b14426/b14426.sh
-JIT/Performance/CodeQuality/BenchmarksGame/pidigits/pi-digits/pi-digits.sh

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -286,9 +286,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\PositiveCases\PositiveCases.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M09.5-PDC\b14426\b14426\b14426.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbglocalloc\_il_dbglocalloc.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>


### PR DESCRIPTION
Reenable b14426 and pi-digits now that #3664 is resolved.  According to #2235, b14426 was also disabled on Windows due to a System.IO.FileLoadException, but it seems to pass now, so presumably that issue was resolved independently, and b14426 can be run everywhere.