### PR TITLE
Fix dbgshim race conditions

### DIFF
--- a/src/dlls/dbgshim/dbgshim.cpp
+++ b/src/dlls/dbgshim/dbgshim.cpp
@@ -54,14 +54,20 @@ Notes:
 
 */
 
+#ifdef FEATURE_PAL
+#define INITIALIZE_SHIM { if (PAL_InitializeDLL() != 0) return E_FAIL; }
+#else
+#define INITIALIZE_SHIM
+#endif
+
 // Contract for public APIs. These must be NOTHROW.
 #define PUBLIC_CONTRACT \
+    INITIALIZE_SHIM \
     CONTRACTL \
     { \
         NOTHROW; \
     } \
-    CONTRACTL_END; \
-
+    CONTRACTL_END;
 
 //-----------------------------------------------------------------------------
 // Public API.
@@ -1780,33 +1786,3 @@ CLRCreateInstance(
     return E_NOTIMPL;
 #endif
 }
-
-#ifdef FEATURE_PAL
-
-EXTERN_C BOOL WINAPI
-DllMain(HANDLE instance, DWORD reason, LPVOID reserved)
-{
-    int err = 0;
-
-    switch (reason)
-    {
-        case DLL_PROCESS_ATTACH:
-        {
-            err = PAL_InitializeDLL();
-            break;
-        }
-
-        case DLL_THREAD_ATTACH:
-            err = PAL_EnterTop();
-            break;
-    }
-
-    if (err != 0)
-    {
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-#endif // FEATURE_PAL


### PR DESCRIPTION
There are two race conditions in the register runtime startup logic: 1) in
CreateProcess (or CreateProcessForLaunch) between the fork() and the execv()
where for VS and mdbg we "see" the coreclr module loaded because the debugger
process and newly created child have the same modules loaded. 2) in attach
between when the child/debuggee loads the coreclr module and when coreclr
finishes initializes the global dac table. In both causes DebugActiveProcess
returns an error when one of the race conditions is hit.

The fix is to create the "continue" named semaphore on the coreclr/debuggee
process side and dbgshim uses that to determine if the coreclr process is
ready and initialized. Fixes issue #4244.

Open the old continue semaphore name and if it doesn't exists create a the new
continue semaphore name for backwards compatibility (see issue 4410).

Do PAL initalization on entry to the public functions instead of the DLLMain handler
which will only be called if the PAL's LoadLibrary is used to load dbgshim. It will be
a lot easier on the debuggers like mdbg to just use dlopen/dlsym and not have to
also call DLLMain.