### PR TITLE
Port Linux Tracing Fixes to RC2

### DIFF
--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -115,6 +115,7 @@ set(VM_SOURCES_DAC_AND_WKS_COMMON
     peimage.cpp
     peimagelayout.cpp
     perfmap.cpp
+    perfinfo.cpp
     precode.cpp
     prestub.cpp
     rejit.cpp

--- a/src/vm/crossgen/CMakeLists.txt
+++ b/src/vm/crossgen/CMakeLists.txt
@@ -150,6 +150,7 @@ endif (WIN32)
 if (CLR_CMAKE_PLATFORM_LINUX)
   list(APPEND VM_CROSSGEN_SOURCES
     ../perfmap.cpp
+    ../perfinfo.cpp
   )
 endif (CLR_CMAKE_PLATFORM_LINUX)
 

--- a/src/vm/domainfile.cpp
+++ b/src/vm/domainfile.cpp
@@ -1310,11 +1310,6 @@ void DomainFile::FinishLoad()
         // Inform metadata that it has been loaded from a native image
         // (and so there was an opportunity to check for or fix inconsistencies in the original IL metadata)
         m_pFile->GetMDImport()->SetVerifiedByTrustedSource(TRUE);
-
-#ifdef FEATURE_PERFMAP
-        // Notify the perfmap of the native image load.
-        PerfMap::LogNativeImageLoad(m_pFile);
-#endif
     }
 
     // Are we absolutely required to use a native image?
@@ -1382,6 +1377,11 @@ void DomainFile::FinishLoad()
     // Set a bit to indicate that the module has been loaded in some domain, and therefore
     // typeloads can involve types from this module. (Used for candidate instantiations.)
     GetModule()->SetIsReadyForTypeLoad();
+
+#ifdef FEATURE_PERFMAP
+    // Notify the perfmap of the IL image load.
+    PerfMap::LogImageLoad(m_pFile);
+#endif
 }
 
 void DomainFile::VerifyExecution()

--- a/src/vm/perfinfo.cpp
+++ b/src/vm/perfinfo.cpp
@@ -12,6 +12,7 @@
 #include "pal.h"
 
 PerfInfo::PerfInfo(int pid)
+  : m_Stream(nullptr)
 {
     LIMITED_METHOD_CONTRACT;
 
@@ -34,8 +35,8 @@ void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
         THROWS;
         GC_NOTRIGGER;
         MODE_PREEMPTIVE;
-        PRECONDITION(pFile != NULL);
-        PRECONDITION(guid != NULL);
+        PRECONDITION(pFile != nullptr);
+        PRECONDITION(guid != nullptr);
     } CONTRACTL_END;
 
     SString value;
@@ -59,7 +60,7 @@ void PerfInfo::WriteLine(SString& type, SString& value)
         MODE_PREEMPTIVE;
     } CONTRACTL_END;
 
-    if (m_Stream == NULL)
+    if (m_Stream == nullptr)
     {
         return;
     }
@@ -92,13 +93,13 @@ void PerfInfo::OpenFile(SString& path)
 
     m_Stream = new (nothrow) CFileStream();
 
-    if (m_Stream != NULL)
+    if (m_Stream != nullptr)
     {
         HRESULT hr = m_Stream->OpenForWrite(path.GetUnicode());
         if (FAILED(hr))
         {
             delete m_Stream;
-            m_Stream = NULL;
+            m_Stream = nullptr;
         }
     }
 }
@@ -108,7 +109,7 @@ PerfInfo::~PerfInfo()
     LIMITED_METHOD_CONTRACT;
 
     delete m_Stream;
-    m_Stream = NULL;
+    m_Stream = nullptr;
 }
 
 

