### PR TITLE
Remove GOLDEN macro

### DIFF
--- a/src/utilcode/perflog.cpp
+++ b/src/utilcode/perflog.cpp
@@ -9,8 +9,7 @@
 #include "sstring.h"
 
 //=============================================================================
-// ALL THE PERF LOG CODE IS COMPILED ONLY IF THE ENABLE_PERF_LOG WAS DEFINED.
-// ENABLE_PERF_LOGis defined if GOLDEN or DISABLE_PERF_LOG is not defined.
+// ALL THE PERF LOG CODE IS COMPILED ONLY IF ENABLE_PERF_LOG IS DEFINED.
 #if defined (ENABLE_PERF_LOG)
 //=============================================================================
 

--- a/src/vm/finalizerthread.cpp
+++ b/src/vm/finalizerthread.cpp
@@ -1284,7 +1284,6 @@ BOOL FinalizerThread::FinalizerThreadWatchDog()
         
         BOOL fTimeOut = (status == WAIT_TIMEOUT) ? TRUE : FALSE;
 
-#ifndef GOLDEN
         if (fTimeOut) 
         {
             if (dwBreakOnFinalizeTimeOut) {
@@ -1292,7 +1291,6 @@ BOOL FinalizerThread::FinalizerThreadWatchDog()
                 DebugBreak();
             }
         }
-#endif // GOLDEN
 
         if (pThread)
         {
@@ -1448,13 +1446,12 @@ BOOL FinalizerThread::FinalizerThreadWatchDogHelper()
         }
     }
 
-#ifndef GOLDEN
-    if (fTimeOut) 
+    if (fTimeOut)
     {
         if (dwBreakOnFinalizeTimeOut){
             DebugBreak();
         }
     }
-#endif
+
     return fTimeOut;
 }


### PR DESCRIPTION
This is a legacy macro that was used to distinguish between 'normal' release builds used for testing vs. 'GOLDEN' shipping builds. That distinction shouldn't exist anymore.

I chose to remove the code in finalizerthread.cpp that was under !GOLDEN, but if anyone really wants it, we could probably keep it in since it's also behind a COMPlus variable.

cc: @jkotas