### PR TITLE
Change the names of the JIT products to `clrjit`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,6 @@ cross/rootfs/*
 
 #python import files
 *.pyc
+
+# JIT32 files
+src/jit32

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -65,11 +65,6 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     set(LIB_UNWINDER unwinder_wks)
 endif (CLR_CMAKE_PLATFORM_UNIX)
 
-set(LIB_JIT ClrJit)
-if (CLR_BUILD_JIT32)
-    set(LIB_JIT ClrJit32)
-endif()
-
 # IMPORTANT! Please do not rearrange the order of the libraries. The linker on Linux is
 # order dependent and changing the order can result in undefined symbols in the shared 
 # library.
@@ -87,7 +82,7 @@ set(CORECLR_LIBRARIES
     mdhotdata_full
     bcltype
     ceefgen
-    ${LIB_JIT}
+    clrjit_static
     comfloat_wks
     corguids
     gcinfo # Condition="'$(TargetCpu)'=='amd64' or '$(TargetCpu)' == 'arm' or '$(TargetCpu)' == 'arm64'"

--- a/src/jit/CMakeLists.txt
+++ b/src/jit/CMakeLists.txt
@@ -168,6 +168,11 @@ endif()
 
 set(CLR_EXPORTED_SYMBOL_FILE ${CLRJIT_EXPORTS_DEF})
 
+set(JIT_BASE_NAME clrjit)
+if (CLR_BUILD_JIT32)
+  set(JIT_BASE_NAME ryujit)
+endif()
+
 add_subdirectory(dll)
 add_subdirectory(crossgen)
 add_subdirectory(standalone)

--- a/src/jit/crossgen/CMakeLists.txt
+++ b/src/jit/crossgen/CMakeLists.txt
@@ -4,4 +4,4 @@ if(CLR_CMAKE_TARGET_ARCH_I386 OR CLR_CMAKE_TARGET_ARCH_ARM)
   add_definitions(-DLEGACY_BACKEND)
 endif()
 
-add_library_clr(jit_crossgen ${SOURCES})
+add_library_clr(${JIT_BASE_NAME}_crossgen ${SOURCES})

--- a/src/jit/dll/CMakeLists.txt
+++ b/src/jit/dll/CMakeLists.txt
@@ -9,13 +9,13 @@ if(CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-fPIC)
     add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
-    add_library_clr(ClrJit
+    add_library_clr(${JIT_BASE_NAME}_static
       STATIC
       ${SHARED_LIB_SOURCES}
     )
-    add_dependencies(ClrJit coreclrpal gcinfo)
+    add_dependencies(${JIT_BASE_NAME}_static coreclrpal gcinfo)
 else()
-    add_library_clr(ClrJit
+    add_library_clr(${JIT_BASE_NAME}_static
        ${SOURCES}
     )
 # Disable up to here (see above) the following for UNIX altjit on Windows 

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -9,7 +9,7 @@ if(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_NETBSD)
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")
 endif(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_NETBSD)
 
-add_library_clr(ryujit
+add_library_clr(${JIT_BASE_NAME}
    SHARED
    ${SHARED_LIB_SOURCES}
 )
@@ -43,9 +43,9 @@ else()
     )
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
-target_link_libraries(ryujit
+target_link_libraries(${JIT_BASE_NAME}
    ${RYUJIT_LINK_LIBRARIES}
 )
 
 # add the install targets
-install_clr(ryujit)
+install_clr(${JIT_BASE_NAME})

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -24,11 +24,6 @@ add_executable_clr(crossgen
   ${crossgen_RESOURCES}
 )
 
-set(LIB_JIT jit_crossgen)
-if (CLR_BUILD_JIT32)
-    set(LIB_JIT jit32_crossgen)
-endif()
-
 target_link_libraries(crossgen
     cee_crossgen
     mdcompiler_crossgen
@@ -36,7 +31,7 @@ target_link_libraries(crossgen
     mdruntimerw_crossgen
     mdhotdata_crossgen
     corguids
-    ${LIB_JIT}
+    clrjit_crossgen
     gcinfo_crossgen
     corzap_crossgen
     mscorlib_crossgen


### PR DESCRIPTION
- The static library to be linked into the CLR is now
  `clrjit_static`
- The static library to be linked into crossgen is now
  `clrjit_crossgen`
- The dynamic library is now `clrjit`