### PR TITLE
Fix 2796: Add query handling of IUnknown for MergeTokenManager and CMapToken

### DIFF
--- a/src/md/enc/rwutil.cpp
+++ b/src/md/enc/rwutil.cpp
@@ -1001,12 +1001,29 @@ ULONG MergeTokenManager::Release()
 
 HRESULT MergeTokenManager::QueryInterface(REFIID riid, void **ppUnk)
 {
-    *ppUnk = 0;
+	if (ppUnk == NULL)
+		return E_INVALIDARG;
 
-    if (riid == IID_IMapToken)
-        *ppUnk = (IUnknown *) (IMapToken *) this;
-    else
-        return (E_NOINTERFACE);
+	if (IsEqualIID(riid, IID_IMapToken))
+	{
+		//*ppUnk = (IUnknown *) (IMapToken *) this;
+		// it should return the accurate type requested,
+		// if IUnknown is returned, it will finally converted to IMapToken*
+		*ppUnk = (IMapToken *) this;
+	}
+	else if (IsEqualIID(riid, IID_IUnknown))
+	{
+		// add query handling for IUnknown
+		// this upcasting (converting a derived-class 
+		// reference or pointer to a base-class) is safe
+		*ppUnk = (IUnknown *) this;
+	}
+	else
+	{
+		*ppUnk = NULL;
+		return (E_NOINTERFACE);
+	}
+
     AddRef();
     return (S_OK);
 }   // TokenManager::QueryInterface
@@ -1121,12 +1138,23 @@ ULONG CMapToken::Release()
 
 HRESULT CMapToken::QueryInterface(REFIID riid, void **ppUnk)
 {
-    *ppUnk = 0;
+	if (ppUnk == NULL)
+		return E_INVALIDARG;
 
-    if (riid == IID_IMapToken)
-        *ppUnk = (IUnknown *) (IMapToken *) this;
-    else
-        return (E_NOINTERFACE);
+	if (IsEqualIID(riid, IID_IMapToken))
+	{
+		*ppUnk = (IMapToken *) this;
+	}
+	else if (IsEqualIID(riid, IID_IUnknown))
+	{
+		*ppUnk = (IUnknown *) this;
+	}
+	else
+	{
+		*ppUnk = NULL;
+		return (E_NOINTERFACE);
+	}
+
     AddRef();
     return (S_OK);
 }   // CMapToken::QueryInterface


### PR DESCRIPTION
Fix [#2796](https://github.com/dotnet/coreclr/issues/2796): Add query handling of IUnknown for MergeTokenManager and CMapToken