### PR TITLE
Revert "Replace uses of FromCancellation -> FromCanceled in mscorlib"

### DIFF
--- a/src/mscorlib/src/System/IO/BufferedStream.cs
+++ b/src/mscorlib/src/System/IO/BufferedStream.cs
@@ -321,7 +321,7 @@ public sealed class BufferedStream : Stream {
     public override Task FlushAsync(CancellationToken cancellationToken) {
 
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCanceled<Int32>(cancellationToken);
+            return Task.FromCancellation<Int32>(cancellationToken);
 
         EnsureNotClosed();        
 
@@ -661,7 +661,7 @@ public sealed class BufferedStream : Stream {
 
         // Fast path check for cancellation already requested
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCanceled<Int32>(cancellationToken);
+            return Task.FromCancellation<Int32>(cancellationToken);
 
         EnsureNotClosed();
         EnsureCanRead();
@@ -1071,7 +1071,7 @@ public sealed class BufferedStream : Stream {
 
         // Fast path check for cancellation already requested
         if (cancellationToken.IsCancellationRequested)
-            return Task.FromCanceled<Int32>(cancellationToken); 
+            return Task.FromCancellation<Int32>(cancellationToken); 
 
         EnsureNotClosed();
         EnsureCanWrite();

--- a/src/mscorlib/src/System/IO/FileStream.cs
+++ b/src/mscorlib/src/System/IO/FileStream.cs
@@ -2444,7 +2444,7 @@ namespace System.IO {
                 return base.ReadAsync(buffer, offset, count, cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<int>(cancellationToken);
+                return Task.FromCancellation<int>(cancellationToken);
 
             if (_handle.IsClosed)
                 __Error.FileNotOpen();
@@ -2496,7 +2496,7 @@ namespace System.IO {
                 return base.WriteAsync(buffer, offset, count, cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
+                return Task.FromCancellation(cancellationToken);
 
             if (_handle.IsClosed)
                 __Error.FileNotOpen();
@@ -2659,7 +2659,7 @@ namespace System.IO {
                 return base.FlushAsync(cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
+                return Task.FromCancellation(cancellationToken);
 
             if (_handle.IsClosed)
                 __Error.FileNotOpen();

--- a/src/mscorlib/src/System/IO/MemoryStream.cs
+++ b/src/mscorlib/src/System/IO/MemoryStream.cs
@@ -185,7 +185,7 @@ namespace System.IO {
         public override Task FlushAsync(CancellationToken cancellationToken) {
 
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
+                return Task.FromCancellation(cancellationToken);
 
             try {
 
@@ -373,7 +373,7 @@ namespace System.IO {
 
             // If cancellation was requested, bail early
             if (cancellationToken.IsCancellationRequested) 
-                return Task.FromCanceled<int>(cancellationToken);
+                return Task.FromCancellation<int>(cancellationToken);
 
             try
             {
@@ -437,7 +437,7 @@ namespace System.IO {
 
             // If cancelled - return fast:
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled(cancellationToken);
+                return Task.FromCancellation(cancellationToken);
            
             // Avoid copying data from this buffer into a temp buffer:
             //   (require that InternalEmulateRead does not throw,
@@ -596,7 +596,7 @@ namespace System.IO {
 
             // If cancellation is already requested, bail early
             if (cancellationToken.IsCancellationRequested) 
-                return Task.FromCanceled(cancellationToken);
+                return Task.FromCancellation(cancellationToken);
 
             try
             {

--- a/src/mscorlib/src/System/IO/Stream.cs
+++ b/src/mscorlib/src/System/IO/Stream.cs
@@ -350,7 +350,7 @@ namespace System.IO {
             // If cancellation was requested, bail early with an already completed task.
             // Otherwise, return a task that represents the Begin/End methods.
             return cancellationToken.IsCancellationRequested
-                        ? Task.FromCanceled<int>(cancellationToken)
+                        ? Task.FromCancellation<int>(cancellationToken)
                         : BeginEndReadAsync(buffer, offset, count);
         }
 
@@ -653,7 +653,7 @@ namespace System.IO {
             // If cancellation was requested, bail early with an already completed task.
             // Otherwise, return a task that represents the Begin/End methods.
             return cancellationToken.IsCancellationRequested
-                        ? Task.FromCanceled(cancellationToken)
+                        ? Task.FromCancellation(cancellationToken)
                         : BeginEndWriteAsync(buffer, offset, count);
         }
 
@@ -854,7 +854,7 @@ namespace System.IO {
                 ValidateCopyToArguments(destination, bufferSize);
                 
                 return cancellationToken.IsCancellationRequested ?
-                    Task.FromCanceled(cancellationToken) :
+                    Task.FromCancellation(cancellationToken) :
                     Task.CompletedTask;
             }
 
@@ -871,7 +871,7 @@ namespace System.IO {
             public override Task FlushAsync(CancellationToken cancellationToken)
             {
                 return cancellationToken.IsCancellationRequested ?
-                    Task.FromCanceled(cancellationToken) :
+                    Task.FromCancellation(cancellationToken) :
                     Task.CompletedTask;
             }
 
@@ -937,7 +937,7 @@ namespace System.IO {
             public override Task WriteAsync(Byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 return cancellationToken.IsCancellationRequested ?
-                    Task.FromCanceled(cancellationToken) :
+                    Task.FromCancellation(cancellationToken) :
                     Task.CompletedTask;
             }
 

--- a/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/mscorlib/src/System/IO/UnmanagedMemoryStream.cs
@@ -282,7 +282,7 @@ namespace System.IO {
         public override Task FlushAsync(CancellationToken cancellationToken) { 
         
             if (cancellationToken.IsCancellationRequested) 
-                return Task.FromCanceled(cancellationToken); 
+                return Task.FromCancellation(cancellationToken); 
 
             try { 
             
@@ -445,7 +445,7 @@ namespace System.IO {
             Contract.EndContractBlock();  // contract validation copied from Read(...) 
       
             if (cancellationToken.IsCancellationRequested)  
-                return Task.FromCanceled<Int32>(cancellationToken); 
+                return Task.FromCancellation<Int32>(cancellationToken); 
         
             try { 
             
@@ -640,7 +640,7 @@ namespace System.IO {
             Contract.EndContractBlock();  // contract validation copied from Write(..) 
                             
             if (cancellationToken.IsCancellationRequested)  
-                return Task.FromCanceled(cancellationToken); 
+                return Task.FromCancellation(cancellationToken); 
          
             try { 
                        

--- a/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/mscorlib/src/System/Threading/SemaphoreSlim.cs
@@ -607,7 +607,7 @@ namespace System.Threading
 
             // Bail early for cancellation
             if (cancellationToken.IsCancellationRequested)
-                return Task.FromCanceled<bool>(cancellationToken);
+                return Task.FromCancellation<bool>(cancellationToken);
 
             lock (m_lockObj)
             {


### PR DESCRIPTION
Reverts dotnet/coreclr#4537

The change broke CoreFx; attempting to upgrade to using the new packages gives compilation errors:
```
System/WindowsRuntimeSystemExtensions.netstandard.cs(119,33): error CS0117: 'Task' does not contain a definition for 'FromCancellation' [/mnt/j/workspace/dotnet_corefx/master/ubuntu14.04_debug_prtest/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj]
System/WindowsRuntimeSystemExtensions.netstandard.cs(195,33): error CS0117: 'Task' does not contain a definition for 'FromCancellation' [/mnt/j/workspace/dotnet_corefx/master/ubuntu14.04_debug_prtest/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj]
System/WindowsRuntimeSystemExtensions.netstandard.cs(298,33): error CS0117: 'Task' does not contain a definition for 'FromCancellation' [/mnt/j/workspace/dotnet_corefx/master/ubuntu14.04_debug_prtest/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj]
System/WindowsRuntimeSystemExtensions.netstandard.cs(407,33): error CS0117: 'Task' does not contain a definition for 'FromCancellation' [/mnt/j/workspace/dotnet_corefx/master/ubuntu14.04_debug_prtest/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj]
```