### PR TITLE
[Discuss] Avoid IEnumeration allocation (List+Dictionary)

### DIFF
--- a/src/mscorlib/mscorlib.shared.sources.props
+++ b/src/mscorlib/mscorlib.shared.sources.props
@@ -1102,6 +1102,9 @@
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Generic\KeyValuePair.cs" />
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Generic\List.cs" />
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Generic\ArraySortHelper.cs" />
+    <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Generic\ObjectPool.cs" />
+    <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Generic\DefaultObjectPool.cs" />
+    <GenericsSources Include="$(BclSourcesRoot)\System\Collections\Generic\PooledIEnumerator.cs" />
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\Collection.cs" />
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\ReadOnlyCollection.cs" />
     <GenericsSources Include="$(BclSourcesRoot)\System\Collections\ObjectModel\ReadOnlyDictionary.cs" />

--- a/src/mscorlib/src/System/Collections/Generic/DefaultObjectPool.cs
+++ b/src/mscorlib/src/System/Collections/Generic/DefaultObjectPool.cs
@@ -1,0 +1,101 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.Collections.Generic
+{
+    internal class DefaultObjectPool<T> : ObjectPool<T> where T : class
+    {
+        /// <summary>The default maximum number of oebjects that are available for rent.</summary>
+        private const int DefaultMaxPooled = 128;
+
+        private readonly T[] _objects;
+
+        private SpinLock _lock; // do not make this readonly; it's a mutable struct
+        private int _index;
+
+        /// <summary>
+        /// Creates the pool with DefaultMaxPooled objects.
+        /// </summary>
+        public DefaultObjectPool()
+            : this(DefaultMaxPooled)
+        {
+        }
+
+        /// <summary>
+        /// Creates the pool with maxPooled objects.
+        /// </summary>
+        public DefaultObjectPool(int maxPooled)
+        {
+            if (maxPooled <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxPooled));
+            }
+
+            _lock = new SpinLock(Debugger.IsAttached); // only enable thread tracking if debugger is attached; it adds non-trivial overheads to Enter/Exit
+            _objects = new T[maxPooled];
+        }
+
+        /// <summary>Tries to take an object from the pool, returns true if sucessful.</summary>
+        public override bool TryRent(out T obj)
+        {
+            T[] objects = _objects;
+            obj = null;
+            // While holding the lock, grab whatever is at the next available index and
+            // update the index.  We do as little work as possible while holding the spin
+            // lock to minimize contention with other threads.  The try/finally is
+            // necessary to properly handle thread aborts on platforms which have them.
+            bool lockTaken = false;
+            try
+            {
+                _lock.Enter(ref lockTaken);
+
+                if (_index < objects.Length)
+                {
+                    obj = objects[_index];
+                    objects[_index++] = null;
+                }
+            }
+            finally
+            {
+                if (lockTaken) _lock.Exit(false);
+            }
+
+            return obj != null;
+        }
+
+        /// <summary>
+        /// Attempts to return the object to the pool.  If successful, the object will be stored
+        /// in the pool; otherwise, the buffer won't be stored.
+        /// </summary>
+        public override void Return(T obj)
+        {
+            if (obj == null)
+            {
+                return;
+            }
+
+            // While holding the spin lock, if there's room available in the array,
+            // put the object into the next available slot.  Otherwise, we just drop it.
+            // The try/finally is necessary to properly handle thread aborts on platforms
+            // which have them.
+            bool lockTaken = false;
+            try
+            {
+                _lock.Enter(ref lockTaken);
+
+                if (_index != 0)
+                {
+                    _objects[--_index] = obj;
+                }
+            }
+            finally
+            {
+                if (lockTaken) _lock.Exit(false);
+            }
+        }
+    }
+}

