### PR TITLE
Fix heap corruption in CPalSynchronizationManager::DoMonitorProcesses

### DIFF
--- a/src/pal/src/synchmgr/synchcontrollers.cpp
+++ b/src/pal/src/synchmgr/synchcontrollers.cpp
@@ -373,7 +373,8 @@ namespace CorUnix
             
             palErr = pSynchManager->RegisterProcessForMonitoring(m_pthrOwner,
                                                                  m_psdSynchData, 
-                                                                 pProcLocalData);            
+                                                                 m_pProcessObject,
+                                                                 pProcLocalData);
             if (NO_ERROR != palErr)
             {
                 goto RWT_exit;
@@ -507,15 +508,19 @@ namespace CorUnix
 
     /*++
     Method:
-      CSynchWaitController::SetProcessLocalData
+      CSynchWaitController::SetProcessData
 
     Accessor Set method for process local data of the target object
     --*/
-    void CSynchWaitController::SetProcessLocalData(CProcProcessLocalData * pProcLocalData)
+    void CSynchWaitController::SetProcessData(IPalObject* pProcessObject, CProcProcessLocalData * pProcLocalData)
     {   
         VALIDATEOBJECT(m_psdSynchData);
 
         _ASSERTE(InternalGetCurrentThread() == m_pthrOwner);
+        _ASSERT_MSG(m_pProcessObject == nullptr, "SetProcessData should not be called more than once");
+        _ASSERT_MSG(pProcessObject != nullptr && pProcessObject->GetObjectType()->GetId() == otiProcess, "Invalid process object passed to SetProcessData");
+
+        m_pProcessObject = pProcessObject;
         m_pProcLocalData = pProcLocalData;
     }
 

--- a/src/pal/src/synchmgr/synchmanager.hpp
+++ b/src/pal/src/synchmgr/synchmanager.hpp
@@ -448,10 +448,11 @@ namespace CorUnix
         // Per-object-type specific data
         //
         // Process (otiProcess)
+        IPalObject *m_pProcessObject; // process that owns m_pProcLocalData, this is stored without a reference
         CProcProcessLocalData * m_pProcLocalData;
         
     public:
-        CSynchWaitController() : m_pProcLocalData(NULL) {}
+        CSynchWaitController() : m_pProcessObject(NULL), m_pProcLocalData(NULL) {}
         virtual ~CSynchWaitController() = default;
         
         //
@@ -472,7 +473,7 @@ namespace CorUnix
 
         CProcProcessLocalData * GetProcessLocalData(void);
 
-        void SetProcessLocalData(CProcProcessLocalData * pProcLocalData);
+        void SetProcessData(IPalObject* pProcessObject, CProcProcessLocalData * pProcLocalData);
     };  
 
     class CSynchStateController : public CSynchControllerBase, 
@@ -539,6 +540,10 @@ namespace CorUnix
             DWORD dwPid;
             DWORD dwExitCode;
             bool fIsActualExitCode;
+
+            // Object that owns pProcLocalData. This is stored, with a reference, to 
+            // ensure that pProcLocalData is not deleted.
+            IPalObject *pProcessObject;
             CProcProcessLocalData * pProcLocalData;
         } MonitoredProcessesListNode;
 
@@ -990,6 +995,7 @@ namespace CorUnix
         PAL_ERROR RegisterProcessForMonitoring(
             CPalThread * pthrCurrent,
             CSynchData *psdSynchData,
+            IPalObject *pProcessObject,
             CProcProcessLocalData * pProcLocalData);
 
         PAL_ERROR UnRegisterProcessForMonitoring(


### PR DESCRIPTION
The PAL's WaitFor*Object support had a bug where if one waited on a process,
stopped, waiting and closed the process handle before the process exitted, then
later on when the process exitted it would corrupt the heap here:

   LONG CPalSynchronizationManager::DoMonitorProcesses(
       CPalThread * pthrCurrent)
    {
...
        if (lRemovingCount > 0)
        {
...
                // Set process status to PS_DONE
                pNode->pProcLocalData->ps = PS_DONE;

The issue is that the local process data would be delete when the process
handle was closed. But the synchronization manager would still have a reference
to it.

To fix this, I changed the synchronization manager to hold onto the PAL object in
addition to the local process data.