--- a/src/vm/perfinfo.cpp
+++ b/src/vm/perfinfo.cpp
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ===========================================================================
+// File: perfinfo.cpp
+//
+
+#include "common.h"
+
+#if defined(FEATURE_PERFMAP) && !defined(DACCESS_COMPILE)
+#include "perfinfo.h"
+#include "pal.h"
+
+PerfInfo::PerfInfo(int pid)
+{
+    LIMITED_METHOD_CONTRACT;
+
+    SString tempPath;
+    if (!WszGetTempPath(tempPath))
+    {
+        return;
+    }
+
+    SString path;
+    path.Printf("%Sperfinfo-%d.map", tempPath.GetUnicode(), pid);
+    OpenFile(path);
+}
+
+// Logs image loads into the process' perfinfo-%d.map file
+void PerfInfo::LogImage(PEFile* pFile, WCHAR* guid)
+{
+    CONTRACTL
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+        PRECONDITION(pFile != NULL);
+        PRECONDITION(guid != NULL);
+    } CONTRACTL_END;
+
+    SString value;
+    const SString& path = pFile->GetPath();
+    value.Printf("%S%c%S", path.GetUnicode(), sDelimiter, guid);
+
+    SString command;
+    command.Printf("%s", "ImageLoad");
+    WriteLine(command, value);
+
+}
+
+// Writes a command line, with "type" being the type of command, with "value" as the command's corresponding instructions/values. This is to be used to log specific information, e.g. LogImage
+void PerfInfo::WriteLine(SString& type, SString& value)
+{
+
+    CONTRACTL    
+    {
+        THROWS;
+        GC_NOTRIGGER;
+        MODE_PREEMPTIVE;
+    } CONTRACTL_END;
+
+    if (m_Stream == NULL)
+    {
+        return;
+    }
+
+    SString line;
+    line.Printf("%S%c%S%c\n",
+            type.GetUnicode(), sDelimiter, value.GetUnicode(), sDelimiter);
+
+    EX_TRY
+    {
+        StackScratchBuffer scratch;
+        const char* strLine = line.GetANSI(scratch);
+        ULONG inCount = line.GetCount();
+        ULONG outCount;
+
+        m_Stream->Write(strLine, inCount, &outCount);
+
+        if (inCount != outCount)
+        {
+            // error encountered
+        }
+    }
+    EX_CATCH{} EX_END_CATCH(SwallowAllExceptions);
+}
+
+// Opens a file ready to be written in.
+void PerfInfo::OpenFile(SString& path)
+{
+    STANDARD_VM_CONTRACT;
+
+    m_Stream = new (nothrow) CFileStream();
+
+    if (m_Stream != NULL)
+    {
+        HRESULT hr = m_Stream->OpenForWrite(path.GetUnicode());
+        if (FAILED(hr))
+        {
+            delete m_Stream;
+            m_Stream = NULL;
+        }
+    }
+}
+
+PerfInfo::~PerfInfo()
+{
+    LIMITED_METHOD_CONTRACT;
+
+    delete m_Stream;
+    m_Stream = NULL;
+}
+
+
+#endif
+
+
+
+
+
+
+
+
+
+

--- a/src/vm/perfinfo.h
+++ b/src/vm/perfinfo.h
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ===========================================================================
+// File: perfinfo.h
+//
+
+#ifndef PERFINFO_H
+#define PERFINFO_H
+
+
+#include "sstring.h"
+#include "fstream.h"
+
+/*
+   A perfinfo-%d.map is created for every process that is created with manage code, the %d
+   being repaced with the process ID.
+   Every line in the perfinfo-%d.map is a type and value, separated by sDelimiter character: type;value
+   type represents what the user might want to do with its given value. value has a format chosen by
+   the user for parsing later on.
+*/
+class PerfInfo {
+public:
+    PerfInfo(int pid);
+    ~PerfInfo();
+    void LogImage(PEFile* pFile, WCHAR* guid); 
+
+private:
+    CFileStream* m_Stream;
+
+    const char sDelimiter = ';';
+
+    void OpenFile(SString& path);
+
+    void WriteLine(SString& type, SString& value);
+
+};
+
+
+#endif

--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -12,7 +12,7 @@
 #include "perfinfo.h"
 #include "pal.h"
 
-PerfMap * PerfMap::s_Current = NULL;
+PerfMap * PerfMap::s_Current = nullptr;
 
 // Initialize the map for the process - called from EEStartupHelper.
 void PerfMap::Initialize()
@@ -35,10 +35,10 @@ void PerfMap::Destroy()
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (s_Current != NULL)
+    if (s_Current != nullptr)
     {
         delete s_Current;
-        s_Current = NULL;
+        s_Current = nullptr;
     }
 }
 
@@ -69,6 +69,8 @@ PerfMap::PerfMap(int pid)
 // Construct a new map without a specified file name.
 // Used for offline creation of NGEN map files.
 PerfMap::PerfMap()
+  : m_FileStream(nullptr)
+  , m_PerfInfo(nullptr)
 {
     LIMITED_METHOD_CONTRACT;
 }
@@ -79,10 +81,10 @@ PerfMap::~PerfMap()
     LIMITED_METHOD_CONTRACT;
 
     delete m_FileStream;
-    m_FileStream = NULL;
+    m_FileStream = nullptr;
 
     delete m_PerfInfo;
-    m_PerfInfo = NULL;
+    m_PerfInfo = nullptr;
 }
 
 // Open the specified destination map file.
@@ -92,13 +94,13 @@ void PerfMap::OpenFile(SString& path)
 
     // Open the file stream.
     m_FileStream = new (nothrow) CFileStream();
