### PR TITLE
Block Ops Refactor

### DIFF
--- a/src/jit/codegenclassic.h
+++ b/src/jit/codegenclassic.h
@@ -286,6 +286,9 @@
                                                              regMaskTP  destReg,
                                                              regMaskTP  bestReg);
 
+    void                genCodeForBlkOp                     (GenTreePtr tree,
+                                                             regMaskTP  destReg);
+
     void                genCodeForTreeSmpOp (GenTreePtr     tree,
                                              regMaskTP      destReg,
                                              regMaskTP      bestReg = RBM_NONE);

--- a/src/jit/codegenlegacy.cpp
+++ b/src/jit/codegenlegacy.cpp
@@ -8853,7 +8853,664 @@ void                CodeGen::genCodeForRelop(GenTreePtr tree,
     genCodeForTree_DONE(tree, reg);
 }
 
+void                CodeGen::genCodeForBlkOp(GenTreePtr tree,
+                                             regMaskTP  destReg)
+{
+    genTreeOps      oper     = tree->OperGet();
+    GenTreePtr      op1      = tree->gtOp.gtOp1;
+    GenTreePtr      op2      = tree->gtGetOp2();
+    regMaskTP       needReg  = destReg;
+    regMaskTP       regs     = regSet.rsMaskUsed;
+    GenTreePtr      opsPtr[3];
+    regMaskTP       regsPtr[3];
 
+    noway_assert(oper == GT_COPYBLK || oper == GT_INITBLK);
+    noway_assert(op1->IsList());
+
+#ifdef _TARGET_ARM_
+    if (tree->AsBlkOp()->IsVolatile())
+    {
+        // Emit a memory barrier instruction before the InitBlk/CopyBlk
+        instGen_MemoryBarrier();
+    }
+#endif
+    {
+        GenTreePtr destPtr, srcPtrOrVal;
+        destPtr = op1->gtOp.gtOp1;
+        srcPtrOrVal = op1->gtOp.gtOp2;
+        noway_assert(destPtr->TypeGet() == TYP_BYREF || varTypeIsIntegral(destPtr->TypeGet()));
+        noway_assert((oper == GT_COPYBLK &&
+            (srcPtrOrVal->TypeGet() == TYP_BYREF || varTypeIsIntegral(srcPtrOrVal->TypeGet())))
+            ||
+            (oper == GT_INITBLK &&
+            varTypeIsIntegral(srcPtrOrVal->TypeGet())));
+
+        noway_assert(op1 && op1->IsList());
+        noway_assert(destPtr && srcPtrOrVal);
+
+#if CPU_USES_BLOCK_MOVE 
+        regs = (oper == GT_INITBLK) ? RBM_EAX : RBM_ESI;   // What is the needReg for Val/Src
+
+        /* Some special code for block moves/inits for constant sizes */
+
+        //
+        // Is this a fixed size COPYBLK?
+        //      or a fixed size INITBLK with a constant init value?
+        //
+        if ((op2->IsCnsIntOrI()) &&
+            ((oper == GT_COPYBLK) || (srcPtrOrVal->IsCnsIntOrI())))
+        {
+            size_t length = (size_t)op2->gtIntCon.gtIconVal;
+            size_t initVal = 0;
+            instruction ins_P, ins_PR, ins_B;
+
+            if (oper == GT_INITBLK)
+            {
+                ins_P = INS_stosp;
+                ins_PR = INS_r_stosp;
+                ins_B = INS_stosb;
+
+                /* Properly extend the init constant from a U1 to a U4 */
+                initVal = 0xFF & ((unsigned)op1->gtOp.gtOp2->gtIntCon.gtIconVal);
+
+                /* If it is a non-zero value we have to replicate      */
+                /* the byte value four times to form the DWORD         */
+                /* Then we change this new value into the tree-node      */
+
+                if (initVal)
+                {
+                    initVal = initVal | (initVal << 8) | (initVal << 16) | (initVal << 24);
+#ifdef _TARGET_64BIT_
+                    if (length > 4)
+                    {
+                        initVal = initVal | (initVal << 32);
+                        op1->gtOp.gtOp2->gtType = TYP_LONG;
+                    }
+                    else
+                    {
+                        op1->gtOp.gtOp2->gtType = TYP_INT;
+                    }
+#endif // _TARGET_64BIT_
+                }
+                op1->gtOp.gtOp2->gtIntCon.gtIconVal = initVal;
+            }
+            else
+            {
+                ins_P = INS_movsp;
+                ins_PR = INS_r_movsp;
+                ins_B = INS_movsb;
+            }
+
+            // Determine if we will be using SSE2
+            unsigned movqLenMin = 8;
+            unsigned movqLenMax = 24;
+
+            bool bWillUseSSE2 = false;
+            bool bWillUseOnlySSE2 = false;
+            bool bNeedEvaluateCnst = true;   // If we only use SSE2, we will just load the constant there. 
+
+#ifdef _TARGET_64BIT_
+
+            // Until we get SSE2 instructions that move 16 bytes at a time instead of just 8
+            // there is no point in wasting space on the bigger instructions
+
+#else // !_TARGET_64BIT_
+
+            if (compiler->opts.compCanUseSSE2)
+            {
+                unsigned curBBweight = compiler->compCurBB->getBBWeight(compiler);
+
+                /* Adjust for BB weight */
+                if (curBBweight == BB_ZERO_WEIGHT)
+                {
+                    // Don't bother with this optimization in
+                    // rarely run blocks
+                    movqLenMax = movqLenMin = 0;
+                }
+                else if (curBBweight < BB_UNITY_WEIGHT)
+                {
+                    // Be less aggressive when we are inside a conditional
+                    movqLenMax = 16;
+                }
+                else if (curBBweight >= (BB_LOOP_WEIGHT*BB_UNITY_WEIGHT) / 2)
+                {
+                    // Be more aggressive when we are inside a loop
+                    movqLenMax = 48;
+                }
+
+                if ((compiler->compCodeOpt() == Compiler::FAST_CODE) || (oper == GT_INITBLK))
+                {
+                    // Be more aggressive when optimizing for speed
+                    // InitBlk uses fewer instructions
+                    movqLenMax += 16;
+                }
+
+                if (compiler->compCodeOpt() != Compiler::SMALL_CODE &&
+                    length >= movqLenMin &&
+                    length <= movqLenMax)
+                {
+                    bWillUseSSE2 = true;
+
+                    if ((length % 8) == 0)
+                    {
+                        bWillUseOnlySSE2 = true;
+                        if (oper == GT_INITBLK && (initVal == 0))
+                        {
+                            bNeedEvaluateCnst = false;
+                            noway_assert((op1->gtOp.gtOp2->OperGet() == GT_CNS_INT));
+                        }
+                    }
+                }
+            }
+
+#endif // !_TARGET_64BIT_
+
+            const bool bWillTrashRegSrc = ((oper == GT_COPYBLK) && !bWillUseOnlySSE2);
+            /* Evaluate dest and src/val */
+
+            if (op1->gtFlags & GTF_REVERSE_OPS)
+            {
+                if (bNeedEvaluateCnst)
+                {
+                    genComputeReg(op1->gtOp.gtOp2, regs, RegSet::EXACT_REG, RegSet::KEEP_REG, bWillTrashRegSrc);
+                }
+                genComputeReg(op1->gtOp.gtOp1, RBM_EDI, RegSet::EXACT_REG, RegSet::KEEP_REG, !bWillUseOnlySSE2);
+                if (bNeedEvaluateCnst)
+                {
+                    genRecoverReg(op1->gtOp.gtOp2, regs, RegSet::KEEP_REG);
+                }
+            }
+            else
+            {
+                genComputeReg(op1->gtOp.gtOp1, RBM_EDI, RegSet::EXACT_REG, RegSet::KEEP_REG, !bWillUseOnlySSE2);
+                if (bNeedEvaluateCnst)
+                {
+                    genComputeReg(op1->gtOp.gtOp2, regs, RegSet::EXACT_REG, RegSet::KEEP_REG, bWillTrashRegSrc);
+                }
+                genRecoverReg(op1->gtOp.gtOp1, RBM_EDI, RegSet::KEEP_REG);
+            }
+
+            bool bTrashedESI = false;
+            bool bTrashedEDI = false;
+
+            if (bWillUseSSE2)
+            {
+                int      blkDisp = 0;
+                regNumber xmmReg = REG_XMM0;
+
+                if (oper == GT_INITBLK)
+                {
+                    if (initVal)
+                    {
+                        getEmitter()->emitIns_R_R(INS_mov_i2xmm, EA_4BYTE, xmmReg, REG_EAX);
+                        getEmitter()->emitIns_R_R(INS_punpckldq, EA_4BYTE, xmmReg, xmmReg);
+                    }
+                    else
+                    {
+                        getEmitter()->emitIns_R_R(INS_xorps, EA_8BYTE, xmmReg, xmmReg);
+                    }
+                }
+
+                JITLOG_THIS(compiler, (LL_INFO100, "Using XMM instructions for %3d byte %s while compiling %s\n",
+                    length, (oper == GT_INITBLK) ? "initblk" : "copyblk", compiler->info.compFullName));
+
+                while (length > 7)
+                {
+                    if (oper == GT_INITBLK)
+                    {
+                        getEmitter()->emitIns_AR_R(INS_movq, EA_8BYTE, xmmReg, REG_EDI, blkDisp);
+                    }
+                    else
+                    {
+                        getEmitter()->emitIns_R_AR(INS_movq, EA_8BYTE, xmmReg, REG_ESI, blkDisp);
+                        getEmitter()->emitIns_AR_R(INS_movq, EA_8BYTE, xmmReg, REG_EDI, blkDisp);
+                    }
+                    blkDisp += 8;
+                    length -= 8;
+                }
+
+                if (length > 0)
+                {
+                    noway_assert(bNeedEvaluateCnst);
+                    noway_assert(!bWillUseOnlySSE2);
+
+                    if (oper == GT_COPYBLK)
+                    {
+                        inst_RV_IV(INS_add, REG_ESI, blkDisp, emitActualTypeSize(srcPtrOrVal->TypeGet()));
+                        bTrashedESI = true;
+                    }
+
+                    inst_RV_IV(INS_add, REG_EDI, blkDisp, emitActualTypeSize(destPtr->TypeGet()));
+                    bTrashedEDI = true;
+
+                    if (length >= REGSIZE_BYTES)
+                    {
+                        instGen(ins_P);
+                        length -= REGSIZE_BYTES;
+                    }
+                }
+            }
+            else if (compiler->compCodeOpt() == Compiler::SMALL_CODE)
+            {
+                /* For small code, we can only use ins_DR to generate fast
+                    and small code. We also can't use "rep movsb" because
+                    we may not atomically reading and writing the DWORD */
+
+                noway_assert(bNeedEvaluateCnst);
+
+                goto USE_DR;
+            }
+            else if (length <= 4 * REGSIZE_BYTES)
+            {
+                noway_assert(bNeedEvaluateCnst);
+
+                while (length >= REGSIZE_BYTES)
+                {
+                    instGen(ins_P);
+                    length -= REGSIZE_BYTES;
+                }
+
+                bTrashedEDI = true;
+                if (oper == GT_COPYBLK)
+                    bTrashedESI = true;
+            }
+            else
+            {
+            USE_DR:
+                noway_assert(bNeedEvaluateCnst);
+
+                /* set ECX to length/REGSIZE_BYTES (in pointer-sized words) */
+                genSetRegToIcon(REG_ECX, length / REGSIZE_BYTES, TYP_I_IMPL);
+
+                length &= (REGSIZE_BYTES - 1);
+
+                instGen(ins_PR);
+
+                regTracker.rsTrackRegTrash(REG_ECX);
+
+                bTrashedEDI = true;
+                if (oper == GT_COPYBLK)
+                    bTrashedESI = true;
+            }
+
+            /* Now take care of the remainder */
+
+#ifdef _TARGET_64BIT_
+            if (length > 4)
+            {
+                noway_assert(bNeedEvaluateCnst);
+                noway_assert(length < 8);
+
+                instGen((oper == GT_INITBLK) ? INS_stosd : INS_movsd);
+                length -= 4;
+
+                bTrashedEDI = true;
+                if (oper == GT_COPYBLK)
+                    bTrashedESI = true;
+            }
+
+#endif // _TARGET_64BIT_
+
+            if (length)
+            {
+                noway_assert(bNeedEvaluateCnst);
+
+                while (length--)
+                {
+                    instGen(ins_B);
+                }
+
+                bTrashedEDI = true;
+                if (oper == GT_COPYBLK)
+                    bTrashedESI = true;
+            }
+
+            noway_assert(bTrashedEDI == !bWillUseOnlySSE2);
+            if (bTrashedEDI)
+                regTracker.rsTrackRegTrash(REG_EDI);
+            if (bTrashedESI)
+                regTracker.rsTrackRegTrash(REG_ESI);
+            // else No need to trash EAX as it wasnt destroyed by the "rep stos"
+
+            genReleaseReg(op1->gtOp.gtOp1);
+            if (bNeedEvaluateCnst) genReleaseReg(op1->gtOp.gtOp2);
+
+        }
+        else
+        {
+            //
+            // This a variable-sized COPYBLK/INITBLK,
+            //   or a fixed size INITBLK with a variable init value,
+            //
+
+            // What order should the Dest, Val/Src, and Size be calculated
+
+            compiler->fgOrderBlockOps(tree, RBM_EDI, regs, RBM_ECX,
+                opsPtr, regsPtr); // OUT arguments
+
+            noway_assert(((oper == GT_INITBLK) && (regs == RBM_EAX)) || ((oper == GT_COPYBLK) && (regs == RBM_ESI)));
+            genComputeReg(opsPtr[0], regsPtr[0], RegSet::EXACT_REG, RegSet::KEEP_REG, (regsPtr[0] != RBM_EAX));
+            genComputeReg(opsPtr[1], regsPtr[1], RegSet::EXACT_REG, RegSet::KEEP_REG, (regsPtr[1] != RBM_EAX));
+            genComputeReg(opsPtr[2], regsPtr[2], RegSet::EXACT_REG, RegSet::KEEP_REG, (regsPtr[2] != RBM_EAX));
+
+            genRecoverReg(opsPtr[0], regsPtr[0], RegSet::KEEP_REG);
+            genRecoverReg(opsPtr[1], regsPtr[1], RegSet::KEEP_REG);
+
+            noway_assert((op1->gtOp.gtOp1->gtFlags & GTF_REG_VAL) &&  // Dest
+                (op1->gtOp.gtOp1->gtRegNum == REG_EDI));
+
+            noway_assert((op1->gtOp.gtOp2->gtFlags & GTF_REG_VAL) &&  // Val/Src
+                (genRegMask(op1->gtOp.gtOp2->gtRegNum) == regs));
+
+            noway_assert((op2->gtFlags & GTF_REG_VAL) &&              // Size
+                (op2->gtRegNum == REG_ECX));
+
+            if (oper == GT_INITBLK)
+                instGen(INS_r_stosb);
+            else
+                instGen(INS_r_movsb);
+
+            regTracker.rsTrackRegTrash(REG_EDI);
+            regTracker.rsTrackRegTrash(REG_ECX);
+
+            if (oper == GT_COPYBLK)
+                regTracker.rsTrackRegTrash(REG_ESI);
+            // else No need to trash EAX as it wasnt destroyed by the "rep stos"
+
+            genReleaseReg(opsPtr[0]);
+            genReleaseReg(opsPtr[1]);
+            genReleaseReg(opsPtr[2]);
+        }
+
+#else // !CPU_USES_BLOCK_MOVE 
+
+#ifndef _TARGET_ARM_
+        // Currently only the ARM implementation is provided
+#error "COPYBLK/INITBLK non-ARM && non-CPU_USES_BLOCK_MOVE"
+#endif
+        //
+        // Is this a fixed size COPYBLK?
+        //      or a fixed size INITBLK with a constant init value?
+        //
+        if ((op2->OperGet() == GT_CNS_INT) &&
+            ((oper == GT_COPYBLK) || (srcPtrOrVal->OperGet() == GT_CNS_INT)))
+        {
+            GenTreePtr  dstOp = op1->gtOp.gtOp1;
+            GenTreePtr  srcOp = op1->gtOp.gtOp2;
+            unsigned    length = (unsigned)op2->gtIntCon.gtIconVal;
+            unsigned    fullStoreCount = length / TARGET_POINTER_SIZE;
+            unsigned    initVal = 0;
+            bool        useLoop = false;
+
+            if (oper == GT_INITBLK)
+            {
+                /* Properly extend the init constant from a U1 to a U4 */
+                initVal = 0xFF & ((unsigned)srcOp->gtIntCon.gtIconVal);
+
+                /* If it is a non-zero value we have to replicate      */
+                /* the byte value four times to form the DWORD         */
+                /* Then we store this new value into the tree-node      */
+
+                if (initVal != 0)
+                {
+                    initVal = initVal | (initVal << 8) | (initVal << 16) | (initVal << 24);
+                    op1->gtOp.gtOp2->gtIntCon.gtIconVal = initVal;
+                }
+            }
+
+            // Will we be using a loop to implement this INITBLK/COPYBLK?
+            if (((oper == GT_COPYBLK) && (fullStoreCount >= 8)) ||
+                ((oper == GT_INITBLK) && (fullStoreCount >= 16)))
+            {
+                useLoop = true;
+            }
+
+            regMaskTP    usedRegs;
+            regNumber    regDst;
+            regNumber    regSrc;
+            regNumber    regTemp;
+
+            /* Evaluate dest and src/val */
+
+            if (op1->gtFlags & GTF_REVERSE_OPS)
+            {
+                genComputeReg(srcOp, (needReg & ~dstOp->gtRsvdRegs), RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
+                assert(srcOp->gtFlags & GTF_REG_VAL);
+
+                genComputeReg(dstOp, needReg, RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
+                assert(dstOp->gtFlags & GTF_REG_VAL);
+                regDst = dstOp->gtRegNum;
+
+                genRecoverReg(srcOp, needReg, RegSet::KEEP_REG);
+                regSrc = srcOp->gtRegNum;
+            }
+            else
+            {
+                genComputeReg(dstOp, (needReg & ~srcOp->gtRsvdRegs), RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
+                assert(dstOp->gtFlags & GTF_REG_VAL);
+
+                genComputeReg(srcOp, needReg, RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
+                assert(srcOp->gtFlags & GTF_REG_VAL);
+                regSrc = srcOp->gtRegNum;
+
+                genRecoverReg(dstOp, needReg, RegSet::KEEP_REG);
+                regDst = dstOp->gtRegNum;
+            }
+            assert(dstOp->gtFlags & GTF_REG_VAL);
+            assert(srcOp->gtFlags & GTF_REG_VAL);
+
+            regDst = dstOp->gtRegNum;
+            regSrc = srcOp->gtRegNum;
+            usedRegs = (genRegMask(regSrc) | genRegMask(regDst));
+            bool dstIsOnStack = (dstOp->gtOper == GT_ADDR && (dstOp->gtFlags & GTF_ADDR_ONSTACK));
+            emitAttr dstType = (varTypeIsGC(dstOp) && !dstIsOnStack) ? EA_BYREF : EA_PTRSIZE;
+            emitAttr srcType;
+
+            if (oper == GT_COPYBLK)
+            {
+                // Prefer a low register,but avoid one of the ones we've already grabbed
+                regTemp = regSet.rsGrabReg(regSet.rsNarrowHint(regSet.rsRegMaskCanGrab() & ~usedRegs, RBM_LOW_REGS));
+                usedRegs |= genRegMask(regTemp);
+                bool srcIsOnStack = (srcOp->gtOper == GT_ADDR && (srcOp->gtFlags & GTF_ADDR_ONSTACK));
+                srcType = (varTypeIsGC(srcOp) && !srcIsOnStack) ? EA_BYREF : EA_PTRSIZE;
+            }
+            else
+            {
+                regTemp = REG_STK;
+                srcType = EA_PTRSIZE;
+            }
+
+            instruction  loadIns = ins_Load(TYP_I_IMPL);   // INS_ldr
+            instruction  storeIns = ins_Store(TYP_I_IMPL);  // INS_str
+
+            int       finalOffset;
+
+            // Can we emit a small number of ldr/str instructions to implement this INITBLK/COPYBLK?
+            if (!useLoop)
+            {
+                for (unsigned i = 0; i < fullStoreCount; i++)
+                {
+                    if (oper == GT_COPYBLK)
+                    {
+                        getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp, regSrc, i * TARGET_POINTER_SIZE);
+                        getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp, regDst, i * TARGET_POINTER_SIZE);
+                        gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
+                        regTracker.rsTrackRegTrash(regTemp);
+                    }
+                    else
+                    {
+                        getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, i * TARGET_POINTER_SIZE);
+                    }
+                }
+
+                finalOffset = fullStoreCount * TARGET_POINTER_SIZE;
+                length -= finalOffset;
+            }
+            else  // We will use a loop to implement this INITBLK/COPYBLK
+            {
+                unsigned   pairStoreLoopCount = fullStoreCount / 2;
+
+                // We need a second temp register for CopyBlk
+                regNumber  regTemp2 = REG_STK;
+                if (oper == GT_COPYBLK)
+                {
+                    // Prefer a low register, but avoid one of the ones we've already grabbed
+                    regTemp2 = regSet.rsGrabReg(regSet.rsNarrowHint(regSet.rsRegMaskCanGrab() & ~usedRegs, RBM_LOW_REGS));
+                    usedRegs |= genRegMask(regTemp2);
+                }
+
+                // Pick and initialize the loop counter register
+                regNumber regLoopIndex;
+                regLoopIndex = regSet.rsGrabReg(regSet.rsNarrowHint(regSet.rsRegMaskCanGrab() & ~usedRegs, RBM_LOW_REGS));
+                genSetRegToIcon(regLoopIndex, pairStoreLoopCount, TYP_INT);
+
+                // Create and define the Basic Block for the loop top
+                BasicBlock * loopTopBlock = genCreateTempLabel();
+                genDefineTempLabel(loopTopBlock);
+
+                // The loop body
+                if (oper == GT_COPYBLK)
+                {
+                    getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp, regSrc, 0);
+                    getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp2, regSrc, TARGET_POINTER_SIZE);
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp, regDst, 0);
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp2, regDst, TARGET_POINTER_SIZE);
+                    getEmitter()->emitIns_R_I(INS_add, srcType, regSrc, 2 * TARGET_POINTER_SIZE);
+                    gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
+                    gcInfo.gcMarkRegSetNpt(genRegMask(regTemp2));
+                    regTracker.rsTrackRegTrash(regSrc);
+                    regTracker.rsTrackRegTrash(regTemp);
+                    regTracker.rsTrackRegTrash(regTemp2);
+                }
+                else // GT_INITBLK
+                {
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, 0);
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, TARGET_POINTER_SIZE);
+                }
+
+                getEmitter()->emitIns_R_I(INS_add, dstType, regDst, 2 * TARGET_POINTER_SIZE);
+                regTracker.rsTrackRegTrash(regDst);
+                getEmitter()->emitIns_R_I(INS_sub, EA_4BYTE, regLoopIndex, 1, INS_FLAGS_SET);
+                emitJumpKind jmpGTS = genJumpKindForOper(GT_GT, CK_SIGNED);
+                inst_JMP(jmpGTS, loopTopBlock);
+
+                regTracker.rsTrackRegIntCns(regLoopIndex, 0);
+
+                length -= (pairStoreLoopCount * (2 * TARGET_POINTER_SIZE));
+
+                if (length & TARGET_POINTER_SIZE)
+                {
+                    if (oper == GT_COPYBLK)
+                    {
+                        getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp, regSrc, 0);
+                        getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp, regDst, 0);
+                    }
+                    else
+                    {
+                        getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, 0);
+                    }
+                    finalOffset = TARGET_POINTER_SIZE;
+                    length -= TARGET_POINTER_SIZE;
+                }
+                else
+                {
+                    finalOffset = 0;
+                }
+            }
+
+            if (length & sizeof(short))
+            {
+                loadIns = ins_Load(TYP_USHORT);   // INS_ldrh
+                storeIns = ins_Store(TYP_USHORT);  // INS_strh
+
+                if (oper == GT_COPYBLK)
+                {
+                    getEmitter()->emitIns_R_R_I(loadIns, EA_2BYTE, regTemp, regSrc, finalOffset);
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_2BYTE, regTemp, regDst, finalOffset);
+                    gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
+                    regTracker.rsTrackRegTrash(regTemp);
+                }
+                else
+                {
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_2BYTE, regSrc, regDst, finalOffset);
+                }
+                length -= sizeof(short);
+                finalOffset += sizeof(short);
+            }
+
+            if (length & sizeof(char))
+            {
+                loadIns = ins_Load(TYP_UBYTE);   // INS_ldrb
+                storeIns = ins_Store(TYP_UBYTE);  // INS_strb
+
+                if (oper == GT_COPYBLK)
+                {
+                    getEmitter()->emitIns_R_R_I(loadIns, EA_1BYTE, regTemp, regSrc, finalOffset);
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_1BYTE, regTemp, regDst, finalOffset);
+                    gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
+                    regTracker.rsTrackRegTrash(regTemp);
+                }
+                else
+                {
+                    getEmitter()->emitIns_R_R_I(storeIns, EA_1BYTE, regSrc, regDst, finalOffset);
+                }
+                length -= sizeof(char);
+            }
+            assert(length == 0);
+
+            genReleaseReg(dstOp);
+            genReleaseReg(srcOp);
+        }
+        else
+        {
+            //
+            // This a variable-sized COPYBLK/INITBLK,
+            //   or a fixed size INITBLK with a variable init value,
+            //
+
+            // What order should the Dest, Val/Src, and Size be calculated
+
+            compiler->fgOrderBlockOps(tree, RBM_ARG_0, RBM_ARG_1, RBM_ARG_2,
+                opsPtr, regsPtr); // OUT arguments
+
+            genComputeReg(opsPtr[0], regsPtr[0], RegSet::EXACT_REG, RegSet::KEEP_REG);
+            genComputeReg(opsPtr[1], regsPtr[1], RegSet::EXACT_REG, RegSet::KEEP_REG);
+            genComputeReg(opsPtr[2], regsPtr[2], RegSet::EXACT_REG, RegSet::KEEP_REG);
+
+            genRecoverReg(opsPtr[0], regsPtr[0], RegSet::KEEP_REG);
+            genRecoverReg(opsPtr[1], regsPtr[1], RegSet::KEEP_REG);
+
+            noway_assert((op1->gtOp.gtOp1->gtFlags & GTF_REG_VAL) && // Dest
+                (op1->gtOp.gtOp1->gtRegNum == REG_ARG_0));
+
+            noway_assert((op1->gtOp.gtOp2->gtFlags & GTF_REG_VAL) && // Val/Src
+                (op1->gtOp.gtOp2->gtRegNum == REG_ARG_1));
+
+            noway_assert((op2->gtFlags & GTF_REG_VAL) &&             // Size
+                (op2->gtRegNum == REG_ARG_2));
+
+            regSet.rsLockUsedReg(RBM_ARG_0 | RBM_ARG_1 | RBM_ARG_2);
+
+            genEmitHelperCall(oper == GT_COPYBLK ? CORINFO_HELP_MEMCPY
+                /* GT_INITBLK */ : CORINFO_HELP_MEMSET,
+                0, EA_UNKNOWN);
+
+            regTracker.rsTrackRegMaskTrash(RBM_CALLEE_TRASH);
+
+            regSet.rsUnlockUsedReg(RBM_ARG_0 | RBM_ARG_1 | RBM_ARG_2);
+            genReleaseReg(opsPtr[0]);
+            genReleaseReg(opsPtr[1]);
+            genReleaseReg(opsPtr[2]);
+        }
+
+        if ((oper == GT_COPYBLK) && tree->AsBlkOp()->IsVolatile())
+        {
+            // Emit a memory barrier instruction after the CopyBlk 
+            instGen_MemoryBarrier();
+        }
+#endif // !CPU_USES_BLOCK_MOVE 
+    }
+}
 BasicBlock dummyBB;
 
 #ifdef _PREFAST_
