### PR TITLE
Enable long GC tests to run on a regular basis

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -357,7 +357,11 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 }
                 break
             case 'longgc':
-                // long GC jobs are triggered by phrase only.
+                assert (os == 'Ubuntu' || os == 'Windows_NT' || os == 'OSX')
+                assert configuration == 'Release'
+                assert architecture == 'x64'
+                Utilities.addPeriodicTrigger(job, '@daily')
+                addEmailPublisher(job, 'dotnetgctests@microsoft.com')
                 break
             case 'ilrt':
                 assert !(os in bidailyCrossList)
@@ -504,7 +508,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                             }
                             break
                         case 'longgc':
-                            if (configuration == 'Release' || configuration == 'Checked') {
+                            if (configuration == 'Release') {
                                 Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Long-Running GC Build & Test", "(?i).*test\\W+${os}\\W+${configuration}\\W+${scenario}.*")
                             }
                             break
@@ -666,7 +670,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                             }
                             break
                         case 'longgc':
-                            if (configuration == 'Release' || configuration == 'Checked') {
+                            if (configuration == 'Release') {
                                 Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Long-Running GC Build & Test", "(?i).*test\\W+${os}\\W+${configuration}\\W+${scenario}.*")
                             }
                             break
@@ -857,7 +861,7 @@ def static addTriggers(def job, def branch, def isPR, def architecture, def os, 
                 }
             } else if (scenario == 'longgc') {
                 if (os == 'Windows_NT'){
-                    if (configuration == 'Release' || configuration == 'Checked'){
+                    if (configuration == 'Release'){
                         Utilities.addGithubPRTriggerForBranch(job, branch, "${os} ${architecture} ${configuration} Long-Running GC Build & Test", "(?i).*test\\W+${os}\\W+${architecture}\\W+${configuration}\\W+${scenario}.*")  
                     }
                 }
@@ -1008,12 +1012,13 @@ combinedScenarios.each { scenario ->
                                 }
                                 break
                             case 'longgc':
-                                if (os != 'Windows_NT') {
+                                if (os != 'Windows_NT' && os != 'Ubuntu' && os != 'OSX') {
                                     return
                                 }
-                                
-                                // only x64 or x86 for now
                                 if (architecture != 'x64') {
+                                    return
+                                }
+                                if (configuration != 'Release') {
                                     return
                                 }
                                 break
@@ -1436,8 +1441,8 @@ combinedScenarios.each { scenario ->
                                 }
                                 break
                             case 'longgc':
-                                //Skip configs that aren't Checked or Release (so just Debug, for now)
-                                if (configuration != 'Checked' && configuration != 'Release') {
+                                // Long GC tests take a long time on non-Release builds
+                                if (configuration != 'Release') {
                                     return
                                 }
                                 break


### PR DESCRIPTION
Now that these tests are stable enough to run on a regular basis, this PR introduces a daily run for Long GC tests on Ubuntu, Windows, and OSX that will email test failures to an email alias.

This PR also disables long GC tests on checked builds for now, since they took an inordinate amount of time to complete.

Open question: is once a day too often, should this be once a week instead?