### PR TITLE
ARM64: Fix Frame with VarArg

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -1135,6 +1135,12 @@ void                CodeGen::genCaptureFuncletPrologEpilogInfo()
 
     unsigned saveRegsCount = genCountBits(rsMaskSaveRegs);
     unsigned saveRegsPlusPSPSize = saveRegsCount * REGSIZE_BYTES + /* PSPSym */ REGSIZE_BYTES;
+    if (compiler->info.compIsVarArgs)
+    {
+        // For varargs we always save all of the integer register arguments
+        // so that they are contiguous with the incoming stack arguments.
+        saveRegsPlusPSPSize += MAX_REG_ARG * REGSIZE_BYTES;
+    }
     unsigned saveRegsPlusPSPSizeAligned = (unsigned)roundUp(saveRegsPlusPSPSize, STACK_ALIGN);
 
     assert(compiler->lvaOutgoingArgSpaceSize % REGSIZE_BYTES == 0);

--- a/src/jit/codegencommon.cpp
+++ b/src/jit/codegencommon.cpp
@@ -3099,7 +3099,10 @@ void                CodeGen::genGenerateCode(void * * codePtr,
     trackedStackPtrsContig = false;
 #elif defined(_TARGET_ARM_)
     // On arm due to prespilling of arguments, tracked stk-ptrs may not be contiguous
-    trackedStackPtrsContig = !compiler->opts.compDbgEnC && !compiler->compIsProfilerHookNeeded();  
+    trackedStackPtrsContig = !compiler->opts.compDbgEnC && !compiler->compIsProfilerHookNeeded();
+#elif defined(_TARGET_ARM64_)
+    // Incoming vararg registers are homed on the top of the stack. Tracked var may not be contiguous.
+    trackedStackPtrsContig = !compiler->opts.compDbgEnC && !compiler->info.compIsVarArgs;
 #else
     trackedStackPtrsContig = !compiler->opts.compDbgEnC;
 #endif

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -3980,7 +3980,7 @@ RelativePath=JIT\Directed\prefix\unaligned\1\arglist\arglist.cmd
 WorkingDir=JIT\Directed\prefix\unaligned\1\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_4424
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [array_tests.cmd_585]
 RelativePath=JIT\Directed\prefix\unaligned\1\array_tests\array_tests.cmd
@@ -4085,7 +4085,7 @@ RelativePath=JIT\Directed\prefix\unaligned\2\arglist\arglist.cmd
 WorkingDir=JIT\Directed\prefix\unaligned\2\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_4424
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [array_tests.cmd_600]
 RelativePath=JIT\Directed\prefix\unaligned\2\array_tests\array_tests.cmd
@@ -4183,7 +4183,7 @@ RelativePath=JIT\Directed\prefix\unaligned\4\arglist\arglist.cmd
 WorkingDir=JIT\Directed\prefix\unaligned\4\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_4424
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [array_tests.cmd_614]
 RelativePath=JIT\Directed\prefix\unaligned\4\array_tests\array_tests.cmd
@@ -4288,7 +4288,7 @@ RelativePath=JIT\Directed\prefix\volatile\1\arglist\arglist.cmd
 WorkingDir=JIT\Directed\prefix\volatile\1\arglist
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [array_tests.cmd_629]
 RelativePath=JIT\Directed\prefix\volatile\1\array_tests\array_tests.cmd


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/4424
JIT homes incoming vararg (8) registers to the top of the stack.
When stack location is computed for local vars, JIT didn't
take it into consideration causing the overlapped stack
offsets for local vars and varargs. The stack offsets of local vars
corresponding to varargs should point to this home area instead of
the newly alloacted slot.