### PR TITLE
Add support for ready to run to NGEN rundown

### DIFF
--- a/src/vm/readytoruninfo.cpp
+++ b/src/vm/readytoruninfo.cpp
@@ -264,7 +264,13 @@ PCODE ReadyToRunInfo::GetEntryPoint(MethodDesc * pMD, BOOL fFixups /*=TRUE*/)
 
 BOOL ReadyToRunInfo::MethodIterator::Next()
 {
-    STANDARD_VM_CONTRACT;
+    CONTRACTL
+    {
+        GC_TRIGGERS;
+        THROWS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
 
     while (++m_methodDefIndex < (int)m_pInfo->m_methodDefEntryPoints.GetCount())
     {
@@ -280,6 +286,47 @@ MethodDesc * ReadyToRunInfo::MethodIterator::GetMethodDesc()
     STANDARD_VM_CONTRACT;
 
     return MemberLoader::GetMethodDescFromMethodDef(m_pInfo->m_pModule, mdtMethodDef | (m_methodDefIndex + 1), FALSE);
+}
+
+MethodDesc * ReadyToRunInfo::MethodIterator::GetMethodDesc_NoRestore()
+{
+    CONTRACTL
+    {
+        GC_TRIGGERS;
+        THROWS;
+        MODE_ANY;
+    }
+    CONTRACTL_END;
+
+    uint offset;
+    if (!m_pInfo->m_methodDefEntryPoints.TryGetAt(m_methodDefIndex, &offset))
+    {
+        return NULL;
+    }
+
+    uint id;
+    offset = m_pInfo->m_nativeReader.DecodeUnsigned(offset, &id);
+
+    if (id & 1)
+    {
+        if (id & 2)
+        {
+            uint val;
+            m_pInfo->m_nativeReader.DecodeUnsigned(offset, &val);
+            offset -= val;
+        }
+
+        id >>= 2;
+    }
+    else
+    {
+        id >>= 1;
+    }
+
+    _ASSERTE(id < m_pInfo->m_nRuntimeFunctions);
+    PCODE pEntryPoint = dac_cast<TADDR>(m_pInfo->m_pLayout->GetBase()) + m_pInfo->m_pRuntimeFunctions[id].BeginAddress;
+
+    return m_pInfo->GetMethodDescForEntryPoint(pEntryPoint);
 }
 
 PCODE ReadyToRunInfo::MethodIterator::GetMethodStartAddress()

--- a/src/vm/readytoruninfo.h
+++ b/src/vm/readytoruninfo.h
@@ -107,6 +107,7 @@ public:
         BOOL Next();
 
         MethodDesc * GetMethodDesc();
+        MethodDesc * GetMethodDesc_NoRestore();
         PCODE GetMethodStartAddress();
     };
 


### PR DESCRIPTION
Tracing tools such as PerfView cannot resolve symbols for ready to run images because native PDBs are not created for these images.

This change enables NGEN rundown to log pre-compiled methods in ready to run images to ensure that PerfView can resolve symbols for these methods.

The goal is to use NGEN rundown while we look into how we can support symbol resolution using PDBs without rundown.