### PR TITLE
enable heap verification for coreclr on all builds

### DIFF
--- a/src/inc/switches.h
+++ b/src/inc/switches.h
@@ -14,10 +14,7 @@
 #define STRESS_THREAD
 #endif
 
-// On CoreCLR, define VERIFY_HEAP only in debug builds
-#if defined(_DEBUG) || !defined(FEATURE_CORECLR)
 #define VERIFY_HEAP
-#endif
 
 #define GC_CONFIG_DRIVEN
 


### PR DESCRIPTION
heap verification needs to be turned on for ret in coreclr. It makes no sense that it's only enabled for dbg - we often can only repro heap corruptions in ret builds.

@swgillespie