--- a/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
+++ b/src/mscorlib/src/System/Collections/Generic/Dictionary.cs
@@ -284,8 +284,14 @@ namespace System.Collections.Generic {
         }
 
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() {
-            return new Enumerator(this, Enumerator.KeyValuePair);
-        }        
+            PooledIEnumerator<KeyValuePair<TKey, TValue>, Enumerator> enumerator;
+            if (!ObjectPool<PooledIEnumerator<KeyValuePair<TKey, TValue>, Enumerator>>.Shared.TryRent(out enumerator))
+            {
+                enumerator = new PooledIEnumerator<KeyValuePair<TKey, TValue>, Enumerator>();
+            }
+            enumerator.Enumerator = new Enumerator(this, Enumerator.KeyValuePair);
+            return enumerator;
+        }
 
         [System.Security.SecurityCritical]  // auto-generated_required
         public virtual void GetObjectData(SerializationInfo info, StreamingContext context) {
@@ -599,7 +605,13 @@ namespace System.Collections.Generic {
         }
 
         IEnumerator IEnumerable.GetEnumerator() {
-            return new Enumerator(this, Enumerator.KeyValuePair);
+            PooledIEnumerator<KeyValuePair<TKey, TValue>, Enumerator> enumerator;
+            if (!ObjectPool<PooledIEnumerator<KeyValuePair<TKey, TValue>, Enumerator>>.Shared.TryRent(out enumerator))
+            {
+                enumerator = new PooledIEnumerator<KeyValuePair<TKey, TValue>, Enumerator>();
+            }
+            enumerator.Enumerator = new Enumerator(this, Enumerator.KeyValuePair);
+            return enumerator;
         }
     
         bool ICollection.IsSynchronized {

--- a/src/mscorlib/src/System/Collections/Generic/List.cs
+++ b/src/mscorlib/src/System/Collections/Generic/List.cs
@@ -569,11 +569,24 @@ namespace System.Collections.Generic {
 
         /// <internalonly/>
         IEnumerator<T> IEnumerable<T>.GetEnumerator() {
-            return new Enumerator(this);
+            PooledIEnumerator<T, Enumerator> enumerator;
+            if (!ObjectPool<PooledIEnumerator<T, Enumerator>>.Shared.TryRent(out enumerator))
+            {
+                enumerator = new PooledIEnumerator<T, Enumerator>();
+            }
+            enumerator.Enumerator = new Enumerator(this);
+            return enumerator;
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() {
-            return new Enumerator(this);
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            PooledIEnumerator<T, Enumerator> enumerator;
+            if (!ObjectPool<PooledIEnumerator<T, Enumerator>>.Shared.TryRent(out enumerator))
+            {
+                enumerator = new PooledIEnumerator<T, Enumerator>();
+            }
+            enumerator.Enumerator = new Enumerator(this);
+            return enumerator;
         }
 
         public List<T> GetRange(int index, int count) {

--- a/src/mscorlib/src/System/Collections/Generic/ObjectPool.cs
+++ b/src/mscorlib/src/System/Collections/Generic/ObjectPool.cs
@@ -1,0 +1,97 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace System.Collections.Generic
+{
+     /// <summary>
+     /// Provides a resource pool that enables reusing instances of type <see cref="T:T"/>. It is up to the user to ensure these objects are reset before returning to pool.
+     /// </summary>
+     /// <remarks>
+     /// <para>
+     /// Ensure these objects are reset before returning to pool. This is so they do not maintain references to objects that should be GC'd and they are ready for reuse.
+     /// </para>
+     /// <para>
+     /// Renting and returning objects with an <see cref="ObjectPool{T}"/> can increase performance
+     /// in situations where objects are created and destroyed frequently, resulting in significant
+     /// memory pressure on the garbage collector.
+     /// </para>
+     /// <para>
+     /// This class is thread-safe.  All members may be used by multiple threads concurrently.
+     /// </para>
+     /// </remarks>
+    internal abstract class ObjectPool<T> where T : class
+    {
+        /// <summary>The lazily-initialized shared pool instance.</summary>
+        private static ObjectPool<T> s_sharedInstance;
+
+        /// <summary>
+        /// Retrieves a shared <see cref="ObjectPool{T}"/> instance.
+        /// </summary>
+        /// <remarks>
+        /// The shared pool provides a default implementation of <see cref="ObjectPool{T}"/>
+        /// that's intended for general applicability. Renting an object from it with <see cref="Rent"/> will result in an 
+        /// existing object being taken from the pool if one is available or in a new 
+        /// object being allocated if one is not available.
+        /// </remarks>
+        public static ObjectPool<T> Shared
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get { return Volatile.Read(ref s_sharedInstance) ?? EnsureSharedCreated(); }
+        }
+
+        /// <summary>Ensures that <see cref="s_sharedInstance"/> has been initialized to a pool and returns it.</summary>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static ObjectPool<T> EnsureSharedCreated()
+        {
+            Interlocked.CompareExchange(ref s_sharedInstance, Create(), null);
+            return s_sharedInstance;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ObjectPool{T}"/> instance using default configuration options.
+        /// </summary>
+        /// <returns>A new <see cref="ObjectPool{T}"/> instance.</returns>
+        public static ObjectPool<T> Create()
+        {
+            return new DefaultObjectPool<T>();
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ObjectPool{T}"/> instance using custom configuration options.
+        /// </summary>
+        /// <param name="maxPooled">The maximum number of object instances that may be stored in the pool.</param>
+        /// <returns>A new <see cref="ObjectPool{T}"/> instance with the specified configuration options.</returns>
+        public static ObjectPool<T> Create(int maxPooled)
+        {
+            return new DefaultObjectPool<T>(maxPooled);
+        }
+
+        public abstract bool TryRent(out T value);
+
+        /// <summary>
+        /// Returns to the pool an object that was previously obtained via <see cref="Rent"/> on the same 
+        /// <see cref="ObjectPool{T}"/> instance.
+        /// Ensure this object is reset before returning to pool. This is so it does do not maintain references to objects that should be GC'd and they are ready for reuse.
+        /// </summary>
+        /// <param name="obj">
+        /// The object previously obtained from <see cref="Rent"/> to return to the pool.
+        /// </param>
+        /// <remarks>
+        /// <para>
+        /// Ensure the object is reset before returning to pool. This is so it does not maintain references to objects that should be GC'd and they are ready for reuse.
+        /// </para>
+        /// <para>
+        /// Once an object has been returned to the pool, the caller gives up all ownership of the buffer 
+        /// and must not use it. The reference returned from a given call to <see cref="Rent"/> must only be
+        /// returned via <see cref="Return"/> once.  The default <see cref="ObjectPool{T}"/>
+        /// may hold onto the returned object in order to rent it again, or it may release the returned object
+        /// if it's determined that the pool already has enough objects stored.
+        /// </para>
+        /// </remarks>
+        public abstract void Return(T obj);
+    }
+}

--- a/src/mscorlib/src/System/Collections/Generic/PooledIEnumerator.cs
+++ b/src/mscorlib/src/System/Collections/Generic/PooledIEnumerator.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Collections.Generic
+{
+    internal class PooledIEnumerator<TValue, TEnumerator> : IEnumerator<TValue> where TEnumerator : IEnumerator<TValue>
+    {
+        public TEnumerator Enumerator;
+        public bool MoveNext() => Enumerator.MoveNext();
+        public TValue Current => Enumerator.Current;
+        object IEnumerator.Current => Current;
+
+        public void Dispose()
+        {
+            Enumerator = default(TEnumerator);
+            ObjectPool<PooledIEnumerator<TValue, TEnumerator>>.Shared.Return(this);
+        }
+        public void Reset()
+        {
+            Enumerator.Reset();
+        }
+    }
+}


### PR DESCRIPTION
(For discussion) 

1M enumerations from 1M objects at 40 MBytes to 5 objects at 1,224 bytes
Current impl takes 846ms and has 12 Gen0 collections (x3.25 slower than struct)
This impl takes 714ms and has 0 GC collections +15% faster than current (x2.7 slower than struct)
(Struct enumerator takes 260ms and has 0 GC collections)

The common `IEnumerator` interface `foreach` code

``` csharp
IList<int> list = new List<int>();
foreach (var value in list)
{
    // ...
}
```

Turns into something like

``` csharp
IEnumerable<int> enum = list.GetEnumerator();
try
{
    while (enum.MoveNext())
    {
        var value = enum.Current;
        // ...
    }
}
finally
{
    enum.Dispose();
}
```

Which boxes the struct enumerator to the interface and causes allocation.

This change introduces `ObjectPool<T>`; closely based on `ArrayPool<T>` - as an `internal` type (so as not to expose new api).

`List<T>` and `Dictionary<TKey, TValue>` use this shared pool for class enumerators which contain the struct enumerator. This allows no boxing/allocation (beyond the initial pool allocations); when the interface is used for List and Dictionary enumeration. 

The enumerator is returned to the pool on the call to Dispose and the struct enumerator set to `default(Enumerator)`.

Interface dispatch will still be slower than using the stuct enumerator however.

Resolves dotnet/roslyn#4446 (Measurements below)

/cc @rynowak, @stephentoub, @davidfowl, @jaredpar, @JonHanna
