### PR TITLE
Fix 2895:Add query handling of ICLRPrivResource for Assembly::CLRPrivResourceAssembly

### DIFF
--- a/src/binder/assembly.cpp
+++ b/src/binder/assembly.cpp
@@ -385,6 +385,12 @@ Exit:
             AddRef();
             *ppv = this;
         }
+		else if (IsEqualIID(riid, __uuidof(ICLRPrivResource)))
+		{
+			AddRef();
+			// upcasting is safe
+			*ppv = static_cast<ICLRPrivResource *>(this);
+		}
         else if (IsEqualIID(riid, __uuidof(ICLRPrivResourceAssembly)))
         {
             AddRef();


### PR DESCRIPTION
Fix [#2895](https://github.com/dotnet/coreclr/issues/2895): Add query handling of ICLRPrivResource for Assembly::CLRPrivResourceAssembly