### PR TITLE
Add coreOverlay option to unix-test-instructions document

### DIFF
--- a/Documentation/building/unix-test-instructions.md
+++ b/Documentation/building/unix-test-instructions.md
@@ -40,6 +40,19 @@ Run tests:
 >     --coreFxNativeBinDir=~/corefx/bin/Linux.x64.Debug
 > ```
 
+The method above will copy dependencies from the set of directories provided to create an 'overlay' directory.
+If you already have an overlay directory prepared with the dependencies you need, you can specify `--coreOverlayDir`
+instead of `--coreClrBinDir`, `--mscorlibDir`, `--coreFxBinDir`, and `--coreFxNativeBinDir`. It would look something like:
+
+
+> ```bash
+> ~/coreclr$ tests/runtest.sh
+>     --testRootDir=~/test/Windows_NT.x64.Debug
+>     --testNativeBinDir=~/coreclr/bin/obj/Linux.x64.Debug/tests
+>     --coreOverlayDir=/path/to/directory/containing/overlay
+> ```
+
+
 Test results will go into:
 
 > `~/test/Windows_NT.x64.Debug/coreclrtests.xml`


### PR DESCRIPTION
Add `--coreOverlay` option usage to `unix-test-instructions.md` for faster unit-testing.
Related PR: #4554 
@adityamandaleeka , PTAL