### PR TITLE
Fix empty perf map files generated by crossgen

### DIFF
--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -73,6 +73,9 @@ PerfMap::PerfMap()
   , m_PerfInfo(nullptr)
 {
     LIMITED_METHOD_CONTRACT;
+
+    // Initialize with no failures.
+    m_ErrorEncountered = false;
 }
 
 // Clean-up resources.


### PR DESCRIPTION
m_ErrorEncountered was not initialized for instances of NativeImagePerfMap.  On debug builds, the value was automatically initialized to zero, but not so on release builds.  Thus, m_ErrorEncountered was always equal to true for release builds, which resulted in nothing ever being written to the file.