### PR TITLE
Inliner: restore ability to dump jit time, plus some cleanup

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2523,11 +2523,12 @@ public :
     InlineInfo*          impInlineInfo;
     InlineStrategy*      m_inlineStrategy;
 
-    // Get the maximum IL size allowed for an inline
-    unsigned             getImpInlineSize() const { return impInlineSize; }
-
     // The Compiler* that is the root of the inlining tree of which "this" is a member.
     Compiler*            impInlineRoot();
+
+#if defined(DEBUG) || defined(INLINE_DATA)
+    unsigned __int64     getInlineCycleCount() { return m_compCycles; }
+#endif // defined(DEBUG) || defined(INLINE_DATA)
 
     bool                 fgNoStructPromotion;        // Set to TRUE to turn off struct promotion for this method.
     bool                 fgNoStructParamPromotion;   // Set to TRUE to turn off struct promotion for parameters this method.
@@ -3087,8 +3088,6 @@ private:
 #endif // DEBUG
 
     bool                seenConditionalJump;
-
-    unsigned            impInlineSize; // max IL size for inlining
 
     static BOOL         impIsAddressInLocal(GenTreePtr tree, GenTreePtr * lclVarTreeOut);
 
@@ -8588,10 +8587,8 @@ public:
     static fgWalkPreFn      gsMarkPtrsAndAssignGroups;  // Shadow param analysis tree-walk
     static fgWalkPreFn      gsReplaceShadowParams;      // Shadow param replacement tree-walk
 
-#define ALWAYS_INLINE_SIZE               16         // Method with <= ALWAYS_INLINE_SIZE IL bytes will always be inlined.
 #define DEFAULT_MAX_INLINE_SIZE         100         // Method with >  DEFAULT_MAX_INLINE_SIZE IL bytes will never be inlined.
                                                     // This can be overwritten by setting complus_JITInlineSize env variable.
-#define IMPLEMENTATION_MAX_INLINE_SIZE  _UI16_MAX   // Maximum method size supported by this implementation 
                                          
 private:
 #ifdef FEATURE_JIT_METHOD_PERF

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -67,21 +67,6 @@ void                Compiler::impInit()
 #endif
 
     seenConditionalJump = false;  
-       
-#ifndef DEBUG
-    impInlineSize = DEFAULT_MAX_INLINE_SIZE;
-#else
-    impInlineSize = JitConfig.JitInlineSize();
-
-    if (compInlineStress())
-        impInlineSize *= 10;
-
-    if (impInlineSize > IMPLEMENTATION_MAX_INLINE_SIZE)
-        impInlineSize = IMPLEMENTATION_MAX_INLINE_SIZE;
-
-    assert(impInlineSize >= ALWAYS_INLINE_SIZE);
-    assert(impInlineSize <= IMPLEMENTATION_MAX_INLINE_SIZE);
-#endif
 }
 
 /*****************************************************************************

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -661,6 +661,12 @@ public:
     // Root context
     InlineContext* GetRootContext();
 
+    // Get IL size for maximum allowable inline
+    unsigned GetMaxInlineILSize()
+    {
+        return m_MaxInlineSize;
+    }
+
     // Number of successful inlines into the root.
     unsigned GetInlineCount()
     {
@@ -679,11 +685,17 @@ public:
     // Dump textual description of inlines done so far.
     void Dump();
 
-
     // Dump data-format description of inlines done so far.
     void DumpData();
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)
+
+    // Some inline limit values
+    enum
+    {
+        ALWAYS_INLINE_SIZE = 16,
+        IMPLEMENTATION_MAX_INLINE_SIZE= _UI16_MAX
+    };
 
 private:
 
@@ -696,7 +708,10 @@ private:
     // Cap on allowable increase in jit time due to inlining.
     // Multiplicative, so BUDGET = 10 means up to 10x increase
     // in jit time.
-    enum { BUDGET = 10 };
+    enum
+    {
+        BUDGET = 10
+    };
 
     // Estimate the jit time change because of this inline.
     int EstimateTime(InlineContext* context);
@@ -718,6 +733,7 @@ private:
     unsigned       m_CandidateCount;
     unsigned       m_InlineAttemptCount;
     unsigned       m_InlineCount;
+    unsigned       m_MaxInlineSize;
     int            m_InitialTimeBudget;
     int            m_InitialTimeEstimate;
     int            m_CurrentTimeBudget;

--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -415,7 +415,7 @@ void LegacyPolicy::NoteInt(InlineObservation obs, int value)
 
             // Now that we know size and forceinline state,
             // update candidacy.
-            if (m_CodeSize <= ALWAYS_INLINE_SIZE)
+            if (m_CodeSize <= InlineStrategy::ALWAYS_INLINE_SIZE)
             {
                 // Candidate based on small size
                 SetCandidate(InlineObservation::CALLEE_BELOW_ALWAYS_INLINE_SIZE);
@@ -425,7 +425,7 @@ void LegacyPolicy::NoteInt(InlineObservation obs, int value)
                 // Candidate based on force inline
                 SetCandidate(InlineObservation::CALLEE_IS_FORCE_INLINE);
             }
-            else if (m_CodeSize <= m_RootCompiler->getImpInlineSize())
+            else if (m_CodeSize <= m_RootCompiler->m_inlineStrategy->GetMaxInlineILSize())
             {
                 // Candidate, pending profitability evaluation
                 SetCandidate(InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);


### PR DESCRIPTION
I zeroed out the jit time measurement when refactoring the data dumping
code to live in the InlineStrategy class, because it required adding a
helper to the Compiler class. Didn't mean to leave it this way, but did.
So, fixing it how I'd meant to all along.

Also, move a few of the inlining related constants and setup computation
over to InlineStrategy. I'd move `DEFAULT_MAX_INLINE_SIZE` too, but it
ends up getting used for some non-inlining purposes, so will hold off on
cleaning that part up.