### PR TITLE
Suppress CS8002 for JIT test projects

### DIFF
--- a/tests/src/JIT/Methodical/Boxing/xlang/_dbgsin_cs_il.csproj
+++ b/tests/src/JIT/Methodical/Boxing/xlang/_dbgsin_cs_il.csproj
@@ -31,6 +31,7 @@
     <Optimize></Optimize>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sin.cs" />

--- a/tests/src/JIT/Methodical/Boxing/xlang/_odbgsin_cs_il.csproj
+++ b/tests/src/JIT/Methodical/Boxing/xlang/_odbgsin_cs_il.csproj
@@ -31,6 +31,7 @@
     <Optimize>True</Optimize>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sin.cs" />

--- a/tests/src/JIT/Methodical/Boxing/xlang/_orelsin_cs_il.csproj
+++ b/tests/src/JIT/Methodical/Boxing/xlang/_orelsin_cs_il.csproj
@@ -31,6 +31,7 @@
     <Optimize>True</Optimize>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sin.cs" />

--- a/tests/src/JIT/Methodical/Boxing/xlang/_relsin_cs_il.csproj
+++ b/tests/src/JIT/Methodical/Boxing/xlang/_relsin_cs_il.csproj
@@ -31,6 +31,7 @@
     <Optimize></Optimize>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="sin.cs" />

--- a/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/EHCopyProp.csproj
+++ b/tests/src/JIT/Methodical/flowgraph/dev10_bug679008/EHCopyProp.csproj
@@ -31,6 +31,7 @@
     <Optimize>True</Optimize>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="EHCopyProp.cs" />

--- a/tests/src/JIT/Methodical/localloc/call/call01_small.csproj
+++ b/tests/src/JIT/Methodical/localloc/call/call01_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="call01.cs" />

--- a/tests/src/JIT/Regression/Dev11/External/dev11_132534/CSharpPart.csproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_132534/CSharpPart.csproj
@@ -30,6 +30,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Core.cs" />

--- a/tests/src/JIT/Regression/Dev11/External/dev11_145295/CSharpPart.csproj
+++ b/tests/src/JIT/Regression/Dev11/External/dev11_145295/CSharpPart.csproj
@@ -32,6 +32,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BadUnwind2.cs" />

--- a/tests/src/JIT/jit64/localloc/eh/eh01_dynamic.csproj
+++ b/tests/src/JIT/jit64/localloc/eh/eh01_dynamic.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_DYNAMIC</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh01.cs" />

--- a/tests/src/JIT/jit64/localloc/eh/eh01_large.csproj
+++ b/tests/src/JIT/jit64/localloc/eh/eh01_large.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_LARGE</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh01.cs" />

--- a/tests/src/JIT/jit64/localloc/eh/eh01_small.csproj
+++ b/tests/src/JIT/jit64/localloc/eh/eh01_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh01.cs" />

--- a/tests/src/JIT/jit64/localloc/eh/eh02_dynamic.csproj
+++ b/tests/src/JIT/jit64/localloc/eh/eh02_dynamic.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_DYNAMIC</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh02.cs" />

--- a/tests/src/JIT/jit64/localloc/eh/eh02_large.csproj
+++ b/tests/src/JIT/jit64/localloc/eh/eh02_large.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_LARGE</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh02.cs" />

--- a/tests/src/JIT/jit64/localloc/eh/eh02_small.csproj
+++ b/tests/src/JIT/jit64/localloc/eh/eh02_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh02.cs" />

--- a/tests/src/JIT/jit64/localloc/ehverify/eh09_dynamic.csproj
+++ b/tests/src/JIT/jit64/localloc/ehverify/eh09_dynamic.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh09.cs" />

--- a/tests/src/JIT/jit64/localloc/ehverify/eh09_large.csproj
+++ b/tests/src/JIT/jit64/localloc/ehverify/eh09_large.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh09.cs" />

--- a/tests/src/JIT/jit64/localloc/ehverify/eh09_small.csproj
+++ b/tests/src/JIT/jit64/localloc/ehverify/eh09_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="eh09.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind01_dynamic.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind01_dynamic.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_DYNAMIC</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind01.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind01_large.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind01_large.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_LARGE</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind01.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind01_small.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind01_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind01.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind02_dynamic.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind02_dynamic.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_DYNAMIC</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind02.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind02_large.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind02_large.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_LARGE</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind02.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind02_small.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind02_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind02.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind03_dynamic.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind03_dynamic.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_DYNAMIC</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind03.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind03_large.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind03_large.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_LARGE</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind03.cs" />

--- a/tests/src/JIT/jit64/localloc/unwind/unwind03_small.csproj
+++ b/tests/src/JIT/jit64/localloc/unwind/unwind03_small.csproj
@@ -31,6 +31,7 @@
     <NoLogo>True</NoLogo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);DESKTOP;LOCALLOC_SMALL</DefineConstants>
+    <NoWarn>$(NoWarn),8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="unwind03.cs" />


### PR DESCRIPTION
"Referenced assembly 'Foo, ...' does not have a strong name."

Happens when a .csproj has a ProjectReference for a .ilproj.  It's not
particularly interesting to give these test assemblies strong names, so
I'm just suppressing the warning.

Fixes #4232
Fixes #4233
Fixes #4234
Fixes #4235
Fixes #4236
Fixes #4237