### PR TITLE
Add a "playlists" flag to runtests.sh that will run a list of tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1451,10 +1451,9 @@ combinedScenarios.each { scenario ->
                     // of in parallel. Only used for long GC tests.
                     def sequentialString = ''
                     
-                    // Whether or not this test run should only run failing test.
-                    // Only used for long GC tests, because they are all ignored in
-                    // normal test runs.
-                    def runFailingString = ''
+                    // Whether or not this test run should run a specific playlist.
+                    // Only used for long GC tests.
+                    def playlistString = ''
                      
                     if (os == 'Ubuntu' && isPR){
                         serverGCString = '--useServerGC'
@@ -1471,11 +1470,9 @@ combinedScenarios.each { scenario ->
                         // the only test running (many of them allocate until OOM).
                         sequentialString = '--sequential'
                         
-                        // Long GC tests all exist in the ignore list because
-                        // they can't run during normal test runs. This is not
-                        // particularly pretty but, until we get a more generalized
-                        // mechanism for coming up with test playlists, it works.
-                        runFailingString = '--runFailingTestsOnly'
+                        // The Long GC playlist contains all of the tests that are
+                        // going to be run.
+                        playlistString = '--playlist ./tests/longRunningGcTests.txt'
                     }
                     
 
@@ -1613,7 +1610,7 @@ combinedScenarios.each { scenario ->
                 --mscorlibDir=\"\${WORKSPACE}/bin/Product/${osGroup}.${architecture}.${configuration}\" \\
                 --coreFxBinDir=\"\${WORKSPACE}/bin/${osGroup}.AnyCPU.Release\" \\
                 --coreFxNativeBinDir=\"\${WORKSPACE}/bin/${osGroup}.${architecture}.Release\" \\
-                ${testEnvOpt} ${serverGCString} ${crossgenStr} ${sequentialString} ${runFailingString}""")
+                ${testEnvOpt} ${serverGCString} ${crossgenStr} ${sequentialString} ${playlistString}""")
                             }
                         }
                     }

--- a/tests/longRunningGcTests.txt
+++ b/tests/longRunningGcTests.txt
@@ -1,0 +1,9 @@
+GC/Features/BackgroundGC/concurrentspin2/concurrentspin2.sh
+GC/Features/LOHCompaction/lohcompactapi2/lohcompactapi2.sh
+GC/Features/LOHCompaction/lohcompactscenariorepro/lohcompactscenariorepro.sh
+GC/Features/LOHCompaction/lohcompact_stress/lohcompact_stress.sh
+GC/Features/PartialCompaction/eco1/eco1.sh
+GC/Features/PartialCompaction/partialcompactiontest/partialcompactiontest.sh
+GC/Features/PartialCompaction/partialcompactionwloh/partialcompactionwloh.sh
+GC/Features/SustainedLowLatency/sustainedlowlatency_race_reverse/sustainedlowlatency_race_reverse.sh
+GC/Features/SustainedLowLatency/sustainedlowlatency_race/sustainedlowlatency_race.sh

--- a/tests/src/CLRTest.Execute.Bash.targets
+++ b/tests/src/CLRTest.Execute.Bash.targets
@@ -165,10 +165,6 @@ then
   exit 0
 fi
       ]]></BashCLRTestEnvironmentCompatibilityCheck>
-      <BashCLRTestGCLongTestSkipCondition Condition="'$(GCLongRunning)' == 'true' And '$(IsLongRunningGCTest)' != 'true'"><![CDATA[
-echo Skipping execution because this is not a long-running GC test
-exit 0
-      ]]></BashCLRTestGCLongTestSkipCondition>
       <BashCLRTestExitCodePrep Condition="$(_CLRTestNeedsToRun)">
 <![CDATA[CLRTestExpectedExitCode=$(CLRTestExitCode)
 echo BEGIN EXECUTION]]>
@@ -316,7 +312,6 @@ $__TestEnv
 
 $(BashEnvironmentVariables)
 $(BashCLRTestEnvironmentCompatibilityCheck)
-$(BashCLRTestGCLongTestSkipCondition)
 $(BashCLRTestArgPrep)
 $(BashCLRTestExitCodePrep)
 # CrossGen Script (when /p:CrossGen=true)


### PR DESCRIPTION
This PR adds a `--playlists` flag to `runtests.sh` that will accept a file of tests and run exactly the tests specified in that file. This PR also ports the existing Long GC test playlist to use the `--playlist` option in CI. The behavior should be the same - only the command-line invocation has changed.