@@ -9708,656 +10365,8 @@ void                CodeGen::genCodeForTreeSmpOp(GenTreePtr tree,
         case GT_COPYBLK:
         case GT_INITBLK:
 
-            noway_assert(oper == GT_COPYBLK || oper == GT_INITBLK);
-            noway_assert(op1->IsList());
-
-#ifdef _TARGET_ARM_
-            if (tree->AsBlkOp()->IsVolatile())
-            {
-                // Emit a memory barrier instruction before the InitBlk/CopyBlk
-                instGen_MemoryBarrier();
-            }
-#endif
-            {
-                GenTreePtr destPtr, srcPtrOrVal;
-                destPtr = op1->gtOp.gtOp1;
-                srcPtrOrVal = op1->gtOp.gtOp2;
-                noway_assert(destPtr->TypeGet() == TYP_BYREF || varTypeIsIntegral(destPtr->TypeGet()));
-                noway_assert((oper == GT_COPYBLK &&
-                    (srcPtrOrVal->TypeGet() == TYP_BYREF || varTypeIsIntegral(srcPtrOrVal->TypeGet())))
-                    ||
-                    (oper == GT_INITBLK &&
-                    varTypeIsIntegral(srcPtrOrVal->TypeGet())));
-
-                noway_assert(op1 && op1->IsList());
-                noway_assert(destPtr && srcPtrOrVal);
-
-#if CPU_USES_BLOCK_MOVE 
-                regs = (oper == GT_INITBLK) ? RBM_EAX : RBM_ESI;   // What is the needReg for Val/Src
-
-                /* Some special code for block moves/inits for constant sizes */
-
-                //
-                // Is this a fixed size COPYBLK?
-                //      or a fixed size INITBLK with a constant init value?
-                //
-                if ((op2->IsCnsIntOrI()) &&
-                    ((oper == GT_COPYBLK) || (srcPtrOrVal->IsCnsIntOrI())))
-                {
-                    size_t length = (size_t)op2->gtIntCon.gtIconVal;
-                    size_t initVal = 0;
-                    instruction ins_P, ins_PR, ins_B;
-
-                    if (oper == GT_INITBLK)
-                    {
-                        ins_P = INS_stosp;
-                        ins_PR = INS_r_stosp;
-                        ins_B = INS_stosb;
-
-                        /* Properly extend the init constant from a U1 to a U4 */
-                        initVal = 0xFF & ((unsigned)op1->gtOp.gtOp2->gtIntCon.gtIconVal);
-
-                        /* If it is a non-zero value we have to replicate      */
-                        /* the byte value four times to form the DWORD         */
-                        /* Then we change this new value into the tree-node      */
-
-                        if (initVal)
-                        {
-                            initVal = initVal | (initVal << 8) | (initVal << 16) | (initVal << 24);
-#ifdef _TARGET_64BIT_
-                            if (length > 4)
-                            {
-                                initVal = initVal | (initVal << 32);
-                                op1->gtOp.gtOp2->gtType = TYP_LONG;
-                            }
-                            else
-                            {
-                                op1->gtOp.gtOp2->gtType = TYP_INT;
-                            }
-#endif // _TARGET_64BIT_
-                        }
-                        op1->gtOp.gtOp2->gtIntCon.gtIconVal = initVal;
-                    }
-                    else
-                    {
-                        ins_P = INS_movsp;
-                        ins_PR = INS_r_movsp;
-                        ins_B = INS_movsb;
-                    }
-
-                    // Determine if we will be using SSE2
-                    unsigned movqLenMin = 8;
-                    unsigned movqLenMax = 24;
-
-                    bool bWillUseSSE2 = false;
-                    bool bWillUseOnlySSE2 = false;
-                    bool bNeedEvaluateCnst = true;   // If we only use SSE2, we will just load the constant there. 
-
-#ifdef _TARGET_64BIT_
-
-                    // Until we get SSE2 instructions that move 16 bytes at a time instead of just 8
-                    // there is no point in wasting space on the bigger instructions
-
-#else // !_TARGET_64BIT_
-
-                    if (compiler->opts.compCanUseSSE2)
-                    {
-                        unsigned curBBweight = compiler->compCurBB->getBBWeight(compiler);
-
-                        /* Adjust for BB weight */
-                        if (curBBweight == BB_ZERO_WEIGHT)
-                        {
-                            // Don't bother with this optimization in
-                            // rarely run blocks
-                            movqLenMax = movqLenMin = 0;
-                        }
-                        else if (curBBweight < BB_UNITY_WEIGHT)
-                        {
-                            // Be less aggressive when we are inside a conditional
-                            movqLenMax = 16;
-                        }
-                        else if (curBBweight >= (BB_LOOP_WEIGHT*BB_UNITY_WEIGHT) / 2)
-                        {
-                            // Be more aggressive when we are inside a loop
-                            movqLenMax = 48;
-                        }
-
-                        if ((compiler->compCodeOpt() == Compiler::FAST_CODE) || (oper == GT_INITBLK))
-                        {
-                            // Be more aggressive when optimizing for speed
-                            // InitBlk uses fewer instructions
-                            movqLenMax += 16;
-                        }
-
-                        if (compiler->compCodeOpt() != Compiler::SMALL_CODE &&
-                            length >= movqLenMin &&
-                            length <= movqLenMax)
-                        {
-                            bWillUseSSE2 = true;
-
-                            if ((length % 8) == 0)
-                            {
-                                bWillUseOnlySSE2 = true;
-                                if (oper == GT_INITBLK && (initVal == 0))
-                                {
-                                    bNeedEvaluateCnst = false;
-                                    noway_assert((op1->gtOp.gtOp2->OperGet() == GT_CNS_INT));
-                                }
-                            }
-                        }
-                    }
-
-#endif // !_TARGET_64BIT_
-
-                    const bool bWillTrashRegSrc = ((oper == GT_COPYBLK) && !bWillUseOnlySSE2);
-                    /* Evaluate dest and src/val */
-
-                    if (op1->gtFlags & GTF_REVERSE_OPS)
-                    {
-                        if (bNeedEvaluateCnst)
-                        {
-                            genComputeReg(op1->gtOp.gtOp2, regs, RegSet::EXACT_REG, RegSet::KEEP_REG, bWillTrashRegSrc);
-                        }
-                        genComputeReg(op1->gtOp.gtOp1, RBM_EDI, RegSet::EXACT_REG, RegSet::KEEP_REG, !bWillUseOnlySSE2);
-                        if (bNeedEvaluateCnst)
-                        {
-                            genRecoverReg(op1->gtOp.gtOp2, regs, RegSet::KEEP_REG);
-                        }
-                    }
-                    else
-                    {
-                        genComputeReg(op1->gtOp.gtOp1, RBM_EDI, RegSet::EXACT_REG, RegSet::KEEP_REG, !bWillUseOnlySSE2);
-                        if (bNeedEvaluateCnst)
-                        {
-                            genComputeReg(op1->gtOp.gtOp2, regs, RegSet::EXACT_REG, RegSet::KEEP_REG, bWillTrashRegSrc);
-                        }
-                        genRecoverReg(op1->gtOp.gtOp1, RBM_EDI, RegSet::KEEP_REG);
-                    }
-
-                    bool bTrashedESI = false;
-                    bool bTrashedEDI = false;
-
-                    if (bWillUseSSE2)
-                    {
-                        int      blkDisp = 0;
-                        regNumber xmmReg = REG_XMM0;
-
-                        if (oper == GT_INITBLK)
-                        {
-                            if (initVal)
-                            {
-                                getEmitter()->emitIns_R_R(INS_mov_i2xmm, EA_4BYTE, xmmReg, REG_EAX);
-                                getEmitter()->emitIns_R_R(INS_punpckldq, EA_4BYTE, xmmReg, xmmReg);
-                            }
-                            else
-                            {
-                                getEmitter()->emitIns_R_R(INS_xorps, EA_8BYTE, xmmReg, xmmReg);
-                            }
-                        }
-
-                        JITLOG_THIS(compiler, (LL_INFO100, "Using XMM instructions for %3d byte %s while compiling %s\n",
-                            length, (oper == GT_INITBLK) ? "initblk" : "copyblk", compiler->info.compFullName));
-
-                        while (length > 7)
-                        {
-                            if (oper == GT_INITBLK)
-                            {
-                                getEmitter()->emitIns_AR_R(INS_movq, EA_8BYTE, xmmReg, REG_EDI, blkDisp);
-                            }
-                            else
-                            {
-                                getEmitter()->emitIns_R_AR(INS_movq, EA_8BYTE, xmmReg, REG_ESI, blkDisp);
-                                getEmitter()->emitIns_AR_R(INS_movq, EA_8BYTE, xmmReg, REG_EDI, blkDisp);
-                            }
-                            blkDisp += 8;
-                            length -= 8;
-                        }
-
-                        if (length > 0)
-                        {
-                            noway_assert(bNeedEvaluateCnst);
-                            noway_assert(!bWillUseOnlySSE2);
-
-                            if (oper == GT_COPYBLK)
-                            {
-                                inst_RV_IV(INS_add, REG_ESI, blkDisp, emitActualTypeSize(srcPtrOrVal->TypeGet()));
-                                bTrashedESI = true;
-                            }
-
-                            inst_RV_IV(INS_add, REG_EDI, blkDisp, emitActualTypeSize(destPtr->TypeGet()));
-                            bTrashedEDI = true;
-
-                            if (length >= REGSIZE_BYTES)
-                            {
-                                instGen(ins_P);
-                                length -= REGSIZE_BYTES;
-                            }
-                        }
-                    }
-                    else if (compiler->compCodeOpt() == Compiler::SMALL_CODE)
-                    {
-                        /* For small code, we can only use ins_DR to generate fast
-                           and small code. We also can't use "rep movsb" because
-                           we may not atomically reading and writing the DWORD */
-
-                        noway_assert(bNeedEvaluateCnst);
-
-                        goto USE_DR;
-                    }
-                    else if (length <= 4 * REGSIZE_BYTES)
-                    {
-                        noway_assert(bNeedEvaluateCnst);
-
-                        while (length >= REGSIZE_BYTES)
-                        {
-                            instGen(ins_P);
-                            length -= REGSIZE_BYTES;
-                        }
-
-                        bTrashedEDI = true;
-                        if (oper == GT_COPYBLK)
-                            bTrashedESI = true;
-                    }
-                    else
-                    {
-                    USE_DR:
-                        noway_assert(bNeedEvaluateCnst);
-
-                        /* set ECX to length/REGSIZE_BYTES (in pointer-sized words) */
-                        genSetRegToIcon(REG_ECX, length / REGSIZE_BYTES, TYP_I_IMPL);
-
-                        length &= (REGSIZE_BYTES - 1);
-
-                        instGen(ins_PR);
-
-                        regTracker.rsTrackRegTrash(REG_ECX);
-
-                        bTrashedEDI = true;
-                        if (oper == GT_COPYBLK)
-                            bTrashedESI = true;
-                    }
-
-                    /* Now take care of the remainder */
-
-#ifdef _TARGET_64BIT_
-                    if (length > 4)
-                    {
-                        noway_assert(bNeedEvaluateCnst);
-                        noway_assert(length < 8);
-
-                        instGen((oper == GT_INITBLK) ? INS_stosd : INS_movsd);
-                        length -= 4;
-
-                        bTrashedEDI = true;
-                        if (oper == GT_COPYBLK)
-                            bTrashedESI = true;
-                    }
-
-#endif // _TARGET_64BIT_
-
-                    if (length)
-                    {
-                        noway_assert(bNeedEvaluateCnst);
-
-                        while (length--)
-                        {
-                            instGen(ins_B);
-                        }
-
-                        bTrashedEDI = true;
-                        if (oper == GT_COPYBLK)
-                            bTrashedESI = true;
-                    }
-
-                    noway_assert(bTrashedEDI == !bWillUseOnlySSE2);
-                    if (bTrashedEDI)
-                        regTracker.rsTrackRegTrash(REG_EDI);
-                    if (bTrashedESI)
-                        regTracker.rsTrackRegTrash(REG_ESI);
-                    // else No need to trash EAX as it wasnt destroyed by the "rep stos"
-
-                    genReleaseReg(op1->gtOp.gtOp1);
-                    if (bNeedEvaluateCnst) genReleaseReg(op1->gtOp.gtOp2);
-
-                }
-                else
-                {
-                    //
-                    // This a variable-sized COPYBLK/INITBLK,
-                    //   or a fixed size INITBLK with a variable init value,
-                    //
-
-                    // What order should the Dest, Val/Src, and Size be calculated
-
-                    compiler->fgOrderBlockOps(tree, RBM_EDI, regs, RBM_ECX,
-                        opsPtr, regsPtr); // OUT arguments
-
-                    noway_assert(((oper == GT_INITBLK) && (regs == RBM_EAX)) || ((oper == GT_COPYBLK) && (regs == RBM_ESI)));
-                    genComputeReg(opsPtr[0], regsPtr[0], RegSet::EXACT_REG, RegSet::KEEP_REG, (regsPtr[0] != RBM_EAX));
-                    genComputeReg(opsPtr[1], regsPtr[1], RegSet::EXACT_REG, RegSet::KEEP_REG, (regsPtr[1] != RBM_EAX));
-                    genComputeReg(opsPtr[2], regsPtr[2], RegSet::EXACT_REG, RegSet::KEEP_REG, (regsPtr[2] != RBM_EAX));
-
-                    genRecoverReg(opsPtr[0], regsPtr[0], RegSet::KEEP_REG);
-                    genRecoverReg(opsPtr[1], regsPtr[1], RegSet::KEEP_REG);
-
-                    noway_assert((op1->gtOp.gtOp1->gtFlags & GTF_REG_VAL) &&  // Dest
-                        (op1->gtOp.gtOp1->gtRegNum == REG_EDI));
-
-                    noway_assert((op1->gtOp.gtOp2->gtFlags & GTF_REG_VAL) &&  // Val/Src
-                        (genRegMask(op1->gtOp.gtOp2->gtRegNum) == regs));
-
-                    noway_assert((op2->gtFlags & GTF_REG_VAL) &&              // Size
-                        (op2->gtRegNum == REG_ECX));
-
-                    if (oper == GT_INITBLK)
-                        instGen(INS_r_stosb);
-                    else
-                        instGen(INS_r_movsb);
-
-                    regTracker.rsTrackRegTrash(REG_EDI);
-                    regTracker.rsTrackRegTrash(REG_ECX);
-
-                    if (oper == GT_COPYBLK)
-                        regTracker.rsTrackRegTrash(REG_ESI);
-                    // else No need to trash EAX as it wasnt destroyed by the "rep stos"
-
-                    genReleaseReg(opsPtr[0]);
-                    genReleaseReg(opsPtr[1]);
-                    genReleaseReg(opsPtr[2]);
-                }
-
-#else // !CPU_USES_BLOCK_MOVE 
-
-#ifndef _TARGET_ARM_
-                // Currently only the ARM implementation is provided
-#error "COPYBLK/INITBLK non-ARM && non-CPU_USES_BLOCK_MOVE"
-#endif
-                //
-                // Is this a fixed size COPYBLK?
-                //      or a fixed size INITBLK with a constant init value?
-                //
-                if ((op2->OperGet() == GT_CNS_INT) &&
-                    ((oper == GT_COPYBLK) || (srcPtrOrVal->OperGet() == GT_CNS_INT)))
-                {
-                    GenTreePtr  dstOp = op1->gtOp.gtOp1;
-                    GenTreePtr  srcOp = op1->gtOp.gtOp2;
-                    unsigned    length = (unsigned)op2->gtIntCon.gtIconVal;
-                    unsigned    fullStoreCount = length / TARGET_POINTER_SIZE;
-                    unsigned    initVal = 0;
-                    bool        useLoop = false;
-
-                    if (oper == GT_INITBLK)
-                    {
-                        /* Properly extend the init constant from a U1 to a U4 */
-                        initVal = 0xFF & ((unsigned)srcOp->gtIntCon.gtIconVal);
-
-                        /* If it is a non-zero value we have to replicate      */
-                        /* the byte value four times to form the DWORD         */
-                        /* Then we store this new value into the tree-node      */
-
-                        if (initVal != 0)
-                        {
-                            initVal = initVal | (initVal << 8) | (initVal << 16) | (initVal << 24);
-                            op1->gtOp.gtOp2->gtIntCon.gtIconVal = initVal;
-                        }
-                    }
-
-                    // Will we be using a loop to implement this INITBLK/COPYBLK?
-                    if (((oper == GT_COPYBLK) && (fullStoreCount >= 8)) ||
-                        ((oper == GT_INITBLK) && (fullStoreCount >= 16)))
-                    {
-                        useLoop = true;
-                    }
-
-                    regMaskTP    usedRegs;
-                    regNumber    regDst;
-                    regNumber    regSrc;
-                    regNumber    regTemp;
-
-                    /* Evaluate dest and src/val */
-
-                    if (op1->gtFlags & GTF_REVERSE_OPS)
-                    {
-                        genComputeReg(srcOp, (needReg & ~dstOp->gtRsvdRegs), RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
-                        assert(srcOp->gtFlags & GTF_REG_VAL);
-
-                        genComputeReg(dstOp, needReg, RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
-                        assert(dstOp->gtFlags & GTF_REG_VAL);
-                        regDst = dstOp->gtRegNum;
-
-                        genRecoverReg(srcOp, needReg, RegSet::KEEP_REG);
-                        regSrc = srcOp->gtRegNum;
-                    }
-                    else
-                    {
-                        genComputeReg(dstOp, (needReg & ~srcOp->gtRsvdRegs), RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
-                        assert(dstOp->gtFlags & GTF_REG_VAL);
-
-                        genComputeReg(srcOp, needReg, RegSet::ANY_REG, RegSet::KEEP_REG, useLoop);
-                        assert(srcOp->gtFlags & GTF_REG_VAL);
-                        regSrc = srcOp->gtRegNum;
-
-                        genRecoverReg(dstOp, needReg, RegSet::KEEP_REG);
-                        regDst = dstOp->gtRegNum;
-                    }
-                    assert(dstOp->gtFlags & GTF_REG_VAL);
-                    assert(srcOp->gtFlags & GTF_REG_VAL);
-
-                    regDst = dstOp->gtRegNum;
-                    regSrc = srcOp->gtRegNum;
-                    usedRegs = (genRegMask(regSrc) | genRegMask(regDst));
-                    bool dstIsOnStack = (dstOp->gtOper == GT_ADDR && (dstOp->gtFlags & GTF_ADDR_ONSTACK));
-                    emitAttr dstType = (varTypeIsGC(dstOp) && !dstIsOnStack) ? EA_BYREF : EA_PTRSIZE;
-                    emitAttr srcType;
-
-                    if (oper == GT_COPYBLK)
-                    {
-                        // Prefer a low register,but avoid one of the ones we've already grabbed
-                        regTemp = regSet.rsGrabReg(regSet.rsNarrowHint(regSet.rsRegMaskCanGrab() & ~usedRegs, RBM_LOW_REGS));
-                        usedRegs |= genRegMask(regTemp);
-                        bool srcIsOnStack = (srcOp->gtOper == GT_ADDR && (srcOp->gtFlags & GTF_ADDR_ONSTACK));
-                        srcType = (varTypeIsGC(srcOp) && !srcIsOnStack) ? EA_BYREF : EA_PTRSIZE;
-                    }
-                    else
-                    {
-                        regTemp = REG_STK;
-                        srcType = EA_PTRSIZE;
-                    }
-
-                    instruction  loadIns = ins_Load(TYP_I_IMPL);   // INS_ldr
-                    instruction  storeIns = ins_Store(TYP_I_IMPL);  // INS_str
-
-                    int       finalOffset;
-
-                    // Can we emit a small number of ldr/str instructions to implement this INITBLK/COPYBLK?
-                    if (!useLoop)
-                    {
-                        for (unsigned i = 0; i < fullStoreCount; i++)
-                        {
-                            if (oper == GT_COPYBLK)
-                            {
-                                getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp, regSrc, i * TARGET_POINTER_SIZE);
-                                getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp, regDst, i * TARGET_POINTER_SIZE);
-                                gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
-                                regTracker.rsTrackRegTrash(regTemp);
-                            }
-                            else
-                            {
-                                getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, i * TARGET_POINTER_SIZE);
-                            }
-                        }
-
-                        finalOffset = fullStoreCount * TARGET_POINTER_SIZE;
-                        length -= finalOffset;
-                    }
-                    else  // We will use a loop to implement this INITBLK/COPYBLK
-                    {
-                        unsigned   pairStoreLoopCount = fullStoreCount / 2;
-
-                        // We need a second temp register for CopyBlk
-                        regNumber  regTemp2 = REG_STK;
-                        if (oper == GT_COPYBLK)
-                        {
-                            // Prefer a low register, but avoid one of the ones we've already grabbed
-                            regTemp2 = regSet.rsGrabReg(regSet.rsNarrowHint(regSet.rsRegMaskCanGrab() & ~usedRegs, RBM_LOW_REGS));
-                            usedRegs |= genRegMask(regTemp2);
-                        }
-
-                        // Pick and initialize the loop counter register
-                        regNumber regLoopIndex;
-                        regLoopIndex = regSet.rsGrabReg(regSet.rsNarrowHint(regSet.rsRegMaskCanGrab() & ~usedRegs, RBM_LOW_REGS));
-                        genSetRegToIcon(regLoopIndex, pairStoreLoopCount, TYP_INT);
-
-                        // Create and define the Basic Block for the loop top
-                        BasicBlock * loopTopBlock = genCreateTempLabel();
-                        genDefineTempLabel(loopTopBlock);
-
-                        // The loop body
-                        if (oper == GT_COPYBLK)
-                        {
-                            getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp, regSrc, 0);
-                            getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp2, regSrc, TARGET_POINTER_SIZE);
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp, regDst, 0);
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp2, regDst, TARGET_POINTER_SIZE);
-                            getEmitter()->emitIns_R_I(INS_add, srcType, regSrc, 2 * TARGET_POINTER_SIZE);
-                            gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
-                            gcInfo.gcMarkRegSetNpt(genRegMask(regTemp2));
-                            regTracker.rsTrackRegTrash(regSrc);
-                            regTracker.rsTrackRegTrash(regTemp);
-                            regTracker.rsTrackRegTrash(regTemp2);
-                        }
-                        else // GT_INITBLK
-                        {
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, 0);
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, TARGET_POINTER_SIZE);
-                        }
-
-                        getEmitter()->emitIns_R_I(INS_add, dstType, regDst, 2 * TARGET_POINTER_SIZE);
-                        regTracker.rsTrackRegTrash(regDst);
-                        getEmitter()->emitIns_R_I(INS_sub, EA_4BYTE, regLoopIndex, 1, INS_FLAGS_SET);
-                        emitJumpKind jmpGTS = genJumpKindForOper(GT_GT, CK_SIGNED);
-                        inst_JMP(jmpGTS, loopTopBlock);
-
-                        regTracker.rsTrackRegIntCns(regLoopIndex, 0);
-
-                        length -= (pairStoreLoopCount * (2 * TARGET_POINTER_SIZE));
-
-                        if (length & TARGET_POINTER_SIZE)
-                        {
-                            if (oper == GT_COPYBLK)
-                            {
-                                getEmitter()->emitIns_R_R_I(loadIns, EA_4BYTE, regTemp, regSrc, 0);
-                                getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regTemp, regDst, 0);
-                            }
-                            else
-                            {
-                                getEmitter()->emitIns_R_R_I(storeIns, EA_4BYTE, regSrc, regDst, 0);
-                            }
-                            finalOffset = TARGET_POINTER_SIZE;
-                            length -= TARGET_POINTER_SIZE;
-                        }
-                        else
-                        {
-                            finalOffset = 0;
-                        }
-                    }
-
-                    if (length & sizeof(short))
-                    {
-                        loadIns = ins_Load(TYP_USHORT);   // INS_ldrh
-                        storeIns = ins_Store(TYP_USHORT);  // INS_strh
-
-                        if (oper == GT_COPYBLK)
-                        {
-                            getEmitter()->emitIns_R_R_I(loadIns, EA_2BYTE, regTemp, regSrc, finalOffset);
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_2BYTE, regTemp, regDst, finalOffset);
-                            gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
-                            regTracker.rsTrackRegTrash(regTemp);
-                        }
-                        else
-                        {
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_2BYTE, regSrc, regDst, finalOffset);
-                        }
-                        length -= sizeof(short);
-                        finalOffset += sizeof(short);
-                    }
-
-                    if (length & sizeof(char))
-                    {
-                        loadIns = ins_Load(TYP_UBYTE);   // INS_ldrb
-                        storeIns = ins_Store(TYP_UBYTE);  // INS_strb
-
-                        if (oper == GT_COPYBLK)
-                        {
-                            getEmitter()->emitIns_R_R_I(loadIns, EA_1BYTE, regTemp, regSrc, finalOffset);
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_1BYTE, regTemp, regDst, finalOffset);
-                            gcInfo.gcMarkRegSetNpt(genRegMask(regTemp));
-                            regTracker.rsTrackRegTrash(regTemp);
-                        }
-                        else
-                        {
-                            getEmitter()->emitIns_R_R_I(storeIns, EA_1BYTE, regSrc, regDst, finalOffset);
-                        }
-                        length -= sizeof(char);
-                    }
-                    assert(length == 0);
-
-                    genReleaseReg(dstOp);
-                    genReleaseReg(srcOp);
-                }
-                else
-                {
-                    //
-                    // This a variable-sized COPYBLK/INITBLK,
-                    //   or a fixed size INITBLK with a variable init value,
-                    //
-
-                    // What order should the Dest, Val/Src, and Size be calculated
-
-                    compiler->fgOrderBlockOps(tree, RBM_ARG_0, RBM_ARG_1, RBM_ARG_2,
-                        opsPtr, regsPtr); // OUT arguments
-
-                    genComputeReg(opsPtr[0], regsPtr[0], RegSet::EXACT_REG, RegSet::KEEP_REG);
-                    genComputeReg(opsPtr[1], regsPtr[1], RegSet::EXACT_REG, RegSet::KEEP_REG);
-                    genComputeReg(opsPtr[2], regsPtr[2], RegSet::EXACT_REG, RegSet::KEEP_REG);
-
-                    genRecoverReg(opsPtr[0], regsPtr[0], RegSet::KEEP_REG);
-                    genRecoverReg(opsPtr[1], regsPtr[1], RegSet::KEEP_REG);
-
-                    noway_assert((op1->gtOp.gtOp1->gtFlags & GTF_REG_VAL) && // Dest
-                        (op1->gtOp.gtOp1->gtRegNum == REG_ARG_0));
-
-                    noway_assert((op1->gtOp.gtOp2->gtFlags & GTF_REG_VAL) && // Val/Src
-                        (op1->gtOp.gtOp2->gtRegNum == REG_ARG_1));
-
-                    noway_assert((op2->gtFlags & GTF_REG_VAL) &&             // Size
-                        (op2->gtRegNum == REG_ARG_2));
-
-                    regSet.rsLockUsedReg(RBM_ARG_0 | RBM_ARG_1 | RBM_ARG_2);
-
-                    genEmitHelperCall(oper == GT_COPYBLK ? CORINFO_HELP_MEMCPY
-                        /* GT_INITBLK */ : CORINFO_HELP_MEMSET,
-                        0, EA_UNKNOWN);
-
-                    regTracker.rsTrackRegMaskTrash(RBM_CALLEE_TRASH);
-
-                    regSet.rsUnlockUsedReg(RBM_ARG_0 | RBM_ARG_1 | RBM_ARG_2);
-                    genReleaseReg(opsPtr[0]);
-                    genReleaseReg(opsPtr[1]);
-                    genReleaseReg(opsPtr[2]);
-                }
-
-                if ((oper == GT_COPYBLK) && tree->AsBlkOp()->IsVolatile())
-                {
-                    // Emit a memory barrier instruction after the CopyBlk 
-                    instGen_MemoryBarrier();
-                }
-#endif // !CPU_USES_BLOCK_MOVE 
-
-                reg = REG_NA;
-            }
-
-            genCodeForTree_DONE(tree, reg);
+            genCodeForBlkOp(tree, destReg);
+            genCodeForTree_DONE(tree, REG_NA);
             return;
 
         case GT_EQ:

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -6008,6 +6008,11 @@ private:
 
     void                rpPredictRefAssign  (unsigned       lclNum);
 
