### PR TITLE
Refactor FEATURE_MERGE_JIT_AND_ENGINE to allow consuming JIT as a dynamic library

### DIFF
--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -130,10 +130,13 @@ add_definitions(-DFEATURE_MANAGED_ETW)
 add_definitions(-DFEATURE_MANAGED_ETW_CHANNELS)
 add_definitions(-DFEATURE_MAIN_CLR_MODULE_USES_CORE_NAME)
 add_definitions(-DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE)
-if(WIN32)
-# Disable the following for UNIX altjit on Windows
-add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
-endif(WIN32)
+
+# TODO_DJIT: Remove this "set" to commence loading JIT dynamically.
+set(FEATURE_MERGE_JIT_AND_ENGINE 1)
+if(FEATURE_MERGE_JIT_AND_ENGINE)
+  # Disable the following for UNIX altjit on Windows
+  add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
+endif(FEATURE_MERGE_JIT_AND_ENGINE)
 add_definitions(-DFEATURE_MULTICOREJIT)
 add_definitions(-DFEATURE_NORM_IDNA_ONLY)
 if(CLR_CMAKE_PLATFORM_UNIX)

--- a/crossgen.cmake
+++ b/crossgen.cmake
@@ -4,7 +4,6 @@ add_definitions(
     -DCROSSGEN_COMPILE
     -DCROSS_COMPILE
     -DFEATURE_NATIVE_IMAGE_GENERATION
-    -DFEATURE_MERGE_JIT_AND_ENGINE
     -DSELF_NO_HOST)
 
 remove_definitions(

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/debian/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>
@@ -23,7 +24,6 @@
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen"/>
-
     <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
 
     <File Include="@(ArchitectureSpecificNativeFile)">

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/osx/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.dylib"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.dylib"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.dylib"/>
     <NativeSplittableBinary Include="$(BinDir)libmscordaccore.dylib"/>
@@ -22,7 +23,6 @@
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscorlib.ni.dll"/>
     <ArchitectureSpecificLibFile Include="$(BinDir)mscorlib.dll"/>
     <ArchitectureSpecificToolFile Include="$(BinDir)crossgen"/>
-
     <ArchitectureSpecificNativeFile Include="@(NativeSplittableBinary)"/>
 
     <File Include="@(ArchitectureSpecificNativeFile)">

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/rhel/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/ubuntu/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <NativeSplittableBinary Include="$(BinDir)libclrjit.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclr.so"/>
     <NativeSplittableBinary Include="$(BinDir)libcoreclrtraceptprovider.so"/>
     <NativeSplittableBinary Include="$(BinDir)libdbgshim.so"/>

--- a/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
+++ b/src/.nuget/Microsoft.NETCore.Runtime.CoreCLR/win/Microsoft.NETCore.Runtime.CoreCLR.pkgproj
@@ -12,6 +12,7 @@
   
   <ItemGroup>
     <ArchitectureSpecificNativeFile Include="$(BinDir)clretwrc.dll"/>
+    <ArchitectureSpecificNativeFile Include="$(BinDir)clrjit.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)coreclr.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)dbgshim.dll"/>
     <ArchitectureSpecificNativeFile Include="$(BinDir)mscordaccore.dll"/>

--- a/src/coreclr/CMakeLists.txt
+++ b/src/coreclr/CMakeLists.txt
@@ -1,5 +1,3 @@
-# Add the Merge flag here is needed. Not needed for RyuJIT if building as a DLL.
-add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 if(WIN32)
   add_subdirectory(hosts)
 endif(WIN32)

--- a/src/dlls/mscoree/coreclr/CMakeLists.txt
+++ b/src/dlls/mscoree/coreclr/CMakeLists.txt
@@ -65,6 +65,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
     set(LIB_UNWINDER unwinder_wks)
 endif (CLR_CMAKE_PLATFORM_UNIX)
 
+if(FEATURE_MERGE_JIT_AND_ENGINE)
+    set(CLRJIT_STATIC clrjit_static)
+endif(FEATURE_MERGE_JIT_AND_ENGINE)
+
 # IMPORTANT! Please do not rearrange the order of the libraries. The linker on Linux is
 # order dependent and changing the order can result in undefined symbols in the shared 
 # library.
@@ -82,7 +86,7 @@ set(CORECLR_LIBRARIES
     mdhotdata_full
     bcltype
     ceefgen
-    clrjit_static
+    ${CLRJIT_STATIC}
     comfloat_wks
     corguids
     gcinfo # Condition="'$(TargetCpu)'=='amd64' or '$(TargetCpu)' == 'arm' or '$(TargetCpu)' == 'arm64'"

--- a/src/inc/corcompile.h
+++ b/src/inc/corcompile.h
@@ -837,6 +837,7 @@ typedef enum
 {
 #ifdef FEATURE_CORECLR
     CORECLR_INFO,
+    CROSSGEN_COMPILER_INFO,
 #else
     CLR_INFO,
     NGEN_COMPILER_INFO,

--- a/src/jit/dll/CMakeLists.txt
+++ b/src/jit/dll/CMakeLists.txt
@@ -7,7 +7,6 @@ endif(CLR_CMAKE_PLATFORM_ARCH_I386 OR CLR_CMAKE_PLATFORM_ARCH_ARM)
 # Disable the following for UNIX altjit on Windows
 if(CLR_CMAKE_PLATFORM_UNIX)
     add_compile_options(-fPIC)
-    add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
     add_library_clr(${JIT_BASE_NAME}_static
       STATIC

--- a/src/jit/standalone/CMakeLists.txt
+++ b/src/jit/standalone/CMakeLists.txt
@@ -4,6 +4,10 @@ add_definitions(-DSELF_NO_HOST)
 add_definitions(-DFEATURE_READYTORUN_COMPILER)
 remove_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
 
+if(CLR_CMAKE_TARGET_ARCH_I386 OR CLR_CMAKE_TARGET_ARCH_ARM)
+  add_definitions(-DLEGACY_BACKEND)
+endif()
+
 if(CLR_CMAKE_PLATFORM_LINUX OR CLR_CMAKE_PLATFORM_NETBSD)
     # This is required to force using our own PAL, not one that we are loaded with.
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Xlinker -Bsymbolic -Bsymbolic-functions")

--- a/src/tools/crossgen/CMakeLists.txt
+++ b/src/tools/crossgen/CMakeLists.txt
@@ -24,6 +24,10 @@ add_executable_clr(crossgen
   ${crossgen_RESOURCES}
 )
 
+if(FEATURE_MERGE_JIT_AND_ENGINE)
+    set(CLRJIT_CROSSGEN clrjit_crossgen)
+endif(FEATURE_MERGE_JIT_AND_ENGINE)
+
 target_link_libraries(crossgen
     cee_crossgen
     mdcompiler_crossgen
@@ -31,7 +35,7 @@ target_link_libraries(crossgen
     mdruntimerw_crossgen
     mdhotdata_crossgen
     corguids
-    clrjit_crossgen
+    ${CLRJIT_CROSSGEN}
     gcinfo_crossgen
     corzap_crossgen
     mscorlib_crossgen

--- a/src/vm/CMakeLists.txt
+++ b/src/vm/CMakeLists.txt
@@ -12,9 +12,6 @@ add_definitions(-DFEATURE_LEAVE_RUNTIME_HOLDER=1)
 add_definitions(-DUNICODE)
 add_definitions(-D_UNICODE)
 
-# Add the Merge flag here is needed
-add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)
-
 if(CMAKE_CONFIGURATION_TYPES) # multi-configuration generator?
   foreach (Config DEBUG CHECKED)  
      set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:${Config}>:WRITE_BARRIER_CHECK=1>)

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -803,8 +803,9 @@ do { \
 #define IfFailGoLog(EXPR) IfFailGotoLog(EXPR, ErrExit)
 #endif
 
+#if defined(FEATURE_MERGE_JIT_AND_ENGINE)
 void            jitOnDllProcessAttach();
-
+#endif // defined(FEATURE_MERGE_JIT_AND_ENGINE)
 
 void EEStartupHelper(COINITIEE fFlags)
 {
@@ -854,15 +855,9 @@ void EEStartupHelper(COINITIEE fFlags)
 #endif // !FEATURE_CORECLR && !CROSSGEN_COMPILE
         }
 
-#ifdef CROSSGEN_COMPILE
-//ARM64TODO: Enable when jit is brought in
- #if defined(_TARGET_ARM64_)
-        //_ASSERTE(!"ARM64:NYI");    
-        
- #else
+#if defined(CROSSGEN_COMPILE) && defined(FEATURE_MERGE_JIT_AND_ENGINE)
         jitOnDllProcessAttach();
- #endif // defined(_TARGET_ARM64_)
-#endif
+#endif // defined(CROSSGEN_COMPILE) && defined(FEATURE_MERGE_JIT_AND_ENGINE)
 
 #ifndef CROSSGEN_COMPILE
         // Initialize Numa and CPU group information

--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1275,7 +1275,7 @@ public:
     static void ClearCaches( void );
     static BOOL IsCacheCleanupRequired();
 
-    static LPWSTR         GetJitName();
+    static LPCWSTR         GetJitName();
 
     static void           Unload(LoaderAllocator *pLoaderAllocator);
 

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -11306,9 +11306,9 @@ void CEEJitInfo::getEHinfo(
 }
 #endif // CROSSGEN_COMPILE
 
-#ifdef CROSSGEN_COMPILE
+#if defined(CROSSGEN_COMPILE)
 EXTERN_C ICorJitCompiler* __stdcall getJit();
-#endif
+#endif // defined(CROSSGEN_COMPILE)
 
 #ifdef FEATURE_INTERPRETER
 static CorJitResult CompileMethodWithEtwWrapper(EEJitManager *jitMgr,
@@ -11364,16 +11364,16 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
 
     BEGIN_SO_TOLERANT_CODE(GetThread());
 
-#ifdef CROSSGEN_COMPILE
+#if defined(CROSSGEN_COMPILE) && !defined(FEATURE_CORECLR)
     ret = getJit()->compileMethod( comp,
                                    info,
                                    flags,
                                    nativeEntry,
                                    nativeSizeOfCode);
 
-#else // CROSSGEN_COMPILE
+#else // defined(CROSSGEN_COMPILE) && !defined(FEATURE_CORECLR)
 
-#ifdef ALLOW_SXS_JIT
+#if defined(ALLOW_SXS_JIT) && !defined(CROSSGEN_COMPILE)
     if (FAILED(ret) && jitMgr->m_alternateJit
 #ifdef FEATURE_STACK_SAMPLING
         && (!samplingEnabled || (flags2 & CORJIT_FLG2_SAMPLING_JIT_BACKGROUND))
@@ -11403,7 +11403,7 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
             ret = CORJIT_SKIPPED;
         }
     }
-#endif // ALLOW_SXS_JIT
+#endif // defined(ALLOW_SXS_JIT) && !defined(CROSSGEN_COMPILE)
 
 #ifdef FEATURE_INTERPRETER
     static ConfigDWORD s_InterpreterFallback;
@@ -11450,6 +11450,7 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
     }
 #endif // FEATURE_INTERPRETER
 
+#if !defined(CROSSGEN_COMPILE)
     // Cleanup any internal data structures allocated 
     // such as IL code after a successfull JIT compile
     // If the JIT fails we keep the IL around and will
@@ -11466,8 +11467,9 @@ CorJitResult invokeCompileMethodHelper(EEJitManager *jitMgr,
         comp->MethodCompileComplete(info->ftn);
 #endif // FEATURE_INTERPRETER
     }
-
-#endif // CROSSGEN_COMPILE
+#endif // !defined(CROSSGEN_COMPILE)
+    
+#endif // defined(CROSSGEN_COMPILE) && !defined(FEATURE_CORECLR)
 
     END_SO_TOLERANT_CODE;
 

--- a/src/vm/pefile.cpp
+++ b/src/vm/pefile.cpp
@@ -1748,11 +1748,11 @@ static void RuntimeVerifyLog(DWORD level, LoggableAssembly *pLogAsm, const WCHAR
 static const LPCWSTR CorCompileRuntimeDllNames[NUM_RUNTIME_DLLS] =
 {
 #ifdef FEATURE_CORECLR
-    MAKEDLLNAME_W(W("CORECLR"))
+    MAKEDLLNAME_W(W("coreclr")),
 #else
     MAKEDLLNAME_W(W("CLR")),
-    MAKEDLLNAME_W(W("CLRJIT"))
 #endif
+    MAKEDLLNAME_W(W("clrjit"))
 };
 
 #if !defined(FEATURE_CORECLR) && !defined(CROSSGEN_COMPILE)
@@ -1828,7 +1828,7 @@ extern HMODULE CorCompileGetRuntimeDll(CorCompileRuntimeDlls id)
 
     // Currently special cased for every entry.
 #ifdef FEATURE_CORECLR
-    static_assert_no_msg(NUM_RUNTIME_DLLS == 1);
+    static_assert_no_msg(NUM_RUNTIME_DLLS == 2);
     static_assert_no_msg(CORECLR_INFO == 0);
 #else // !FEATURE_CORECLR
     static_assert_no_msg(NUM_RUNTIME_DLLS == 2);


### PR DESCRIPTION
This change enables consuming the JIT as a dynamic library, as opposed to getting statically linked. For now, I have kept FEATURE_MERGE_JIT_AND_ENGINE incase we need it in the short-term. 

Since the runtime and JIT were in the CoreCLR package (since JIT was statically linked), I am keeping the JIT in the CoreCLR nuget package. This will be fixed in the next phase once https://github.com/dotnet/coreclr/pull/4478 is merged. 

@jkotas @pgavlin PTAL

CC @russellhadley @RussKeldorph @schellap