### PR TITLE
Bail out early in CopyToAsync if a cancellation is requested

### DIFF
--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -134,8 +134,10 @@ namespace System.IO {
         public virtual Task CopyToAsync(Stream destination, Int32 bufferSize, CancellationToken cancellationToken)
         {
             ValidateCopyToArguments(destination, bufferSize);
-
-            return CopyToAsyncInternal(destination, bufferSize, cancellationToken);
+            
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                CopyToAsyncInternal(destination, bufferSize, cancellationToken);
         }
 
         private async Task CopyToAsyncInternal(Stream destination, Int32 bufferSize, CancellationToken cancellationToken)


### PR DESCRIPTION
This PR adds a conditional so that rather than just forwarding the cancellation token to the `ReadAsync` and `WriteAsync` methods in `CopyToAsync`, it short-circuits if a cancellation was already requested. (This already seems to be the behavior of [`ReadAsync`](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/IO/Stream.cs#L352) and [`WriteAsync`](https://github.com/dotnet/coreclr/blob/master/src/mscorlib/src/System/IO/Stream.cs#L655), so I'm not sure why this method isn't doing it as well.)

Note: I'm well aware that this could be a breaking change in some cases, e.g. if a subclass of `Stream` overrides `ReadAsync` and doesn't bail out early on the cancellation token, or returns a non-zero integer. For example:

```cs
public class Foo : MemoryStream
{
    public async override Task<int> ReadAsync(byte[] b, int o, int c, CancellationToken t)
    {
        return 1;
    }
}

// previously would go in an infinite loop; now throws a TCE
await new Foo().CopyToAsync(Stream.Null, 1, new CancellationToken(true));
```

@stephentoub and @jkotas, what do you think of this change? If it's OK, then I can submit tests to CoreFX in another PR.