### PR TITLE
Delete Non-Windows Arm64 Job

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -864,8 +864,8 @@ combinedScenarios.each { scenario ->
 					// Skip totally unimplemented (in CI) configurations.
                     switch (architecture) {
                         case 'arm64':
-                            // Windows or cross compiled Ubuntu
-                            if (os != 'Windows_NT' && os != 'Ubuntu') {
+                            // Windows only
+                            if (os != 'Windows_NT') {
                                 return
                             }
                             break


### PR DESCRIPTION
It appears we're still creating jobs for arm64 non-windows although we don't run it.
This should fix it.