### PR TITLE
Inliner: enable xml format dump for inlines

### DIFF
--- a/src/jit/compiler.cpp
+++ b/src/jit/compiler.cpp
@@ -4292,7 +4292,7 @@ DoneCleanUp:
 }
 
 #ifdef DEBUG
-unsigned        Compiler::Info::compMethodHash()
+unsigned        Compiler::Info::compMethodHash() const
 {
     if (compMethodHashPrivate == 0)
     {
@@ -4373,6 +4373,7 @@ void Compiler::compCompileFinish()
 #if defined(DEBUG) || defined(INLINE_DATA)
 
     m_inlineStrategy->DumpData();
+    m_inlineStrategy->DumpXml();
 
 #endif
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7727,8 +7727,10 @@ public :
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
 #ifdef DEBUG
-        unsigned        compMethodHashPrivate;
-        unsigned        compMethodHash();
+        // Method hash is logcally const, but computed
+        // on first demand.
+        mutable unsigned compMethodHashPrivate;
+        unsigned         compMethodHash() const;
 #endif
 
 #ifdef PSEUDORANDOM_NOP_INSERTION

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -562,10 +562,13 @@ public:
 #if defined(DEBUG) || defined(INLINE_DATA)
 
     // Dump the full subtree, including failures
-    void Dump(int indent = 0);
+    void Dump(unsigned indent = 0);
 
     // Dump only the success subtree, with rich data
-    void DumpData(int indent = 0);
+    void DumpData(unsigned indent = 0);
+
+    // Dump full subtree in xml format
+    void DumpXml(FILE* file = stderr, unsigned indent = 0);
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
@@ -687,6 +690,9 @@ public:
 
     // Dump data-format description of inlines done so far.
     void DumpData();
+
+    // Dump xml-formatted description of inlines
+    void DumpXml(FILE* file = stderr, unsigned indent = 0);
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -191,6 +191,7 @@ CONFIG_STRING(TailCallOpt, W("TailCallOpt"))
 
 #if defined(DEBUG) || defined(INLINE_DATA)
 CONFIG_INTEGER(JitInlineDumpData, W("JitInlineDumpData"), 0)
+CONFIG_INTEGER(JitInlineDumpXml, W("JitInlineDumpXml"), 0)
 CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)


### PR DESCRIPTION
Add new config option to dump inline trees as XML, and implement
dumping support.