### PR TITLE
Fix PS version log path

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -233,7 +233,7 @@ for %%X in (powershell.exe) do (set __PSDir=%%~$PATH:X)
 if not defined __PSDir goto :NoPS
 
 :: Validate Powershell version
-set PS_VERSION_LOG=%~dp0ps-version.log
+set "PS_VERSION_LOG=%__LogsDir%\ps-version.log"
 powershell -NoProfile -ExecutionPolicy unrestricted -Command "$PSVersionTable.PSVersion.Major" > %PS_VERSION_LOG%
 set /P PS_VERSION=< %PS_VERSION_LOG%
 if %PS_VERSION% LEQ 2 (


### PR DESCRIPTION
The PS version log path is incorrectly set to the root of the current drive when
building for ARM64 with toolset_dir set. In that case, the `%~dp0` doesn't hold
the current drive and directory anymore.
I have fixed it by using `__LogsDir` instead. It it a good practice to put generated
files somewhere under the bin folder and the logs directory seems appropriate.