### PR TITLE
Revert "Fix empty perf map files generated by crossgen"

### DIFF
--- a/src/vm/perfmap.cpp
+++ b/src/vm/perfmap.cpp
@@ -68,9 +68,6 @@ PerfMap::PerfMap(int pid)
 PerfMap::PerfMap()
 {
     LIMITED_METHOD_CONTRACT;
-
-    // Initialize with no failures.
-    m_ErrorEncountered = false;
 }
 
 // Clean-up resources.


### PR DESCRIPTION
Reverts dotnet/coreclr#4463