### PR TITLE
ARM: Fix compile error for unw usage with clang-3.8

### DIFF
--- a/src/pal/src/CMakeLists.txt
+++ b/src/pal/src/CMakeLists.txt
@@ -91,9 +91,10 @@ elseif(PAL_CMAKE_PLATFORM_ARCH_ARM64)
   )
 endif()
 
-if(CLR_CMAKE_PLATFORM_UNIX_TARGET_ARM)
-set_source_files_properties(exception/seh.cpp PROPERTIES COMPILE_FLAGS -Wno-error=inline-asm)
-endif(CLR_CMAKE_PLATFORM_UNIX_TARGET_ARM)
+if(PAL_CMAKE_PLATFORM_ARCH_ARM)
+  set_source_files_properties(exception/seh.cpp PROPERTIES COMPILE_FLAGS -Wno-error=inline-asm)
+endif(PAL_CMAKE_PLATFORM_ARCH_ARM)
+
 set(SOURCES
   cruntime/file.cpp
   cruntime/filecrt.cpp


### PR DESCRIPTION
This fix is also needed when using clang-3.8
Previous related patch is #4260