### PR TITLE
Fix #3570: RyuJIT x86: Float/Double mismatch in CodeGen::genStoreInd()

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2621,12 +2621,12 @@ GenTreePtr  Compiler::impImplicitIorI4Cast(GenTreePtr  tree,
 GenTreePtr  Compiler::impImplicitR4orR8Cast(GenTreePtr  tree,
                                             var_types   dstTyp)
 {
-#ifdef _TARGET_64BIT_
+#ifndef LEGACY_BACKEND
    if (varTypeIsFloating(tree) && varTypeIsFloating(dstTyp) && (dstTyp != tree->gtType))
    {
        tree = gtNewCastNode(dstTyp, tree, dstTyp);
    }
-#endif // _TARGET_64BIT_
+#endif // !LEGACY_BACKEND
 
     return tree;
 }
@@ -9818,7 +9818,7 @@ ARR_LD_POST_VERIFY:
                 {
                     arrayElem = typeInfo::nativeInt();
                 }
-#endif // _TARGET_64_BIT
+#endif // _TARGET_64BIT_
                 Verify(tiArray.IsNullObjRef() ||
                        typeInfo::AreEquivalent(verGetArrayElemType(tiArray), arrayElem), "bad array");
 
@@ -9887,7 +9887,6 @@ ARR_LD_POST_VERIFY:
             }
             else
             {
-                // On Amd64 add an explicit cast between float and double
                 op2 = impImplicitR4orR8Cast(op2, op1->TypeGet());
                 op1 = gtNewAssignNode(op1, op2);
             }
@@ -10822,7 +10821,6 @@ STIND_POST_VERIFY:
 
             impBashVarAddrsToI(op1, op2);
 
-            // On Amd64 add an explicit cast between float and double
             op2 = impImplicitR4orR8Cast(op2, lclTyp);
 
 #ifdef _TARGET_64BIT_


### PR DESCRIPTION
There is code in the importer to insert explicit converts between float and double
but it was only running for `_TARGET_64BIT_`. I changed this to a more appropriate
`!_LEGACY_BACKEND_`.