### PR TITLE
Update configuration knob documentation to reflect host configuration options

### DIFF
--- a/Documentation/project-docs/clr-complus-conf-docgen.sh
+++ b/Documentation/project-docs/clr-complus-conf-docgen.sh
@@ -1,14 +1,76 @@
 #!/usr/bin/env bash
 
+# This script generates documentation about the various configuration options that
+# are available and how to use them.
+
 # Requires git, GNU bash and GNU m4 to run.
 
-DATE=`date +%D`;
-COMMIT=`git rev-parse --short HEAD`
+#################################
+# Print script usage
+#################################
 
 if [ ! -r "$1" -o -z "$2" ]; then
 	echo "usage: $0 <path to clrconfigvalues.h> <output file>"
 	exit 1;
 fi
+
+#################################
+# Intro section of the document
+#################################
+
+read -r -d '' INTROSECTION << "EOF"
+
+There are two primary ways to configure runtime behavior: CoreCLR hosts can pass in key-value string pairs during runtime initialization, or users can set special variables in the environment or registry. Today, the set of configuration options that can be set via the former method is relatively small, but moving forward, we expect to add more options there. Each set of options is described below.
+
+EOF
+
+#################################
+# Host configuration knobs section of the document
+# 
+# Contains information about the key-value pairs that can be
+# passed in by a host during CoreCLR initialization.
+#################################
+
+read -r -d '' HOSTCONFIGURATIONKNOBSSECTION << "EOF"
+
+## Host Configuration Knobs
+
+These can be passed in by a host during initialization. Note that the values are all passed in as strings, so if the type is boolean, the value would be the string "true" or "false", and if it's a numeric value, it would be in the form "123".
+
+Name | Description | Type
+-----|-------------|------
+System.GC.Concurrent|Enable concurrent GC|boolean
+System.GC.Server|Enable server GC|boolean
+System.GC.RetainVM|Put segments that should be deleted on a standby list for future use instead of releasing them back to the OS|boolean
+System.Threading.ThreadPool.MinThreads|Override MinThreads for the ThreadPool worker pool|numeric
+System.Threading.ThreadPool.MaxThreads|Override MaxThreads for the ThreadPool worker pool|numeric
+
+EOF
+
+#################################
+# CLRConfig section of the document
+# 
+# This section contains a table of COMPlus configurations that's 
+# generated based on the contents of the clrconfigvalues.h header.
+#################################
+
+CLRCONFIGSECTIONTITLE="## Environment/Registry Configuration Knobs"
+DATE=`date +%D`;
+COMMIT=`git rev-parse --short HEAD`
+GENERATEDTABLEINFO="This table is machine-generated from commit $COMMIT on ${DATE}. It might be out of date."
+
+read -r -d '' CLRCONFIGSECTIONCONTENTS << "EOF"
+When using these configurations from environment variables, the variables need to have the `COMPlus_` prefix in their names. e.g. To set DumpJittedMethods to 1, add the environment variable `COMPlus_DumpJittedMethods=1`.
+
+See also [Dumps and Other Tools](../botr/ryujit-overview.md#dumps-and-other-tools) for more information.
+
+Name | Description | Type | Class | Default Value | Flags 
+-----|-------------|------|-------|---------------|-------
+EOF
+
+#################################
+# M4 script for processing macros
+#################################
 
 read -r -d '' M4SCRIPT << "EOF"
 changequote(`"', `"')
@@ -26,23 +88,18 @@ define("CONFIG_STRING_INFO_EX", "`$2` | $3 | STRING | patsubst("$1", "_.*", "") 
 define("RETAIL_CONFIG_STRING_INFO_EX", "`$2` | $3 | STRING | patsubst("$1", "_.*", "") | | patsubst(patsubst("$4", "CLRConfig::", ""), "|", "/")")dnl
 define("W", "$1")dnl
 dnl
-#CLR Configuration Knobs
 
 EOF
 
-INFO="This Document is machine-generated from commit $COMMIT on ${DATE}. It might be out of date."
+#################################
+# Write contents to file
+#################################
 
-read -r -d '' HEADER << "EOF"
-When using these configurations from environment variables, the variable need to have `COMPlus_` prefix in its name. e.g. To set DumpJittedMethods to 1, add `COMPlus_DumpJittedMethods=1` to envvars.
+cat <(echo "$INTROSECTION") <(echo)\
+    <(echo "$HOSTCONFIGURATIONKNOBSSECTION") <(echo)\
+    <(echo "$CLRCONFIGSECTIONTITLE") <(echo)\
+    <(echo "$GENERATEDTABLEINFO") > "$2";
 
-See also [Dumps and Other Tools](../botr/ryujit-overview.md#dumps-and-other-tools) for more information.
-
-Name | Description | Type | Class | Default Value | Flags 
------|-------------|------|-------|---------------|-------
-EOF
-
-
-cat <(echo "$M4SCRIPT") <(echo) \
-	<(echo "$INFO") <(echo) \
-	<(echo "$HEADER") <(cat "$1" | sed "/^\/\//d" | sed "/^#/d" | sed "s/\\\\\"/'/g" | sed "/^$/d"  ) \
-	| m4 | sed "s/;$//" > "$2";
+cat <(echo "$M4SCRIPT") \
+    <(echo "$CLRCONFIGSECTIONCONTENTS") <(cat "$1" | sed "/^\/\//d" | sed "/^#/d" | sed "s/\\\\\"/'/g" | sed "/^$/d"  ) \
+    | m4 | sed "s/;$//" >> "$2";

--- a/Documentation/project-docs/clr-configuration-knobs.md
+++ b/Documentation/project-docs/clr-configuration-knobs.md
@@ -1,9 +1,22 @@
+There are two primary ways to configure runtime behavior: CoreCLR hosts can pass in key-value string pairs during runtime initialization, or users can set special variables in the environment or registry. Today, the set of configuration options that can be set via the former method is relatively small, but moving forward, we expect to add more options there. Each set of options is described below.
 
-#CLR Configuration Knobs
+## Host Configuration Knobs
 
-This Document is machine-generated from commit 26efa5f on 03/17/16. It might be out of date.
+These can be passed in by a host during initialization. Note that the values are all passed in as strings, so if the type is boolean, the value would be the string "true" or "false", and if it's a numeric value, it would be in the form "123".
 
-When using these configurations from environment variables, the variable need to have `COMPlus_` prefix in its name. e.g. To set DumpJittedMethods to 1, add `COMPlus_DumpJittedMethods=1` to envvars.
+Name | Description | Type
+-----|-------------|------
+System.GC.Concurrent|Enable concurrent GC|boolean
+System.GC.Server|Enable server GC|boolean
+System.GC.RetainVM|Put segments that should be deleted on a standby list for future use instead of releasing them back to the OS|boolean
+System.Threading.ThreadPool.MinThreads|Override MinThreads for the ThreadPool worker pool|numeric
+System.Threading.ThreadPool.MaxThreads|Override MaxThreads for the ThreadPool worker pool|numeric
+
+## Environment/Registry Configuration Knobs
+
+This table is machine-generated from commit ae2d2f3 on 04/20/16. It might be out of date.
+
+When using these configurations from environment variables, the variables need to have the `COMPlus_` prefix in their names. e.g. To set DumpJittedMethods to 1, add the environment variable `COMPlus_DumpJittedMethods=1`.
 
 See also [Dumps and Other Tools](../botr/ryujit-overview.md#dumps-and-other-tools) for more information.
 
@@ -182,7 +195,7 @@ Name | Description | Type | Class | Default Value | Flags
 `GCPollType` |  | DWORD | EXTERNAL | | 
 `NewGCCalc` |  | STRING | EXTERNAL | | REGUTIL_default
 `GCprnLvl` | Specifies the maximum level of GC logging | DWORD | UNSUPPORTED | | 
-`GCRetainVM` | When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way) | DWORD | UNSUPPORTED | | 
+`GCRetainVM` | When set we put the segments that should be deleted on a standby list (instead of releasing them back to the OS) which will be considered to satisfy new segment requests (note that the same thing can be specified via API which is the supported way) | DWORD | UNSUPPORTED | 0 | 
 `GCSegmentSize` | Specifies the managed heap segment size | DWORD | UNSUPPORTED | | 
 `GCLOHCompact` | Specifies the LOH compaction mode | DWORD | UNSUPPORTED | | 
 `gcAllowVeryLargeObjects` | allow allocation of 2GB+ objects on GC heap | DWORD | EXTERNAL | 0 | 


### PR DESCRIPTION
Modify the script that generates clr-configuration-knobs.md to include information about the configuration options passed in by hosts.

Update clr-configuration-knobs.md with a new version generated by running this script.

cc: @kouvel