### PR TITLE
ARM64: Fix NativeCallable

### DIFF
--- a/src/vm/method.cpp
+++ b/src/vm/method.cpp
@@ -5393,18 +5393,22 @@ BOOL MethodDesc::HasNativeCallableAttribute()
     }
     CONTRACTL_END;
 
-// enable only for amd64 now, other platforms are not tested.
-#if defined(_TARGET_AMD64_) 
-
 #ifdef FEATURE_CORECLR
     HRESULT hr = GetMDImport()->GetCustomAttributeByName(GetMemberDef(),
         g_NativeCallableAttribute,
         NULL,
         NULL);
-    return (hr == S_OK);
+    if (hr == S_OK)
+    {
+        // enable only for amd64/arm64 now, other platforms are not tested.
+#if defined(_TARGET_AMD64_) || defined(_TARGET_ARM64_)
+        return TRUE;
+#else
+        _ASSERTE(!"HasNativeCallableAttribute is not yet implemented.");
+#endif // _TARGET_AMD64_ || _TARGET_ARM64_
+    }
 #endif //FEATURE_CORECLR
 
-#endif //_TARGET_AMD64_
     return FALSE;
 }
 

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -158,7 +158,7 @@ RelativePath=Interop\NativeCallable\NativeCallableTest\NativeCallableTest.cmd
 WorkingDir=Interop\NativeCallable\NativeCallableTest
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;RT;EXPECTED_FAIL;ISSUE_4422;REL_PASS;ASSERT_ONLY
+Categories=Pri0;RT;EXPECTED_PASS
 HostStyle=0
 [BoolTest.cmd_23]
 RelativePath=Interop\PrimitiveMarshalling\Bool\BoolTest\BoolTest.cmd


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/4422
The issue is that JIT didn't pass UMEntryThunk for the managed function
entry point which is invoked from the native function.
The fix is to enable NativeCallable attribute check to get the right entry point.