-    if(m_FileStream != NULL)
+    if(m_FileStream != nullptr)
     {
         HRESULT hr = m_FileStream->OpenForWrite(path.GetUnicode());
         if(FAILED(hr))
         {
             delete m_FileStream;
-            m_FileStream = NULL;
+            m_FileStream = nullptr;
         }
     }
 }
@@ -136,12 +138,12 @@ void PerfMap::LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize)
         THROWS;
         GC_NOTRIGGER;
         MODE_PREEMPTIVE;
-        PRECONDITION(pMethod != NULL);
-        PRECONDITION(pCode != NULL);
+        PRECONDITION(pMethod != nullptr);
+        PRECONDITION(pCode != nullptr);
         PRECONDITION(codeSize > 0);
     } CONTRACTL_END;
 
-    if (m_FileStream == NULL || m_ErrorEncountered)
+    if (m_FileStream == nullptr || m_ErrorEncountered)
     {
         // A failure occurred, do not log.
         return;
@@ -168,7 +170,7 @@ void PerfMap::LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize)
 
 void PerfMap::LogImageLoad(PEFile * pFile)
 {
-    if (s_Current != NULL)
+    if (s_Current != nullptr)
     {
         s_Current->LogImage(pFile);
     }
@@ -181,11 +183,11 @@ void PerfMap::LogImage(PEFile * pFile)
         THROWS;
         GC_NOTRIGGER;
         MODE_PREEMPTIVE;
-        PRECONDITION(pFile != NULL);
+        PRECONDITION(pFile != nullptr);
     } CONTRACTL_END;
 
 
-    if (m_FileStream == NULL || m_ErrorEncountered)
+    if (m_FileStream == nullptr || m_ErrorEncountered)
     {
         // A failure occurred, do not log.
         return;
@@ -207,7 +209,7 @@ void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t cod
 {
     LIMITED_METHOD_CONTRACT;
 
-    if (s_Current != NULL)
+    if (s_Current != nullptr)
     {
         s_Current->LogMethod(pMethod, pCode, codeSize);
     }
@@ -216,8 +218,8 @@ void PerfMap::LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t cod
 void PerfMap::GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned int nSigSize)
 {
     CONTRACTL{
-        PRECONDITION(pFile != NULL);
-        PRECONDITION(pwszSig != NULL);
+        PRECONDITION(pFile != nullptr);
+        PRECONDITION(pwszSig != nullptr);
         PRECONDITION(nSigSize >= 39);
     } CONTRACTL_END;
 
@@ -262,7 +264,7 @@ void NativeImagePerfMap::LogDataForModule(Module * pModule)
     STANDARD_VM_CONTRACT;
 
     PEImageLayout * pLoadedLayout = pModule->GetFile()->GetLoaded();
-    _ASSERTE(pLoadedLayout != NULL);
+    _ASSERTE(pLoadedLayout != nullptr);
 
     SIZE_T baseAddr = (SIZE_T)pLoadedLayout->GetBase();
 

--- a/src/vm/perfmap.h
+++ b/src/vm/perfmap.h
@@ -10,6 +10,8 @@
 #include "sstring.h"
 #include "fstream.h"
 
+class PerfInfo;
+
 // Generates a perfmap file.
 class PerfMap
 {
@@ -19,6 +21,9 @@ private:
 
     // The file stream to write the map to.
     CFileStream * m_FileStream;
+
+    // The perfinfo file to log images to.
+    PerfInfo* m_PerfInfo;
 
     // Set to true if an error is encountered when writing to the file.
     bool m_ErrorEncountered;
@@ -43,10 +48,10 @@ protected:
     // Does the actual work to log a method to the map.
     void LogMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize);
 
-    // Does the actual work to log a native image load to the map.
-    void LogNativeImage(PEFile * pFile);
+    // Does the actual work to log an image
+    void LogImage(PEFile * pFile);
 
-    // Get the native image signature and store it as a string.
+    // Get the image signature and store it as a string.
     static void GetNativeImageSignature(PEFile * pFile, WCHAR * pwszSig, unsigned int nSigSize);
 
 public:
@@ -54,7 +59,7 @@ public:
     static void Initialize();
 
     // Log a native image load to the map.
-    static void LogNativeImageLoad(PEFile * pFile);
+    static void LogImageLoad(PEFile * pFile);
 
     // Log a JIT compiled method to the map.
     static void LogJITCompiledMethod(MethodDesc * pMethod, PCODE pCode, size_t codeSize);


### PR DESCRIPTION
Port two changes to RC2 to ensure that E2E tracing on Linux works:

1. Log image loads when tracing is enabled so that we can use crossgen to generate perfmap files at trace collection time.
2. Fix a crash in image load logging.

These changes are needed in order to resolve R2R symbols in performance traces on Linux.