### PR TITLE
Fix error in invocation of runtests.sh for long GC tests

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1509,7 +1509,7 @@ combinedScenarios.each { scenario ->
                         
                         // The Long GC playlist contains all of the tests that are
                         // going to be run.
-                        playlistString = '--playlist ./tests/longRunningGcTests.txt'
+                        playlistString = '--playlist=./tests/longRunningGcTests.txt'
                     }
                     
 


### PR DESCRIPTION
The `playlists` option accepts its parameter with an equals sign, not a space.