### PR TITLE
Minimize buffer allocations in Stream.CopyTo for seekable streams

### DIFF
--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -199,6 +199,14 @@ namespace System.IO {
                     // introduced, we don't need to worry about the other overload
                     // performing nonexistent/different argument validation. We can
                     // simply call ValidateCopyToArguments again here, and return.
+
+                    // NOTE NOTE NOTE: If the other CopyTo overload is made virtual in
+                    // the future, do the same thing as what we do in CopyToAsync and
+                    // set bufferSize to 1 and just call the other overload. That will
+                    // ensure consistent behavior when a stream still has bytes left or
+                    // no bytes left, e.g. if a stream overrides the method and doesn't
+                    // do argument validation, fooStream.CopyTo(null) shouldn't throw
+                    // regardless of whether fooStream has used up all of its bytes or not.
                     ValidateCopyToArguments(destination, bufferSize: 1); // Validate the argument if we short-circuit, for compat
                     return; // No bytes to copy, so this is a noop
                 }

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -143,7 +143,7 @@ namespace System.IO {
                 else
                 {
                     long remaining = length - position;
-                    if (remaining <= length) // In the case of a positive overflow, stick to the default size
+                    if (remaining > 0) // In the case of a positive overflow, stick to the default size
                         bufferSize = (int)Math.Min(bufferSize, remaining);
                 }
             }
@@ -205,7 +205,7 @@ namespace System.IO {
                 else
                 {
                     long remaining = length - position;
-                    if (remaining <= length) // In the case of a positive overflow, stick to the default size
+                    if (remaining > 0) // In the case of a positive overflow, stick to the default size
                         bufferSize = (int)Math.Min(bufferSize, remaining);
                 }
             }

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -116,7 +116,16 @@ namespace System.IO {
         [ComVisible(false)]
         public Task CopyToAsync(Stream destination)
         {
-            return CopyToAsync(destination, _DefaultCopyBufferSize);
+            int bufferSize = _DefaultCopyBufferSize;
+            if (CanSeek)
+            {
+                long remaining = Length - Position;
+                if (remaining <= 0)
+                    return Task.CompletedTask; // No bytes to copy, so this is a noop
+                bufferSize = (int)Math.Min(bufferSize, remaining);
+            }
+            
+            return CopyToAsync(destination, bufferSize);
         }
 
         [HostProtection(ExternalThreading = true)]
@@ -155,7 +164,16 @@ namespace System.IO {
         // the current position.
         public void CopyTo(Stream destination)
         {
-            CopyTo(destination, _DefaultCopyBufferSize);
+            int bufferSize = _DefaultCopyBufferSize;
+            if (CanSeek)
+            {
+                long remaining = Length - Position;
+                if (remaining <= 0)
+                    return; // No bytes left, so this is a noop
+                bufferSize = (int)Math.Min(bufferSize, remaining);
+            }
+            
+            CopyTo(destination, bufferSize);
         }
 
         public void CopyTo(Stream destination, int bufferSize)

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -122,7 +122,10 @@ namespace System.IO {
                 long length = Length;
                 long position = Position;
                 if (length <= position) // Handles negative overflows
+                {
+                    ValidateCopyToArguments(destination, bufferSize: 1); // Validate the argument if we short-circuit, for compat
                     return Task.CompletedTask; // No bytes to copy, so this is a noop
+                }
                 long remaining = length - position;
                 if (remaining <= length) // In the case of a positive overflow, stick to the default size
                     bufferSize = (int)Math.Min(bufferSize, remaining);
@@ -173,7 +176,10 @@ namespace System.IO {
                 long length = Length;
                 long position = Position;
                 if (length <= position) // Handles negative overflows
+                {
+                    ValidateCopyToArguments(destination, bufferSize: 1); // Validate the argument if we short-circuit, for compat
                     return; // No bytes to copy, so this is a noop
+                }
                 long remaining = length - position;
                 if (remaining <= length) // In the case of a positive overflow, stick to the default size
                     bufferSize = (int)Math.Min(bufferSize, remaining);

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -119,10 +119,13 @@ namespace System.IO {
             int bufferSize = _DefaultCopyBufferSize;
             if (CanSeek)
             {
-                long remaining = Length - Position;
-                if (remaining <= 0)
+                long length = Length;
+                long position = Position;
+                if (length <= position) // Handles negative overflows
                     return Task.CompletedTask; // No bytes to copy, so this is a noop
-                bufferSize = (int)Math.Min(bufferSize, remaining);
+                long remaining = length - position;
+                if (remaining <= length) // In the case of a positive overflow, stick to the default size
+                    bufferSize = (int)Math.Min(bufferSize, remaining);
             }
             
             return CopyToAsync(destination, bufferSize);
@@ -167,10 +170,13 @@ namespace System.IO {
             int bufferSize = _DefaultCopyBufferSize;
             if (CanSeek)
             {
-                long remaining = Length - Position;
-                if (remaining <= 0)
-                    return; // No bytes left, so this is a noop
-                bufferSize = (int)Math.Min(bufferSize, remaining);
+                long length = Length;
+                long position = Position;
+                if (length <= position) // Handles negative overflows
+                    return; // No bytes to copy, so this is a noop
+                long remaining = length - position;
+                if (remaining <= length) // In the case of a positive overflow, stick to the default size
+                    bufferSize = (int)Math.Min(bufferSize, remaining);
             }
             
             CopyTo(destination, bufferSize);


### PR DESCRIPTION
The current implementation of `Stream.CopyTo` allocates a giant, 81920-byte buffer if no `bufferSize` parameter is passed. This is incredibly wasteful if the stream we're copying from can seek, because then we can use the `Length` and `Position` properties to determine how many bytes are left and allocate a buffer of that size. This PR alters the bodies of `CopyTo` and `CopyToAsync` to do that.

Right now I don't want this to be merged, since there are several points of contention that need to be addressed:

- Should the optimization should occur inside/outside the virtual methods? (I did it outside, so all `Stream` subclasses would benefit from this.)
- This change introduces 3 new virtual method calls: `CanSeek`, `Length`, and `Position`. `CanSeek` probably shouldn't throw, and neither should the other two if the stream can seek, but I'm still a bit iffy about this change.
- How should streams with `Length < Position` be handled? This can arise in classes like `MemoryStream` if you do something like this:

  ```cs
  var stream = new MemoryStream { Position = 123 };

  Console.WriteLine(stream.Position); // -> 123
  Console.WriteLine(stream.Length); // -> 0
  ```

  Right now I'm handling it by short-circuiting (the same as if `Length == Position`), since I'm assuming that would also mean there are no bytes left in the stream. Should I instead fallback to the default behavior (keeping the buffer size at `81920`) here, to minimize the risk of a compat issue?

I have tested these changes with [these instructions](https://github.com/dotnet/coreclr/blob/master/Documentation/building/testing-with-corefx.md), and (assuming I did them right) they seem to be working as far as I can see.

@stephentoub @jkotas PTAL