### PR TITLE
NetBSD limits name of a semaphore to 15 characters (inc. null)

### DIFF
--- a/src/pal/src/thread/process.cpp
+++ b/src/pal/src/thread/process.cpp
@@ -49,6 +49,7 @@ Abstract:
 #include <sys/resource.h>
 #include <debugmacrosext.h>
 #include <semaphore.h>
+#include <stdint.h>
 
 #ifdef __APPLE__
 #include <sys/sysctl.h>
@@ -130,9 +131,18 @@ Volatile<LONG> terminator = 0;
 // Process ID of this process.
 DWORD gPID = (DWORD) -1;
 
+// The lowest common supported semaphore length, including null character
+// NetBSD-7.99.25: 15 characters
+// MacOSX 10.11: 31 -- Core 1.0 RC2 compatibility
+#if defined(__NetBSD__)
+#define CLR_SEM_MAX_NAMELEN 15
+#else
+#define CLR_SEM_MAX_NAMELEN (NAME_MAX - 4)
+#endif
+
 // The runtime waits on this semaphore if the dbgshim startup semaphore exists
 Volatile<sem_t *> g_continueSem = SEM_FAILED;
-char g_continueSemName[NAME_MAX - 4];
+char g_continueSemName[CLR_SEM_MAX_NAMELEN];
 
 // Function to call during PAL/process shutdown/abort
 Volatile<PSHUTDOWN_CALLBACK> g_shutdownCallback = nullptr;
@@ -1398,9 +1408,26 @@ static bool IsCoreClrModule(const char* pModulePath)
 // to clean up its semaphore. 
 // Note to anyone modifying these names in the future: Semaphore names on OS X are limited
 // to SEM_NAME_LEN characters, including null. SEM_NAME_LEN is 31 (at least on OS X 10.11).
+// NetBSD limits semaphore names to 15 characters, including null (at least up to 7.99.25).
+// Keep 31 length for Core 1.0 RC2 compatibility
+#if defined(__NetBSD__)
+static const char* RuntimeStartupSemaphoreName = "/clrst%08llx";
+static const char* RuntimeOldContinueSemaphoreName = "/clrco%08llx";
+static const char* RuntimeContinueSemaphoreName = "/clrct%08llx";
+#else
 static const char* RuntimeStartupSemaphoreName = "/clrst%08x%016llx";
 static const char* RuntimeOldContinueSemaphoreName = "/clrco%08x%016llx";
 static const char* RuntimeContinueSemaphoreName = "/clrct%08x%016llx";
+#endif
+
+#if defined(__NetBSD__)
+static uint64_t HashSemaphoreName(uint64_t a, uint64_t b)
+{
+	return (a ^ b) & 0xffffffff;
+}
+#else
+#define HashSemaphoreName(a,b) a,b
+#endif
 
 class PAL_RuntimeStartupHelper
 {
@@ -1437,12 +1464,12 @@ public:
     {
         if (m_startupSem != SEM_FAILED)
         {
-            char startupSemName[NAME_MAX - 4];
+            char startupSemName[CLR_SEM_MAX_NAMELEN];
             sprintf_s(startupSemName,
                       sizeof(startupSemName),
                       RuntimeStartupSemaphoreName,
-                      m_processId,
-                      m_processIdDisambiguationKey);
+                      HashSemaphoreName(m_processId,
+                                        m_processIdDisambiguationKey));
 
             sem_close(m_startupSem);
             sem_unlink(startupSemName);
@@ -1501,7 +1528,7 @@ public:
     PAL_ERROR Register()
     {
         CPalThread *pThread = InternalGetCurrentThread();
-        char startupSemName[NAME_MAX - 4];
+        char startupSemName[CLR_SEM_MAX_NAMELEN];
         PAL_ERROR pe = NO_ERROR;
 
         // See semaphore name format for details about this value. We store it so that
@@ -1513,8 +1540,8 @@ public:
         sprintf_s(startupSemName,
                   sizeof(startupSemName),
                   RuntimeStartupSemaphoreName,
-                  m_processId,
-                  m_processIdDisambiguationKey);
+                  HashSemaphoreName(m_processId,
+                                    m_processIdDisambiguationKey));
 
         TRACE("PAL_RuntimeStartupHelper.Register startup sem '%s'\n", startupSemName);
 
@@ -1618,15 +1645,15 @@ public:
 
     void StartupHelperThread()
     {
-        char continueSemName[NAME_MAX - 4];
+        char continueSemName[CLR_SEM_MAX_NAMELEN];
         sem_t *continueSem = SEM_FAILED;
         PAL_ERROR pe = NO_ERROR;
 
         sprintf_s(continueSemName,
                   sizeof(continueSemName),
                   RuntimeContinueSemaphoreName,
-                  m_processId,
-                  m_processIdDisambiguationKey);
+                  HashSemaphoreName(m_processId,
+                                    m_processIdDisambiguationKey));
 
         TRACE("StartupHelperThread continue sem '%s'\n", continueSemName);
 
@@ -1793,15 +1820,15 @@ BOOL
 PALAPI
 PAL_NotifyRuntimeStarted()
 {
-    char startupSemName[NAME_MAX - 4];
+    char startupSemName[CLR_SEM_MAX_NAMELEN];
     sem_t *startupSem = SEM_FAILED;
     BOOL result = TRUE;
 
     UINT64 processIdDisambiguationKey = 0;
     GetProcessIdDisambiguationKey(gPID, &processIdDisambiguationKey);
 
-    sprintf_s(startupSemName, sizeof(startupSemName), RuntimeStartupSemaphoreName, gPID, processIdDisambiguationKey);
-    sprintf_s(g_continueSemName, sizeof(g_continueSemName), RuntimeOldContinueSemaphoreName, gPID, processIdDisambiguationKey);
+    sprintf_s(startupSemName, sizeof(startupSemName), RuntimeStartupSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
+    sprintf_s(g_continueSemName, sizeof(g_continueSemName), RuntimeOldContinueSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
 
     TRACE("PAL_NotifyRuntimeStarted opening continue (old) '%s' startup '%s'\n", g_continueSemName, startupSemName);
 
@@ -1810,7 +1837,7 @@ PAL_NotifyRuntimeStarted()
     if (g_continueSem == SEM_FAILED)
     {
         // Create the new continue semaphore name "clrctXXXX"
-        sprintf_s(g_continueSemName, sizeof(g_continueSemName), RuntimeContinueSemaphoreName, gPID, processIdDisambiguationKey);
+        sprintf_s(g_continueSemName, sizeof(g_continueSemName), RuntimeContinueSemaphoreName, HashSemaphoreName(gPID, processIdDisambiguationKey));
 
         TRACE("PAL_NotifyRuntimeStarted creating continue '%s'\n", g_continueSemName);
 


### PR DESCRIPTION
Introduce new variable: `CLR_SEM_MAX_NAMELEN` to track the shortest allowable
length of the path. Change algorithm to generate a semaphore name to OR instead
of the string concatenation.