### PR TITLE
Fix SysV calling convention bug in interop. We need to treat delegate…

### DIFF
--- a/src/vm/methodtable.cpp
+++ b/src/vm/methodtable.cpp
@@ -2921,15 +2921,17 @@ bool MethodTable::ClassifyEightBytesWithNativeLayout(SystemVStructRegisterPassin
             case NFT_ANSICHAR:
             case NFT_WINBOOL:
             case NFT_CBOOL:
+            case NFT_DELEGATE:
+            case NFT_SAFEHANDLE:
+            case NFT_CRITICALHANDLE:
                 fieldClassificationType = SystemVClassificationTypeInteger;
                 break;
 
-            case NFT_DELEGATE:
+            // It's not clear what the right behavior for NTF_DECIMAL and NTF_DATE is
+            // But those two types would only make sense on windows. We can revisit this later
             case NFT_DECIMAL:
             case NFT_DATE:
             case NFT_ILLEGAL:
-            case NFT_SAFEHANDLE:
-            case NFT_CRITICALHANDLE:
             default:
                 return false;
             }

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -161,7 +161,6 @@ JIT/Methodical/Boxing/xlang/_relsin_cs_il/_relsin_cs_il.sh
 JIT/Methodical/localloc/call/call01_small/call01_small.sh
 JIT/Regression/Dev11/External/dev11_145295/CSharpPart/CSharpPart.sh
 Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutExp/MarshalStructAsLayoutExp.sh
-Interop/StructMarshalling/PInvoke/MarshalStructAsLayoutSeq/MarshalStructAsLayoutSeq.sh
 GC/LargeMemory/Allocation/finalizertest/finalizertest.sh
 GC/LargeMemory/API/gc/reregisterforfinalize/reregisterforfinalize.sh
 GC/LargeMemory/API/gc/collect/collect.sh


### PR DESCRIPTION
… field (NFT_DELEGATE) as INTEGER (as per SysV spec) since it is a pointer type, otherwise we would end up passing it via stack which would cause all sorts of badness. Same for SAFEHANDLE/CRITICALHANDLE. It's not clear to me what the right semantics for DATE/CURRENCY is but they are Windows-only types, so we probably don't care yet.