### PR TITLE
Fix issue building mscorlib.dll

### DIFF
--- a/src/vm/win32threadpool.cpp
+++ b/src/vm/win32threadpool.cpp
@@ -2669,7 +2669,7 @@ BOOL ThreadpoolMgr::RegisterWaitForSingleObject(PHANDLE phNewWaitObject,
         // thread that will PostQueuedCompletionStatus (the dedicated WaitThread).
         // This event correlates with ThreadPoolIODequeue in ThreadpoolMgr::AsyncCallbackCompletion
         if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, ThreadPoolIOEnqueue))
-            FireEtwThreadPoolIOEnqueue((LPOVERLAPPED)waitInfo, Callback, (dwFlag & WAIT_SINGLE_EXECUTION) == 0, GetClrInstanceId());
+            FireEtwThreadPoolIOEnqueue((LPOVERLAPPED)waitInfo, reinterpret_cast<void*>(Callback), (dwFlag & WAIT_SINGLE_EXECUTION) == 0, GetClrInstanceId());
     
         BOOL status = QueueUserAPC((PAPCFUNC)InsertNewWaitForSelf, threadCB->threadHandle, (size_t) waitInfo);
 
@@ -3233,7 +3233,7 @@ DWORD __stdcall ThreadpoolMgr::AsyncCallbackCompletion(PVOID pArgs)
         // We fire the "dequeue" ETW event here, before executing the user code, to enable correlation with
         // the ThreadPoolIOEnqueue fired in ThreadpoolMgr::RegisterWaitForSingleObject
         if (ETW_EVENT_ENABLED(MICROSOFT_WINDOWS_DOTNETRUNTIME_PROVIDER_Context, ThreadPoolIODequeue))
-            FireEtwThreadPoolIODequeue(waitInfo, waitInfo->Callback, GetClrInstanceId());
+            FireEtwThreadPoolIODequeue(waitInfo, reinterpret_cast<void*>(waitInfo->Callback), GetClrInstanceId());
 
         // the user callback can throw, the host must be prepared to handle it.
         // SQL is ok, since they have a top-level SEH handler. However, there's


### PR DESCRIPTION
```
/home/kamil/tmp/coreclr/src/vm/win32threadpool.cpp:2672:13: error: no matching function for call to 'FireEtwThreadPoolIOEnqueue'
            FireEtwThreadPoolIOEnqueue((LPOVERLAPPED)waitInfo, Callback, (dwFlag & WAIT_SINGLE_EXECUTION) == 0, reinterpret_cast<void*>(GetClrInstanceId()));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kamil/tmp/coreclr/bin/obj/Linux.x64.Debug/src/inc/clretwallmain.h:972:14: note: candidate function not viable: no known conversion from
      'WAITORTIMERCALLBACK' (aka 'void (*)(void *, unsigned char)') to 'const void *' for 2nd argument; take the address of the argument with &
inline ULONG FireEtwThreadPoolIOEnqueue(
             ^
/home/kamil/tmp/coreclr/src/vm/win32threadpool.cpp:3236:13: error: no matching function for call to 'FireEtwThreadPoolIODequeue'
            FireEtwThreadPoolIODequeue(waitInfo, waitInfo->Callback, reinterpret_cast<void*>(GetClrInstanceId()));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kamil/tmp/coreclr/bin/obj/Linux.x64.Debug/src/inc/clretwallmain.h:985:14: note: candidate function not viable: no known conversion from
      'WAITORTIMERCALLBACK' (aka 'void (*)(void *, unsigned char)') to 'const void *' for 2nd argument; take the address of the argument with &
inline ULONG FireEtwThreadPoolIODequeue(
             ^
```

Reported on Ubuntu-14.04.2 LTS with clang 3.8.0