### PR TITLE
Establish stack frame inside CallEHFunclet

### DIFF
--- a/src/pal/inc/unixasmmacrosarm.inc
+++ b/src/pal/inc/unixasmmacrosarm.inc
@@ -208,12 +208,21 @@ C_FUNC(\Name\()_End):
         mov \Register, sp
 .endm
 
+.macro PROLOG_STACK_SAVE_WITH_OFFSET Register, Offset
+        .setfp \Register, sp, \Offset
+        add \Register, sp, \Offset
+.endm
+
 .macro EPILOG_STACK_FREE Size
         add sp, sp, \Size
 .endm
 
 .macro EPILOG_STACK_RESTORE Register
         mov sp, \Register
+.endm
+
+.macro EPILOG_STACK_RESTORE_WITH_OFFSET Register, Offset
+        sub sp, \Register, \Offset
 .endm
 
 .macro EPILOG_BRANCH Target

--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -99,6 +99,7 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler
 
         PROLOG_PUSH  "{r4-r11, lr}"
+        PROLOG_STACK_SAVE r7
         alloc_stack  4
 
         // On entry:
@@ -111,7 +112,9 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         // Save the SP of this function
         str sp, [r3]
         // apply the non-volatiles corresponding to the CrawlFrame
-        ldm r2, {r4-r11}
+        ldm r2!, {r4-r6}
+        add r2, r2, #4
+        ldm r2!, {r8-r11}
         // Invoke the funclet
         blx r1
 

--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -99,7 +99,8 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler
 
         PROLOG_PUSH  "{r4-r11, lr}"
-        PROLOG_STACK_SAVE r7
+        .setfp r7, sp, #12
+        add r7, sp, #12
         alloc_stack  4
 
         // On entry:
@@ -128,7 +129,8 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         NESTED_ENTRY CallEHFilterFunclet, _TEXT, NoHandler
 
         PROLOG_PUSH  "{r4-r11, lr}"
-        PROLOG_STACK_SAVE r7
+        .setfp r7, sp, #12
+        add r7, sp, #12
         alloc_stack  4
 
         // On entry:

--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -127,7 +127,8 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         // frame pointer for accessing the locals in the parent method.
         NESTED_ENTRY CallEHFilterFunclet, _TEXT, NoHandler
 
-        PROLOG_PUSH  "{lr}"
+        PROLOG_PUSH  "{r4-r11, lr}"
+        PROLOG_STACK_SAVE r7
         alloc_stack  4
 
         // On entry:
@@ -143,6 +144,6 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         blx r2
 
         free_stack   4
-        EPILOG_POP   "{pc}"
+        EPILOG_POP   "{r4-r11, pc}"
 
         NESTED_END CallEHFilterFunclet, _TEXT

--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -99,8 +99,7 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         NESTED_ENTRY CallEHFunclet, _TEXT, NoHandler
 
         PROLOG_PUSH  "{r4-r11, lr}"
-        .setfp r7, sp, #12
-        add r7, sp, #12
+        PROLOG_STACK_SAVE_WITH_OFFSET r7, #12
         alloc_stack  4
 
         // On entry:
@@ -129,8 +128,7 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         NESTED_ENTRY CallEHFilterFunclet, _TEXT, NoHandler
 
         PROLOG_PUSH  "{r4-r11, lr}"
-        .setfp r7, sp, #12
-        add r7, sp, #12
+        PROLOG_STACK_SAVE_WITH_OFFSET r7, #12
         alloc_stack  4
 
         // On entry:


### PR DESCRIPTION
This commit revises the implementation of CallEHFunclet to establish
stack frame appropriately.

This commit allows libunwind to work correctly for the frame created by
CallEHFunclet.