### PR TITLE
Separate TryDsc and ExnFlowDsc

### DIFF
--- a/src/jit/block.cpp
+++ b/src/jit/block.cpp
@@ -55,7 +55,7 @@ EHSuccessorIter::EHSuccessorIter(Compiler* comp, BasicBlock* block) :
     m_comp(comp),
     m_block(block),
     m_curRegSucc(NULL),
-    m_curTry(comp->ehGetBlockTryDsc(block)),
+    m_curTry(comp->ehGetBlockExnFlowDsc(block)),
     m_remainingRegSuccs(block->NumSucc(comp))
 {
     // If "block" is a "leave helper" block (the empty BBJ_ALWAYS block that pairs with a
@@ -93,7 +93,7 @@ void EHSuccessorIter::FindNextRegSuccTry()
 
             // If the try region started by "m_curRegSucc" (represented by newTryIndex) contains m_block,
             // we've already yielded its handler, as one of the EH handler successors of m_block itself.
-            if (m_comp->bbInTryRegions(newTryIndex, m_block))
+            if (m_comp->bbInExnFlowRegions(newTryIndex, m_block))
                 continue;
 
             // Otherwise, consider this try.
@@ -162,18 +162,19 @@ flowList* Compiler::BlockPredsWithEH(BasicBlock* blk)
 #endif // MEASURE_BLOCK_SIZE
         }
 
-        // Now add all blocks within the try (except for second blocks of BBJ_CALLFINALLY/BBJ_ALWAYS pairs;
+        // Now add all blocks handled by this handler (except for second blocks of BBJ_CALLFINALLY/BBJ_ALWAYS pairs;
         // these cannot cause transfer to the handler...)
         BasicBlock* prevBB = NULL;
 
         // TODO-Throughput: It would be nice if we could iterate just over the blocks in the try, via
         // something like:
         //   for (BasicBlock* bb = ehblk->ebdTryBeg; bb != ehblk->ebdTryLast->bbNext; bb = bb->bbNext)
