### PR TITLE
Replace uses of FromCancellation -> FromCanceled in mscorlib

### DIFF
--- a/src/mscorlib/src/System/IO/BufferedStream.cs
+++ b/src/mscorlib/src/System/IO/BufferedStream.cs
@@ -321,7 +321,7 @@ public sealed class BufferedStream : Stream {
     public override Task FlushAsync(CancellationToken cancellationToken) {
 
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCancellation<Int32>(cancellationToken);
+            return Task.FromCanceled<Int32>(cancellationToken);
 
         EnsureNotClosed();        
 
@@ -661,7 +661,7 @@ public sealed class BufferedStream : Stream {
 
         // Fast path check for cancellation already requested
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCancellation<Int32>(cancellationToken);
+            return Task.FromCanceled<Int32>(cancellationToken);
 
         EnsureNotClosed();
         EnsureCanRead();
@@ -1071,7 +1071,7 @@ public sealed class BufferedStream : Stream {
 
         // Fast path check for cancellation already requested
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCancellation<Int32>(cancellationToken); 
+            return Task.FromCanceled<Int32>(cancellationToken); 
 
         EnsureNotClosed();
         EnsureCanWrite();

--- a/src/mscorlib/src/System/IO/FileStream.cs
+++ b/src/mscorlib/src/System/IO/FileStream.cs
@@ -2444,7 +2444,7 @@ namespace System.IO {
                 return base.ReadAsync(buffer, offset, count, cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation<int>(cancellationToken);
+                return Task.FromCanceled<int>(cancellationToken);
 
             if (_handle.IsClosed)
                 __Error.FileNotOpen();
@@ -2496,7 +2496,7 @@ namespace System.IO {
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             if (_handle.IsClosed)
                 __Error.FileNotOpen();
@@ -2659,7 +2659,7 @@ namespace System.IO {
                 return base.FlushAsync(cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             if (_handle.IsClosed)
                 __Error.FileNotOpen();

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -385,7 +385,7 @@ namespace System.IO {
             }
             catch (OperationCanceledException oce)
             {
-                return Task.FromCanceled<int>(oce);
+                return Task.FromCancellation<int>(oce);
             }
             catch (Exception exception)
             {
@@ -605,7 +605,7 @@ namespace System.IO {
             }
             catch (OperationCanceledException oce)
             {
-                return Task.FromCanceled<VoidTaskResult>(oce);
+                return Task.FromCancellation<VoidTaskResult>(oce);
             }
             catch (Exception exception)
             {

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -185,7 +185,7 @@ namespace System.IO {
         public override Task FlushAsync(CancellationToken cancellationToken) {
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             try {
 
@@ -373,7 +373,7 @@ namespace System.IO {
 
             // If cancellation was requested, bail early
             if (cancellationToken.IsCancellationRequested) 
-                return Task.FromCancellation<int>(cancellationToken);
+                return Task.FromCanceled<int>(cancellationToken);
 
             try
             {
@@ -385,7 +385,7 @@ namespace System.IO {
             }
             catch (OperationCanceledException oce)
             {
-                return Task.FromCancellation<int>(oce);
+                return Task.FromCanceled<int>(oce);
             }
             catch (Exception exception)
             {
@@ -437,7 +437,7 @@ namespace System.IO {
 
             // If cancelled - return fast:
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
            
             // Avoid copying data from this buffer into a temp buffer:
             //   (require that InternalEmulateRead does not throw,
@@ -596,7 +596,7 @@ namespace System.IO {
 
             // If cancellation is already requested, bail early
             if (cancellationToken.IsCancellationRequested) 
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             try
             {
@@ -605,7 +605,7 @@ namespace System.IO {
             }
             catch (OperationCanceledException oce)
             {
-                return Task.FromCancellation<VoidTaskResult>(oce);
+                return Task.FromCanceled<VoidTaskResult>(oce);
             }
             catch (Exception exception)
             {

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -854,7 +854,7 @@ namespace System.IO {
                 ValidateCopyToArguments(destination, bufferSize);
                 
                 return cancellationToken.IsCancellationRequested ?
-                    Task.FromCancellation(cancellationToken) :
+                    Task.FromCanceled(cancellationToken) :
                     Task.CompletedTask;
             }
 

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -350,7 +350,7 @@ namespace System.IO {
             // If cancellation was requested, bail early with an already completed task.
             // Otherwise, return a task that represents the Begin/End methods.
             return cancellationToken.IsCancellationRequested
-                        ? Task.FromCancellation<int>(cancellationToken)
+                        ? Task.FromCanceled<int>(cancellationToken)
                         : BeginEndReadAsync(buffer, offset, count);
         }
 
@@ -653,7 +653,7 @@ namespace System.IO {
             // If cancellation was requested, bail early with an already completed task.
             // Otherwise, return a task that represents the Begin/End methods.
             return cancellationToken.IsCancellationRequested
-                        ? Task.FromCancellation(cancellationToken)
+                        ? Task.FromCanceled(cancellationToken)
                         : BeginEndWriteAsync(buffer, offset, count);
         }
 
@@ -871,7 +871,7 @@ namespace System.IO {
             public override Task FlushAsync(CancellationToken cancellationToken)
             {
                 return cancellationToken.IsCancellationRequested ?
-                    Task.FromCancellation(cancellationToken) :
+                    Task.FromCanceled(cancellationToken) :
                     Task.CompletedTask;
             }
 
@@ -937,7 +937,7 @@ namespace System.IO {
             public override Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 return cancellationToken.IsCancellationRequested ?
-                    Task.FromCancellation(cancellationToken) :
+                    Task.FromCanceled(cancellationToken) :
                     Task.CompletedTask;
             }
 

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -282,7 +282,7 @@ namespace System.IO {
         public override Task FlushAsync(CancellationToken cancellationToken) { 
         
             if (cancellationToken.IsCancellationRequested) 
-                return Task.FromCancellation(cancellationToken); 
+                return Task.FromCanceled(cancellationToken); 
 
             try { 
             
@@ -445,7 +445,7 @@ namespace System.IO {
             Contract.EndContractBlock();  // contract validation copied from Read(...) 
       
             if (cancellationToken.IsCancellationRequested)  
-                return Task.FromCancellation<Int32>(cancellationToken); 
+                return Task.FromCanceled<Int32>(cancellationToken); 
         
             try { 
             
@@ -640,7 +640,7 @@ namespace System.IO {
             Contract.EndContractBlock();  // contract validation copied from Write(..) 
                             
             if (cancellationToken.IsCancellationRequested)  
-                return Task.FromCancellation(cancellationToken); 
+                return Task.FromCanceled(cancellationToken); 
          
             try { 
                        

--- a/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
@@ -607,7 +607,7 @@ namespace System.Threading
 
             // Bail early for cancellation
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation<bool>(cancellationToken);
+                return Task.FromCanceled<bool>(cancellationToken);
 
             lock (m_lockObj)
             {

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -5591,7 +5591,7 @@ namespace System.Threading.Tasks
         [FriendAccessAllowed]
         internal static Task FromCancellation(CancellationToken cancellationToken)
         {
-            return FromCancellation(cancellationToken);
+            return FromCanceled(cancellationToken);
         }
         
         /// <summary>Creates a <see cref="Task{TResult}"/> that's completed due to cancellation with the specified token.</summary>

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -5511,7 +5511,7 @@ namespace System.Threading.Tasks
             return signaledTaskIndex;
         }
 
-        #region FromResult / FromException / FromCancellation
+        #region FromResult / FromException / FromCanceled
 
         /// <summary>Creates a <see cref="Task{TResult}"/> that's completed successfully with the specified result.</summary>
         /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
@@ -5549,32 +5549,12 @@ namespace System.Threading.Tasks
         /// <summary>Creates a <see cref="Task"/> that's completed due to cancellation with the specified token.</summary>
         /// <param name="cancellationToken">The token with which to complete the task.</param>
         /// <returns>The canceled task.</returns>
-        [FriendAccessAllowed]
-        internal static Task FromCancellation(CancellationToken cancellationToken)
-        {
-            if (!cancellationToken.IsCancellationRequested) throw new ArgumentOutOfRangeException("cancellationToken");
-            Contract.EndContractBlock();
-            return new Task(true, TaskCreationOptions.None, cancellationToken);
-        }
-
-        /// <summary>Creates a <see cref="Task"/> that's completed due to cancellation with the specified token.</summary>
-        /// <param name="cancellationToken">The token with which to complete the task.</param>
-        /// <returns>The canceled task.</returns>
         public static Task FromCanceled(CancellationToken cancellationToken)
         {
-            return FromCancellation(cancellationToken);
-        }
-
-        /// <summary>Creates a <see cref="Task{TResult}"/> that's completed due to cancellation with the specified token.</summary>
-        /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
-        /// <param name="cancellationToken">The token with which to complete the task.</param>
-        /// <returns>The canceled task.</returns>
-        [FriendAccessAllowed]
-        internal static Task<TResult> FromCancellation<TResult>(CancellationToken cancellationToken)
-        {
-            if (!cancellationToken.IsCancellationRequested) throw new ArgumentOutOfRangeException("cancellationToken");
+            if (!cancellationToken.IsCancellationRequested)
+                throw new ArgumentOutOfRangeException("cancellationToken");
             Contract.EndContractBlock();
-            return new Task<TResult>(true, default(TResult), TaskCreationOptions.None, cancellationToken);
+            return new Task(true, TaskCreationOptions.None, cancellationToken);
         }
 
         /// <summary>Creates a <see cref="Task{TResult}"/> that's completed due to cancellation with the specified token.</summary>
@@ -5583,14 +5563,17 @@ namespace System.Threading.Tasks
         /// <returns>The canceled task.</returns>
         public static Task<TResult> FromCanceled<TResult>(CancellationToken cancellationToken)
         {
-            return FromCancellation<TResult>(cancellationToken);
+            if (!cancellationToken.IsCancellationRequested)
+                throw new ArgumentOutOfRangeException("cancellationToken");
+            Contract.EndContractBlock();
+            return new Task<TResult>(true, default(TResult), TaskCreationOptions.None, cancellationToken);
         }
 
         /// <summary>Creates a <see cref="Task{TResult}"/> that's completed due to cancellation with the specified exception.</summary>
         /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
         /// <param name="exception">The exception with which to complete the task.</param>
         /// <returns>The canceled task.</returns>
-        internal static Task<TResult> FromCancellation<TResult>(OperationCanceledException exception)
+        internal static Task<TResult> FromCanceled<TResult>(OperationCanceledException exception)
         {
             if (exception == null) throw new ArgumentNullException("exception");
             Contract.EndContractBlock();
@@ -5718,7 +5701,7 @@ namespace System.Threading.Tasks
 
             // Short-circuit if we are given a pre-canceled token
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
 
             // Kick off initial Task, which will call the user-supplied function and yield a Task.
             Task<Task> task1 = Task<Task>.Factory.StartNew(function, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
@@ -5769,7 +5752,7 @@ namespace System.Threading.Tasks
 
             // Short-circuit if we are given a pre-canceled token
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCancellation<TResult>(cancellationToken);
+                return Task.FromCanceled<TResult>(cancellationToken);
 
             // Kick off initial Task, which will call the user-supplied function and yield a Task.
             Task<Task<TResult>> task1 = Task<Task<TResult>>.Factory.StartNew(function, cancellationToken, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
@@ -5876,7 +5859,7 @@ namespace System.Threading.Tasks
             if (cancellationToken.IsCancellationRequested)
             {
                 // return a Task created as already-Canceled
-                return Task.FromCancellation(cancellationToken);
+                return Task.FromCanceled(cancellationToken);
             }
             else if (millisecondsDelay == 0)
             {

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -5573,7 +5573,7 @@ namespace System.Threading.Tasks
         /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
         /// <param name="exception">The exception with which to complete the task.</param>
         /// <returns>The canceled task.</returns>
-        internal static Task<TResult> FromCanceled<TResult>(OperationCanceledException exception)
+        internal static Task<TResult> FromCancellation<TResult>(OperationCanceledException exception)
         {
             if (exception == null) throw new ArgumentNullException("exception");
             Contract.EndContractBlock();

--- a/src/mscorlib/src/System/Threading/Tasks/Task.cs
+++ b/src/mscorlib/src/System/Threading/Tasks/Task.cs
@@ -5583,6 +5583,28 @@ namespace System.Threading.Tasks
             Contract.Assert(succeeded, "This should always succeed on a new task.");
             return task;
         }
+        
+#if !FEATURE_CORECLR 
+        /// <summary>Creates a <see cref="Task"/> that's completed due to cancellation with the specified token.</summary>
+        /// <param name="cancellationToken">The token with which to complete the task.</param>
+        /// <returns>The canceled task.</returns>
+        [FriendAccessAllowed]
+        internal static Task FromCancellation(CancellationToken cancellationToken)
+        {
+            return FromCancellation(cancellationToken);
+        }
+        
+        /// <summary>Creates a <see cref="Task{TResult}"/> that's completed due to cancellation with the specified token.</summary>
+        /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
+        /// <param name="cancellationToken">The token with which to complete the task.</param>
+        /// <returns>The canceled task.</returns>
+        [FriendAccessAllowed]
+        internal static Task<TResult> FromCancellation<TResult>(CancellationToken cancellationToken)
+        {
+            return FromCanceled<TResult>(cancellationToken);
+        }
+#endif
+        
         #endregion
 
         #region Run methods


### PR DESCRIPTION
.NET 4.6 introduces the `Task.FromCanceled` APIs, which let a `Task` be created from a `CancellationToken`. For some reason, it looks like they forward to an internal `FromCancellation` method which does the exact same thing, and for some reason the latter is in more use throughout mscorlib. (Maybe since it was being used pre-.NET 4.6?) Either way, it's no longer needed, so I removed the method and replaced all uses of `FromCancellation` with `FromCanceled`.

Other changes:

- Renamed `FromCancellation<T>(OperationCanceledException)` internal method to `FromCanceled`, which looks like it's being used by `MemoryStream`

@jkotas PTAL