+    regMaskTP           rpPredictBlkAsgRegUse(GenTreePtr    tree,
+                                              rpPredictReg  predictReg,
+                                              regMaskTP     lockedRegs,
+                                              regMaskTP     rsvdRegs);
+
     regMaskTP           rpPredictTreeRegUse (GenTreePtr     tree,
                                              rpPredictReg   predictReg,
                                              regMaskTP      lockedRegs,

--- a/src/jit/lclvars.cpp
+++ b/src/jit/lclvars.cpp
@@ -1560,7 +1560,8 @@ void   Compiler::lvaCanPromoteStructType(CORINFO_CLASS_HANDLE     typeHnd,
         if (sortFields)
         {
             // Sort the fields according to the increasing order of the field offset.
-            // This is needed because the fields need to be pushed on stack (for GT_LDOBJ) in order.
+            // This is needed because the fields need to be pushed on stack (when referenced
+            // as a struct) in order.
             qsort(StructPromotionInfo->fields, 
                   StructPromotionInfo->fieldCnt, 
                   sizeof(*StructPromotionInfo->fields), 

--- a/src/jit/optcse.cpp
+++ b/src/jit/optcse.cpp
@@ -2128,7 +2128,7 @@ bool                Compiler::optIsCSEcandidate(GenTreePtr tree)
     var_types   type = tree->TypeGet();
     genTreeOps  oper = tree->OperGet();
 
-    // TODO-1stClassStructs: Enable CSE for TYP_SIMD (depends on either transforming
+    // TODO-1stClassStructs: Enable CSE for struct types (depends on either transforming
     // to use regular assignments, or handling copyObj.
     if (varTypeIsStruct(type) || type == TYP_VOID)
         return false;

--- a/src/jit/rationalize.cpp
+++ b/src/jit/rationalize.cpp
@@ -848,23 +848,18 @@ void Rationalizer::MorphAsgIntoStoreLcl(GenTreeStmt* stmt, GenTreePtr pTree)
     GenTreePtr lhs = pTree->gtGetOp1();
     GenTreePtr rhs = pTree->gtGetOp2();
 
-    assert(lhs->OperGet() == GT_LCL_VAR ||
-           lhs->OperGet() == GT_LCL_FLD);
+    genTreeOps lhsOper = lhs->OperGet();
+    genTreeOps storeOper;
 
+    assert(lhsOper == GT_LCL_VAR || lhsOper == GT_LCL_FLD);
+
+    storeOper = storeForm(lhsOper);
 #ifdef DEBUG
-    if (lhs->OperGet() == GT_LCL_VAR)
-    {
-        JITDUMP("rewriting GT_ASG(GT_LCL_VAR, X) to GT_STORE_LCL_VAR(X)\n");
-    }
-    else
-    {
-        assert(lhs->OperGet() == GT_LCL_FLD);
-        JITDUMP("rewriting GT_ASG(GT_LCL_FLD, X) to GT_STORE_LCL_FLD(X)\n");
-    }
+    JITDUMP("rewriting asg(%s, X) to %s(X)\n", GenTree::NodeName(lhsOper), GenTree::NodeName(storeOper));
 #endif // DEBUG
 
     GenTreeLclVarCommon* var = lhs->AsLclVarCommon();
-    pTree->SetOper(storeForm(var->OperGet()));
+    pTree->SetOper(storeOper);
     GenTreeLclVarCommon* dst = pTree->AsLclVarCommon();
     dst->SetLclNum(var->gtLclNum);
     dst->SetSsaNum(var->gtSsaNum);

--- a/src/jit/regalloc.cpp
+++ b/src/jit/regalloc.cpp
@@ -1647,6 +1647,230 @@ void Compiler::rpPredictRefAssign(unsigned lclNum)
 #endif // NOGC_WRITE_BARRIERS
 }
 
+/*****************************************************************************
+ *
+ * Predict the internal temp physical register usage for a block assignment tree,
+ * by setting tree->gtUsedRegs.
+ * Records the internal temp physical register usage for this tree.
+ * Returns a mask of interfering registers for this tree.
+ *
+ * Each of the switch labels in this function updates regMask and assigns tree->gtUsedRegs 
+ * to the set of scratch registers needed when evaluating the tree.  
+ * Generally tree->gtUsedRegs and the return value retMask are the same, except when the
+ * parameter "lockedRegs" conflicts with the computed tree->gtUsedRegs, in which case we
+ * predict additional internal temp physical registers to spill into.
+ *
+ *    tree       - is the child of a GT_IND node
+ *    predictReg - what type of register does the tree need
+ *    lockedRegs - are the registers which are currently held by a previously evaluated node.
+ *                 Don't modify lockedRegs as it is used at the end to compute a spill mask.
+ *    rsvdRegs   - registers which should not be allocated because they will
+ *                 be needed to evaluate a node in the future
+ *               - Also, if rsvdRegs has the RBM_LASTUSE bit set then
+ *                 the rpLastUseVars set should be saved and restored
+ *                 so that we don't add any new variables to rpLastUseVars.
+ */
+regMaskTP           Compiler::rpPredictBlkAsgRegUse(GenTreePtr    tree,
+                                                    rpPredictReg  predictReg,
+                                                    regMaskTP     lockedRegs,
+                                                    regMaskTP     rsvdRegs)
+{
+    regMaskTP       regMask         = RBM_NONE;
+    regMaskTP       interferingRegs = RBM_NONE;
+
+    bool           hasGCpointer   = false;
+    bool           dstIsOnStack   = false;
+    bool           useMemHelper   = false;  
+    bool           useBarriers    = false;
+
+    GenTreeBlkOp*  blkNode        = tree->AsBlkOp();
+    GenTreePtr     dstAddr        = blkNode->Dest();
+    GenTreePtr     op1            = blkNode->gtGetOp1();
+    GenTreePtr     srcAddrOrFill  = op1->gtGetOp2();
+    GenTreePtr     sizeNode       = blkNode->gtGetOp2();
+
+    size_t         blkSize        = 0;
+
+    hasGCpointer = ((tree->gtFlags & GTF_BLK_HASGCPTR) != 0);
+
+    bool isCopyBlk = tree->OperIsCopyBlkOp();
+    bool isCopyObj = (tree->OperGet() == GT_COPYOBJ);
+    bool isInitBlk = (tree->OperGet() == GT_INITBLK);
+
+    if (sizeNode->OperGet() == GT_CNS_INT)
+    {
+        if (sizeNode->IsIconHandle(GTF_ICON_CLASS_HDL))
+        {
+            if (isCopyObj)
+            {
+                dstIsOnStack = (dstAddr->gtOper == GT_ADDR && (dstAddr->gtFlags & GTF_ADDR_ONSTACK));
+            }
+
+            CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE) sizeNode->gtIntCon.gtIconVal;
+            blkSize = roundUp(info.compCompHnd->getClassSize(clsHnd), TARGET_POINTER_SIZE);
+        }
+        else  // gtIconVal contains amount to copy
+        {
+            blkSize = (unsigned) sizeNode->gtIntCon.gtIconVal;
+        }
+
+        if (isInitBlk)
+        {
+            if (srcAddrOrFill->OperGet() != GT_CNS_INT)
+            {
+                useMemHelper = true;  
+            }
+        }
+    }
+    else
+    {
+        useMemHelper = true;  
+    }
+            
+    if (hasGCpointer && !dstIsOnStack)
+    {
+        useBarriers = true;
+    }
+
+#ifdef _TARGET_ARM_
+    //
+    // On ARM For COPYBLK & INITBLK we have special treatment for constant lengths.
+    //
+    if (!useMemHelper && !useBarriers)
+    {
+        bool     useLoop        = false;
+        unsigned fullStoreCount = blkSize / TARGET_POINTER_SIZE;
+                
+        // A mask to use to force the predictor to choose low registers (to reduce code size)
+        regMaskTP avoidReg = (RBM_R12|RBM_LR);
+
+        // Allow the src and dst to be used in place, unless we use a loop, in which
+        // case we will need scratch registers as we will be writing to them.
+        rpPredictReg srcAndDstPredict = PREDICT_REG;
+
+        // Will we be using a loop to implement this INITBLK/COPYBLK?
+        if ((isCopyBlk && (fullStoreCount >= 8)) ||
+            (isInitBlk && (fullStoreCount >= 16))) 
+        {
+            useLoop = true;
+            avoidReg = RBM_NONE;
+            srcAndDstPredict = PREDICT_SCRATCH_REG;
+        }
+
+        if (op1->gtFlags & GTF_REVERSE_OPS)
+        {
+            regMask |= rpPredictTreeRegUse(srcAddrOrFill, srcAndDstPredict, lockedRegs, dstAddr->gtRsvdRegs | avoidReg | RBM_LASTUSE);
+            regMask |= rpPredictTreeRegUse(dstAddr, srcAndDstPredict, lockedRegs | regMask, avoidReg);
+        }
+        else
+        {
+            regMask |= rpPredictTreeRegUse(dstAddr, srcAndDstPredict, lockedRegs, srcAddrOrFill->gtRsvdRegs | avoidReg | RBM_LASTUSE); 
+            regMask |= rpPredictTreeRegUse(srcAddrOrFill, srcAndDstPredict, lockedRegs | regMask, avoidReg);
+        }
+
+        // We need at least one scratch register for a copyBlk
+        if (isCopyBlk)
+        {
+            // Pick a low register to reduce the code size
+            regMask |= rpPredictRegPick(TYP_INT, PREDICT_SCRATCH_REG, lockedRegs | regMask | avoidReg);
+        }
+
+        if (useLoop)
+        {
+            if (isCopyBlk)
+            {
+                // We need a second temp register for a copyBlk (our code gen is load two/store two)
+                // Pick another low register to reduce the code size
+                regMask |= rpPredictRegPick(TYP_INT, PREDICT_SCRATCH_REG, lockedRegs | regMask | avoidReg);
+            }
+
+            // We need a loop index register
+            regMask |= rpPredictRegPick(TYP_INT, PREDICT_SCRATCH_REG, lockedRegs | regMask);
+        }
+
+        tree->gtUsedRegs = dstAddr->gtUsedRegs |
+                           srcAddrOrFill->gtUsedRegs |
+                           (regMaskSmall)regMask;
+
+        return interferingRegs;
+    }
+#endif
+    // What order should the Dest, Val/Src, and Size be calculated
+    GenTreePtr      opsPtr [3];
+    regMaskTP       regsPtr[3];
+
+#if defined(_TARGET_XARCH_)
+    fgOrderBlockOps(tree,
+            RBM_EDI, (isInitBlk) ? RBM_EAX : RBM_ESI, RBM_ECX,
+            opsPtr, regsPtr);
+
+    // We're going to use these, might as well make them available now
+
+    codeGen->regSet.rsSetRegsModified(RBM_EDI | RBM_ECX);
+    if (isCopyBlk)
+        codeGen->regSet.rsSetRegsModified(RBM_ESI);
+
+#elif defined(_TARGET_ARM_)
+
+    if (useMemHelper)
+    {
+        // For all other cases that involve non-constants, we just call memcpy/memset
+        // JIT helpers
+        fgOrderBlockOps(tree, RBM_ARG_0, RBM_ARG_1, RBM_ARG_2, opsPtr, regsPtr);
+        interferingRegs |= RBM_CALLEE_TRASH;
+#ifdef DEBUG
+        if (verbose)
+            printf("Adding interference with RBM_CALLEE_TRASH for memcpy/memset\n"); 
+#endif
+    }
+    else // useBarriers
+    {
+        assert(useBarriers);
+        assert(isCopyBlk);
+
+        fgOrderBlockOps(tree, RBM_ARG_0, RBM_ARG_1, REG_TMP_1, opsPtr, regsPtr);
+
+        // For this case Codegen will call the CORINFO_HELP_ASSIGN_BYREF helper
+        interferingRegs |= RBM_CALLEE_TRASH_NOGC;
+#ifdef DEBUG
+        if (verbose)
+            printf("Adding interference with RBM_CALLEE_TRASH_NOGC for Byref WriteBarrier\n"); 
+#endif
+    }
+#else  // !_TARGET_X86_ && !_TARGET_ARM_
+#error "Non-ARM or x86 _TARGET_ in RegPredict for INITBLK/COPYBLK"
+#endif // !_TARGET_X86_ && !_TARGET_ARM_
+    regMask |= rpPredictTreeRegUse(opsPtr[0],
+                                   rpGetPredictForMask(regsPtr[0]),
+                                   lockedRegs, 
+                                   opsPtr[1]->gtRsvdRegs | opsPtr[2]->gtRsvdRegs | RBM_LASTUSE);
+    regMask |= regsPtr[0];
+    opsPtr[0]->gtUsedRegs |= regsPtr[0];
+    rpRecordRegIntf(regsPtr[0], compCurLife
+                    DEBUGARG("movsd dest"));
+
+    regMask |= rpPredictTreeRegUse(opsPtr[1],
+                                   rpGetPredictForMask(regsPtr[1]),
+                                   lockedRegs | regMask, 
+                                   opsPtr[2]->gtRsvdRegs | RBM_LASTUSE);
+    regMask |= regsPtr[1];
+    opsPtr[1]->gtUsedRegs |= regsPtr[1];
+    rpRecordRegIntf(regsPtr[1], compCurLife
+                    DEBUGARG("movsd src"));
+
+    regMask |= rpPredictTreeRegUse(opsPtr[2],
+                                   rpGetPredictForMask(regsPtr[2]),
+                                   lockedRegs | regMask, 
+                                   RBM_NONE);
+    regMask |= regsPtr[2];
+    opsPtr[2]->gtUsedRegs |= regsPtr[2];
+
+    tree->gtUsedRegs = opsPtr[0]->gtUsedRegs |
+                       opsPtr[1]->gtUsedRegs |
+                       opsPtr[2]->gtUsedRegs |
+                       (regMaskSmall)regMask;
+    return interferingRegs;
+}
 
 /*****************************************************************************
  *
@@ -4121,195 +4345,9 @@ HANDLE_SHIFT_COUNT:
         case GT_COPYOBJ:
         case GT_COPYBLK:
         case GT_INITBLK:
-        {
-            regMask = 0;
-
-            bool      hasGCpointer;    hasGCpointer   = false;
-            bool      dstIsOnStack;    dstIsOnStack   = false;
-            bool      useMemHelper;    useMemHelper   = false;  
-            bool      useBarriers;     useBarriers    = false; 
-
-            size_t    blkSize;         blkSize        = 0;
-
-            hasGCpointer = ((tree->gtFlags & GTF_BLK_HASGCPTR) != 0);
-
-            if (op2->OperGet() == GT_CNS_INT)
-            {
-                if (op2->IsIconHandle(GTF_ICON_CLASS_HDL))
-                {
-                    if (tree->OperGet() == GT_COPYOBJ)
-                    {
-                        GenTreePtr  dstObj = op1->gtOp.gtOp1;
-                        dstIsOnStack = (dstObj->gtOper == GT_ADDR && (dstObj->gtFlags & GTF_ADDR_ONSTACK));
-                    }
-
-                    CORINFO_CLASS_HANDLE clsHnd = (CORINFO_CLASS_HANDLE) op2->gtIntCon.gtIconVal;
-                    blkSize = roundUp(info.compCompHnd->getClassSize(clsHnd), TARGET_POINTER_SIZE);
-                }
-                else  // gtIconVal contains amount to copy
-                {
-                    blkSize = (unsigned) op2->gtIntCon.gtIconVal;
-                }
-
-                if (tree->OperGet() == GT_INITBLK)
-                {
-                    GenTreePtr  initVal = op1->gtOp.gtOp2;
-                    if (initVal->OperGet() != GT_CNS_INT)
-                    {
-                         useMemHelper = true;  
-                    }
-                }
-            }
-            else
-            {
-                useMemHelper = true;  
-            }
-            
-            // If we are copying any GC pointers then the GTF_BLK_HASGCPTR flags must be set
-            if (hasGCpointer && !dstIsOnStack)
-            {
-                useBarriers = true;
-            }
-
-#ifdef _TARGET_ARM_
-            //
-            // On ARM For COPYBLK & INITBLK we have special treatment for constant lengths.
-            //
-            if (!useMemHelper && !useBarriers)
-            {
-                bool     useLoop        = false;
-                unsigned fullStoreCount = blkSize / TARGET_POINTER_SIZE;
-                
-                // A mask to use to force the predictor to choose low registers (to reduce code size)
-                regMaskTP avoidReg = (RBM_R12|RBM_LR);
-
-                // Allow the src and dst to be used in place, unless we use a loop, in which
-                // case we will need scratch registers as we will be writing to them.
-                rpPredictReg srcAndDstPredict = PREDICT_REG;
-
-                // Will we be using a loop to implement this INITBLK/COPYBLK?
-                if ((GenTree::OperIsCopyBlkOp(oper) && (fullStoreCount >= 8)) ||
-                    ((oper == GT_INITBLK)  && (fullStoreCount >= 16))) 
-                {
-                    useLoop = true;
-                    avoidReg = RBM_NONE;
-                    srcAndDstPredict = PREDICT_SCRATCH_REG;
-                }
-
-                if (op1->gtFlags & GTF_REVERSE_OPS)
-                {
-                    regMask |= rpPredictTreeRegUse(op1->gtOp.gtOp2, srcAndDstPredict, lockedRegs, op1->gtOp.gtOp1->gtRsvdRegs | avoidReg | RBM_LASTUSE);
-                    regMask |= rpPredictTreeRegUse(op1->gtOp.gtOp1, srcAndDstPredict, lockedRegs | regMask, avoidReg);
-                }
-                else
-                {
-                    regMask |= rpPredictTreeRegUse(op1->gtOp.gtOp1, srcAndDstPredict, lockedRegs, op1->gtOp.gtOp2->gtRsvdRegs | avoidReg | RBM_LASTUSE); 
-                    regMask |= rpPredictTreeRegUse(op1->gtOp.gtOp2, srcAndDstPredict, lockedRegs | regMask, avoidReg);
-                }
-
-                // We need at least one scratch register for a GT_COPYBLK
-                if (GenTree::OperIsCopyBlkOp(oper))
-                {
-                    // Pick a low register to reduce the code size
-                    regMask |= rpPredictRegPick(TYP_INT, PREDICT_SCRATCH_REG, lockedRegs | regMask | avoidReg);
-                }
-
-                if (useLoop)
-                {
-                    if (GenTree::OperIsCopyBlkOp(oper))
-                    {
-                        // We need a second temp register for a GT_COPYBLK (our code gen is load two/store two)
-                        // Pick another low register to reduce the code size
-                        regMask |= rpPredictRegPick(TYP_INT, PREDICT_SCRATCH_REG, lockedRegs | regMask | avoidReg);
-                    }
-
-                    // We need a loop index register
-                    regMask |= rpPredictRegPick(TYP_INT, PREDICT_SCRATCH_REG, lockedRegs | regMask);
-                }
-
-                tree->gtUsedRegs = op1->gtOp.gtOp1->gtUsedRegs |
-                                   op1->gtOp.gtOp2->gtUsedRegs |
-                                   (regMaskSmall)regMask;
-
-                regMask = 0;
-                goto RETURN_CHECK;
-            }
-#endif
-            // What order should the Dest, Val/Src, and Size be calculated
-
-#if defined(_TARGET_XARCH_)
-            fgOrderBlockOps(tree,
-                    RBM_EDI, (oper == GT_INITBLK) ? RBM_EAX : RBM_ESI, RBM_ECX,
-                    opsPtr, regsPtr);
-
-            // We're going to use these, might as well make them available now
-
-            codeGen->regSet.rsSetRegsModified(RBM_EDI | RBM_ECX);
-            if (GenTree::OperIsCopyBlkOp(oper))
-                codeGen->regSet.rsSetRegsModified(RBM_ESI);
-
-#elif defined(_TARGET_ARM_)
-
-            if (useMemHelper)
-            {
-                // For all other cases that involve non-constants, we just call memcpy/memset
-                // JIT helpers
-                fgOrderBlockOps(tree, RBM_ARG_0, RBM_ARG_1, RBM_ARG_2, opsPtr, regsPtr);
-                interferingRegs |= RBM_CALLEE_TRASH;
-#ifdef DEBUG
-                if (verbose)
-                    printf("Adding interference with RBM_CALLEE_TRASH for memcpy/memset\n"); 
-#endif
-            }
-            else // useBarriers
-            {
-                assert(useBarriers);
-                assert(GenTree::OperIsCopyBlkOp(oper));
-
-                fgOrderBlockOps(tree, RBM_ARG_0, RBM_ARG_1, REG_TMP_1, opsPtr, regsPtr);
-
-                // For this case Codegen will call the CORINFO_HELP_ASSIGN_BYREF helper
-                interferingRegs |= RBM_CALLEE_TRASH_NOGC;
-#ifdef DEBUG
-                if (verbose)
-                    printf("Adding interference with RBM_CALLEE_TRASH_NOGC for Byref WriteBarrier\n"); 
-#endif
-            }
-#else  // !_TARGET_X86_ && !_TARGET_ARM_
-#error "Non-ARM or x86 _TARGET_ in RegPredict for INITBLK/COPYBLK"
-#endif // !_TARGET_X86_ && !_TARGET_ARM_
-            regMask |= rpPredictTreeRegUse(opsPtr[0],
-                                           rpGetPredictForMask(regsPtr[0]),
-                                           lockedRegs, 
-                                           opsPtr[1]->gtRsvdRegs | opsPtr[2]->gtRsvdRegs | RBM_LASTUSE);
-            regMask |= regsPtr[0];
-            opsPtr[0]->gtUsedRegs |= regsPtr[0];
-            rpRecordRegIntf(regsPtr[0], compCurLife
-                            DEBUGARG("movsd dest"));
-
-            regMask |= rpPredictTreeRegUse(opsPtr[1],
-                                           rpGetPredictForMask(regsPtr[1]),
-                                           lockedRegs | regMask, 
-                                           opsPtr[2]->gtRsvdRegs | RBM_LASTUSE);
-            regMask |= regsPtr[1];
-            opsPtr[1]->gtUsedRegs |= regsPtr[1];
-            rpRecordRegIntf(regsPtr[1], compCurLife
-                            DEBUGARG("movsd src"));
-
-            regMask |= rpPredictTreeRegUse(opsPtr[2],
-                                           rpGetPredictForMask(regsPtr[2]),
-                                           lockedRegs | regMask, 
-                                           RBM_NONE);
-            regMask |= regsPtr[2];
-            opsPtr[2]->gtUsedRegs |= regsPtr[2];
-
-            tree->gtUsedRegs = opsPtr[0]->gtUsedRegs |
-                               opsPtr[1]->gtUsedRegs |
-                               opsPtr[2]->gtUsedRegs |
-                               (regMaskSmall)regMask;
+            interferingRegs |= rpPredictBlkAsgRegUse(tree, predictReg,lockedRegs,rsvdRegs);
             regMask = 0;
             goto RETURN_CHECK;
-        }
 
         case GT_OBJ:
             {


### PR DESCRIPTION
Refactor the legacy code dealing with block ops to minimize diffs when they are replaced with assignments.
Also a couple of comment edits and a small cleanup in rationalizer.