+        //     (plus adding in any filter blocks outside the try whose exceptions are handled here).
         // That doesn't work, however: funclets have caused us to sometimes split the body of a try into
         // more than one sequence of contiguous blocks.  We need to find a better way to do this.
         for (BasicBlock* bb = fgFirstBB; bb != NULL; prevBB = bb, bb = bb->bbNext)
         {
-            if (bbInTryRegions(tryIndex, bb) && (prevBB == NULL || !prevBB->isBBCallAlwaysPair()))
+            if (bbInExnFlowRegions(tryIndex, bb) && (prevBB == NULL || !prevBB->isBBCallAlwaysPair()))
             {
                 res = new (this, CMK_FlowList) flowList(bb, res);
 

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -1486,6 +1486,7 @@ public:
     bool                bbInCatchHandlerILRange (BasicBlock * blk);
     bool                bbInFilterILRange       (BasicBlock * blk);
     bool                bbInTryRegions          (unsigned regionIndex, BasicBlock * blk);
+    bool                bbInExnFlowRegions      (unsigned regionIndex, BasicBlock * blk);
     bool                bbInHandlerRegions      (unsigned regionIndex, BasicBlock * blk);
     bool                bbInCatchHandlerRegions (BasicBlock * tryBlk, BasicBlock * hndBlk);
     unsigned short      bbFindInnermostCommonTryRegion (BasicBlock  * bbOne, BasicBlock  * bbTwo);
@@ -1525,9 +1526,14 @@ public:
     // Return the EH descriptor for the most nested filter or handler region this BasicBlock is a member of (or nullptr if this block is not in a filter or handler region).
     EHblkDsc*           ehGetBlockHndDsc(BasicBlock* block);
 
+    // Return the EH descriptor for the most nested region that may handle exceptions raised in this BasicBlock (or nullptr if this block's exceptions propagate to caller).
+    EHblkDsc*           ehGetBlockExnFlowDsc(BasicBlock* block);
+
     EHblkDsc*           ehIsBlockTryLast(BasicBlock* block);
     EHblkDsc*           ehIsBlockHndLast(BasicBlock* block);
     bool                ehIsBlockEHLast(BasicBlock* block);
+
+    bool                ehBlockHasExnFlowDsc(BasicBlock* block);
 
     // Return the region index of the most nested EH region this block is in.
     unsigned            ehGetMostNestedRegionIndex(BasicBlock* block, bool* inTryRegion);

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -2144,7 +2144,7 @@ void                Compiler::impSpillLclRefs(ssize_t lclNum)
            live on entry to the handler.
            Just spill 'em all without considering the liveness */
 
-        bool xcptnCaught = compCurBB->hasTryIndex() &&
+        bool xcptnCaught = ehBlockHasExnFlowDsc(compCurBB) &&
                            (tree->gtFlags & (GTF_CALL | GTF_EXCEPT));
 
         /* Skip the tree if it doesn't have an affected reference,

--- a/src/jit/liveness.cpp
+++ b/src/jit/liveness.cpp
@@ -1154,16 +1154,13 @@ void                Compiler::fgExtendDbgLifetimes()
 VARSET_VALRET_TP    Compiler::fgGetHandlerLiveVars(BasicBlock *block)
 {
     noway_assert(block);
-    noway_assert(block->hasTryIndex());
+    noway_assert(ehBlockHasExnFlowDsc(block));
 
     VARSET_TP VARSET_INIT_NOCOPY(liveVars, VarSetOps::MakeEmpty(this));
-    unsigned  XTnum = block->getTryIndex();
+    EHblkDsc* HBtab = ehGetBlockExnFlowDsc(block);
 
     do
     {
-        noway_assert(XTnum < compHndBBtabCount);
-        EHblkDsc* HBtab = ehGetDsc(XTnum);
-
         /* Either we enter the filter first or the catch/finally */
 
         if (HBtab->HasFilter())
@@ -1186,11 +1183,16 @@ VARSET_VALRET_TP    Compiler::fgGetHandlerLiveVars(BasicBlock *block)
 
         /* If we have nested try's edbEnclosing will provide them */
         noway_assert((HBtab->ebdEnclosingTryIndex == EHblkDsc::NO_ENCLOSING_INDEX) ||
-                     (HBtab->ebdEnclosingTryIndex  > XTnum));
+                     (HBtab->ebdEnclosingTryIndex  > ehGetIndex(HBtab)));
 
-        XTnum = HBtab->ebdEnclosingTryIndex;
+        unsigned outerIndex = HBtab->ebdEnclosingTryIndex;
+        if (outerIndex == EHblkDsc::NO_ENCLOSING_INDEX)
+        {
+            break;
+        }
+        HBtab = ehGetDsc(outerIndex);
 
-    } while (XTnum != EHblkDsc::NO_ENCLOSING_INDEX);
+    } while (true);
 
     return liveVars;
 }
@@ -1293,9 +1295,9 @@ void                Compiler::fgLiveVarAnalysis(bool updateInternalOnly)
 
             heapLiveIn = (heapLiveOut && !block->bbHeapDef) || block->bbHeapUse;
 
-            /* Is this block part of a 'try' statement? */
+            /* Can exceptions from this block be handled (in this function)? */
 
-            if  (block->hasTryIndex())
+            if  (ehBlockHasExnFlowDsc(block))
             {
                 VARSET_TP VARSET_INIT_NOCOPY(liveVars, fgGetHandlerLiveVars(block));
 
@@ -1520,7 +1522,7 @@ VARSET_VALRET_TP    Compiler::fgUpdateLiveSet(VARSET_VALARG_TP  liveSet,
                 //
                 assert(VarSetOps::IsEmptyIntersection(this, newLiveSet, varBits) ||
                        opts.compDbgCode || lvaTable[tree->gtLclVarCommon.gtLclNum].lvAddrExposed ||
-                       (compCurBB != NULL && compCurBB->hasTryIndex()));
+                       (compCurBB != NULL && ehBlockHasExnFlowDsc(compCurBB)));
                 VarSetOps::UnionD(this, newLiveSet, varBits);
             }
         }
@@ -2729,7 +2731,7 @@ void                Compiler::fgInterBlockLocalVarLiveness()
 
         VARSET_TP VARSET_INIT_NOCOPY(volatileVars, VarSetOps::MakeEmpty(this));
 
-        if  (block->hasTryIndex())
+        if  (ehBlockHasExnFlowDsc(block))
         {
             VarSetOps::Assign(this, volatileVars, fgGetHandlerLiveVars(block));
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -12094,7 +12094,7 @@ GenTree* Compiler::fgMorphSmpOpOptional(GenTreeOp* tree)
                    the assignment should not proceed
                    We are safe with an assignment to a local variables
                  */
-                if (compCurBB->hasTryIndex())
+                if (ehBlockHasExnFlowDsc(compCurBB))
                     break;
                 if (!dstIsSafeLclVar)
                     break;
@@ -14202,7 +14202,7 @@ void                Compiler::fgMorphStmts(BasicBlock * block,
         if (fgFoldConditional(block))
             continue;
 
-        if  (block->hasTryIndex())
+        if  (ehBlockHasExnFlowDsc(block))
             continue;
 
 #if OPT_MULT_ADDSUB

--- a/tests/src/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.cs
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.cs
@@ -1,0 +1,263 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+class C
+{
+    public static int Main(string[] args)
+    {
+        int error = Test1();
+        error += Test2();
+        error += Test3();
+        error += Test3b();
+        error += Test4();
+        error += Test5();
+        error += Test6();
+        Console.WriteLine(error == 0 ? "Pass" : "Fail");
+        return 100 + error;
+    }
+
+    static int Test1()
+    {
+        try {
+            return Test1Inner();
+        }
+        catch {
+            return 1;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test1Inner()
+    {
+        int i = 3;
+        do
+        {
+            try
+            {
+                throw new Exception();
+            }
+            // we should be decrementing i here, it does not happen
+            catch (Exception) when (--i < 0)
+            {
+                Console.Write("e");
+                break;
+            }
+            catch (Exception)
+            {
+                // just printing constant 3 here
+                //000000b5  mov         ecx,3
+                //000000ba  call        000000005B3CBAF0
+                Print1(i);
+            }
+        } while (true);
+
+        return 0;
+    }
+
+    static int limit = 10;
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static void Print1(int i)
+    {
+        if (limit > 0) {
+            Console.Write(i.ToString());
+            --limit;
+        }
+        else {
+            throw new Exception();
+        }
+    }
+
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test2()
+    {
+        int x = 1, y = 5;
+        try {
+            throw new Exception();
+        } catch when (Print2(Print2(0, --x), ++x) == 1) {
+        } catch {
+            // Need a PHI here for x that includes the decremented
+            // value; doesn't happen if we don't realize that exceptions
+            // at the first call to Print2 can reach here.
+            // Without it, we might const-prop a 1 here which is
+            // incorrect when the first Print2 call throws.
+            y = Print2(1, x);
+        }
+
+        return y;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Print2(int i, int j)
+    {
+        if (i == 0)
+            throw new Exception();
+
+        Console.WriteLine(j.ToString());
+        return j;
+    }
+
+    static int Test3()
+    {
+        return Test3(0, 50);
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test3(int x, int y) // must pass 50 for y
+    {
+        try {
+            throw new Exception();
+        }
+        // Need to make sure the increment to y is not
+        // hoisted to before the call to Throw(x).  If
+        // the importer doesn't realize that an exception
+        // from Throw(x) can be caught in this method, it
+        // won't separate Throw(x) out from the Ignore(..)
+        // tree, but will still separate out ++y, creating
+        // the bad reordering
+        catch when (Ignore(Throw(x), ++y)) { }
+        catch { Print3(y); }
+
+        return y - 50; // Caller should pass '50'
+    }
+
+    static int Test3b()
+    {
+        return Test3b(new int[5], 50);
+    }
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test3b(int[] x, int y)
+    {
+        try {
+            throw new Exception();
+        }
+        // Same as Test3 except that the tree which raises
+        // an exception is the array access x[100] instead
+        // of a call.
+        catch when (Ignore(x[100], ++y)) { }
+        catch { Print3(y); }
+
+        return y - 50; // Caller should pass '50'
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static bool Ignore(int a, int b) { return false; }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Throw(int n) { throw new Exception(); }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Print3(int i)
+    {
+        Console.WriteLine(i.ToString());
+        return i;
+    }
+
+    class BoxedBool
+    {
+        public bool Field;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test4()
+    {
+        return Test4(new BoxedBool(), new Exception());
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test4(BoxedBool box, Exception e)
+    {
+        bool b = box.Field;
+
+        try {
+            throw e;
+        }
+        // This filter side-effects the heap and then throws an
+        // exception which is caught by the outer catch; make
+        // sure we recognize the heap modification and don't think
+        // we can value-number the load here the same as the load
+        // on entry to the function.
+        catch when ((box.Field = true) && ((BoxedBool)null).Field) {
+        }
+        catch {
+            b = box.Field;
+        }
+
+        if (b) {
+            Console.WriteLine("true");
+        }
+        else {
+            Console.WriteLine("false");
+        }
+
+        return (b ? 0 : 1);
+    }
+
+
+    static int Test5()
+    {
+        int n = int.MaxValue - 1;
+        int m = Test5(n);
+        return (m == n ? 0 : 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test5(int n)
+    {
+        try {
+            throw new Exception();
+        }
+        catch when (Filter5(ref n)) { }
+        catch { }
+        return n;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static bool Filter5(ref int n)
+    {
+        // Codegen'ing this as
+        //   add [addr_of_n], 2
+        //   jo throw_ovf
+        // would incorrectly modify n on the path where
+        // the exception occurs.
+        n = checked(n + 2);
+        return (n != 0);
+    }
+
+
+    static int Test6()
+    {
+        int n = int.MaxValue - 3;
+        int m = Test6(n);
+        return (m == n + 2 ? 0 : 1);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    static int Test6(int n)
+    {
+        try {
+            throw new Exception();
+        }
+        catch when (Filter6(ref n)) { }
+        catch { }
+        return n;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    static bool Filter6(ref int n)
+    {
+        // Codegen'ing this as
+        //   add [addr_of_n], 4
+        //   jo throw_ovf
+        // would incorrectly increment n by 4 rather than 2
+        // on the path where the exception occurs.
+        checked {
+            n += 2;
+            n += 2;
+        }
+        return (n != 0);
+    }
+}

--- a/tests/src/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.csproj
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_4044/GitHub_4044.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{03791641-ED25-42C4-AD81-FCCF7E47DC2E}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <PropertyGroup>
+    <DebugType></DebugType>
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildProjectName).cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="$(JitPackagesConfigFileDirectory)minimal\project.json" />
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <PropertyGroup>
+    <ProjectJson>$(JitPackagesConfigFileDirectory)minimal\project.json</ProjectJson>
+    <ProjectLockJson>$(JitPackagesConfigFileDirectory)minimal\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/JIT/Regression/JitBlue/GitHub_4044/app.config
+++ b/tests/src/JIT/Regression/JitBlue/GitHub_4044/app.config
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.20.0" newVersion="4.0.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encoding" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.IO" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.10.0" newVersion="4.0.10.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Supplement the helpers for finding a block's `TryDsc` (the `EHblkDsc` of
the innermost `try` region containing it) and a block's `HndDsc` (the
`EHblkDsc` of the innermost handler it is part of) with helpers for
finding a block's `ExnFlowDsc` (the `EHblkDsc` of the innermost handler to
which control may be transferred if an exception occurs in the given
block).

The `ExnFlowDsc` is the same as the `TryDsc` in most cases, but differs
for blocks in filter expressions -- when an exception escapes a filter,
that new exception is discarded and the search for a handler for the prior
exception is resumed at the next-outer handler, which corresponds to the
next-outer try enclosing the try that the filter protects.  This is not
the try enclosing the filter itself for "mutual-protect" clauses such as
are generated for
  try {
    ...
  } catch when (E) { // <-- E is not in the 'try' but an exception
    ...              //     in it causes flow to go to the 'finally'
  } finally {
    ...
  }

This change adds helpers around the `ExnFlowDsc` and updates code that
was using the `TryDsc`/`TryIndex` where appropriate.

This fixes #4044.