### PR TITLE
Add exclusions for RyuJIT x86 and x86 TestEnv

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -7,12 +7,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b13621\b13621\*" >
             <Issue>2235</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14585\b14585\*" >
-            <Issue>2235</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15307\b15307\*" >
-            <Issue>2235</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b16102\b16102\*" >
             <Issue>2236</Issue>
         </ExcludeList>
@@ -20,9 +14,6 @@
             <Issue>2235</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57367\b57367\*" >
-            <Issue>2235</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b20785\b20785\*" >
             <Issue>2235</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b399444\b399444a\*" >
@@ -297,7 +288,7 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\Interop\BestFitMapping\BestFitMapping\BestFitMapping.cmd" >
              <Issue>3571</Issue>
-	</ExcludeList>
+	    </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\doublinknoleak\*">
              <Issue>3392</Issue>
         </ExcludeList>
@@ -366,6 +357,16208 @@
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\baseservices\exceptions\regressions\Dev11\147911\test147911\*">
              <Issue>3651</Issue>
+        </ExcludeList>
+    </ItemGroup>
+    <ItemGroup Condition="'$(BuildArch)' == 'x86'">
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\rem_r8\rem_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\mul_r8\mul_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\sub_r8\sub_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ckfinite_r8\ckfinite_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\add_r8\add_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ckfinite\ckfinite.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59948\b59948\b59948.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\div_r8\div_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_ckfinite_r8\ldc_ckfinite_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\neg_r8\neg_r8.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b108366\b108366\b108366.cmd" >
+             <Issue>3549</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_XModuletest1-xmod\_XModuletest1-xmod.cmd" >
+             <Issue>3554</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_XAssemblytest1-xassem\_XAssemblytest1-xassem.cmd" >
+             <Issue>3554</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\test1-xassem\test1-xassem.cmd" >
+             <Issue>3554</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_Simpletest1\_Simpletest1.cmd" >
+             <Issue>3554</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev10_94677\loopvt\loopvt.cmd" >
+             <Issue>3569</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_And_Op_cs_do\Double_And_Op_cs_do.cmd" >
+             <Issue>3596</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Or_Op_cs_do\Double_Or_Op_cs_do.cmd" >
+             <Issue>3596</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06595\b06595\b06595.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b11413\b11413\b11413.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP2c\SP2c.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b92568\b92568\b92568.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b04257\b04257\b04257.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91021\b91021\b91021.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b04639\b04639\b04639.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow01_mul\overflow01_mul.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_816617\DevDiv_816617_r\DevDiv_816617_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-1\_dbgunsafe-1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatOvfToInt2_ro\FloatOvfToInt2_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\mul_ovf\mul_ovf.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\sub_i8\sub_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value020\box-unbox-value020.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08172\b08172\b08172.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgarray\_il_dbgarray.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ldc\ldc.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-6\_relunsafe-6.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14294\b14294\b14294.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-0\_dbgunsafe-0.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46583\b46583\b46583.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\mul_i8\mul_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\pop\pop.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b16473\b16473\b16473.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b27917\b27917\b27917.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\long_cs_d\long_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\mul_ovf_i8\mul_ovf_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25813\b25813\b25813.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovfldiv1_il_d\ovfldiv1_il_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\AbsGeneric_ro\AbsGeneric_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_815941\devdiv_815941\devdiv_815941.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b47093\b47093\b47093.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\lim\lim_002\lim_002.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_r8_i8\conv_ovf_r8_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\long_cs_r\long_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59949\b59949\b59949.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_relarray\_il_relarray.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgarray3\_il_dbgarray3.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort_cs_d\ushort_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_ret_i8\ldc_ret_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\xor\xor.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface015\castclass-interface015.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\CnsLng1\CnsLng1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-4\_relunsafe-4.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\decimal_cs_do\decimal_cs_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05784\b05784\b05784.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_180411\devdiv_180411\devdiv_180411.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\init_uint32\init_uint32.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\enum\castclass-enum003\castclass-enum003.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_r8_i8\ldc_conv_ovf_r8_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30799\b30799\b30799.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface014\box-unbox-interface014.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ldarg_n\ldarg_n.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong_cs_r\ulong_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics010\box-unbox-generics010.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgtailcall\_il_dbgtailcall.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface014\castclass-interface014.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-1\_relunsafe-1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_u8\_il_relhuge_u8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\bool_cs_r\bool_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14591\b14591\b14591.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatInfinitiesToInt_d\FloatInfinitiesToInt_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\float_cs_ro\float_cs_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\SqrtGeneric_ro\SqrtGeneric_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\lur\lur_02\lur_02.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82249\b82249\b82249.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\sbyte_cs_d\sbyte_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\div_i8\div_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40199\b40199\b40199.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\init_int32\init_int32.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\decimal_cs_r\decimal_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8_cs_ro\i8_cs_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgarray2\_il_dbgarray2.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\float_cs_do\float_cs_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08107\b08107\b08107.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-0\_relunsafe-0.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovfldiv1_il_r\ovfldiv1_il_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b223924\b223924\b223924.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44985\b44985\b44985.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow03_add\overflow03_add.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\neg\neg.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\tail\tail.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b14364\b14364\b14364.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\33objref_cs_r\33objref_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovflrem1_il_r\ovflrem1_il_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\SqrtGeneric_r\SqrtGeneric_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatInfinitiesToInt_r\FloatInfinitiesToInt_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-4\_dbgunsafe-4.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorDot_r\VectorDot_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16503\b16503\b16503.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-3\_dbgunsafe-3.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8nanconv_il_r\r8nanconv_il_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b79852\b79852\b79852.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b45956\b45956\b45956.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPConvDbl2Lng\FPConvDbl2Lng.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\deepcall\deepcall.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_816617\DevDiv_816617_d\DevDiv_816617_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72996\b72996\b72996.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value010\box-unbox-value010.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow04_mul\overflow04_mul.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass020\castclass020.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\div\div.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71722\b71722\b71722.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8flat_cs_do\i8flat_cs_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow02_mul\overflow02_mul.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\AbsGeneric_r\AbsGeneric_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40380\b40380\b40380.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP2b\SP2b.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow02_add\overflow02_add.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort_cs_r\ushort_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\decimal_cs_ro\decimal_cs_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72518\b72518\b72518.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\not\not.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\LongArgsAndReturn\LongArgsAndReturn.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldarg_i8\ldarg_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint_cs_d\uint_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59337\b59337\b59337.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ret_i8\ret_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow03_div\overflow03_div.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox010\box-unbox010.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatInfinitiesToInt_do\FloatInfinitiesToInt_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\clr-x64-JIT\v4.0\b602182\b602182\b602182.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b487372\b487372\b487372.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54566\b54566\b54566.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\div_u8\div_u8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-2\_dbgunsafe-2.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b77304\b77304\b77304.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP2a\SP2a.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08109\b08109\b08109.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b13569\b13569\b13569.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b66533\b66533\b66533.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43033\b43033\b43033.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-5\_relunsafe-5.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05780\b05780\b05780.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4nanconv_il_d\r4nanconv_il_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\IntConv\IntConv.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow04_add\overflow04_add.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31493\b31493\b31493.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-RTM\b539509\b539509\b539509.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\float_cs_r\float_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\double_cs_ro\double_cs_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-5\_dbgunsafe-5.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b84916\b84916\b84916.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong_cs_d\ulong_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b33125\b33125\b33125.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b52760\b52760\b52760.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow01_add\overflow01_add.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b04319\b04319\b04319.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\byte_cs_r\byte_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\init_uint64\init_uint64.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\double_cs_r\double_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8_cs_r\i8_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\543645\test\test.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\CodeSize1\CodeSize1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP2\SP2.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57518\b57518\b57518.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatOvfToInt2_do\FloatOvfToInt2_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldarga_i8\ldarga_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\init_struct\init_struct.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow03_sub\overflow03_sub.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\double_cs_d\double_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59478\b59478\b59478.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgjump\_il_dbgjump.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b45984\b45984\b45984.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\mul\mul.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41129\b41129\b41129.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b108129\b108129\b108129.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8nanconv_il_d\r8nanconv_il_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w5d_cs_d\10w5d_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4nanconv_il_r\r4nanconv_il_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-02_cs_r\3w1d-02_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35779\b35779\b35779.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06436\b06436\b06436.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w5d_cs_ro\10w5d_cs_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_mul_ovf_i8\ldc_mul_ovf_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_mul_ovf_u8\ldc_mul_ovf_u8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b31343\b31343\b31343.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15222\b15222\b15222.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ret\ret.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint_cs_r\uint_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\DumpDisasm\JitMinOpts\CodeSize1\CodeSize1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\rem_i8\rem_i8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\BitwiseOperations_r\BitwiseOperations_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass009\castclass009.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\CodeSize0\CodeSize0.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovflrem1_il_d\ovflrem1_il_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b13522\b13522\b13522.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatInfinitiesToInt_ro\FloatInfinitiesToInt_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b28598\b28598\b28598.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25507\b25507\b25507.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\mismatch64\mismatch64\mismatch64.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\rem\rem.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b91944\b91944\b91944.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28597\b28597\b28597.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\mul_ovf_u8\mul_ovf_u8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\decimal_cs_d\decimal_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b36301\b36301\b36301.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-2\_relunsafe-2.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow02_sub\overflow02_sub.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Burgers\Burgers\Burgers.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics010\castclass-generics010.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35354\b35354\b35354.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\shl\shl.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ldvirtftncalli_il_d\ldvirtftncalli_il_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPConvF2Lng\FPConvF2Lng.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\float_cs_d\float_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_dbgldobj_I8\_il_dbgldobj_I8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8_cs_do\i8_cs_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8flat_cs_ro\i8flat_cs_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatOvfToInt2_r\FloatOvfToInt2_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\short_cs_d\short_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_dbgsizeof64\_il_dbgsizeof64.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b489329\b489329\b489329.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics009\box-unbox-generics009.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass010\castclass010.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39397\b39397\b39397.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M12-Beta2\b46847\b46847\b46847.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface015\box-unbox-interface015.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w5d_cs_r\10w5d_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43719\b43719\b43719.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\shr\shr.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-02_cs_d\3w1d-02_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox009\box-unbox009.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ldvirtftncalli_il_r\ldvirtftncalli_il_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\init_int64\init_int64.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b07900\b07900\b07900.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\Dev10_884217_IL\Dev10_884217_IL.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\byte_cs_d\byte_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37830\b37830\b37830.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b309576\b309576\b309576.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b06440\b06440a\b06440a.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b07411\b07411\b07411.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53980\b53980\b53980.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\33objref_cs_d\33objref_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39417\b39417\b39417.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_dbgunsafe-6\_dbgunsafe-6.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_il_relhugedim\_il_relhugedim.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b66226\b66226\b66226.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\enum\box-unbox-enum003\box-unbox-enum003.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46569\b46569\b46569.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15797\b15797\b15797.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\int_cs_r\int_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorExp_ro\VectorExp_ro.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\double_cs_do\double_cs_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorExp_r\VectorExp_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b32613\b32613\b32613.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53942\b53942a\b53942a.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M11-Beta1\b45679\b45679\b45679.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics020\box-unbox-generics020.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow04_sub\overflow04_sub.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\char_cs_d\char_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\rem_u8\rem_u8.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b06440\b06440c\b06440c.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\char_cs_r\char_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ldargs_stargs\ldargs_stargs.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\int_cs_d\int_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b14366\b14366\b14366.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679053\regionLive\regionLive.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow01_sub\overflow01_sub.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w5d_cs_do\10w5d_cs_do.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\conv\conv.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b16294\b16294\b16294.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow02_div\overflow02_div.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05639\b05639\b05639.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8_cs_d\i8_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_reljump\_il_reljump.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b223936\b223936\b223936.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_154899\DynamicStaticAlignment\DynamicStaticAlignment.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\539509\test1\test1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow01_div\overflow01_div.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b45541\b45541\b45541.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b49104\b49104\b49104.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25739\b25739\b25739.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_reltailcall\_il_reltailcall.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b80365\b80365\b80365.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37214\b37214\b37214.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_relunsafe-3\_relunsafe-3.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28522\b28522\b28522.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82247\b82247\b82247.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b12274\b12274\b12274.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25474\b25474\b25474.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41002\b41002\b41002.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relnegIndexRngChkElim\_il_relnegIndexRngChkElim.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b72218\b72218\b72218.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31283\b31283\b31283.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics020\castclass-generics020.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05619\b05619\b05619.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow04_div\overflow04_div.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_il_dbghugedim\_il_dbghugedim.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b80737\b80737\b80737.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06754\b06754\b06754.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43160\b43160\b43160.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\or\or.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32801\b32801\b32801.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\Conv_R4\Conv_R4.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ldarg_starg\ldarg_starg.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_135245\R3Trasher1\R3Trasher1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics009\castclass-generics009.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75890\b75890\b75890.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70994\b70994\b70994.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b47080\b47080\b47080.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b06440\b06440b\b06440b.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b19101\b19101\b19101.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b85317\b85317\b85317.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox020\box-unbox020.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\sbyte_cs_r\sbyte_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\sub\sub.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\short_cs_r\short_cs_r.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06730\b06730\b06730.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Overflow\FloatOvfToInt2_d\FloatOvfToInt2_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\bool_cs_d\bool_cs_d.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\118414\118414\118414.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_239804\ShowLocallocAlignment\ShowLocallocAlignment.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow03_mul\overflow03_mul.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value009\box-unbox-value009.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b27873\b27873\b27873.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b33792\b33792\b33792.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41621\b41621\b41621.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i1_un\conv_ovf_i1_un.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31903\b31903\b31903.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25835\b25835\b25835.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b33362\b33362\b33362.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68045\b68045\b68045.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b36304\b36304\b36304.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\Conv_I4\Conv_I4.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv2_cs_ro\callconv2_cs_ro.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50033\b50033\b50033.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b31273\b31273\b31273.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b66679\b66679\b66679.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b36030\b36030\b36030.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05933\b05933\b05933.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv2_cs_do\callconv2_cs_do.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_10427\conv_ovf_i4\conv_ovf_i4.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b65087\b65087\b65087.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b55923\b55923\b55923.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_u8_u4\conv_ovf_u8_u4.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39381\b39381\b39381.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59947\b59947\b59947.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_u8_u4\ldc_conv_ovf_u8_u4.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b20079\b20079\b20079.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59554\b59554\b59554.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b45015\b45015\b45015.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\conv_ovf\conv_ovf.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40269\b40269\b40269.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b80824\b80824\b80824.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_i8_i4\ldc_conv_ovf_i8_i4.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14769\b14769\b14769.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54565\b54565\b54565.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b36975\b36975\b36975.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53942\b53942b\b53942b.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_646049\Dev11_646049\Dev11_646049.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgconvovf_i8_i\_il_dbgconvovf_i8_i.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b69528\b69528\b69528.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b103058\b103058\b103058.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08797\b08797\b08797.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b67819\b67819\b67819.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b31321\b31321\b31321.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16554\b16554\b16554.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37256\b37256\b37256.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b30868\b30868\b30868.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70289\b70289\b70289.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40411\b40411\b40411.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b14617\b14617\b14617.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgconvovf_i8_u\_il_dbgconvovf_i8_u.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M09.5-PDC\b16935\b16935\b16935.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59822\b59822\b59822.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b33388\b33388\b33388.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv2_cs_ro\callconv2_cs_ro.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25468\b25468\b25468.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39455\b39455\b39455.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b27564\b27564\b27564.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\373472\test\test.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i8_i4\conv_ovf_i8_i4.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b63823\b63823\b63823.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv2_cs_do\callconv2_cs_do.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44204\b44204\b44204.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_200492\DevDiv_200492\DevDiv_200492.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16922\b16922\b16922.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b32614\b32614\b32614.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75944\b75944\b75944.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldloc_i8\ldloc_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35344\b35344\b35344.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ceq\ceq.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\fielda_tests\fielda_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\and_u8\and_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b98958\b98958\b98958.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\regalloc1\regalloc1.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_dbgsizeof32\_il_dbgsizeof32.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_i8\ldc_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_il_relval_cctor\_il_relval_cctor.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679955\indexMinusOne\indexMinusOne.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b175679\b175679\b175679.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26512\b26512\b26512.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26153\b26153\b26153.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\not_u8\not_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b88793\b88793\b88793.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\fielda_tests\fielda_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\stfldstatic2_il_r\stfldstatic2_il_r.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31784\b31784\b31784.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\cgt\cgt.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-03_cs_d\5w1d-03_cs_d.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b55197\b55197\b55197.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\stfldstatic1_il_d\stfldstatic1_il_d.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14350\b14350\b14350.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\fielda_tests\fielda_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82866\b82866\b82866.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b42013\b42013\b42013.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b49322\b49322\b49322.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\stind_i2\stind_i2.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71099\b71099\b71099.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\stfldstatic1_il_r\stfldstatic1_il_r.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b55197\Desktop\b55197\b55197.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\array_tests\array_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgseq\_il_dbgseq.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\StaticValueField\StaticValueField.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b47886\b47886\b47886.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14070\b14070\b14070.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14067\b14067b\b14067b.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\cgt_u8\cgt_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b49335\b49335\b49335.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\pop8\pop8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-03_cs_ro\5w1d-03_cs_ro.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ldfldstatic_il_r\ldfldstatic_il_r.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14431\b14431\b14431.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\LotsOfInlines\LotsOfInlines.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43994\b43994\b43994.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\clt\clt.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-03_cs_r\5w1d-03_cs_r.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Coverage\b39946\b39946.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14197\b14197\b14197.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43958\b43958\b43958.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\field_tests\field_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b26496\b26496\b26496.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\clt_u8\clt_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\clt_i8\clt_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\Conv_I8\Conv_I8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37238\b37238\b37238.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\stind_i4\stind_i4.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bge_i8\bge_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_il_dbgval_cctor\_il_dbgval_cctor.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bge_un_i8\bge_un_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\array_tests\array_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\field_tests\field_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\field_tests\field_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14067\b14067a\b14067a.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-03_cs_do\5w1d-03_cs_do.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\field_tests\field_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ble_i8\ble_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\and\and.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Ldind_r\Ldind_r.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ldfldstatic_il_d\ldfldstatic_il_d.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28596\b28596\b28596.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b39946\b39946\b39946.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\IntrinsicTest_Overflow\IntrinsicTest_Overflow.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b91953\b91953\b91953.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b76511\b76511\b76511.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\cgt_i8\cgt_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\fielda_tests\fielda_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43010\b43010\b43010.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46867\b46867\b46867.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\dup8\dup8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41918\b41918\b41918.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\hijacking\hijacking.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ceq_i8\ceq_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b15617\b15617\b15617.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_relval_ctor\_relval_ctor.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\refs\refs.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\array_tests\array_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\stloc_i8\stloc_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ble_u8\ble_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44410\b44410\b44410.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\array_tests\array_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14326\b14326\b14326.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44657\b44657\b44657.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\field_tests\field_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bgt_u8\bgt_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_dbgval_ctor\_dbgval_ctor.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_il_dbgval_ctor_newobj\_il_dbgval_ctor_newobj.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b49142\b49142\b49142.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30905\b30905\b30905.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\beq_i8\beq_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_speed_dbgval_ctor\_speed_dbgval_ctor.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b29727\b29727\b29727.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bgt_i8\bgt_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40216\b40216\b40216.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_speed_relval_ctor\_speed_relval_ctor.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\fielda_tests\fielda_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\blt_i8\blt_i8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\blt_u8\blt_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\ehDescriptorPtrUpdate\ehDescriptorPtrUpdate.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bne_u8\bne_u8.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b63730\b63730\b63730.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Ldind_ro\Ldind_ro.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\ctor\_il_relval_ctor_newobj\_il_relval_ctor_newobj.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\array_tests\array_tests.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\stfldstatic2_il_d\stfldstatic2_il_d.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44879\b44879\b44879.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26155\b26155\b26155.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b36302\b36302\b36302.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i00\mcc_i00.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b67987\b67987\b67987.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b102759\b102759\b102759.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b79250\b79250\b79250.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow3_cs_d\pow3_cs_d.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\neg_i8\neg_i8.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b48554\b48554b\b48554b.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b94306\b94306\b94306.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_neg_i8\ldc_neg_i8.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i01\mcc_i01.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b29456\b29456\b29456.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b34952\b34952\b34952.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b04384\b04384\b04384.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow3_cs_r\pow3_cs_r.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102964\test\test.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\471729\test\test.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\Dev10_863995\Dev10_863995.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_il_dbgrotarg_valref\_il_dbgrotarg_valref.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_il_relrotarg_valref\_il_relrotarg_valref.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structva1_1\structva1_1.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\structarr_cs_d\structarr_cs_d.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\MemberAccess\interface_struct02\interface_struct02.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_dbgrotarg_valref\_dbgrotarg_valref.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_relrotarg_valref\_opt_relrotarg_valref.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\pidigits\pi-digits\pi-digits.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\ret_struct_test4\ret_struct_test4.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\MemberAccess\interface_struct01\interface_struct01.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\structarr_cs_d\structarr_cs_d.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_relrotarg_valref\_relrotarg_valref.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\structarr_cs_r\structarr_cs_r.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\structarr_cs_r\structarr_cs_r.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\ret_struct_test1\ret_struct_test1.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_dbgrotarg_valref\_opt_dbgrotarg_valref.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_il_relrefarg_box_val\_il_relrefarg_box_val.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct9_2\struct9_2.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_il_dbgrefarg_box_val\_il_dbgrefarg_box_val.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbglocal\_il_dbglocal.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31289\b31289\b31289.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldrem_cs_do\lclfldrem_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldind_i4\ldind_i4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\gcref2\gcref2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b61185\b61185\b61185.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong_cs_ro\ulong_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relmuldiv\_speed_relmuldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldfld_mulovf\_speed_rels_ldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclflddiv_cs_ro\lclflddiv_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b02051\b02051\b02051.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i4div_cs_d\i4div_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\zeroinit_il_r\zeroinit_il_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15155\b15155\b15155.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-02_cs_r\200w1d-02_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldc_div\_rels_ldc_div.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43115\b43115\b43115.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldsfld_mul\_rels_ldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r4div_cs_d\r4div_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u4rem_cs_r\u4rem_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit6\_opt_relexplicit6.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit7\_opt_dbgexplicit7.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b31102\b31102\b31102.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\bool_cs_do\bool_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\beq_r8\beq_r8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint64_r\uint64_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-02_cs_do\200w1d-02_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldfld_mulovf\_dbgs_ldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b00722\b00722\b00722.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14068\b14068\b14068.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_speed_rellcs_long\_speed_rellcs_long.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldadd_cs_do\lclfldadd_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\interlocked\regalloc2\regalloc2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit7\_dbgexplicit7.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b63726\b63726\b63726.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldadd_cs_ro\lclfldadd_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldfld_mul\_il_dbgldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_dbgsuperlong\_dbgsuperlong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relldsfld_mul\_relldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\ldind_stind\ldind_stind.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_speed_dbglcs_long\_speed_dbglcs_long.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\decimaldiv_cs_d\decimaldiv_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldc_mul\_il_rels_ldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit1\_relexplicit1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit7\_relexplicit7.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint_cs_ro\uint_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstenum_d\isinstenum_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b60142\b60142\b60142.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-02_cs_ro\200w1d-02_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bge_un_r4\bge_un_r4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldfld_mul\_il_dbgs_ldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\args1\args1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b34951\b34951\b34951.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int64_ro\int64_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldfld_mulovf\_il_dbgs_ldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldrem_cs_ro\lclfldrem_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgldfld_mul\_dbgldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldc_div\_il_dbgs_ldc_div.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b74182\b74182\b74182.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldfld_mulovf\_il_rels_ldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldc_mulovf\_speed_rels_ldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort_cs_do\ushort_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relldc_mulovf\_il_relldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25459\b25459\b25459.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53994\b53994\b53994.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\ilseq\_il_reltypeEqualOp\_il_reltypeEqualOp.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679053\flowgraph\flowgraph.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14135\b14135\b14135.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70267\b70267\b70267.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w250d_cs_do\10w250d_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldind_i8\ldind_i8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit3\_dbgexplicit3.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\short_cs_do\short_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug675304\loopIV_init\loopIV_init.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldsfld_mulovf\_dbgs_ldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\decimaldiv_cs_r\decimaldiv_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relldsfld_mul\_speed_relldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow3_cs_ro\pow3_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed1_cs_d\mixed1_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldc_mulovf\_il_dbgldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit8\_opt_relexplicit8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b48614\b48614\b48614.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\c_localloc\c_localloc.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8flat_cs_d\i8flat_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit6\_dbgexplicit6.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_relchain\_il_relchain.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51420\b51420\b51420.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\zeroinit_il_d\zeroinit_il_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i4rem_cs_r\i4rem_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_rellocal\_il_rellocal.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit8\_dbgexplicit8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14325\b14325\b14325.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit3\_opt_relexplicit3.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldsfld_mulovf\_speed_rels_ldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relldfld_mul\_il_relldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b487364\b487364\b487364.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-02_cs_ro\3w1d-02_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldc_div\_il_rels_ldc_div.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b69512\b69512\b69512.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i4rem_cs_d\i4rem_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldfld_mul\_speed_rels_ldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b20217\b20217\b20217.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56068\b56068\b56068.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArray_r\VectorArray_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16928\b16928\b16928.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28080\b28080\b28080.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relformat\_il_relformat.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit7\_opt_relexplicit7.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\113574\113574\113574.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_dbglcs_long\_dbglcs_long.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44224\b44224\b44224.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldc_mulovf\_dbgs_ldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ulong_cs_do\ulong_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b46566\b46566\b46566.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_2610\GitHub_2610\GitHub_2610.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54611\b54611\b54611.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit4\_opt_dbgexplicit4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b125091\b125091\b125091.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgldfld_mulovf\_speed_dbgldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldc_mul\_speed_dbgs_ldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint64_d\uint64_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relmuldiv\_relmuldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldsfld_mul\_speed_dbgs_ldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43121\b43121\b43121.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b31448\b31448\b31448.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\ldind_stind\ldind_stind.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\1000w1d_cs_ro\1000w1d_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r4rem_cs_r\r4rem_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldind_u2\ldind_u2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldfld_mul\_rels_ldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16881\b16881b\b16881b.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\ushort_cs_ro\ushort_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28594\b28594\b28594.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\uint_cs_do\uint_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\byte_cs_ro\byte_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit5\_relexplicit5.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint64_do\uint64_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\beq_r4\beq_r4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Sums_r\Sums_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclflddiv_cs_do\lclflddiv_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16881\b16881a\b16881a.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u4div_cs_r\u4div_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51463\b51463\b51463.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldmul_cs_ro\lclfldmul_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relldfld_mul\_speed_relldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30892\b30892\b30892.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30862\b30862\b30862.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_muldiv\_speed_rels_muldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\33objref_cs_ro\33objref_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_rellcs_long\_rellcs_long.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldsub_cs_do\lclfldsub_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst2_ro\isinst2_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldc_div\_speed_rels_ldc_div.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w250d_cs_d\10w250d_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgmuldiv\_speed_dbgmuldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\long_cs_ro\long_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b77950\b77950\b77950.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldmul_cs_do\lclfldmul_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relldsfld_mulovf\_relldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbghuge_filter\_il_dbghuge_filter.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relldfld_mul\_relldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59782\b59782\b59782.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ldtoken\_il_dbgtypes\_il_dbgtypes.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b69227\b69227\b69227.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i4div_cs_r\i4div_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgldsfld_mulovf\_dbgldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25491\b25491\b25491.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_relsuperlong\_relsuperlong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit6\_relexplicit6.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_il_dbgsuperlong\_il_dbgsuperlong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bge_r4\bge_r4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\ebvts\cs\generics\generics\repro52\repro52.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u4rem_cs_d\u4rem_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldfld_mulovf\_il_dbgldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgshortsig\_il_dbgshortsig.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldsfld_mulovf\_il_dbgs_ldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59320\b59320\b59320.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_muldiv\_dbgs_muldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b80373\b80373\b80373.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53977\b53977\b53977.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r8rem_cs_r\r8rem_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_muldiv\_il_dbgs_muldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relldfld_mulovf\_relldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbglongsig\_il_dbglongsig.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldfld_mul\_dbgs_ldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed1_cs_ro\mixed1_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldind_i2\ldind_i2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgmuldiv\_il_dbgmuldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\SIMD\RayTracer\RayTracer\RayTracer.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\char_cs_ro\char_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit3\_relexplicit3.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\1000w1d_cs_d\1000w1d_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgldfld_mulovf\_dbgldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46576\b46576\b46576.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53884\b53884\b53884.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_77709\BadCheckedAdd1\BadCheckedAdd1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldfld_mul\_il_rels_ldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_il_dbglcs_long\_il_dbglcs_long.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgarray1\_il_dbgarray1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_il_relsuperlong\_il_relsuperlong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldind_u4\ldind_u4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b61028\b61028\b61028.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_il_rellcs_long\_il_rellcs_long.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relldc_mul\_speed_relldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b73207\b73207\b73207.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int64_d\int64_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldfld_mul\_speed_dbgs_ldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbglocalloc\_il_dbglocalloc.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\543229\test\test.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit5\_opt_dbgexplicit5.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31292\b31292\b31292.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit2\_relexplicit2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r8div_cs_d\r8div_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldsfld_mul\_dbgs_ldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit6\_opt_dbgexplicit6.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25701\b25701\b25701.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldc_mul\_il_dbgldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b34953\b34953\b34953.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\stind_i8\stind_i8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\sbyte_cs_do\sbyte_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldc_div\_dbgs_ldc_div.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\localloc\localloc.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed1_cs_r\mixed1_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgldsfld_mul\_dbgldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82715\b82715\b82715.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_il_dbglcs_ulong\_il_dbglcs_ulong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit5\_dbgexplicit5.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w250d_cs_ro\10w250d_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16499\b16499b\b16499b.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit1\_dbgexplicit1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit8\_relexplicit8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b268908\b268908\b268908.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\osr\osr015\osr015.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\int_cs_ro\int_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\long_cs_do\long_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstenum_r\isinstenum_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst2_do\isinst2_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArrayInit_r\VectorArrayInit_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit2\_opt_relexplicit2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50027\b50027\b50027.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit8\_opt_dbgexplicit8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldc_mulovf\_speed_dbgs_ldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldsfld_mul\_il_rels_ldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgldc_mul\_dbgldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72160\b72160\b72160.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_relldobj_I8\_il_relldobj_I8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_relexplicit4\_relexplicit4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\directed\ldloca_s_i8\ldloca_s_i8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\int_cs_do\int_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_il_relbox\_il_relbox.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_muldiv\_il_rels_muldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst2_r\isinst2_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relshortsig\_il_relshortsig.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Bytemark\Bytemark\Bytemark.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int64_r\int64_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgldsfld_mulovf\_speed_dbgldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16895\b16895\b16895.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\sbyte_cs_ro\sbyte_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44983\b44983\b44983.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b530694\b530694\b530694.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_rellongsig\_il_rellongsig.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldc_mulovf\_rels_ldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_speed_relsuperlong\_speed_relsuperlong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit2\_opt_dbgexplicit2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relldc_mul\_relldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-02_cs_d\200w1d-02_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldc_mul\_il_dbgs_ldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26748\b26748\b26748.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r8rem_cs_d\r8rem_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_ldc_mul\_dbgs_ldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\1000w1d_cs_r\1000w1d_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b89797\b89797\b89797.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ldtoken\_il_reltypes\_il_reltypes.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r8div_cs_r\r8div_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relldsfld_mulovf\_speed_relldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit1\_opt_relexplicit1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int64_do\int64_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\superlong\_speed_dbgsuperlong\_speed_dbgsuperlong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57492\b57492\b57492.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26888\b26888\b26888.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldsfld_mulovf\_il_rels_ldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\Rotate\Rotate.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bge_un_r8\bge_un_r8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relldfld_mulovf\_speed_relldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchF\Adams\Adams\Adams.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgldsfld_mul\_speed_dbgldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\decimalrem_cs_d\decimalrem_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59953\b59953\b59953.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed1_cs_do\mixed1_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldsfld_mul\_il_dbgs_ldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Sums_ro\Sums_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldc_mul\_rels_ldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b73786\b73786\b73786.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldfld_mulovf\_speed_dbgs_ldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit5\_opt_relexplicit5.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b33888\b33888\b33888.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relldc_mul\_il_relldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_ldc_mulovf\_il_dbgs_ldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgldfld_mul\_speed_dbgldfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91223\b91223\b91223.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54006\b54006\b54006.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\smallFrame\smallFrame.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow3_cs_do\pow3_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit4\_dbgexplicit4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit1\_opt_dbgexplicit1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14927\b14927\b14927.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16049\b16049\b16049.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r4rem_cs_d\r4rem_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldsub_cs_ro\lclfldsub_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relldsfld_mul\_il_relldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_muldiv\_rels_muldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\601425\stret\stret.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\ldind_stind\ldind_stind.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679955\volatileLocal1\volatileLocal1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b33335\b33335\b33335.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\Desktop\_il_relthread-race\_il_relthread-race.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgsimple\_il_dbgsimple.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\33objref_cs_do\33objref_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75250\b75250\b75250.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgldc_mulovf\_dbgldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldsfld_mulovf\_rels_ldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679955\volatileLocal2\volatileLocal2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26020\b26020\b26020.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u4div_cs_d\u4div_cs_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r4div_cs_r\r4div_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\1000w1d_cs_do\1000w1d_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31547\b31547\b31547.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_relexplicit4\_opt_relexplicit4.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldsfld_mulovf\_il_dbgldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_ldc_mulovf\_il_rels_ldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14199\b14199\b14199.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b20249\b20249\b20249.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgldc_mul\_speed_dbgldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b69225\b69225\b69225.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25463\b25463\b25463.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_il_dbgbox\_il_dbgbox.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-02_cs_do\3w1d-02_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_relldc_mulovf\_speed_relldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\gcref1\gcref1.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82160\b82160\b82160.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16896\b16896\b16896.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b178128\b178128\b178128.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgformat\_il_dbgformat.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\bool_cs_ro\bool_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71179\b71179\b71179.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57493\b57493\b57493.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_ldfld_mulovf\_rels_ldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43963\b43963\b43963.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_relldc_mulovf\_relldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldsfld_mulovf\_speed_dbgs_ldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\ldind_stind\ldind_stind.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72161\b72161\b72161.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\short_cs_ro\short_cs_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relldfld_mulovf\_il_relldfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71831\b71831\b71831.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorCopyToArray_r\VectorCopyToArray_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\10w250d_cs_r\10w250d_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint64_ro\uint64_ro.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgmuldiv\_dbgmuldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldsfld_mul\_speed_rels_ldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\decimalrem_cs_r\decimalrem_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\byte_cs_do\byte_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\add_ovf\add_ovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_3449\GitHub_3449\GitHub_3449.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgfinally\_il_dbgfinally.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8flat_cs_r\i8flat_cs_r.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgldsfld_mul\_il_dbgldsfld_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgtry\_il_dbgtry.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_dbgexplicit2\_dbgexplicit2.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b63725\b63725\b63725.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_opt_dbgexplicit3\_opt_dbgexplicit3.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst2_d\isinst2_d.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_dbgchain\_il_dbgchain.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_il_rellcs_ulong\_il_rellcs_ulong.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59952\b59952\b59952.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_muldiv\_speed_dbgs_muldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\ldind_stind\ldind_stind.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\DataTypes\char_cs_do\char_cs_do.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\bge_r8\bge_r8.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relldsfld_mulovf\_il_relldsfld_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70964\b70964\b70964.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_ldc_div\_speed_dbgs_ldc_div.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgldc_mulovf\_speed_dbgldc_mulovf.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_relmuldiv\_il_relmuldiv.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_ldc_mul\_speed_rels_ldc_mul.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_dbglcs_ulong\_dbglcs_ulong.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b43714\b43714\b43714.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i8_u8\conv_ovf_i8_u8.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b33135\b33135\b33135.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40721\b40721\b40721.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b58360\b58360\b58360.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_rellcs_ulong\_rellcs_ulong.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37578\b37578\b37578.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_u8\_il_dbghuge_u8.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b33361\b33361\b33361.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b84909\b84909\b84909.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_u8_i8\ldc_conv_ovf_u8_i8.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31423\b31423\b31423.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b74939\b74939\b74939.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b47906\b47906\b47906.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28805\b28805\b28805.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b49435\b49435\b49435.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b13509\b13509\b13509.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56349\b56349\b56349.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b86139\b86139\b86139.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46897\b46897\b46897.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59508\b59508\b59508.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_speed_dbglcs_ulong\_speed_dbglcs_ulong.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\arrays\_speed_rellcs_ulong\_speed_rellcs_ulong.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b05737\b05737\b05737.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_conv_ovf_i8_u8\ldc_conv_ovf_i8_u8.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b73283\b73283\b73283.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b61215\b61215\b61215.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b40006\b40006\b40006.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b45439\b45439\b45439.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_u8_i8\conv_ovf_u8_i8.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30869\b30869\b30869.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b35486\b35486\b35486.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75888\b75888\b75888.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31452\b31452\b31452.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41164\b41164\b41164.cmd" >
+             <Issue>4174</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71120\b71120\b71120.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_rellocalloc\_il_rellocalloc.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_relsizeof64\_il_relsizeof64.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_dbgsizeof64\_dbgsizeof64.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_relfinally\_il_relfinally.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\dependentlifetimes\dependentlifetimes.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_relsizeof64\_relsizeof64.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_reltry\_il_reltry.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_relsimple\_il_relsimple.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b92693\b92693\b92693.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\boxunbox\_il_relhuge_filter\_il_relhuge_filter.cmd" >
+             <Issue>4175</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorCopyToArray_ro\VectorCopyToArray_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-4\_speed_dbgunsafe-4.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72932\b72932\b72932.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-5\_speed_relunsafe-5.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u8div_cs_r\u8div_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i8rem_cs_do\i8rem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u4div_cs_do\u4div_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i4div_cs_ro\i4div_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-3\_speed_relunsafe-3.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-3\_speed_dbgunsafe-3.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u4div_cs_ro\u4div_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldrem_cs_d\lclfldrem_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u4rem_cs_ro\u4rem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u8rem_cs_d\u8rem_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldrem_cs_r\lclfldrem_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r4div_cs_ro\r4div_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-6\_speed_dbgunsafe-6.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i8div_cs_r\i8div_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\overlddiv_cs_ro\overlddiv_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r8rem_cs_ro\r8rem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r8rem_cs_do\r8rem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Haar-likeFeaturesGeneric_r\Haar-likeFeaturesGeneric_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u8rem_cs_do\u8rem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Haar-likeFeaturesGeneric_ro\Haar-likeFeaturesGeneric_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\overldrem_cs_ro\overldrem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i8div_cs_d\i8div_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b140902\b140902\b140902.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldadd_cs_r\lclfldadd_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\decimaldiv_cs_ro\decimaldiv_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldmul_cs_d\lclfldmul_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-5\_speed_dbgunsafe-5.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u8div_cs_d\u8div_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u8rem_cs_ro\u8rem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-2\_speed_dbgunsafe-2.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\overlddiv_cs_d\overlddiv_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclflddiv_cs_d\lclflddiv_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-0\_speed_dbgunsafe-0.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r4rem_cs_ro\r4rem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r4div_cs_do\r4div_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\overldrem_cs_do\overldrem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i8rem_cs_d\i8rem_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i8div_cs_do\i8div_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r8div_cs_ro\r8div_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_dbgunsafe-1\_speed_dbgunsafe-1.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u8rem_cs_r\u8rem_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i4div_cs_do\i4div_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u8div_cs_do\u8div_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-1\_speed_relunsafe-1.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorGet_ro\VectorGet_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArrayInit_ro\VectorArrayInit_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\u4rem_cs_do\u4rem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\decimalrem_cs_ro\decimalrem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldsub_cs_d\lclfldsub_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldadd_cs_d\lclfldadd_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\overldrem_cs_r\overldrem_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\i8div_cs_ro\i8div_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-6\_speed_relunsafe-6.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldmul_cs_r\lclfldmul_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i8rem_cs_ro\i8rem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-4\_speed_relunsafe-4.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\r4rem_cs_do\r4rem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i4rem_cs_do\i4rem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-2\_speed_relunsafe-2.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\overlddiv_cs_r\overlddiv_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\decimaldiv_cs_do\decimaldiv_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\r8div_cs_do\r8div_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\overlddiv_cs_do\overlddiv_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclfldsub_cs_r\lclfldsub_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\decimalrem_cs_do\decimalrem_cs_do.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\u8div_cs_ro\u8div_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i4rem_cs_ro\i4rem_cs_ro.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_165544\seqpts\seqpts.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\unsafecsharp\_speed_relunsafe-0\_speed_relunsafe-0.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\overldrem_cs_d\overldrem_cs_d.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\rem\i8rem_cs_r\i8rem_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\lclflddiv_cs_r\lclflddiv_cs_r.cmd" >
+             <Issue>4176</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumps5\_il_dbgjumps5.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfault_jmp\_il_relcatchfault_jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfinally_jmpind\_il_relcatchfinally_jmpind.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumps5\_il_reljumps5.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfinally_jmp\_il_dbgcatchfinally_jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relrecurse_jmpi\_il_relrecurse_jmpi.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfinally_jmpind\_il_dbgcatchfinally_jmpind.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\jmp\jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumps1\_il_reljumps1.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumps1\_il_dbgjumps1.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug642944\GCMaskForGSCookie\GCMaskForGSCookie.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relrecurse_jmp\_il_relrecurse_jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\il\jmp_ret\jmp_ret.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\il\jmp_impl\jmp_impl.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\il\jmp_dbg\jmp_dbg.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfinally_jmp\_il_relcatchfinally_jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\il\jmp_opt\jmp_opt.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgrecurse_jmp\_il_dbgrecurse_jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfault_jmp\_il_dbgcatchfault_jmp.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgrecurse_jmpi\_il_dbgrecurse_jmpi.cmd" >
+             <Issue>4177</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\filter2_r\filter2_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtryfinally_r\throwinnestedtryfinally_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b11949\b11949\b11949.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\mixedhandler\filterfiltercatchcatch_d\filterfiltercatchcatch_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\filter3_r\filter3_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71318\b71318\b71318.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59546\b59546\b59546.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\mixedhandler\catchfiltercatch_r\catchfiltercatch_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_relfilter\_il_relfilter.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtryexcept_d\nestedtryexcept_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56149\b56149\b56149.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedexceptnofin_r\throwincascadedexceptnofin_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\faultbeforetrybody_d\faultbeforetrybody_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytrycatch_do\tryfinallytrycatch_do.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\faultbeforetrybody_r\faultbeforetrybody_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtryfault_r\throwinnestedtryfault_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowinfinallyaftercatch_ro\rethrowinfinallyaftercatch_ro.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinexcept_r\throwinexcept_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\606733\Bug606733\Bug606733.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b70909\b70909\b70909.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\throwbox\filter\filter.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryexcept_r\tryexcept_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\throwbox\fault\fault.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b55216\b55216\b55216.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b112982\b112982\b112982.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\filter1_r\filter1_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedexceptnofin_d\throwincascadedexceptnofin_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowexcept_r\trythrowexcept_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtryfault_d\nestedtryfault_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\FaultHandlers\Simple\Simple\Simple.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtryfault_r\nestedtryfault_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68872\b68872\b68872.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\filter2_d\filter2_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\FaultHandlers\Nesting\Nesting\Nesting.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfaulttrycatch_d\tryfaulttrycatch_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinexcept_d\throwinexcept_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowexcept_d\trythrowexcept_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtryfinally_d\throwinnestedtryfinally_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\filter3_d\filter3_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfaulttrycatch_r\tryfaulttrycatch_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\sehhandlerbeforetry_d\sehhandlerbeforetry_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_dbgfault\_dbgfault.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfault_r\tryfault_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\fgloop2\fgloop2.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfault_d\tryfault_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_relfault\_relfault.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b07341\b07341\b07341.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\mixedhandler\catchfiltercatch_d\catchfiltercatch_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\filter1_d\filter1_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\FaultHandlers\CallOrder\CallOrder\CallOrder.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfault\_il_dbgcatchfault.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtryexcept_r\throwinnestedtryexcept_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtryfault_d\throwinnestedtryfault_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\mixedhandler\filterfiltercatchcatch_r\filterfiltercatchcatch_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b81938\b81938\b81938.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_dbgfilter\_il_dbgfilter.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b84971\b84971\b84971.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtryexcept_d\throwinnestedtryexcept_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\sehhandlerbeforetry_r\sehhandlerbeforetry_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowinfinallyaftercatch_do\rethrowinfinallyaftercatch_do.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfault\_il_relcatchfault.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtryexcept_r\nestedtryexcept_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\excepobj\excepobj\excepobj.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\seh_tests\seh_tests.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytrycatch_d\tryfinallytrycatch_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\fault\fault\fault.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\mixed3\mixed3\mixed3.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytrycatch_ro\tryfinallytrycatch_ro.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytrycatch_r\tryfinallytrycatch_r.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryexcept_d\tryexcept_d.cmd" >
+             <Issue>4178</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Roslyn\CscBench\CscBench.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\nongentogen03\nongentogen03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null019\castclass-null019.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNmul_cs_do\r4NaNmul_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i87\mcc_i87.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics007\castclass-generics007.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics023\castclass-generics023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\callconv\_relinstance_cs\_relinstance_cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret6_1\structret6_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null018\castclass-null018.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value042\box-unbox-value042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface003\box-unbox-interface003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\instance_equalnull_class01\instance_equalnull_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\gcincatch_r\gcincatch_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i77\mcc_i77.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP1\SP1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox037\box-unbox037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null043\castclass-null043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\call_static01\call_static01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null011\castclass-null011.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value038\box-unbox-value038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\instance_passing_struct01\instance_passing_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ldtoken\_il_relptr_types\_il_relptr_types.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug614098\intToByte\intToByte.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i60\mcc_i60.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value032\box-unbox-value032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b193264\b193264\b193264.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics042\box-unbox-generics042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\AddingSequence_r\AddingSequence_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_il_r\class1_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox041\box-unbox041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hasvalue_do\hasvalue_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b77951\b77951\b77951.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b176032\b176032\b176032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct2_5\struct2_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed2_cs_do\mixed2_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sf0C_r\hfa_sf0C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNdiv_cs_ro\r8NaNdiv_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_dbghan3\_il_dbghan3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorSub_r\VectorSub_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value023\box-unbox-value023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_27971\UninitializedHighWord\UninitializedHighWord.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_dbghan3_ctor\_il_dbghan3_ctor.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNadd_cs_d\r4NaNadd_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null017\castclass-null017.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nd2B_r\hfa_nd2B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b91377\b91377\b91377.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorIntEquals_r\VectorIntEquals_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstinterface_ro\isinstinterface_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nf1E_r\hfa_nf1E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\gentogen01\gentogen01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\try1_r\try1_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics004\box-unbox-generics004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hashcode_d\hashcode_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct2_5_2\struct2_5_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null004\castclass-null004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sf1E_r\hfa_sf1E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b41852\b41852\b41852.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd1E_d\hfa_nd1E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics045\box-unbox-generics045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Vector3Interop_ro\Vector3Interop_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\static_assignment_struct01\static_assignment_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_speed_dbggc_nested\_speed_dbggc_nested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null041\castclass-null041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null024\box-unbox-null024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorIntEquals_ro\VectorIntEquals_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.2\ddb\b429039\b429039\b429039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\instance_equalnull_class01\instance_equalnull_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null003\box-unbox-null003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i72\mcc_i72.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct6_2\struct6_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sf0C_d\hfa_sf0C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nf2A_r\hfa_nf2A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null032\castclass-null032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop6_cs_ro\loop6_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i16\mcc_i16.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumper3\_il_reljumper3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nf1G_d\hfa_nf1G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNdiv_cs_d\r4NaNdiv_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nd0B_r\hfa_nd0B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sd1C_r\hfa_sd1C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_dbgldobj_U2\_il_dbgldobj_U2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nd1A_d\hfa_nd1A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i75\mcc_i75.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\instance_passing_class01\instance_passing_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorReturn_r\VectorReturn_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_relhan3_ctor\_relhan3_ctor.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\StoreElement_ro\StoreElement_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null006\box-unbox-null006.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMin_ro\VectorMin_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null017\box-unbox-null017.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP1d\SP1d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i63\mcc_i63.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\instance_assignment_struct01\instance_assignment_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\instance_equalnull_class01\instance_equalnull_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess2_cs_ro\straccess2_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics038\box-unbox-generics038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP1b\SP1b.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null006\castclass-null006.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics030\castclass-generics030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null029\box-unbox-null029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_ref\_il_reli_ref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass025\castclass025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i14\mcc_i14.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\static_assignment_class01\static_assignment_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i02\mcc_i02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i33\mcc_i33.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_class_instance01\general_class_instance01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface002\castclass-interface002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i66\mcc_i66.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstvaluetype_do\isinstvaluetype_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nf1A_r\hfa_nf1A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null022\box-unbox-null022.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nd0A_d\hfa_nd0A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nf2E_d\hfa_nf2E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\LdfldGeneric_r\LdfldGeneric_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Ctors_r\Ctors_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i85\mcc_i85.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNmul_cs_ro\r4NaNmul_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass045\castclass045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse1_cs_d\cse1_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics011\castclass-generics011.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics037\box-unbox-generics037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorDiv_ro\VectorDiv_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstinterface_do\isinstinterface_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value034\box-unbox-value034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hasvalue_d\hasvalue_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\refanyval\refanyval.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct5_4\struct5_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse2_cs_ro\cse2_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sd2A_d\hfa_sd2A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hasvalue_r\hasvalue_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sd2C_d\hfa_sd2C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess1_cs_d\straccess1_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CreateGeneric_r\CreateGeneric_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\try3_d\try3_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\static_passing_class01\static_passing_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value031\box-unbox-value031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_dbgstress3\_speed_dbgstress3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_relstress3\_speed_relstress3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorRelOp_ro\VectorRelOp_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp1_6\structfp1_6.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i03\mcc_i03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorRelOp_r\VectorRelOp_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\InstanceCalls\InstanceCalls.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstboxed_ro\isinstboxed_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_dbgknight\_il_dbgknight.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Boxing\box_unbox01\box_unbox01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\structs\systemvbringup\structinregs\structinregs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nf2E_r\hfa_nf2E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNadd_cs_r\r4NaNadd_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Serialization\Serialize\Serialize.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMatrix_ro\VectorMatrix_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\value_r\value_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null028\box-unbox-null028.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct5\struct5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\instance_assignment_struct01\instance_assignment_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics013\castclass-generics013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\callconv\_dbginstance_il\_dbginstance_il.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstboxed_do\isinstboxed_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i06\mcc_i06.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\args2\args2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null037\castclass-null037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\baseclass01\baseclass01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sd1E_d\hfa_sd1E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgu_native\_il_dbgu_native.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\nullcomparaison_r\nullcomparaison_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics042\castclass-generics042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics001\box-unbox-generics001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nd0G_r\hfa_nd0G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\misc\Dev10_615402\Dev10_615402.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_relfibo_cs\_relfibo_cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics034\box-unbox-generics034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nf0G_d\hfa_nf0G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nd1A_r\hfa_nd1A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics021\castclass-generics021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\tostring_do\tostring_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\class02\class02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b35784\b35784\b35784.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\LdfldGeneric_ro\LdfldGeneric_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nf0B_r\hfa_nf0B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess2_cs_do\straccess2_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass042\castclass042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i12\mcc_i12.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNdiv_cs_r\r4NaNdiv_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nf2B_r\hfa_nf2B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\catch1_r\catch1_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics015\castclass-generics015.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value043\box-unbox-value043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd0E_d\hfa_nd0E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst_do\isinst_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNmul_cs_r\r4NaNmul_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nd2A_r\hfa_nd2A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sf1C_r\hfa_sf1C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_speed_relcall\_speed_relcall.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_GenericMethods\Inline_GenericMethods.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNrem_cs_r\r8NaNrem_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox045\box-unbox045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArray_ro\VectorArray_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbgrefanyval\_il_dbgrefanyval.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret5_1\structret5_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i76\mcc_i76.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_class_static01\general_class_static01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse1_cs_do\cse1_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\V8\Richards\Richards\Richards.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox038\box-unbox038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null028\castclass-null028.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstvaluetype_ro\isinstvaluetype_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_dbgknight\_dbgknight.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNsub_cs_ro\r8NaNsub_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface001\box-unbox-interface001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstenum_do\isinstenum_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics040\box-unbox-generics040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\try2_d\try2_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop6_cs_d\loop6_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstinterface_r\isinstinterface_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNsub_cs_do\r8NaNsub_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null003\castclass-null003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i57\mcc_i57.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct4_4\struct4_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_struct_static01\general_struct_static01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow2_cs_r\pow2_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2c_il_d\25param2c_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgvtret2\_il_dbgvtret2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNsub_cs_r\r8NaNsub_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null030\box-unbox-null030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics003\castclass-generics003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\transitive_instance01\transitive_instance01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret1_1\structret1_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nd2B_d\hfa_nd2B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\BitwiseOperations_ro\BitwiseOperations_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nd0C_r\hfa_nd0C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct4_5\struct4_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i52\mcc_i52.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\manyintf\ctest_cs_r\ctest_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics039\castclass-generics039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\class03\class03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sd1A_r\hfa_sd1A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i50\mcc_i50.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sf1A_d\hfa_sf1A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sf2B_d\hfa_sf2B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nf2B_d\hfa_nf2B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct3\struct3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b441487\b441487\b441487.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\constructor_do\constructor_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass021\castclass021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface003\castclass-interface003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\identity3_il_d\identity3_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_struct\_il_relhuge_struct.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\invocation_r\invocation_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i67\mcc_i67.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b28141\b28141\b28141.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstvaluetype_d\isinstvaluetype_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null021\castclass-null021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface002\box-unbox-interface002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\invocation_do\invocation_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNrem_cs_d\r8NaNrem_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArgs_ro\VectorArgs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_dbggcreport\_speed_dbggcreport.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\static_equalnull_class01\static_equalnull_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2b_il_r\25param2b_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ndpw\160545\simple\simple.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sd2G_d\hfa_sd2G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox013\box-unbox013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp2_1\structfp2_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\static_assignment_class01\static_assignment_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null045\castclass-null045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sd0E_d\hfa_sd0E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNsub_cs_d\r4NaNsub_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics031\box-unbox-generics031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\static_passing_class01\static_passing_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_speed_relhan3_ctor\_speed_relhan3_ctor.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\static_equalnull_class01\static_equalnull_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct4\struct4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null007\box-unbox-null007.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i07\mcc_i07.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sf2E_r\hfa_sf2E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\instance_assignment_class01\instance_assignment_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\singleRefField\singleRefField.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNmul_cs_r\r8NaNmul_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox024\box-unbox024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\gcreport\gcreport.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b392262\b392262\b392262.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nf0C_r\hfa_nf0C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null021\box-unbox-null021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\phoenix\62322\test\test.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\struct02\struct02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sf2A_r\hfa_sf2A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nd2C_d\hfa_nd2C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\gentonongen03\gentonongen03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sd2C_r\hfa_sd2C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics025\castclass-generics025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sf2G_d\hfa_sf2G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMatrix_r\VectorMatrix_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNsub_cs_do\r4NaNsub_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\test1\test1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\static_equalnull_struct01\static_equalnull_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null041\box-unbox-null041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct3_4\struct3_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgee\_il_dbgee.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\constructor_r\constructor_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxinterface_r\boxunboxinterface_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null030\castclass-null030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sd0G_d\hfa_sd0G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics023\box-unbox-generics023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp2_3\structfp2_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nf0C_d\hfa_nf0C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMin_r\VectorMin_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse2_cs_r\cse2_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgdd\_il_dbgdd.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nf0B_d\hfa_nf0B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPArray\FPArray.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass031\castclass031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null013\box-unbox-null013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value040\box-unbox-value040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumper4\_il_dbgjumper4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\122239\outermostFinally\outermostFinally.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_dbgcall\_dbgcall.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72687\b72687\b72687.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nf0G_r\hfa_nf0G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics028\castclass-generics028.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sd1G_r\hfa_sd1G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass041\castclass041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorAbs_ro\VectorAbs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_28763\R3Contention\R3Contention.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct1_4\struct1_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics043\box-unbox-generics043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct7_1\struct7_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassinterface_r\castclassinterface_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_1296\GitHub_1296\GitHub_1296.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_dbgrefanyval\_dbgrefanyval.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics014\box-unbox-generics014.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\static_equalnull_struct01\static_equalnull_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\inlining\bug505642\test\test.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nd1G_d\hfa_nd1G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblArray\DblArray.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sd0G_r\hfa_sd0G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\static_equalnull_struct01\static_equalnull_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNdiv_cs_do\r4NaNdiv_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics019\box-unbox-generics019.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics003\box-unbox-generics003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_ref\_il_relu_ref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value030\box-unbox-value030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret5_2\structret5_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b12425\b12425\b12425.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null018\box-unbox-null018.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null015\box-unbox-null015.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp3_1\structfp3_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i82\mcc_i82.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null027\box-unbox-null027.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_dbgldobj_R8\_il_dbgldobj_R8.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null022\castclass-null022.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox042\box-unbox042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sd0C_d\hfa_sd0C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse1_cs_r\cse1_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\invocation_ro\invocation_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_dbgnested\_il_dbgnested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumper5\_il_dbgjumper5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics019\castclass-generics019.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct1\struct1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\AbsSqrt_r\AbsSqrt_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse1_cs_ro\cse1_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Coverage\chaos65204782cs\chaos65204782cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics027\box-unbox-generics027.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass029\castclass029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassinterface_d\castclassinterface_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\try3_r\try3_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNmul_cs_ro\r8NaNmul_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructABI\StructABI\StructABI.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfpseh6_1\structfpseh6_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNsub_cs_d\r8NaNsub_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null015\castclass-null015.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null040\box-unbox-null040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\instance_equalnull_struct01\instance_equalnull_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hashcode_do\hashcode_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value029\box-unbox-value029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14716\b14716\b14716.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret6_3\structret6_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_relnative\_relnative.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst_d\isinst_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value041\box-unbox-value041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null012\castclass-null012.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\class01\class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\catch1_d\catch1_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null001\castclass-null001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_reljumper\_reljumper.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sf1G_r\hfa_sf1G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics024\castclass-generics024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgaa\_il_dbgaa.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\static_equalnull_class01\static_equalnull_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sf1C_d\hfa_sf1C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b210352\csharptester\csharptester.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i04\mcc_i04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hashcode_ro\hashcode_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CreateGeneric_ro\CreateGeneric_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\static_assignment_class01\static_assignment_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54667\b54667\b54667.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null009\castclass-null009.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null014\castclass-null014.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\instance_assignment_class01\instance_assignment_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nf1G_r\hfa_nf1G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\nongentogen02\nongentogen02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret2_2\structret2_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass044\castclass044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nd0C_d\hfa_nd0C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nf2A_d\hfa_nf2A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox026\box-unbox026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\ETW\TailCallCases\TailCallCases.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics022\box-unbox-generics022.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass043\castclass043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorSet_r\VectorSet_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nf1C_r\hfa_nf1C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct2_4\struct2_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\instance_equalnull_struct01\instance_equalnull_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\BoxUnbox_r\BoxUnbox_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\gc_nested\gc_nested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sd0E_r\hfa_sd0E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\StructFldAddr\StructFldAddr.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null010\castclass-null010.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nf2G_d\hfa_nf2G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct1_5\struct1_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sd1C_d\hfa_sd1C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP1a\SP1a.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sf0B_r\hfa_sf0B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNdiv_cs_ro\r4NaNdiv_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\jitinterface\bug603649\bug603649.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51575\b51575\b51575.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null005\box-unbox-null005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgnestval_cs\_dbgnestval_cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14228\b14228\b14228.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp1_4\structfp1_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\Dev10_846218\Dev10_846218.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\V8\Crypto\Crypto\Crypto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_dbgfibo_cs\_dbgfibo_cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbglcs\_il_dbglcs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i36\mcc_i36.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i31\mcc_i31.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumper3\_il_dbgjumper3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox044\box-unbox044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\instance_passing_struct01\instance_passing_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorAdd_ro\VectorAdd_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null023\castclass-null023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\class02\class02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null016\box-unbox-null016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value021\box-unbox-value021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox043\box-unbox043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNsub_cs_ro\r4NaNsub_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMax_ro\VectorMax_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics005\castclass-generics005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value026\box-unbox-value026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\nested\nested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_relgcreport\_speed_relgcreport.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\catch2_r\catch2_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct6_5\struct6_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nf0E_r\hfa_nf0E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge_struct\huge_struct.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b399444\b399444b\b399444b.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp2_4\structfp2_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd1E_r\hfa_nd1E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox025\box-unbox025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics008\castclass-generics008.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumper4\_il_reljumper4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null026\box-unbox-null026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow2_cs_do\pow2_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i61\mcc_i61.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp2_2\structfp2_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\class03\class03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nd2A_d\hfa_nd2A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_struct\_il_dbghuge_struct.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\gentogen02\gentogen02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics012\castclass-generics012.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Ldfld_ro\Ldfld_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics024\box-unbox-generics024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nd1G_r\hfa_nd1G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\struct03\struct03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass024\castclass024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_dbgjumper\_dbgjumper.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics006\box-unbox-generics006.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hasvalue_ro\hasvalue_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b21015\b21015\b21015.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics018\castclass-generics018.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface004\castclass-interface004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i73\mcc_i73.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_dbgldobj_R4\_il_dbgldobj_R4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\struct16args\struct16args.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgvtret\_il_dbgvtret.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret6_2\structret6_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null032\box-unbox-null032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null026\castclass-null026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass033\castclass033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null042\castclass-null042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b29343\b29343\b29343.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\identity3_il_r\identity3_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret1_3\structret1_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Coverage\chaos56200037cs\chaos56200037cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\catch2_d\catch2_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess2_cs_d\straccess2_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox029\box-unbox029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14277\b14277\b14277.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_il_d\class2_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nf1A_d\hfa_nf1A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i54\mcc_i54.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox021\box-unbox021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i56\mcc_i56.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\static_assignment_struct01\static_assignment_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sf2C_d\hfa_sf2C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumper2\_il_dbgjumper2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sf1G_d\hfa_sf1G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMul_ro\VectorMul_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null029\castclass-null029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null042\box-unbox-null042.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i13\mcc_i13.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_relaa\_il_relaa.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\instance_passing_struct01\instance_passing_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null010\box-unbox-null010.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\static_passing_struct01\static_passing_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop6_cs_do\loop6_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics016\box-unbox-generics016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b17023\b17023\b17023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox023\box-unbox023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value025\box-unbox-value025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct07\struct07.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\mismatch32\mismatch32\mismatch32.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i11\mcc_i11.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\manyintf\ctest_cs_d\ctest_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNrem_cs_do\r4NaNrem_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i62\mcc_i62.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i83\mcc_i83.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_131317\BadBox1\BadBox1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2a_cs_d\25param2a_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass013\castclass013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgcalli\_il_dbgcalli.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_relgc_nested\_relgc_nested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNmul_cs_do\r8NaNmul_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_relee\_il_relee.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14443\b14443\b14443.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics028\box-unbox-generics028.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b27980\b27980\b27980.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassvaluetype_d\castclassvaluetype_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics032\box-unbox-generics032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Vector3_r\Vector3_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\struct05\struct05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_relknight\_relknight.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null025\castclass-null025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox030\box-unbox030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\TypeParameters\default_struct01\default_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_relvtret\_relvtret.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass037\castclass037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd2E_d\hfa_nd2E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\constructor_ro\constructor_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\nullcomparaison_d\nullcomparaison_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct2\struct2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\DivSignedUnsignedTest_r\DivSignedUnsignedTest_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relu_native\_il_relu_native.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct5_2\struct5_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null002\castclass-null002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics006\castclass-generics006.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics037\castclass-generics037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null004\box-unbox-null004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_nd0B_d\hfa_nd0B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i81\mcc_i81.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null034\castclass-null034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMul_r\VectorMul_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\arrgetlen_il_r\arrgetlen_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null027\castclass-null027.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\struct04\struct04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_il_d\class1_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP1a2\SP1a2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass030\castclass030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sf2B_r\hfa_sf2B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_dbgstress3\_dbgstress3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nd2G_r\hfa_nd2G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_speed_dbgnested\_speed_dbgnested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNrem_cs_r\r4NaNrem_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess1_cs_do\straccess1_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null001\box-unbox-null001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null020\box-unbox-null020.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\baseclass05\baseclass05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_3b\_il_dbgtest_3b.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2a_cs_r\25param2a_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\structarr_cs_r\structarr_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface005\castclass-interface005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNdiv_cs_do\r8NaNdiv_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null037\box-unbox-null037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNdiv_cs_d\r8NaNdiv_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNrem_cs_d\r4NaNrem_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nf2C_r\hfa_nf2C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b15539\b15539\b15539.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_il_dbghuge_gcref\_il_dbghuge_gcref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null012\box-unbox-null012.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret3_2\structret3_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\simple1\simple1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorSqrt_r\VectorSqrt_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNrem_cs_ro\r8NaNrem_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_relldobj_V\_il_relldobj_V.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b102887\b102887\b102887.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ndpw\21015\interior_pointer\interior_pointer.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp4_1\structfp4_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\catch3_d\catch3_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\534486\exchange\exchange.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface001\castclass-interface001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics018\box-unbox-generics018.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstgenerics_d\isinstgenerics_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass026\castclass026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct4_2\struct4_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b464149\b464149\b464149.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sf2A_d\hfa_sf2A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b491215\b491215\b491215.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_speed_dbgcall\_speed_dbgcall.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null040\castclass-null040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\structarr_cs_ro\structarr_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics032\castclass-generics032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct6\struct6.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41391\b41391\b41391.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Structs\struct02\struct02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b416667\b416667\b416667.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\StoreElement_r\StoreElement_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\class02\class02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null019\box-unbox-null019.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstinterface_d\isinstinterface_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null038\box-unbox-null038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\tostring_r\tostring_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sd0A_r\hfa_sd0A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNadd_cs_do\r4NaNadd_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\dynamic_methods\bug_445388\bug_445388.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null002\box-unbox-null002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop6_cs_r\loop6_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorDiv_r\VectorDiv_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53226\b53226a\b53226a.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null045\box-unbox-null045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics033\box-unbox-generics033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorUnused_r\VectorUnused_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72699\b72699\b72699.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\baseclass02\baseclass02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nd1C_d\hfa_nd1C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\460412\test\test.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_relrefanyval\_il_relrefanyval.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgnative\_il_dbgnative.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd2E_r\hfa_nd2E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_il_d\vt4_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow2_cs_d\pow2_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\IntArraySum\IntArraySum.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_dbgvtret\_dbgvtret.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics043\castclass-generics043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox032\box-unbox032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sf0A_r\hfa_sf0A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null009\box-unbox-null009.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp1_5\structfp1_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b431098\b431098\b431098.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics008\box-unbox-generics008.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\static_assignment_struct01\static_assignment_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i32\mcc_i32.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sf0E_d\hfa_sf0E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nf1C_d\hfa_nf1C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sd0B_d\hfa_sd0B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct5_5\struct5_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret2_1\structret2_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\Dev11_14131\VectorForwarder\VectorForwarder.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i37\mcc_i37.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\gentogen03\gentogen03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassvaluetype_do\castclassvaluetype_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics031\castclass-generics031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b404051\b404051\b404051.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i51\mcc_i51.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\try2_r\try2_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst_r\isinst_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct1_2\struct1_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null039\box-unbox-null039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null011\box-unbox-null011.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_dbgctor_recurse\_dbgctor_recurse.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i80\mcc_i80.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null033\castclass-null033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\transitive_static01\transitive_static01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null025\box-unbox-null025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_relnative\_speed_relnative.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b102860\b102860\b102860.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_ref\_il_dbgu_ref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox040\box-unbox040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstvaluetype_r\isinstvaluetype_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstboxed_r\isinstboxed_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\V8\DeltaBlue\DeltaBlue\DeltaBlue.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorAdd_r\VectorAdd_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Structs\struct01\struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNrem_cs_do\r8NaNrem_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumper1\_il_dbgjumper1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics038\castclass-generics038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct3_2\struct3_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics005\box-unbox-generics005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b219940\b219940\b219940.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed2_cs_ro\mixed2_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics044\castclass-generics044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret4_1\structret4_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics026\castclass-generics026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value016\box-unbox-value016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sd2E_d\hfa_sd2E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59899\b59899\b59899.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null044\castclass-null044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nf0A_d\hfa_nf0A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\Call_instance01_do\Call_instance01_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\callconv\_dbginstance_cs\_dbginstance_cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\binarytrees\binarytrees\binarytrees.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51817\b51817\b51817.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\MinMax_r\MinMax_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\static_passing_struct01\static_passing_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null008\castclass-null008.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b31398\b31398\b31398.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_dbggc_nested\_dbggc_nested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Serialization\Deserialize\Deserialize.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstgenerics_r\isinstgenerics_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Coverage\chaos55915408cs\chaos55915408cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nf2G_r\hfa_nf2G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_relvtret2\_il_relvtret2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null005\castclass-null005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics039\box-unbox-generics039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sf0B_d\hfa_sf0B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nf2C_d\hfa_nf2C_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass016\castclass016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i05\mcc_i05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox039\box-unbox039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics002\box-unbox-generics002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp1_1\structfp1_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\boxunboxvaluetype_do\boxunboxvaluetype_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics040\castclass-generics040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b11553\b11553\b11553.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14428\b14428\b14428.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2a_cs_do\25param2a_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorGet_r\VectorGet_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct6_4\struct6_4.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxinterface_d\boxunboxinterface_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics015\box-unbox-generics015.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics001\castclass-generics001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\value_ro\value_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b87284\b87284\b87284.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i71\mcc_i71.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\GCOverReporting\GCOverReporting.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct2_2\struct2_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_dbgldobj_I\_il_dbgldobj_I.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sd2A_r\hfa_sd2A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_dbghan3_ctor\_dbghan3_ctor.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface004\box-unbox-interface004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value044\box-unbox-value044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_relrefanyval\_relrefanyval.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\structarr_cs_do\structarr_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\RecursiveTailCall\RecursiveTailCall.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\instance_assignment_class01\instance_assignment_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorHWAccel_r\VectorHWAccel_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstgenerics_do\isinstgenerics_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface005\box-unbox-interface005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Structs\struct03\struct03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\struct03\struct03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\Call_instance01_d\Call_instance01_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\structarr_cs_d\structarr_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value033\box-unbox-value033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox034\box-unbox034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics041\box-unbox-generics041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nd0A_r\hfa_nd0A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_il_r\class2_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null008\box-unbox-null008.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassvaluetype_ro\castclassvaluetype_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null024\castclass-null024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null044\box-unbox-null044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorSub_ro\VectorSub_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics017\castclass-generics017.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null039\castclass-null039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass038\castclass038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNadd_cs_do\r8NaNadd_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i74\mcc_i74.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics029\box-unbox-generics029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2b_il_d\25param2b_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_3b\_il_reltest_3b.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics030\box-unbox-generics030.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\class01\class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sd0C_r\hfa_sd0C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sd1G_d\hfa_sd1G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNadd_cs_d\r8NaNadd_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_ref\_il_dbgi_ref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_relctor_recurse\_relctor_recurse.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\class04\class04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstenum_ro\isinstenum_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfpseh5_1\structfpseh5_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b440158\b440158\b440158.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b202743\b202743\b202743.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse2_cs_do\cse2_cs_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2a_cs_ro\25param2a_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null013\castclass-null013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_relcall\_relcall.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret1_2\structret1_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i15\mcc_i15.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value037\box-unbox-value037.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess1_cs_ro\straccess1_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\TypeParameters\default_class01\default_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNadd_cs_r\r8NaNadd_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\tostring_d\tostring_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\boxunboxvaluetype_r\boxunboxvaluetype_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_speed_dbghan3_ctor\_speed_dbghan3_ctor.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\gcincatch_d\gcincatch_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\baseclass03\baseclass03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b610750\b610750_32vs64\b610750_32vs64.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_speed_dbgrefanyval\_speed_dbgrefanyval.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics045\castclass-generics045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value045\box-unbox-value045.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox016\box-unbox016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value024\box-unbox-value024.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Mul_r\Mul_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface018\castclass-interface018.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_relnestval_cs\_relnestval_cs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics033\castclass-generics033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret4_2\structret4_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\arrgetlen_il_d\arrgetlen_il_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_il_relhuge_gcref\_il_relhuge_gcref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret3_3\structret3_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\DivSignedUnsignedTest_ro\DivSignedUnsignedTest_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNrem_cs_ro\r4NaNrem_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\call_instance01\call_instance01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\general_struct_instance01\general_struct_instance01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\instance_assignment_struct01\instance_assignment_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass040\castclass040.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nd0G_d\hfa_nd0G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\class05\class05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sd1A_d\hfa_sd1A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics029\castclass-generics029.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics016\castclass-generics016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\instance_equalnull_struct01\instance_equalnull_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i30\mcc_i30.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b28077\b28077\b28077.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_relstress3\_relstress3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_dbgnested\_dbgnested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sd2B_d\hfa_sd2B_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNdiv_cs_r\r8NaNdiv_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp6_1\structfp6_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nd0E_r\hfa_nd0E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_il_r\vt4_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\constructor_d\constructor_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b16198\b16198\b16198.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNmul_cs_d\r4NaNmul_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sf0E_r\hfa_sf0E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sf0G_d\hfa_sf0G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed2_cs_d\mixed2_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp1_2\structfp1_2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ldtoken\_il_dbgptr_types\_il_dbgptr_types.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\struct01\struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\BoxUnbox_ro\BoxUnbox_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\nongentogen01\nongentogen01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstboxed_d\isinstboxed_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sf1E_d\hfa_sf1E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\cse2_cs_d\cse2_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics021\box-unbox-generics021.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i17\mcc_i17.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\params-varargs\params-varargs.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbginitializearray_enum\_il_dbginitializearray_enum.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relinitializearray_enum\_il_relinitializearray_enum.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null033\box-unbox-null033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinst_ro\isinst_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sd2E_r\hfa_sd2E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret5_3\structret5_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_dbgnative\_speed_dbgnative.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null014\box-unbox-null014.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Misc\gettype\gettypetypeofmatrix\gettypetypeofmatrix.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sf2G_r\hfa_sf2G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumper5\_il_reljumper5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nd2C_r\hfa_nd2C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics002\castclass-generics002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\gentonongen02\gentonongen02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b10665\b10665\b10665.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\instance_passing_class01\instance_passing_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class07\class07.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_13748\ReflectOnField\ReflectOnField.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nf1E_d\hfa_nf1E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SP1c\SP1c.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorArgs_r\VectorArgs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b163200\b163200\b163200.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess2_cs_r\straccess2_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics013\box-unbox-generics013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret4_3\structret4_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_relgcreport\_relgcreport.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp5_1\structfp5_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_r\CircleInConvex_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgstress2\_il_dbgstress2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Vector3Interop_r\Vector3Interop_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i35\mcc_i35.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_nf0E_d\hfa_nf0E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass039\castclass039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchF\LLoops\LLoops\LLoops.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics014\castclass-generics014.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorMax_r\VectorMax_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sd0B_r\hfa_sd0B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics044\box-unbox-generics044.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret3_1\structret3_1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\static_passing_struct01\static_passing_struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\cs\unsafe_r\unsafe_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30864\b30864\b30864.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value039\box-unbox-value039.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\Call_instance01_r\Call_instance01_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testB\hfa_sd2B_r\hfa_sd2B_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\StructAsParam_Method\StructAsParam_Method.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics011\box-unbox-generics011.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface018\box-unbox-interface018.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sd2G_r\hfa_sd2G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reldd\_il_reldd.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null034\box-unbox-null034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_sf0G_r\hfa_sf0G_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i53\mcc_i53.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\sealedCastVariance\sealedCastVariance.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassvaluetype_r\castclassvaluetype_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b102615\b102615\b102615.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass032\castclass032.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i64\mcc_i64.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow2_cs_ro\pow2_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i70\mcc_i70.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Ldfld_r\Ldfld_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Locals\instance_passing_class01\instance_passing_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\regression\DDB148379\ddb148379\ddb148379.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics022\castclass-generics022.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Vector4_r\Vector4_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\tostring_ro\tostring_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null031\castclass-null031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\FractalPerf\FractalPerf\FractalPerf.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_relnested\_relnested.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i34\mcc_i34.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\zeroInitStackSlot\zeroInitStackSlot.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_DelegateStruct\Inline_DelegateStruct.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\cs\unsafe_d\unsafe_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorAbs_r\VectorAbs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SpAddr\SpAddr.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\test3\test3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53226\b53226b\b53226b.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_sf2C_r\hfa_sf2C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\convert_static01\convert_static01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structret2_3\structret2_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i65\mcc_i65.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\boxunboxvaluetype_ro\boxunboxvaluetype_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b140298\b140298\b140298.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\tailcall_AV\tailcall_AV.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i55\mcc_i55.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct3_5\struct3_5.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics012\box-unbox-generics012.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Conversions\Reference\gentonongen01\gentonongen01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\value_d\value_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sf1A_r\hfa_sf1A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i84\mcc_i84.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgtypedref\_dbgtypedref.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorInit_r\VectorInit_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics017\box-unbox-generics017.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\class03\class03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_nf0A_r\hfa_nf0A_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\hashcode_r\hashcode_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_111914\BadMax1\BadMax1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\isinstgenerics_ro\isinstgenerics_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\array\array.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testC\hfa_nd1C_r\hfa_nd1C_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorUnused_ro\VectorUnused_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNadd_cs_ro\r4NaNadd_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null031\box-unbox-null031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\native\native.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgnestval_il\_dbgnestval_il.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\invocation_d\invocation_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\test2\test2.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\class01\class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null023\box-unbox-null023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null016\castclass-null016.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b76267\b76267\b76267.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structfp1_3\structfp1_3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sf0A_d\hfa_sf0A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sf2E_d\hfa_sf2E_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testE\hfa_sd1E_r\hfa_sd1E_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null038\castclass-null038.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics007\box-unbox-generics007.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i10\mcc_i10.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relnative\_il_relnative.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNmul_cs_d\r8NaNmul_cs_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox031\box-unbox031.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass034\castclass034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StructPromote\SpAddrAT\SpAddrAT.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_relcalli\_il_relcalli.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value013\box-unbox-value013.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r4NaNsub_cs_r\r4NaNsub_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics041\castclass-generics041.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\struct01\struct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_dbgnative\_dbgnative.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\catch3_r\catch3_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_dbggcreport\_dbggcreport.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics026\box-unbox-generics026.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null007\castclass-null007.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\null\castclass-null020\castclass-null020.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b29583\b29583\b29583.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Classes\baseclass04\baseclass04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_relhan3_ctor\_il_relhan3_ctor.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\mixed2_cs_r\mixed2_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testG\hfa_nd2G_d\hfa_nd2G_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass023\castclass023.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox033\box-unbox033.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess1_cs_r\straccess1_cs_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\r8NaNadd_cs_ro\r8NaNadd_cs_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param2c_il_r\25param2c_il_r.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics034\castclass-generics034.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics027\castclass-generics027.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\mcc\interop\mcc_i86\mcc_i86.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_dbgldobj_V\_il_dbgldobj_V.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorSqrt_ro\VectorSqrt_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\Call_instance01_ro\Call_instance01_ro.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Constraints\convert_instance01\convert_instance01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Parameters\static_passing_class01\static_passing_class01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchI\BenchE\BenchE\BenchE.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\generics\box-unbox-generics025\box-unbox-generics025.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\null\box-unbox-null043\box-unbox-null043.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\Interfaces\struct02\struct02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_relhan3\_il_relhan3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\value_do\value_do.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\generics\castclass-generics004\castclass-generics004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\leave\try1_d\try1_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\hfa\main\testA\hfa_sd0A_d\hfa_sd0A_d.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxinterface_ro\boxunboxinterface_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassinterface_ro\castclassinterface_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_r8\_il_relhuge_r8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_d\int16_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relisinst_calli\_il_relisinst_calli.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\PositiveCases\PositiveCases.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\Recursion\Recursion.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b374944\b374944\b374944.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_il_reliface2\_il_reliface2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct02\struct02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr8a_cs_d\convr8a_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_reltry_cs\_reltry_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\unboxnullable_r\unboxnullable_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class01\class01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relcastclass_newobj\_relcastclass_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_dbglcs_gcref\_dbglcs_gcref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\rangecheckinfinally_ro\rangecheckinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_815940\DevDiv_815940_r\DevDiv_815940_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblAddConst\DblAddConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_r\class1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface016\box-unbox-interface016.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b609988\Desktop\b609988\b609988.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-06_cs_d\5w1d-06_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class06\class06.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_No_Op_cs_d\Double_No_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_911875\DevDiv_911875_ro\DevDiv_911875_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_relfr8\_il_relfr8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\loopinfinally_r\loopinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\inl\caninline_do\caninline_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfilter_r\throwinfilter_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovflrem2_il_r\ovflrem2_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b409617\b409617\b409617.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgcastclass_ldloc\_il_dbgcastclass_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\div2\div2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b76717\b76717\b76717.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACC_ro\CGRecurseACC_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FactorialRec\FactorialRec.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15783\b15783\b15783.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samethrowtwice_ro\samethrowtwice_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallynestedintry_30_r\throwinfinallynestedintry_30_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value014\box-unbox-value014.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit4_r\tryCatchFinallyThrow_nonlocalexit4_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\catchbeforetrybody_d\catchbeforetrybody_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_ro\dblarray4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b13944\b13944\b13944.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\cprop001_do\cprop001_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_u2\_il_dbgrefloc_u2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\tryfinallyincatchtry_d\tryfinallyincatchtry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate012\Delegate012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ldsshrstsfld_il_r\ldsshrstsfld_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpathfn_r\throwinfinallyerrpathfn_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\enum\box-unbox-enum001\box-unbox-enum001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\ldfldunboxedvt\ldfldunboxedvt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\plainarr_cs_d\plainarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface010\box-unbox-interface010.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblAvg6\DblAvg6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\localgotoinahandler_do\localgotoinahandler_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\pointerexpr1_1\pointerexpr1_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b359564\b359564\b359564.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b112348\b112348\b112348.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\throwincatch_d\throwincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest1\fgtest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_816617\DevDiv_816617_ro\DevDiv_816617_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_nonf_il_d\intrinsic_nonf_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcsmax\_speed_rellcsmax.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\unboxnullable_do\unboxnullable_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_f8\_il_relrefarg_f8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M09.5-PDC\b12008\b12008\b12008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadoponerrorinfunclet_d\deadoponerrorinfunclet_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\cs\unsafe_do\unsafe_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface012\castclass-interface012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcsmax\_dbglcsmax.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgenum_il\_dbgenum_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgconv_i8_u\_il_dbgconv_i8_u.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_oreltailjump_cs\_oreltailjump_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M14-SP1\b119538\b119538b\b119538b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_vfld\_il_reli_vfld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise4_cs_ro\precise4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_qsort1\_il_dbgi_qsort1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_d\arithm32_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\329169\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_b473131\b473131_struct\b473131_struct.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1c_il_d\25param1c_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1_cs_ro\xprecise1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\610378\vsw610378\vsw610378.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowwithhandlerscatchingbase_ro\rethrowwithhandlerscatchingbase_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\528315\simple-repro\simple-repro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samethrowtwice_r\samethrowtwice_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Xor_Op_cs_ro\Double_Xor_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Or_Op_cs_d\Float_Or_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b608198\b608198\b608198.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_RecursiveMethod21\Inline_RecursiveMethod21.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_815940\DevDiv_815940_do\DevDiv_815940_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\plainarr_cs_do\plainarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_cs_d\uint8_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\cond64_il_d\cond64_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_relcast_throw\_relcast_throw.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass001\castclass001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Base_4\Test_CSharp_Base_4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPMul\FPMul.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryfinallythrow_nonlocalexit_ro\tryfinallythrow_nonlocalexit_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxblk\cpblk3_il_r\cpblk3_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b16054\b16054\b16054.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPDist\FPDist.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b115253\b115253\b115253.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b99403\b99403\b99403.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_il_reltest3\_il_reltest3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\inl\caninline_d\caninline_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox027\box-unbox027.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Base_1\Generic_Test_CSharp_Base_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reliu2\_il_reliu2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relisinst_ldloc\_speed_relisinst_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit3_r\tryCatchFinallyThrow_nonlocalexit3_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_speed_relgcarr\_speed_relgcarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b10666\b10666\b10666.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassenum_do\castclassenum_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchbackwardswithcatch_r\branchbackwardswithcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallyrecursive_20_d\throwinfinallyrecursive_20_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_No_Op_cs_ro\Int_No_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Coverage\b518440\b518440.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_reldeep\_reldeep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\assemname_cs_d\assemname_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b309548\b309548\b309548.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nonlocalexitinroot\nonlocalexitinroot.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\tailcall\tailcall\tailcall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_relcastclass_catch\_il_relcastclass_catch.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_f4\_il_relrefarg_f4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nonlocalexitintry\nonlocalexitintry.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_And_Op_cs_d\Double_And_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\intarr_cs_d\intarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\array-il\_Arrayssimple3\_Arrayssimple3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\morph\_relsin_cs\_relsin_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08944\b08944b\b08944b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\cascadedcatch_r\cascadedcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44861\b44861\b44861.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\throw_cs_r\throw_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b27077\b27077\b27077.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\simplerethrow_d\simplerethrow_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise4_cs_d\precise4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\607586\607586\607586.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgisinst_ldloc\_il_dbgisinst_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\SciMark\SciMark\SciMark.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1b_cs_ro\xprecise1b_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1b_cs_do\precise1b_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\568666\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nullsdarr_il_d\nullsdarr_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-01_cs_r\3w1d-01_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\simpledeadehregion_d\simpledeadehregion_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_speed_dbgcatchfinally_tail\_speed_dbgcatchfinally_tail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\228572\conv_dbg\conv_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_vfld\_il_relu_vfld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgiu1\_il_dbgiu1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgii1\_il_dbgii1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_And_Op_cs_do\Bool_And_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\throwincatch_ro\throwincatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcsbas\_dbglcsbas.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexit_do\simplenonlocalexit_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadoponerror_d\deadoponerror_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_array_merge\_il_dbgu_array_merge.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatch_do\trycatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_relconcurgc_il\_relconcurgc_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_il_dbgtest2\_il_dbgtest2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\add\add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Peer_2\Generic_Test_CSharp_Peer_2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\valuetype_d\valuetype_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relisinst_ldarg\_il_relisinst_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b36332\b36332\b36332.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\localvarincatch_d\localvarincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorInit_ro\VectorInit_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpath_d\throwinfinallyerrpath_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\structarr_cs_ro\structarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b46292\b46292\b46292.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress3_ro\CgStress3_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\Struct01_instance\Struct01_instance.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\loopEH\loopEH.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\rem_dbg\rem_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface012\box-unbox-interface012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_neg_range\_il_dbgint32_neg_range.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate017\Delegate017.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_i_u2\_il_relcompat_i_u2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_ro\uint8_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_dbgarrres\_dbgarrres.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_do\class2_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\517867\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_fld\_il_relu_fld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass018\castclass018.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxenum_r\boxunboxenum_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_do\class1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwisfirstinstruction_r\throwisfirstinstruction_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytryfinally_r\tryfinallytryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_d\dblarray4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_implicit\_il_dbgtest_implicit.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit3_d\tryCatchFinallyThrow_nonlocalexit3_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchbackwardswithcatch_d\branchbackwardswithcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-06_cs_r\5w1d-06_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b321799\b321799\b321799.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\generics_d\generics_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct06\struct06.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71231\b71231\b71231.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794631\DevDiv_794631_r\DevDiv_794631_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit1_r\tryCatchFinallyThrow_nonlocalexit1_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\delegate_d\delegate_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytryfinally_do\tryfinallytryfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass011\castclass011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldexpr1\fieldexpr1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox022\box-unbox022.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\throwincatch_do\throwincatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldexpr2\fieldexpr2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface011\castclass-interface011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_o2\_il_relrefloc_o2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_dbgcastclass_catch_neg\_il_dbgcastclass_catch_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\volatilestaticfield\volatilestaticfield.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_relunbox\_il_relunbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_4115\GitHub_4115\GitHub_4115.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxinterface_do\boxunboxinterface_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_b473131\b473131_byte\b473131_byte.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b16378\b16378\b16378.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\524070\test1\test1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldfldstatic1_il_d\ldfldstatic1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinally_d\throwinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallywith2reachableendfinally_r\tryfinallywith2reachableendfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatch_ro\trythrowcatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgfr8\_il_dbgfr8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value006\box-unbox-value006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchnestedtype_do\trycatchnestedtype_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\params-none\params-none.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\doublearr_cs_d\doublearr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPFillArray\FPFillArray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt3_cs_r\vt3_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\eh1\eh1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinally_r\throwinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Peer_6\Generic_Test_CSharp_Peer_6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b91855\b91855\b91855.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\cpobj\cpobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\endfinallyinloop_d\endfinallyinloop_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int8_il_d\int8_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt1_cs_d\vt1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcsmixed\_dbglcsmixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_range1\_il_relint32_range1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\switchdefaultonly2_il_d\switchdefaultonly2_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\thiscall\_dbgthisnull\_dbgthisnull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\apps\bouncingball_cs_d\bouncingball_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_speed_relbinop\_speed_relbinop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_and\VolatileTest_op_and.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Or_Op_cs_r\Float_Or_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadcodeincatch_d\deadcodeincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\cond32_il_r\cond32_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchbackwardswithfinally_d\branchbackwardswithfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72422\b72422\b72422.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\140713\innerFinally_r\innerFinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev14\DevDiv_876169\DevDiv_876169_r\DevDiv_876169_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_r8_r4_inl\_il_dbgcompat_r8_r4_inl.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59297\b59297\b59297.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\morph\_dbgsin_cs\_dbgsin_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytryfinally_d\tryfinallytryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relselfref\_il_relselfref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\ArrayBound_o\ArrayBound_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_conv\_il_relu_conv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchoutoftryfinally_r\branchoutoftryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_il_reltest2\_il_reltest2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\fgtest2\fgtest2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b12795\b12795\b12795.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59678\b59678\b59678.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Or_Op_cs_ro\Float_Or_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b602004\b602004\b602004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\ceeillegal\ceeillegal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\doublearr_cs_r\doublearr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\DumpDisasm\JitMinOpts\BBCnt1\BBCnt1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowwithhandlerscatchingbase_d\rethrowwithhandlerscatchingbase_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b19289\b19289\b19289.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinally_50_d\throwinfinally_50_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray\HugeArray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Or_Op_cs_r\Bool_Or_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\DumpDisasm\JitMinOpts\InstrCnt1\InstrCnt1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop4_cs_d\loop4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_76013\Dev11_76013\Dev11_76013.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value007\box-unbox-value007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1_cs_r\precise1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise4_cs_d\xprecise4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinally_r\tryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b471305\b471305\b471305.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_r8\_il_dbgrefloc_r8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr4_r_try\simpleexpr4_r_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1b_cs_do\xprecise1b_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b19171\b19171\b19171.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow0_cs_ro\pow0_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_dbgsin_cs_cs\_dbgsin_cs_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_ro\arithm32_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14059\b14059\b14059.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b102962\b102962a\b102962a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1_d_loop_try\staticFieldExprUnchecked1_d_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_No_Op_cs_r\Double_No_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b109721\b109721\b109721.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfilter_r\badcodeafterfilter_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\trashreg_il_d\trashreg_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset3_o\nestedTryRegionsWithSameOffset3_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\DumpDisasm\JitMinOpts\LVNumCnt1\LVNumCnt1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgisinst_ldloc\_dbgisinst_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Coverage\arglist_pos\arglist_pos.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_0_5a\_il_dbgint32_0_5a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfaulttrycatchfn_d\tryfaulttrycatchfn_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\gettypetypeof\gettypetypeofmatrix\gettypetypeofmatrix.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\labelbeforefinally_r\labelbeforefinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\SimpleArray_01_o\SimpleArray_01_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Arrays\Simple2\Simple2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4_cs_d\r4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox011\box-unbox011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51875\b51875\b51875.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\Desktop\throw_cs_ro\throw_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexit_ro\simplenonlocalexit_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\verify\verify01_dynamic\verify01_dynamic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_dbgdeep\_dbgdeep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\ArrayWithFunc_o\ArrayWithFunc_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_cs_r\arithm64_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_reladdress\_il_reladdress.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexitnestedintrycatch_do\simplenonlocalexitnestedintrycatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8_cs_r\r8_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\oponerror_r\oponerror_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b188478\b188478\b188478.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgptr\_il_dbgptr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgiu4\_il_dbgiu4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_il_relrefarg_box_f8\_il_relrefarg_box_f8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_r\stringarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\StaticCalls\StaticCalls.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relcastclass_newobj\_speed_relcastclass_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-01_cs_do\5w1d-01_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\Desktop\throw_cs_do\throw_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b598031\test2\test2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_speed_reljumps\_speed_reljumps.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\NoMetaData\NoMetaData.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPDiv\FPDiv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\test_noalloca\test_noalloca.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\nativeint_il_d\nativeint_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Xor_Op_cs_r\Double_Xor_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value019\box-unbox-value019.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_speed_relsizeof\_speed_relsizeof.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadtryfinallythrow_r\deadtryfinallythrow_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatchfinally_r\trythrowcatchfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b02062\b02062\b02062.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_range2\_il_relint32_range2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_cs_d\arithm32_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b518440\b518440\b518440.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b38269\b38269\b38269.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_cs_d\intrinsic_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgcastclass_call\_il_dbgcastclass_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relconv_i8_i\_il_relconv_i8_i.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh06_dynamic\eh06_dynamic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samerethrowtwice_ro\samerethrowtwice_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_relthrow\_relthrow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_r\class2_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b13647\b13647\b13647.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\osr\osr001\osr001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samerethrowtwice_do\samerethrowtwice_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcsvalbox\_speed_rellcsvalbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_speed_relobj\_speed_relobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgobjref\_il_dbgobjref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-02_cs_do\5w1d-02_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass027\castclass027.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\trycatchintryfinally_do\trycatchintryfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh08_dynamic\eh08_dynamic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads1_cs_do\threads1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_ro\class2_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr2\simpleexpr2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit1_do\tryCatchFinallyThrow_nonlocalexit1_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\JaggedArray_o\JaggedArray_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPConvF2F\FPConvF2F.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinally_ro\throwinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\rethrow\Rethrow1\Rethrow1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\delegate\delegate.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ndpw\14888\objectusedonlyinhandler\objectusedonlyinhandler.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b44297\b44297\b44297.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_cs_ro\arithm64_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\simplerethrow_ro\simplerethrow_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgenum_cs\_dbgenum_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_815940\DevDiv_815940_ro\DevDiv_815940_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxenum_ro\boxunboxenum_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_speed_rellcs_gcref\_speed_rellcs_gcref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\localgotoinahandler_d\localgotoinahandler_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\nativeint_il_r\nativeint_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_odbgnestval_cs\_odbgnestval_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow0_cs_r\pow0_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\nonlocalexitfromnestedcatch_ro\nonlocalexitfromnestedcatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\404708\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b184799\b184799\b184799.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\fasta\fasta\fasta.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_orelfibo_cs\_orelfibo_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_457559\Dev11_457559\Dev11_457559.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b92073\b92073\b92073.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcsval\_speed_rellcsval.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_And_Op_cs_d\Int_And_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\simplerethrow_r\simplerethrow_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\DevDiv2_8863\DevDiv2_8863\DevDiv2_8863.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeaftertry_d\badcodeaftertry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\sysinfo_il\sysinfo_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value027\box-unbox-value027.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_i4_i1\_il_dbgcompat_i4_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_cs_d\arithm64_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACC_d\CGRecurseACC_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b43694\b43694\b43694.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate010\Delegate010.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Convert\minopts_convu1\minopts_convu1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPSub\FPSub.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14640\b14640\b14640.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Arrays\Complex2\Complex2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcsmixed\_speed_dbglcsmixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\cpobj\cpobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Base_2\Generic_Test_CSharp_Base_2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\identity\_il_dbglivecall\_il_dbglivecall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b103838\b103838\b103838.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress3_do\CgStress3_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reli4i1\_il_reli4i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-02_cs_d\5w1d-02_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b604247\b604247\b604247.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\thiscall\_speed_relthisnull\_speed_relthisnull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794115\DevDiv_794115_do\DevDiv_794115_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b02345\b02345\b02345.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray3_cs_do\dblarray3_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\MultiDim\struct01_instance\struct01_instance.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgcastclass_call\_dbgcastclass_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface011\box-unbox-interface011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\tlstest_il_d\tlstest_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\verify\verify01_small\verify01_small.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b311420\b311420\b311420.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b565808\b565808\b565808.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_d\uint32_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relisinst_call\_speed_relisinst_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_relenum_cs\_relenum_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value003\box-unbox-value003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\cascadedcatch_ro\cascadedcatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\funclet\funclet.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\tryfinallyloop_do\tryfinallyloop_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\byrefconvert_il_d\byrefconvert_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b79642\b79642\b79642.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nestedfinallycall_d\nestedfinallycall_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\mixed\mixed_cs_ro\mixed_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\cond32_il_d\cond32_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Xor_Op_cs_r\Float_Xor_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\ldobj\ldobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\ref2byref_il_r\ref2byref_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_rellengthm2\_il_rellengthm2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\valuetype_r\valuetype_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b93635\b93635\b93635.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Arrays\Simple1\Simple1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\doublearr_cs_do\doublearr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeaftercatch_d\badcodeaftercatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_relsin_cs\_relsin_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_relsizeof\_il_relsizeof.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchnestedtype_ro\trycatchnestedtype_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox012\box-unbox012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M12-Beta2\b26323\b26323\b26323.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b42387\b42387\b42387.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_f8\_il_dbgrefarg_f8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\leaveinsameregion_d\leaveinsameregion_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\classarr_cs_do\classarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxblk\cpblk3_il_d\cpblk3_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_r8\_il_relrefloc_r8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_cs_do\uint16_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_Recursion\Inline_Recursion.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\reversedhandlers_r\reversedhandlers_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-06_cs_do\5w1d-06_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_static01\specific_class_static01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_relenum_il\_relenum_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedcatch_d\throwincascadedcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14077\b14077\b14077.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh08_small\eh08_small.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_No_Op_cs_do\Bool_No_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedcatchnofin_d\throwincascadedcatchnofin_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPSubConst\FPSubConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class05\class05.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b02352\b02352\b02352.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_objref\_il_relhuge_objref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\generics2_d\generics2_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\classarr_cs_d\classarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value008\box-unbox-value008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value005\box-unbox-value005.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadtryfinallythrow_d\deadtryfinallythrow_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblAdd\DblAdd.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b10939\b10939\b10939.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794631\DevDiv_794631_ro\DevDiv_794631_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Linq\Linq\Linq.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_seq\_il_reli_seq.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_box\_il_reli_box.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeArray1\HugeArray1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcsbox\_dbglcsbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblFillArray\DblFillArray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reliu4\_il_reliu4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_box\_il_relu_box.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgi4u4\_il_dbgi4u4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadtrycatch_r\deadtrycatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate005\Delegate005.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\cs\unsafe_ro\unsafe_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_cs_d\int32_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\backwardleave_d\backwardleave_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate016\Delegate016.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\throw2dimarray_r\throw2dimarray_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_relfr4\_il_relfr4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b29068\b29068\b29068.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_speed_dbgbinop\_speed_dbgbinop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_qsort1\_il_dbgu_qsort1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallynestedintry_30_do\throwinfinallynestedintry_30_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_seq\_il_dbgu_seq.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06811\b06811\b06811.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\labelbeginningfinally_d\labelbeginningfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\byrefconvert_il_r\byrefconvert_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b111130\b111130\b111130.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr4d_il_r\convr4d_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4_cs_ro\i4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpathfn_do\throwinfinallyerrpathfn_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate028\Delegate028.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\classarr_cs_r\classarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_i2_bool\_il_dbgcompat_i2_bool.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\multihandler_do\multihandler_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtrycatch_r\nestedtrycatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\throw1dimarray_r\throw1dimarray_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgisinst_calli\_il_dbgisinst_calli.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_cs_r\uint32_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Coverage\chaos55915408cs_o\chaos55915408cs_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Xor_Op_cs_d\Double_Xor_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_do\bigvtbl_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b11490\b11490\b11490.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_o\_il_relrefloc_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_flow\_il_relu_flow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface016\castclass-interface016.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate027\Delegate027.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\castClassEH\castClassEH.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowinfinallyinsidecatch_d\rethrowinfinallyinsidecatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_d\bigvtbl_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate024\Delegate024.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\gc-pinned-code-motion\gc-pinned-code-motion.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_odbgenum_cs\_odbgenum_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b400791\_b400971b400971\_b400971b400971.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50145\b50145c\b50145c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\jaggedarr_cs_r\jaggedarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\strswitchfinal_r\strswitchfinal_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b124232\b124232\b124232.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-01_cs_d\5w1d-01_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinnestedfinally_d\throwinnestedfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_relsin_cs_cs\_relsin_cs_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\nonlocalexitfromnestedcatch_do\nonlocalexitfromnestedcatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\valueTypeBoxing\valueTypeBoxing.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\refTypesdynamic\refTypesdynamic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nonlocalgotoinatryblockinahandler\nonlocalgotoinatryblockinahandler.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_o\_il_dbgrefloc_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_qsort1\_il_relu_qsort1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50145\b50145b\b50145b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relcastclass_ldloc\_il_relcastclass_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\575343\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3b_il_d\25param3b_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate030\Delegate030.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_ro\int16_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_dbgsizeof\_dbgsizeof.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinally_do\throwinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\commutativecse\ccse_cs_r\ccse_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovfldiv2_il_d\ovfldiv2_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate029\Delegate029.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b609280\b609280\b609280.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68757\b68757\b68757.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value001\box-unbox-value001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\flowgraph\xaddmuly_cs_r\xaddmuly_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\perf\doublealign\objects\objects.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\nullcomparaison_do\nullcomparaison_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox028\box-unbox028.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgcastclass_ldarg\_speed_dbgcastclass_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b138117\b138117\b138117.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate015\Delegate015.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_vfld\_il_dbgu_vfld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28787\b28787\b28787.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassenum_d\castclassenum_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_cs_r\uint8_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_dbgcast_throw\_dbgcast_throw.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\testeit_r\testeit_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_relbox\_relbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b91074\b91074\b91074.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeexpr1\hugeexpr1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\jaggedarr_cs_ro\jaggedarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_dbgtry_cs\_dbgtry_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgisinst_ldloc\_speed_dbgisinst_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\forwardleaveincatch_r\forwardleaveincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcsmax\_speed_dbglcsmax.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcsval\_rellcsval.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr4a_cs_r\convr4a_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchsimpletype_d\trycatchsimpletype_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\tryfinallyloop_ro\tryfinallyloop_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr2_r_try\arrayexpr2_r_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinally_ro\tryfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\volatilefromfinally\volatilefromfinally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_array_merge\_il_reli_array_merge.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop1_cs_do\loop1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_do\arithm32_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\cprop001_ro\cprop001_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox008\box-unbox008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class01_static\class01_static.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1_r_loop\staticFieldExprUnchecked1_r_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Xor_Op_cs_d\Float_Xor_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Xor_Op_cs_ro\Int_Xor_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\stringarr_cs_r\stringarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallyrecursive_20_do\throwinfinallyrecursive_20_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b309555\b309555\b309555.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\clr-x64-JIT\v2.1\b601838\b601838\b601838.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1_cs_r\xprecise1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit4_do\tryCatchFinallyThrow_nonlocalexit4_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\ldobj\ldobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\MultiDim\struct01\struct01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ceeillegal_il_r\ceeillegal_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\switchinfinally_ro\switchinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_r4\_il_dbghuge_r4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\verif\sniff\fg\ver_fg_13\ver_fg_13.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32879\b32879\b32879.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\rethrowincatchnestedinfinally_r\rethrowincatchnestedinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray3_cs_d\dblarray3_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_dbgbinop\_dbgbinop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-01_cs_ro\5w1d-01_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyintryfilter3_r\throwinfinallyintryfilter3_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Or_Op_cs_ro\Bool_Or_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b66425\b66425\b66425.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\asurt\143616\foo\foo.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_c\_il_dbgrefloc_c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatch_d\trythrowcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\severaldeadehregions_d\severaldeadehregions_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_ro\class1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8flat_cs_d\r8flat_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowwithhandlerscatchingbase_r\rethrowwithhandlerscatchingbase_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchoutofnestedtryfinally_d\branchoutofnestedtryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_relii4\_il_relii4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b561129\b561129\b561129.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15526\b15526\b15526.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallywith2endfinally_d\tryfinallywith2endfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b09246\b09246\b09246.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadEHregionacrossBB_d\deadEHregionacrossBB_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\simplerethrow_do\simplerethrow_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise4_cs_r\precise4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\assemname_cs_ro\assemname_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcsval\_speed_dbglcsval.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b10802\b10802\b10802.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_cs_do\arithm32_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\array\_il_dbgarrays\_il_dbgarrays.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\RunBenchmarks\RunBenchmarks\RunBenchmarks.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadEHregionacrossBB_r\deadEHregionacrossBB_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface017\castclass-interface017.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\throwwithhandlerscatchingbase_r\throwwithhandlerscatchingbase_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\conv_dbg\conv_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56772\b56772\b56772.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Xor_Op_cs_do\Double_Xor_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit3_ro\tryCatchFinallyThrow_nonlocalexit3_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\inl\caninline_r\caninline_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchsimpletype_do\trycatchsimpletype_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\emptyfinally_d\emptyfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinnestedcatch_d\throwinnestedcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads2_cs_ro\threads2_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_cs_d\catchrettoinnertry_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_oreltry_cs\_oreltry_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\Desktop\prefldinit3_il_r\prefldinit3_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_il_dbgiface2\_il_dbgiface2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3b_il_r\25param3b_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Or_Op_cs_d\Double_Or_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeaftercatch_r\badcodeaftercatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset1_o\nestedTryRegionsWithSameOffset1_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\nonlocalexitfromnestedcatch_r\nonlocalexitfromnestedcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\doublearr_cs_d\doublearr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\148343\148343.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\generics_r\generics_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate023\Delegate023.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_conv\_il_dbgi_conv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_1\_il_dbgint32_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_d\arithm64_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\throw_cs_d\throw_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Or_Op_cs_do\Bool_Or_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\doublearr_cs_do\doublearr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-04_cs_d\5w1d-04_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Peer_1\Generic_Test_CSharp_Peer_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_dbgcastclass_catch\_il_dbgcastclass_catch.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPAvg6\FPAvg6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_relfilter\_relfilter.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28927\b28927\b28927.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25paramMixed_il_r\25paramMixed_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\misc\_il_dbgrefarg_box_f8\_il_dbgrefarg_box_f8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reli4u1\_il_reli4u1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Xor_Op_cs_ro\Bool_Xor_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\switchincatch_do\switchincatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset2\nestedTryRegionsWithSameOffset2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b19394\b19394\b19394.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinally_d\tryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\cpobj\cpobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblSub\DblSub.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b141062\b141062\b141062.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\struct_opcodes\struct_opcodes.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcsbox\_speed_dbglcsbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\nbody\nbody\nbody.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop3_il_d\loop3_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_prop\_il_reli_prop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_relcatchfinally_tail\_relcatchfinally_tail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\LngConv\LngConv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\ExcepFilters\mixed\mixed\mixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relisinst_ldarg\_relisinst_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_relconst\_il_relconst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\575343\test2\test2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr8a_cs_r\convr8a_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate032\Delegate032.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_or\VolatileTest_op_or.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_911875\DevDiv_911875_d\DevDiv_911875_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samethrowtwice_d\samethrowtwice_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b402658\b402658\b402658.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox007\box-unbox007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value002\box-unbox-value002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowwithhandlerscatchingbase_do\rethrowwithhandlerscatchingbase_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\switchdefaultonly1_il_d\switchdefaultonly1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_i4\_il_relrefloc_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_dbgiface1\_dbgiface1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_r4_r8_inl\_il_relcompat_r4_r8_inl.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\throwinfinallyintryfilter3\throwinfinallyintryfilter3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_r\int32_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41234\b41234\b41234.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinally_do\throwinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_il_dbgtest1\_il_dbgtest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\valuetype\valuetype.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\throwinfinallyintryfilter1\throwinfinallyintryfilter1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_r\dblarray4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_mod\VolatileTest_op_mod.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_r4\_il_relhuge_r4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b42918\b42918\b42918.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPVar\FPVar.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalexittobeginningoftry_ro\nonlocalexittobeginningoftry_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit2_do\tryCatchFinallyThrow_nonlocalexit2_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatch_do\trythrowcatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\throwinfinallyintryfilter2\throwinfinallyintryfilter2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtryfinally_d\nestedtryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblAvg2\DblAvg2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i2\_il_relrefarg_i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\methodthrowsinfinally_do\methodthrowsinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\switchincatch_d\switchincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_c\_opt_dbgrefarg_c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\add\add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxblk\initblk3_il_r\initblk3_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_d\uint16_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_array_merge\_il_dbgi_array_merge.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\333007\test1\test1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_d\catchrettoinnertry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\TypeParameters\MultiDim\class01\class01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_0_5b\_il_relint32_0_5b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_s\_il_dbgrefarg_s.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_d_loop_try\staticFieldExpr1_d_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcsbas\_speed_rellcsbas.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relisinst_ldloc\_il_relisinst_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_cs_ro\uint8_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassinterface_do\castclassinterface_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgisinst_ldarg\_speed_dbgisinst_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryfinallythrow_nonlocalexit_d\tryfinallythrow_nonlocalexit_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise2_cs_ro\precise2_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\objectBoxing\objectBoxing.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_o2\_il_dbgrefloc_o2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_And_Op_cs_ro\Double_And_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgvalftn\_il_dbgvalftn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\AttributeConflict\AttributeConflict.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b113286\b113286\b113286.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise4_cs_do\xprecise4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgii2\_il_dbgii2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpathfn_d\throwinfinallyerrpathfn_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\hashcode\ctest1_cs_r\ctest1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Or_Op_cs_d\Bool_Or_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50145\b50145\b50145.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_rellcs\_rellcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b598649\b598649\b598649.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\v4\dev10_804810\dev10_804810\dev10_804810.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgqperm\_il_dbgqperm.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_cs_r\arithm32_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relisinst_newobj\_speed_relisinst_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr4a_cs_ro\convr4a_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relrecurse_calli\_il_relrecurse_calli.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_No_Op_cs_r\Int_No_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_0_5a\_il_relint32_0_5a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowinfinallyaftercatch_r\rethrowinfinallyaftercatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgi4i1\_il_dbgi4i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt2_cs_r\vt2_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_20929\dev11_20929_ro\dev11_20929_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_r8_r4_inl\_il_relcompat_r8_r4_inl.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress1_ro\CgStress1_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relisinst_call\_il_relisinst_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_qsort2\_il_relu_qsort2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_speed_dbgbox\_speed_dbgbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPConvI2F\FPConvI2F.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_conv\_il_reli_conv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgi4u2\_il_dbgi4u2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinally_do\tryfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\clr-x64-JIT\v4.0\DevDiv34372\overRepLocalOpt\overRepLocalOpt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14066\b14066\b14066.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_speed_relthrow\_speed_relthrow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_dbgfibo_il\_dbgfibo_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_r8_r4\_il_relcompat_r8_r4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtryfinally_r\nestedtryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit1_ro\tryCatchFinallyThrow_nonlocalexit1_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate026\Delegate026.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_145295\CSharpPart\CSharpPart.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_Vars\Inline_Vars.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4flat_cs_d\i4flat_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\commutativecse\ccse_cs_d\ccse_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Peer_2\Test_CSharp_Peer_2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_speed_dbglcs_gcref\_speed_dbglcs_gcref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr4_r\simpleexpr4_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_dbgselfref\_dbgselfref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\jaggedarr_cs_r\jaggedarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass017\castclass017.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr4d_il_d\convr4d_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1_r_loop_try\staticFieldExprUnchecked1_r_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b598034\b598034\b598034.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblRoots\DblRoots.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray2_cs_d\dblarray2_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedexcept_d\throwincascadedexcept_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_speed_dbgcast_throw\_speed_dbgcast_throw.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\manyintf\ctest_cs_ro\ctest_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedcatch_r\throwincascadedcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\commutativecse\ccse_cs_do\ccse_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallywith2reachableendfinally_d\tryfinallywith2reachableendfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt2_cs_d\vt2_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b98431\b98431\b98431.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794631\DevDiv_794631_d\DevDiv_794631_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b61515\b61515\b61515.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_r\uint16_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox005\box-unbox005.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_objref\_il_dbghuge_objref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_168744\DevDiv_168744\DevDiv_168744.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relconv_i8_u\_il_relconv_i8_u.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_dbgisinst_catch_neg\_il_dbgisinst_catch_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_do\uint16_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion2\NullCheckAssertion2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr8a_cs_do\convr8a_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\switchincatch_r\switchincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_r4_r8_inl\_il_dbgcompat_r4_r8_inl.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_prop\_il_relu_prop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_i4\_il_dbghuge_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwincatch_ro\throwincatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\InlineThrow\InlineThrow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_speed_reliface1\_speed_reliface1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\apps\bouncingball_cs_do\bouncingball_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_relrecurse\_relrecurse.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_911875\DevDiv_911875_do\DevDiv_911875_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1a_cs_r\25param1a_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACA_r\CGRecurseACA_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_And_Op_cs_r\Bool_And_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop1_cs_ro\loop1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\cprop001_r\cprop001_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPNeg\FPNeg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06859\b06859\b06859.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\LVNumCnt1\LVNumCnt1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_cs_do\uint32_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface009\box-unbox-interface009.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b30251\b30251\b30251.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\switchdefaultonly2_il_r\switchdefaultonly2_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt3_il_r\vt3_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblSubConst\DblSubConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\jaggedarr_cs_ro\jaggedarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\jaggedarr_cs_d\jaggedarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass005\castclass005.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b82048\b82048\b82048.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26324\b26324a\b26324a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray3_cs_r\dblarray3_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_r8_r4\_il_dbgcompat_r8_r4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\plainarr_cs_r\plainarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\Dev11_243742\app\app.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtrycatch_r\throwinnestedtrycatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt1_cs_do\vt1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatchtrycatch_ro\trycatchtrycatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_And_Op_cs_d\Bool_And_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Fields\getclassfrommethodparam\getclassfrommethodparam.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Peer_3\Test_CSharp_Peer_3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadrgninfunclet_r\deadrgninfunclet_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b142473\b142473\b142473.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\336666\test1\test1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\static-ref\static-ref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgi4i2\_il_dbgi4i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Typeof\dynamicTypes\dynamicTypes.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAC_r\CGRecurseAAC_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass028\castclass028.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Or_Op_cs_do\Int_Or_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b00719\b00719\b00719.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_NewObj\Inline_NewObj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_speed_dbgjumps\_speed_dbgjumps.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_dbgobj\_dbgobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794631\DevDiv_794631_do\DevDiv_794631_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\doublearr_cs_ro\doublearr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_i_u2\_il_dbgcompat_i_u2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt1_il_d\vt1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\ldfldstatic1_il_r\ldfldstatic1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_il_reldeep2\_il_reldeep2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b091942\b091942\b091942.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\basics\throwisfirstinstruction\throwisfirstinstruction.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b151497\b151497\b151497.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\ilseq\_il_relCommonBase\_il_relCommonBase.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\102974\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\divrem\div\negSignedMod\negSignedMod.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovfldiv2_il_r\ovfldiv2_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-02_cs_r\5w1d-02_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b102879\b102879\b102879.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\intarr_cs_r\intarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_f4\_il_dbgrefarg_f4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwincatch_do\throwincatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\ddb\87766\ddb87766\ddb87766.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relcastclass_ldloc\_speed_relcastclass_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_Simpletest2\_Simpletest2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_f8\_opt_dbgrefarg_f8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\enum\castclass-enum001\castclass-enum001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblCall1\DblCall1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_ro\uint32_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\multihandler_r\multihandler_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32303\b32303\b32303.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b11762\b11762\b11762.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b49778\b49778\b49778.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1b_cs_d\precise1b_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_box\_il_dbgu_box.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\structref1_1\structref1_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_b473131\b473131_intptr\b473131_intptr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_dbgcatchfinally\_dbgcatchfinally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadrgninfunclet_d\deadrgninfunclet_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr2_r_loop_try\arrayexpr2_r_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Peer_1\Test_CSharp_Peer_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_odbgtry_cs\_odbgtry_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\140713\innerFinally_do\innerFinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcsvalbox\_rellcsvalbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3a_cs_r\25param3a_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryfinallythrow_nonlocalexit_r\tryfinallythrow_nonlocalexit_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M11-Beta1\b40138\b40138\b40138.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcs\_rellcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b42929\b42929\b42929.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh05_dynamic\eh05_dynamic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_static01\specific_struct_static01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_c\_il_dbgrefarg_c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\doublearr_cs_r\doublearr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\vbil\vbil.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\inlining\dev10_bug719093\variancesmall\variancesmall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_speed_dbglcs\_speed_dbglcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b76590\b76590\b76590.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField1\HugeField1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads1_cs_r\threads1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_reliface1\_reliface1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcsvalbox\_dbglcsvalbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_r\uint8_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b141358\b141358\b141358.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgcastclass_newobj\_speed_dbgcastclass_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b08944\b08944a\b08944a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\apps\bouncingball_cs_r\bouncingball_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_RecursiveMethod\Inline_RecursiveMethod.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_cs_do\intrinsic_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_No_Op_cs_ro\Float_No_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relisinst_newobj\_relisinst_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatchtrycatch_r\trycatchtrycatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_20929\dev11_20929_do\dev11_20929_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59857\b59857\b59857.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\BBCnt0\BBCnt0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_dbgrefarg_s\_dbgrefarg_s.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-01_cs_ro\3w1d-01_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\mul1_dbg\mul1_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\trybodyinbetweencatchhandlers_d\trybodyinbetweencatchhandlers_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\verify\verify01_large\verify01_large.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_150586\DevDiv_150586\DevDiv_150586.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface006\castclass-interface006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relcastclass_ldloc\_relcastclass_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop1_cs_d\loop1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcsmixed\_speed_rellcsmixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4flat_cs_ro\i4flat_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgiu2\_il_dbgiu2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_add\VolatileTest_op_add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b47975\b47975\b47975.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\mul1_opt\mul1_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Xor_Op_cs_do\Int_Xor_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\gcincatch_do\gcincatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr4_r_loop\simpleexpr4_r_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass022\castclass022.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_0_5b\_il_dbgint32_0_5b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_i2\_il_dbgrefarg_i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relisinst_call\_relisinst_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadnonlocalexit_r\deadnonlocalexit_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\manyintf\ctest_cs_do\ctest_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b59858\b59858\b59858.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14616\b14616\b14616.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh06_large\eh06_large.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblCall2\DblCall2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value015\box-unbox-value015.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b81618\b81618\b81618.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPSmall\FPSmall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcs2\_dbglcs2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\labelbeforefinally_d\labelbeforefinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_il_dbglcs_ldlen\_il_dbglcs_ldlen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\array-il\_Arrayscomplex3\_Arrayscomplex3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\mixedexpr1_r\mixedexpr1_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\nested\nested.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\ldstr\ldstr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b50145\b50145a\b50145a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_relii1\_il_relii1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallywith2endfinally_r\tryfinallywith2endfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_And_Op_cs_r\Int_And_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatch_d\trycatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\153682\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_i1\_il_dbgrefarg_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_sub\VolatileTest_op_sub.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relinstftn\_il_relinstftn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface013\castclass-interface013.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b12399\b12399\b12399.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relcastclass_call\_speed_relcastclass_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\tryfinallyintrycatchwithleaveintotry_r\tryfinallyintrycatchwithleaveintotry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_speed_relarrres\_speed_relarrres.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b42732\b42732\b42732.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\switchdefaultonly3_il_d\switchdefaultonly3_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\141358\uncaughtException_d\uncaughtException_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i1\_il_relrefarg_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\jaggedarr_cs_d\jaggedarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray3_cs_ro\dblarray3_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate031\Delegate031.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15203\b15203\b15203.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\classic\classic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b54971\b54971\b54971.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51875\Desktop\b51875\b51875.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\localgotoinahandler_r\localgotoinahandler_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b02076\b02076\b02076.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_dbgsin_il\_dbgsin_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\cascadedexcept_r\cascadedexcept_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\BadMatrixMul_o\BadMatrixMul_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass012\castclass012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\classic_r\classic_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relcastclass_ldarg\_speed_relcastclass_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgisinst_ldarg\_dbgisinst_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\finallybeforetrybody_r\finallybeforetrybody_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b51565\b51565\b51565.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\vswhidbey\148190\baduwinfo\baduwinfo.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\inl\caninline_ro\caninline_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgfloat64_range2\_il_dbgfloat64_range2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads2_cs_do\threads2_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug647189\ssa_tuIsAddr\ssa_tuIsAddr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_b\_il_dbghuge_b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30838\b30838\b30838.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_relrefarg_s\_relrefarg_s.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox002\box-unbox002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgcastclass_call\_speed_dbgcastclass_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\Gcd\Gcd.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\byrefsubbyref1_il_d\byrefsubbyref1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b119026\b119026b\b119026b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_relii2\_il_relii2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbgselfref\_il_dbgselfref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate020\Delegate020.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\cprop001_d\cprop001_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value011\box-unbox-value011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr8d_il_d\convr8d_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox018\box-unbox018.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\commutativecse\ccse_cs_ro\ccse_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b323557\b323557-ret\b323557-ret.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15864\b15864\b15864.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate025\Delegate025.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\methodthrowsinfinally_ro\methodthrowsinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACC_do\CGRecurseACC_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\subbyref_il_d\subbyref_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_o\_il_dbgrefarg_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Or_Op_cs_r\Double_Or_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4flat_cs_ro\r4flat_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgisinst_call\_dbgisinst_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinally_50_r\throwinfinally_50_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v1-m08\b12668\b12668\b12668.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_v\_il_relcompat_v.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgcastclass_ldarg\_dbgcastclass_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\InstrCnt1\InstrCnt1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b143840\b143840\b143840.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\add\add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_d\straccess3_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_s\_opt_relrefarg_s.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\methodthrowsinfinally_d\methodthrowsinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\throwbox\finally\finally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_prop\_il_dbgi_prop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox017\box-unbox017.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\iface\_speed_dbgiface1\_speed_dbgiface1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_815942\devdiv_815942\devdiv_815942.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\leaveinsameregion_r\leaveinsameregion_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_r4\_il_dbgrefloc_r4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b608066\b608066\b608066.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcsval\_dbglcsval.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\plainarr_cs_ro\plainarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\prefldinit2_il_d\prefldinit2_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPRem\FPRem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25882\b25882\b25882.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_qsort2\_il_dbgi_qsort2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgisinst_newobj\_dbgisinst_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_do\uint8_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b15728\b15728\b15728.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\cpobj\cpobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_cs_r\int16_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_cs_r\int32_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_dbgthrow\_dbgthrow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\140713\innerFinally_ro\innerFinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgisinst_newobj\_speed_dbgisinst_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\oponerror_ro\oponerror_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4_cs_d\i4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\nativeuint_il_d\nativeuint_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_instance02\specific_struct_instance02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_do\arithm64_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_neg_range\_il_relint32_neg_range.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\identity\_il_dbgvolatile\_il_dbgvolatile.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\params-object\params-object.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Base_4\Generic_Test_CSharp_Base_4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\Desktop\throw_cs_d\throw_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nonlocalexitinfinally\nonlocalexitinfinally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatchfinally_d\trythrowcatchfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_ro\int32_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop4_cs_ro\loop4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-01_cs_r\5w1d-01_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Coverage\b433189\b433189.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b63743\b63743\b63743.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\stfldstatic1_il_d\stfldstatic1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_speed_relrecurse\_speed_relrecurse.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M14-SP1\b119538\b119538a\b119538a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\nestedtrycatch_d\nestedtrycatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_flow\_il_reli_flow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_r4_r8\_il_dbgcompat_r4_r8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b360587\b360587\b360587.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-04_cs_r\5w1d-04_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15468\b15468\b15468.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\oddsize\oddsize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_relfibo_il\_relfibo_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct9\struct9.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b610562\b610562\b610562.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b147816\b147816\b147816.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\lim\lim_001\lim_001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit1_d\tryCatchFinallyThrow_nonlocalexit1_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\524070\test2\test2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow0_cs_d\pow0_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinallynestedintry_ro\throwinfinallynestedintry_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\GenericStructs\GenericStructs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_do\uint32_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b99219\b99219\b99219.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset3\nestedTryRegionsWithSameOffset3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_relcatchfinally\_relcatchfinally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\loopinfinally_ro\loopinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\Call1\Call1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_relobjref\_il_relobjref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\byrefsubbyref1\byrefsubbyref1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b152292\b152292\b152292.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt1_il_r\vt1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_rellcs_gcref\_rellcs_gcref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value012\box-unbox-value012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate009\Delegate009.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug619534\twoEndFinallys\twoEndFinallys.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14057\b14057\b14057.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794115\DevDiv_794115_r\DevDiv_794115_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b40347\b40347\b40347.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\rangecheckinfinally_d\rangecheckinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\classarr_cs_ro\classarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblNeg\DblNeg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\simpledeadehregion_r\simpledeadehregion_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-04_cs_do\5w1d-04_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_il_dbgdeep1\_il_dbgdeep1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_dbgcatchfinally_tail\_dbgcatchfinally_tail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPConvF2I\FPConvF2I.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\generics2\generics2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\lifetime\lifetime1\lifetime1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b15786\b15786\b15786.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\mixed\mixed_cs_do\mixed_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit2_d\tryCatchFinallyThrow_nonlocalexit2_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_il_rellcs_ldlen\_il_rellcs_ldlen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b213516\b213516\b213516.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfaulttrycatchfn_r\tryfaulttrycatchfn_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalgotoinatryblockinahandler_d\nonlocalgotoinatryblockinahandler_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwoutside_do\throwoutside_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_No_Op_cs_do\Int_No_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14396\b14396\b14396.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\cascadedcatch_d\cascadedcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface017\box-unbox-interface017.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPCall1\FPCall1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Peer_3\Generic_Test_CSharp_Peer_3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\prefldinit2_il_r\prefldinit2_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b118260\b118260\b118260.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt3_cs_d\vt3_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_odbgtailjump_cs\_odbgtailjump_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\switchdefaultonly3_il_r\switchdefaultonly3_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_r\straccess3_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4flat_cs_do\i4flat_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\finallybeforetrybody_d\finallybeforetrybody_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinclassconstructor_r\throwinclassconstructor_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_No_Op_cs_ro\Double_No_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcsmax\_rellcsmax.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\ref2byref_il_d\ref2byref_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b450688\b450688\b450688.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_And_Op_cs_d\Float_And_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\2branchesoutoftry_d\2branchesoutoftry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4_cs_r\i4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\backwardleaveincatch_r\backwardleaveincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug619534\moduleHandleCache\moduleHandleCache.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatchfinally_do\trythrowcatchfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress2_r\CgStress2_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4flat_cs_do\r4flat_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\testeit_d\testeit_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\struct8\struct8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface007\castclass-interface007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relcastclass_ldarg\_relcastclass_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Coverage\chaos56200037cs_o\chaos56200037cs_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b323557\b323557-dbg\b323557-dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion7\NullCheckAssertion7.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassenum_r\castclassenum_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise2_cs_r\xprecise2_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\InstrCnt0\InstrCnt0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev14\DevDiv_876169\DevDiv_876169_do\DevDiv_876169_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_il_reltest1\_il_reltest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\MemberAccess\class_instance01\class_instance01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_dbglcs\_dbglcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class2_cs_d\class2_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b07211\b07211\b07211.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_cs_r\intrinsic_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\strswitchfinal_do\strswitchfinal_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_132534\CSharpPart\CSharpPart.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b08020\b08020\b08020.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\implicitDownConv\implicitDownConv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAC_ro\CGRecurseAAC_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\tryfinallyloop_d\tryfinallyloop_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\stfldstatic1_il_r\stfldstatic1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgconcurgc_il\_dbgconcurgc_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b83702\b83702\b83702.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalexittobeginningoftry_r\nonlocalexittobeginningoftry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\9param\9param.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b78392\b78392\b78392.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise2_cs_r\precise2_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\cascadedcatch_do\cascadedcatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_qsort2\_il_reli_qsort2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\catchbeforetrybody_r\catchbeforetrybody_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b425314\b425314\b425314.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value004\box-unbox-value004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_i4\_opt_relrefarg_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass003\castclass003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\throw1dimarray_d\throw1dimarray_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_speed_dbgobj\_speed_dbgobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexit_d\simplenonlocalexit_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgi8u8\_il_dbgi8u8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\TypeParameters\Jagged\struct01\struct01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1_ro_loop\staticFieldExprUnchecked1_ro_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\fastaredux\fastaredux\fastaredux.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate003\Delegate003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_relrotarg_double\_opt_relrotarg_double.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\zeroinit\init_byte\init_byte.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\CPropOverflow\CPropOverflow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\tryfinallytryfinally_ro\tryfinallytryfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatch_r\trythrowcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\cpobj\cpobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Or_Op_cs_r\Int_Or_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25paramMixed_il_d\25paramMixed_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_i4\_il_dbgrefloc_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26324\b26324b\b26324b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_dbgfilter\_dbgfilter.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_dbglcs\_dbglcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise4_cs_r\xprecise4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchsimpletype_r\trycatchsimpletype_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfinally_ind\_il_dbgcatchfinally_ind.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\rem_opt\rem_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblMulConst\DblMulConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b415164\b415164\b415164.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPAddConst\FPAddConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\loopinfinally_do\loopinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPAvg2\FPAvg2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\refpinned2iu_il_d\refpinned2iu_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\rangecheckinfinally_r\rangecheckinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallynestedintry_30_d\throwinfinallynestedintry_30_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b65407\b65407\b65407.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\leaveintotrybody_d\leaveintotrybody_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_array_merge\_il_relu_array_merge.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\BenchmarksGame\spectralnorm\spectralnorm\spectralnorm.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_1\staticFieldExpr1_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\throwwithhandlerscatchingbase_d\throwwithhandlerscatchingbase_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1_cs_d\xprecise1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\cascadedcatch_r\cascadedcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b100336\b100336\b100336.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\bne_dbg\bne_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadtryfinally_d\deadtryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\prefldinit1_il_r\prefldinit1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_ro\stringarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate002\Delegate002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\branchoverendfinally_d\branchoverendfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray2_cs_r\dblarray2_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b48850\b48850\b48850.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpath_do\throwinfinallyerrpath_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyintryfilter1_r\throwinfinallyintryfilter1_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\stringarr_cs_d\stringarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_static02\specific_struct_static02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\rethrowincatchnestedinfinally_do\rethrowincatchnestedinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4flat_cs_r\r4flat_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_cs_ro\int32_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b448208\Desktop\b448208\b448208.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relldnull\_il_relldnull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1_cs_ro\precise1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\switchinfinally_r\switchinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_dbgjumps\_dbgjumps.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_No_Op_cs_d\Bool_No_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_o\_il_relrefarg_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\Dev10_844071\Dev10_844071.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeinsidefinally_r\badcodeinsidefinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1_cs_do\precise1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\228572\conv_opt\conv_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchnestedtype_r\trycatchnestedtype_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\enum\castclass-enum002\castclass-enum002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_1323\GitHub_1323\GitHub_1323.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b85477\b85477\b85477.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b333008\b333008\b333008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct03\struct03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\throwbox\rethrow\rethrow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate018\Delegate018.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox014\box-unbox014.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\mixed\mixed_cs_r\mixed_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\trycatchintryfinally_r\trycatchintryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPDivConst\FPDivConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relcastclass_call\_il_relcastclass_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_m1\_il_relint32_m1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgldnull\_il_dbgldnull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\Desktop\add\add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwoutside_ro\throwoutside_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\catchretnonlocalexitinfunclet_ro\catchretnonlocalexitinfunclet_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt3_il_d\vt3_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_cs_d\int16_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\loopstrswitchgoto_r\loopstrswitchgoto_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess4\straccess4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convx_il_r\convx_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress3_d\CgStress3_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgisinst_call\_speed_dbgisinst_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\TypeOfAssertion\TypeOfAssertion.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\thiscall\_speed_dbgthisnull\_speed_dbgthisnull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_mul\VolatileTest_op_mul.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcs\_speed_dbglcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b180381\b180381b\b180381b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_seq\_il_dbgi_seq.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldfldstatic1_il_r\ldfldstatic1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr2_r\arrayexpr2_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbglength0\_il_dbglength0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\multihandler_d\multihandler_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadoponerrorinfunclet_r\deadoponerrorinfunclet_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Reordered\Test_HndIndex_10_Reordered.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr4_r_loop_try\simpleexpr4_r_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\jaggedarr_cs_do\jaggedarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbgldelem_get\_il_dbgldelem_get.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relstress2\_il_relstress2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\tailcall\tailcall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface006\box-unbox-interface006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise4_cs_ro\xprecise4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b111192\b111192\b111192.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise4_cs_do\precise4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b353858\b353858\b353858.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\intarr_cs_do\intarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_cs_do\int32_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpathfn_ro\throwinfinallyerrpathfn_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACC_r\CGRecurseACC_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadoponerror_r\deadoponerror_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress1_do\CgStress1_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh07_dynamic\eh07_dynamic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\throw_cs_ro\throw_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\LargeNumberOfArgs\LargeNumberOfArgs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06680\b06680\b06680.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\hashcode\ctest1_cs_d\ctest1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\stfldstatic1_il_d\stfldstatic1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Base_3\Generic_Test_CSharp_Base_3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nonlocalexitincatch\nonlocalexitincatch.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgcastclass_newobj\_dbgcastclass_newobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\LVNumCnt0\LVNumCnt0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\port\_speed_rellcs\_speed_rellcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b103846\b103846\b103846.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ceeillegal_il_d\ceeillegal_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwincatch_d\throwincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinallynestedintry_r\throwinfinallynestedintry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_static02\specific_class_static02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress2_ro\CgStress2_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_s\_il_relrefarg_s.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1_r\staticFieldExprUnchecked1_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\prefldinit4_il_d\prefldinit4_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_do\straccess3_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcs\_speed_rellcs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14779\b14779\b14779.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\nullsdarr\nullsdarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow1\pow1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b09287\b09287\b09287.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug619534\finallyclone\finallyclone.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Misc\SIDEEFFECTS\BadRegArgs\BadRegArgs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Or_Op_cs_ro\Int_Or_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexitnestedintrycatch_ro\simplenonlocalexitnestedintrycatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_c\_opt_relrefarg_c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt2_cs_ro\vt2_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbgldelema\_il_dbgldelema.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalgotoinatryblockinahandler_r\nonlocalgotoinatryblockinahandler_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_enum\_il_relcompat_enum.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\prefldinit1_il_d\prefldinit1_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int8_il_r\int8_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b114628\b114628\b114628.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowinfinallyinsidecatch_r\rethrowinfinallyinsidecatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\rethrowinfinallyaftercatch_d\rethrowinfinallyaftercatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\callconv\_relinstance_il\_relinstance_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\assemname_cs_do\assemname_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcs2\_rellcs2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\volatilefield\volatilefield.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldExprUnchecked1\fieldExprUnchecked1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\ldobj\ldobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_XAssemblytest2-xassem\_XAssemblytest2-xassem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_dbgbox\_dbgbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass015\castclass015.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_cs_ro\intrinsic_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\throw2dimarray_d\throw2dimarray_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface013\box-unbox-interface013.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface008\box-unbox-interface008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4_cs_do\i4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblRem\DblRem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyintryfilter1_d\throwinfinallyintryfilter1_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_dbgtry_il\_dbgtry_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\strswitchfinal_ro\strswitchfinal_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_f4\_opt_relrefarg_f4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfault_d\badcodeafterfault_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\mixedexpr1_r_loop\mixedexpr1_r_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Xor_Op_cs_do\Float_Xor_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinnestedfinally_ro\throwinnestedfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b598031\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_rellength0\_il_rellength0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchoutoftryfinally_d\branchoutoftryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b609988\b609988\b609988.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_dbgtest1\_dbgtest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxenum_do\boxunboxenum_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4_cs_r\r4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M09.5-PDC\b14426\b14426\b14426.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh07_large\eh07_large.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfault_r\badcodeafterfault_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_No_Op_cs_ro\Bool_No_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b119026\b119026a\b119026a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_cs_d\uint16_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinclassconstructor_do\throwinclassconstructor_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b449827\b449827\b449827.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_0\_il_relint32_0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblDiv\DblDiv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b119294\b119294\b119294.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_i4\_il_relrefarg_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\doublearr_cs_ro\doublearr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_il_dbgtest3\_il_dbgtest3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3a_cs_d\25param3a_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass004\castclass004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_d\stringarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b04612\b04612\b04612.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.2\ddb\ddb188478\DDB188478\DDB188478.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchbackwardswithfinally_r\branchbackwardswithfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_dbggcarr\_dbggcarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\severalnesteddeadehregions_d\severalnesteddeadehregions_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_r_loop_try\staticFieldExpr1_r_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\loopstrswitchgoto_do\loopstrswitchgoto_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfilter_d\throwinfilter_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadtryfinally_r\deadtryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_NormalizeStack\Inline_NormalizeStack.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3c_il_r\25param3c_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\hashcode\ctest1_cs_ro\ctest1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b07483\b07483\b07483.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b21296\b21296\b21296.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class02\class02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct04\struct04.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Xor_Op_cs_d\Int_Xor_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug675304\arrayDim\arrayDim.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3a_cs_do\25param3a_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\volatilecpobj_il_r\volatilecpobj_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\oponerror_do\oponerror_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75988\b75988\b75988.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_speed_dbgarrres\_speed_dbgarrres.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\forwardleaveincatch_d\forwardleaveincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b16570\b16570\b16570.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\structarr_cs_do\structarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\catchretnonlocalexitinfunclet_r\catchretnonlocalexitinfunclet_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14673\b14673\b14673.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b32345\b32345\b32345.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_Simpleb207621\_Simpleb207621.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relptr\_il_relptr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinclassconstructor_ro\throwinclassconstructor_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_No_Op_cs_r\Bool_No_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relconvovf_i8_i\_il_relconvovf_i8_i.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_i2\_il_relrefloc_i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_f4\_opt_dbgrefarg_f4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class01_instance\class01_instance.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relgcval_nested\_il_relgcval_nested.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblArea\DblArea.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyintryfilter2_d\throwinfinallyintryfilter2_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_speed_dbgcatchfinally\_speed_dbgcatchfinally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_91048\UseTrashedVfp1\UseTrashedVfp1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\static-none\static-none.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads2_cs_d\threads2_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh06_small\eh06_small.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_cs_ro\arithm32_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_ro\bigvtbl_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b10827\b10827\b10827.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Xor_Op_cs_d\Bool_Xor_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_struct_instance01\specific_struct_instance01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_d\vt4_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\classarr_cs_do\classarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt2_cs_do\vt2_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass002\castclass002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_relsizeof\_relsizeof.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\Desktop\add\add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_instance02\specific_class_instance02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\loopstrswitchgoto_d\loopstrswitchgoto_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b130333\b130333\b130333.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relvalftn\_il_relvalftn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxblk\initblk3_il_d\initblk3_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_0\_il_dbgint32_0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value018\box-unbox-value018.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray2_cs_ro\dblarray2_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion1\NullCheckAssertion1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads1_cs_d\threads1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_i1\_opt_dbgrefarg_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\ldobj\ldobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b12053\b12053\b12053.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794115\DevDiv_794115_ro\DevDiv_794115_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyintryfilter2_r\throwinfinallyintryfilter2_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_speed_relbox\_speed_relbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgii4\_il_dbgii4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\refpinned2iu_il_r\refpinned2iu_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_b473131\b473131\b473131.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbginstftn\_il_dbginstftn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\stringarr_cs_do\stringarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefarg_i4\_il_dbgrefarg_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgfloat64_range1\_il_dbgfloat64_range1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_cs_d\uint32_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relcastclass_ldarg\_il_relcastclass_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\generics2_r\generics2_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value022\box-unbox-value022.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\nativeuint_il_r\nativeuint_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\EHCopyProp\EHCopyProp.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_And_Op_cs_ro\Int_And_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\mixedexpr1_d_loop_try\mixedexpr1_d_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b369916\b369916\b369916.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\9_and_alloca2\9_and_alloca2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_cs_do\catchrettoinnertry_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_dbgrecurse\_dbgrecurse.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_And_Op_cs_do\Float_And_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b302558\b302558\b302558.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_relobj\_relobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b10828\b10828\b10828.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_o\_opt_relrefarg_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit4_ro\tryCatchFinallyThrow_nonlocalexit4_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\cond64_il_r\cond64_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPMath\FPMath.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_b\_il_relhuge_b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgisinst_call\_il_dbgisinst_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8_cs_do\r8_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\regress\vswhidbey\339415\339415.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\structarr_cs_do\structarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbggcarr\_il_dbggcarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b405223\b405223\b405223.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_reljumps\_reljumps.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr1_1\simpleexpr1_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\cascadedexcept_d\cascadedexcept_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\loopstrswitchgoto_ro\loopstrswitchgoto_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\reversedtryblock_r\reversedtryblock_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\549880\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox001\box-unbox001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\compiler\FilterToHandler\FilterToHandler.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b106158\b106158\b106158.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_r4\_il_relrefloc_r4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relfloat64_range2\_il_relfloat64_range2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_20929\dev11_20929_d\dev11_20929_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcs2\_speed_dbglcs2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8flat_cs_do\r8flat_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\labelbeginningfinally_r\labelbeginningfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_b473131\b473131_fld\b473131_fld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\multihandler_ro\multihandler_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_And_Op_cs_r\Float_And_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nestedfinallycall_r\nestedfinallycall_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_dbgrefarg_o\_dbgrefarg_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\jaggedarr_cs_d\jaggedarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reli4u4\_il_reli4u4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPMulConst\FPMulConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_qsort2\_il_dbgu_qsort2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1a_cs_d\25param1a_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_f8\_opt_relrefarg_f8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass007\castclass007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgi4u1\_il_dbgi4u1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Coverage\chaos65204782cs_o\chaos65204782cs_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_794115\DevDiv_794115_d\DevDiv_794115_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\classarr_cs_ro\classarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit4_d\tryCatchFinallyThrow_nonlocalexit4_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_relcastclass_calli\_il_relcastclass_calli.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatch_ro\trycatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblMul\DblMul.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm32_r\arithm32_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinally_ro\throwinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\jaggedarr_cs_r\jaggedarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfinally_ind\_il_relcatchfinally_ind.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\jaggedarr_cs_do\jaggedarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\trycatchintryfinally_ro\trycatchintryfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\nullsdarr_il_r\nullsdarr_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_shr\VolatileTest_op_shr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr4_d_loop_try\simpleexpr4_d_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeaftertry_r\badcodeaftertry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatchtrycatch_do\trycatchtrycatch_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b589202\b589202\b589202.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit2_r\tryCatchFinallyThrow_nonlocalexit2_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\tryfinallyloop_r\tryfinallyloop_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfault_d\throwinfault_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise2_cs_ro\xprecise2_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trythrowcatchfinally_ro\trythrowcatchfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinally_50_do\throwinfinally_50_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalgotoinatryblockinahandler_do\nonlocalgotoinatryblockinahandler_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_No_Op_cs_do\Double_No_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b115932\b115932a\b115932a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\callconv\gc_ctor_il_d\gc_ctor_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalexittobeginningoftry_d\nonlocalexittobeginningoftry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b60723\b60723\b60723.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nestedtry\throwinnestedtrycatch_d\throwinnestedtrycatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_relisinst_catch_neg\_il_relisinst_catch_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b426654\b426654\b426654.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug621705\ptuple_lost\ptuple_lost.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\delegateParamCallTarget\delegateParamCallTarget.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\strswitchfinal_d\strswitchfinal_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\emptyfinally_r\emptyfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox006\box-unbox006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b77713\b77713\b77713.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_No_Op_cs_d\Float_No_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinnestedfinally_r\throwinnestedfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_relgcarr\_relgcarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value017\box-unbox-value017.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\ArrayWith2Loops_o\ArrayWith2Loops_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samethrowtwice_do\samethrowtwice_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_handler\Inline_handler.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate006\Delegate006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b320147\b320147\b320147.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_do\vt4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_d\int32_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyintryfilter3_d\throwinfinallyintryfilter3_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise2_cs_d\xprecise2_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4flat_cs_d\r4flat_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1b_cs_ro\precise1b_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_relmdarray\_il_relmdarray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b66583\b66583\b66583.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_relcastclass_catch_neg\_il_relcastclass_catch_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\add\add.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_relldelema\_il_relldelema.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinallynestedintry_d\throwinfinallynestedintry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_qsort1\_il_reli_qsort1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\mul_exception_opt\mul_exception_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_r\uint32_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_XAssemblytest4-xassem\_XAssemblytest4-xassem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\bigvtbl\bigvtbl_cs_r\bigvtbl_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b13691\b13691\b13691.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_relrefarg_o\_relrefarg_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b178119\b178119\b178119.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop1_cs_r\loop1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b124409\b124409\b124409.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_do\catchrettoinnertry_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbgmdarray\_il_dbgmdarray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_prop\_il_dbgu_prop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_XModuletest4-xmod\_XModuletest4-xmod.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relvirtftn\_il_relvirtftn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relu_seq\_il_relu_seq.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise2_cs_d\precise2_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_No_Op_cs_do\Float_No_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\trycatchintryfinally_d\trycatchintryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b423755\Desktop\b423755\b423755.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbglengthm2\_il_dbglengthm2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\perf\doublealign\Locals\Locals.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_r\catchrettoinnertry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\MultiDim\class01\class01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_vfld\_il_dbgi_vfld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4_cs_ro\r4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\rangecheckinfinally_do\rangecheckinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\identity\_il_relvolatile\_il_relvolatile.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\static-object\static-object.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr4a_cs_d\convr4a_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_4421\Dev11_4421\Dev11_4421.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_il_dbgbinop\_il_dbgbinop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr3\simpleexpr3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b29351\b29351\b29351.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\bne_opt\bne_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\hugeSimpleExpr1\hugeSimpleExpr1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\comp32_il_d\comp32_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_ro\arithm64_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\branchoverendfinally_r\branchoverendfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_5437\Dev11_5437\Dev11_5437.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_speed_relselfref\_speed_relselfref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b71093\b71093\b71093.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b180381\b180381a\b180381a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\throwwithhandlerscatchingbase_ro\throwwithhandlerscatchingbase_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_speed_dbgsizeof\_speed_dbgsizeof.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPAdd\FPAdd.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_reltest1\_reltest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh07_small\eh07_small.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1_cs_d\precise1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\array\_il_relarrays\_il_relarrays.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\ref2iu_il_d\ref2iu_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b170362\b170362\b170362.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexit_r\simplenonlocalexit_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwoutside_d\throwoutside_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_cs_r\catchrettoinnertry_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\loopinfinally_d\loopinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_relisinst_ldarg\_speed_relisinst_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_911875\DevDiv_911875_r\DevDiv_911875_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b68361\b68361\b68361.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_No_Op_cs_d\Int_No_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_i2\_opt_dbgrefarg_i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgrecurse_calli\_il_dbgrecurse_calli.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexitnestedintrycatch_r\simplenonlocalexitnestedintrycatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relfloat64_range1\_il_relfloat64_range1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_range1\_il_dbgint32_range1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_orelnestval_cs\_orelnestval_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgconv_i8_i\_il_dbgconv_i8_i.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion6\NullCheckAssertion6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate019\Delegate019.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\classic_d\classic_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b77707\b77707\b77707.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Base_3\Test_CSharp_Base_3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit3_do\tryCatchFinallyThrow_nonlocalexit3_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface009\castclass-interface009.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\interface\box-unbox-interface007\box-unbox-interface007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_ro\vt4_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt2_il_r\vt2_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Xor_Op_cs_ro\Float_Xor_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ldsshrstsfld_il_d\ldsshrstsfld_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_range2\_il_dbgint32_range2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b88797\b88797\b88797.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcsmixed\_rellcsmixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_cs_do\int16_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\value\box-unbox-value028\box-unbox-value028.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1_cs_do\xprecise1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Convert\implicitConv\implicitConv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samerethrowtwice_d\samerethrowtwice_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr4_ro_loop\simpleexpr4_ro_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise1b_cs_r\precise1b_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev14\DevDiv_876169\DevDiv_876169_ro\DevDiv_876169_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\byref2iu_il_d\byref2iu_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_speed_dbgrecurse\_speed_dbgrecurse.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_And_Op_cs_r\Double_And_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\Dev11_90434\UseUnalignedDouble\UseUnalignedDouble.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\Desktop\throw_cs_r\throw_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\forceinlining\NegativeCases\NegativeCases.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr2_il_r\ldelemnullarr2_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\severaldeadehregions_r\severaldeadehregions_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b56780\b56780\b56780.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\fact\fact.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Misc\SIDEEFFECTS\SideEffects\SideEffects.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b28158\b28158_64\b28158_64.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\classarr_cs_d\classarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\intarr_cs_ro\intarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_MultipleReturn\Inline_MultipleReturn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_speed_dbgdeep\_speed_dbgdeep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40141\b40141\b40141.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b43693\b43693\b43693.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExprUnchecked1_r_try\staticFieldExprUnchecked1_r_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\castclassenum_ro\castclassenum_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads1_cs_ro\threads1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPArea\FPArea.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt3_cs_do\vt3_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_dbgrotarg_double\_opt_dbgrotarg_double.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\trybodyinbetweencatchhandlers_r\trybodyinbetweencatchhandlers_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_fld\_il_dbgu_fld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30128\b30128\b30128.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAA_d\CGRecurseAAA_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Xor_Op_cs_r\Bool_Xor_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop3_il_r\loop3_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_u2\_il_relrefloc_u2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\params-value\params-value.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\jaggedarr_cs_do\jaggedarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpath_r\throwinfinallyerrpath_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\structarr_cs_ro\structarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\generics\generics.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\552940\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress2_d\CgStress2_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\perf\doublealign\Arrays\Arrays.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\stringarr_cs_do\stringarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28776\b28776\b28776.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i4\i4flat_cs_r\i4flat_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\subbyref_il_r\subbyref_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_conv\_il_dbgu_conv.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_relknight\_il_relknight.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgvirtftn\_il_dbgvirtftn.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-02_cs_ro\5w1d-02_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Base_6\Generic_Test_CSharp_Base_6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedexcept_r\throwincascadedexcept_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh05_small\eh05_small.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop4_cs_r\loop4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchsimpletype_ro\trycatchsimpletype_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion4\NullCheckAssertion4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reliu1\_il_reliu1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalexittonestedsibling_r\nonlocalexittonestedsibling_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reli4u2\_il_reli4u2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorReturn_ro\VectorReturn_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblDist\DblDist.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b63183\b63183\b63183.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8_cs_ro\r8_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1c_il_r\25param1c_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\callconv\val_ctor_il_r\val_ctor_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcsvalbox\_speed_dbglcsvalbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\samerethrowtwice_r\samerethrowtwice_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgtailjump_cs\_dbgtailjump_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\mixedexpr1_r_try\mixedexpr1_r_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_dbgaddress\_il_dbgaddress.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\B168384\LdfldaHack\LdfldaHack.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\2branchesoutoftry_r\2branchesoutoftry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-01_cs_d\3w1d-01_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b84128\b84128\b84128.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reli8u8\_il_reli8u8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Xor_Op_cs_r\Int_Xor_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\throwincatch_r\throwincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPCall2\FPCall2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\callconv\_odbginstance_cs\_odbginstance_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8flat_cs_r\r8flat_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_do\int16_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_ro\uint16_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b52838\b52838\b52838.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_il_dbgdeep2\_il_dbgdeep2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_speed_relcatchfinally\_speed_relcatchfinally.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b18049\b18049\b18049.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\rethrowincatchnestedinfinally_d\rethrowincatchnestedinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\switchinfinally_do\switchinfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\unboxnullable_d\unboxnullable_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\reversedhandlers_d\reversedhandlers_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise2_cs_do\xprecise2_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate021\Delegate021.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Base_2\Test_CSharp_Base_2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3a_cs_ro\25param3a_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\jump\jump.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbgconst\_il_dbgconst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_speed_relcatchfinally_tail\_speed_relcatchfinally_tail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox019\box-unbox019.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b30586\b30586\b30586.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\tail\tail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relgcarr\_il_relgcarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\ConstantProp\ConstantProp.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\flowgraph\xaddmuly_cs_do\xaddmuly_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_cs_ro\uint16_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\threads2_cs_r\threads2_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convx_il_d\convx_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion5\NullCheckAssertion5.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\mul_exception_dbg\mul_exception_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinclassconstructor_d\throwinclassconstructor_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_speed_dbgselfref\_speed_dbgselfref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\bug595776\bug595776\bug595776.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop4_cs_do\loop4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt1_cs_ro\vt1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-EJIT\V1-M11-Beta1\b45046\b45046\b45046.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b174294\b174294\b174294.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_orelenum_cs\_orelenum_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_SideAffects\Inline_SideAffects.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_il_relbinop\_il_relbinop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_dbgsin_cs\_dbgsin_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b31182\b31182\b31182.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b40347\b40347\b40347.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgcastclass_ldarg\_il_dbgcastclass_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\div_dbg\div_dbg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefarg_c\_il_relrefarg_c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\StrAccess\straccess3_cs_ro\straccess3_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M02\b115932\b115932b\b115932b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\identity\_il_rellivecall\_il_rellivecall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_speed_relcast_throw\_speed_relcast_throw.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b113493\b113493\b113493.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\140713\innerFinally_d\innerFinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_dbgrotarg_objref\_opt_dbgrotarg_objref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\ovflrem2_il_d\ovflrem2_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\comp64_il_r\comp64_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress1_d\CgStress1_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b106272\b106272\b106272.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct01_static\struct01_static.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class03\class03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\boxunboxenum_d\boxunboxenum_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox004\box-unbox004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\RngchkStress2_o\RngchkStress2_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\tryfinallyintrycatchwithleaveintotry_d\tryfinallyintrycatchwithleaveintotry_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalgotoinatryblockinahandler_ro\nonlocalgotoinatryblockinahandler_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_speed_reldeep\_speed_reldeep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\prefldinit4_il_r\prefldinit4_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_cs_ro\catchrettoinnertry_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\throw_cs_do\throw_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblVar\DblVar.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_il_relldelem_get\_il_relldelem_get.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_No_Op_cs_r\Float_No_Op_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Peer_4\Test_CSharp_Peer_4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\classarr_cs_d\classarr_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\cascadedcatchret\throwincascadedcatchnofin_r\throwincascadedcatchnofin_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_xor\VolatileTest_op_xor.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1b_il_d\25param1b_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-04_cs_ro\5w1d-04_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\regression\bug584219\inliningVars\inliningVars.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_relselfref\_relselfref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nonlocalexitinhandler\nonlocalexitinhandler.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\static-mixed\static-mixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\classarr_cs_do\classarr_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgu_flow\_il_dbgu_flow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b147924\b147924\b147924.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\stfldstatic1_il_r\stfldstatic1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset1\nestedTryRegionsWithSameOffset1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struc01\struc01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\TypeParameters\Jagged\class01\class01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_r4_r8\_il_relcompat_r4_r8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_Simpletest4\_Simpletest4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_617302\Dev11_617302\Dev11_617302.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\intrinsic_nonf_il_r\intrinsic_nonf_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_c\_il_relrefloc_c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\catchretnonlocalexitinfunclet_d\catchretnonlocalexitinfunclet_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\3w1d-01_cs_do\3w1d-01_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_Many\Inline_Many.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_dbgfr4\_il_dbgfr4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwincatch_r\throwincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b101147\b101147\b101147.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_implicit\_il_reltest_implicit.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b09495\b09495\b09495.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relconvovf_i8_u\_il_relconvovf_i8_u.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Generic_Test_CSharp_Peer_4\Generic_Test_CSharp_Peer_4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_d\uint8_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate004\Delegate004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate001\Delegate001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b64579\b64579\b64579.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\regress\vswhidbey\143837\143837.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\mixed\mixed_cs_d\mixed_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\leave\leave1\leave1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\CopyProp\CopyProp.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallyrecursive_20_r\throwinfinallyrecursive_20_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\RngchkStress1_o\RngchkStress1_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinally_d\throwinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\141358\uncaughtException_r\uncaughtException_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Misc\function_pointer\funcptrtest\funcptrtest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\test4-xassem\test4-xassem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatchtrycatch_d\trycatchtrycatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\generics\trycatchnestedtype_d\trycatchnestedtype_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\virtualstubdispatch\hashcode\ctest1_cs_do\ctest1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadcodeincatch_r\deadcodeincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\class04\class04.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldfldunboxedvt_il_r\ldfldunboxedvt_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\deep\_il_reldeep1\_il_reldeep1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_i2_bool\_il_relcompat_i2_bool.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\oponerror_d\oponerror_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_r_loop\staticFieldExpr1_r_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr8a_cs_ro\convr8a_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldfldr4_il_r\ldfldr4_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_relisinst_catch\_il_relisinst_catch.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r4\r4_cs_do\r4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06812\b06812\b06812.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\MultiDim\class01_static\class01_static.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b14475\b14475\b14475.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr1\arrayexpr1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\mixedexpr1_r_loop_try\mixedexpr1_r_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray1_cs_d\dblarray1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\newarr\newarr\newarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\ref2iu_il_r\ref2iu_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relisinst_ldloc\_relisinst_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeinsidefinally_d\badcodeinsidefinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgisinst_ldarg\_il_dbgisinst_ldarg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_816617\DevDiv_816617_do\DevDiv_816617_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cprop\cprop002\cprop002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_174983\devdiv_174983\devdiv_174983.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\reversedtryblock_d\reversedtryblock_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_dbgrefarg_f4\_dbgrefarg_f4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\cascadedcatch_d\cascadedcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_speed_dbgcastclass_ldloc\_speed_dbgcastclass_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwisfirstinstruction_d\throwisfirstinstruction_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relgcval_sideeffect\_il_relgcval_sideeffect.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\RVAInit\simple\simple.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_r\int16_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_reltailjump_cs\_reltailjump_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh05_large\eh05_large.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallyrecursive_20_ro\throwinfinallyrecursive_20_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinnestedfinally_do\throwinnestedfinally_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\ldobj\ldobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\tlstest_il_r\tlstest_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_relarrres\_relarrres.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev11\DevDiv_376412\DevDiv_376412\DevDiv_376412.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\NullCheckAssertion3\NullCheckAssertion3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\class1_cs_d\class1_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param3c_il_d\25param3c_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\assemname_cs_r\assemname_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b19679\b19679\b19679.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAC_do\CGRecurseAAC_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\simple\precise2_cs_do\precise2_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_r\staticFieldExpr1_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_i1\_opt_relrefarg_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_relrotarg_float\_opt_relrotarg_float.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\struct05\struct05.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcs2\_speed_rellcs2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACA_ro\CGRecurseACA_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\severalnesteddeadehregions_r\severalnesteddeadehregions_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\141358\uncaughtException_do\uncaughtException_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_i4_i1\_il_relcompat_i4_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\enum\box-unbox-enum002\box-unbox-enum002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\localgotoinahandler_ro\localgotoinahandler_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev14\DevDiv_876169\DevDiv_876169_d\DevDiv_876169_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\catchtryintryfinally_r\catchtryintryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\switchdefaultonly1_il_r\switchdefaultonly1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_relcastclass_call\_relcastclass_call.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcsbox\_rellcsbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\JitMinOpts\Perf\BBCnt1\BBCnt1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\tailcall\tailcall.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\switchincatch_ro\switchincatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_relqperm\_il_relqperm.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint32_cs_ro\uint32_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadtrycatch_d\deadtrycatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Double_Or_Op_cs_ro\Double_Or_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b75509\b75509\b75509.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\callconv\_orelinstance_cs\_orelinstance_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06924\b06924\b06924.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_obj\_il_relcompat_obj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\VolatileTest_op_div\VolatileTest_op_div.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPError\FPError.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass014\castclass014.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_relrefarg_f4\_relrefarg_f4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30630\b30630\b30630.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\callconv\gc_ctor_il_r\gc_ctor_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\FinallyExec\nestedTryRegionsWithSameOffset2_o\nestedTryRegionsWithSameOffset2_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\MultiDim\class01_instance\class01_instance.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\TypeParameters\MultiDim\struct01\struct01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass019\castclass019.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_And_Op_cs_ro\Bool_And_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress1_r\CgStress1_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\mathfunc\mathfunc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1b_il_r\25param1b_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b92289\b92289\b92289.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAA_do\CGRecurseAAA_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldfldunboxedvt_il_d\ldfldunboxedvt_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_815940\DevDiv_815940_d\DevDiv_815940_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b10841\b10841\b10841.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\catchretnonlocalexitinfunclet_do\catchretnonlocalexitinfunclet_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAA_ro\CGRecurseAAA_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\Desktop\nullcomparaison_ro\nullcomparaison_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox003\box-unbox003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\backwardleave_r\backwardleave_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\catchrettoinnertry_ro\catchrettoinnertry_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_cs_do\arithm64_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate013\Delegate013.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate008\Delegate008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface008\castclass-interface008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_fld\_il_dbgi_fld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\GitHub_2580\GitHub_2580\GitHub_2580.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\nullabletypes\unboxnullable_ro\unboxnullable_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\FPRoots\FPRoots.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\interface\castclass-interface010\castclass-interface010.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b30126\b30126\b30126.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\mixedexpr1_ro_loop\mixedexpr1_ro_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAA_r\CGRecurseAAA_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline\Inline.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_relrefloc_i1\_il_relrefloc_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_20929\dev11_20929_r\dev11_20929_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_dbgrotarg_float\_opt_dbgrotarg_float.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\trycatch_r\trycatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\test2-xassem\test2-xassem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\rotate\_opt_relrotarg_objref\_opt_relrotarg_objref.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\Localloc\Localloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_speed_reltest1\_speed_reltest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\CheckedCtor\Test_CSharp_Base_1\Test_CSharp_Base_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinfinallynestedintry_do\throwinfinallynestedintry_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwoutside_r\throwoutside_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate022\Delegate022.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\endfinallyinloop_r\endfinallyinloop_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\sysinfo_cs\sysinfo_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\byrefsubbyref1_il_r\byrefsubbyref1_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr8d_il_r\convr8d_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\DblDivConst\DblDivConst.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b102533\b102533\b102533.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_r_try\staticFieldExpr1_r_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACA_d\CGRecurseACA_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_Or_Op_cs_d\Int_Or_Op_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\inl\inl001\inl001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray1_cs_r\dblarray1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b121938\ConstToString\ConstToString.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_il_dbgisinst_catch\_il_dbgisinst_catch.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint8_cs_do\uint8_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\rngchk\ArrayWithThread_o\ArrayWithThread_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray4_cs_do\dblarray4_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\fieldexpr1_1\fieldexpr1_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_il_dbgcastclass_calli\_il_dbgcastclass_calli.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryCatchFinallyThrow_nonlocalexit2_ro\tryCatchFinallyThrow_nonlocalexit2_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\rethrowincatchnestedinfinally_ro\rethrowincatchnestedinfinally_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\methodthrowsinfinally_r\methodthrowsinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\classarr_cs_r\classarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b06464\b06464\b06464.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr2_ro_loop\arrayexpr2_ro_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Bool_Xor_Op_cs_do\Bool_Xor_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\refbyref\byref2iu_il_r\byref2iu_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b147147\b147147\b147147.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray2_cs_do\dblarray2_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt2_il_d\vt2_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1b_cs_d\xprecise1b_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\callconv\val_ctor_il_d\val_ctor_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\finallytryintryfinally_r\finallytryintryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b28158\b28158\b28158.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.1-M1-Beta1\b140711\b140711\b140711.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\Jagged\Struct01\Struct01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass008\castclass008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_rellcsbox\_speed_rellcsbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\staticFieldExpr1_ro_loop\staticFieldExpr1_ro_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b569942\b569942\b569942.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldelemnullarr2_il_d\ldelemnullarr2_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\misc\_speed_dbggcarr\_speed_dbggcarr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\callvirt\_speed_dbgtest1\_speed_dbgtest1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\SEH\_speed_dbgthrow\_speed_dbgthrow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Arrays\ConstructedTypes\MultiDim\struct01_static\struct01_static.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\trashreg_il_r\trashreg_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Int_And_Op_cs_do\Int_And_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Exceptions\specific_class_instance01\specific_class_instance01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b309539\b309539\b309539.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinallynestedintry_30_ro\throwinfinallynestedintry_30_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalexittonestedsibling_d\nonlocalexittonestedsibling_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_relnestval_il\_relnestval_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\flowgraph\xaddmuly_cs_ro\xaddmuly_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\implicit\_il_reli4i2\_il_reli4i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfault_r\throwinfault_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_odbgfibo_cs\_odbgfibo_cs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinally_r\throwinfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\rethrow\throwwithhandlerscatchingbase_do\throwwithhandlerscatchingbase_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr2_r_loop\arrayexpr2_r_loop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_dbgint32_m1\_il_dbgint32_m1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_i2\_il_dbgrefloc_i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\DDB\b33183\b33183\b33183.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\intrinsic\pow\pow0_cs_do\pow0_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\HugeField2\HugeField2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-06_cs_ro\5w1d-06_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt3_cs_ro\vt3_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray1_cs_ro\dblarray1_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\FPtrunc\convr4a_cs_do\convr4a_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\flowgraph\xaddmuly_cs_d\xaddmuly_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relgcval\_il_relgcval.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\SIMD\ConsoleMandel\ConsoleMandel\ConsoleMandel.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\seh\_reltry_il\_reltry_il.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\Dev11_468598\Test_HndIndex_10_Plain\Test_HndIndex_10_Plain.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b423755\b423755\b423755.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\nonlocalexit\throwinfinally_50_ro\throwinfinally_50_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\DevDiv_150265\DevDiv_150265\DevDiv_150265.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\finallytryintryfinally_d\finallytryintryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b07947\b07947\b07947.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\delegate_r\delegate_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8flat_cs_ro\r8flat_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_And_Op_cs_ro\Float_And_Op_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_il_dbgunbox\_il_dbgunbox.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_s\_opt_dbgrefarg_s.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\simplenonlocalexitnestedintrycatch_d\simplenonlocalexitnestedintrycatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-QFE\b151440\params-mixed\params-mixed.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\badcodeafterfilter_d\badcodeafterfilter_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\div_opt\div_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\comp32_il_r\comp32_il_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\box-unbox\box-unbox\box-unbox015\box-unbox015.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\deadcode\deadnonlocalexit_d\deadnonlocalexit_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\ReturnStruct_Method\ReturnStruct_Method.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-RTM\b475589\b475589\b475589.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\comp64_il_d\comp64_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b611219\b611219\b611219.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_flow\_il_dbgi_flow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_speed_dbglcsbas\_speed_dbglcsbas.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\jaggedarr_cs_ro\jaggedarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseACA_do\CGRecurseACA_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_i4\_opt_dbgrefarg_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\volatilecpobj_il_d\volatilecpobj_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\lcs\_rellcsbas\_rellcsbas.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\uint16_cs_r\uint16_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\simpleexpr1\simpleexpr1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\basics\throwinfinallyerrpath_ro\throwinfinallyerrpath_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate011\Delegate011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-Beta1\b169333\b169333\b169333.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_il_dbgsizeof\_il_dbgsizeof.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_dbghuge_r8\_il_dbghuge_r8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_relrefarg_i2\_opt_relrefarg_i2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\arrayexpr2_d_loop_try\arrayexpr2_d_loop_try.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt4_cs_r\vt4_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\nonlocalexittobeginningoftry_do\nonlocalexittobeginningoftry_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\ldfldr4_il_d\ldfldr4_il_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\xassem\xprecise1b_cs_r\xprecise1b_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\CGRecurse\CGRecurseAAC_d\CGRecurseAAC_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int16_cs_ro\int16_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\valuetypes\nullable\castclass\castclass\castclass006\castclass006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress3_r\CgStress3_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\NaN\arithm64_r\arithm64_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\dev10\b402701\b402701\b402701.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\InnerProd\stringarr_cs_ro\stringarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\gcincatch_ro\gcincatch_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\finallyexec\tryfinallythrow_nonlocalexit_do\tryfinallythrow_nonlocalexit_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\dev11_13912\dev11_13912\dev11_13912.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b16382\b16382\b16382.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\catchtryintryfinally_d\catchtryintryfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b99969\b99969\b99969.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\AssertionPropagation\regression\dev10\bug573840\bug573840\bug573840.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cse\pointerexpr1\pointerexpr1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_il_dbgrefloc_i1\_il_dbgrefloc_i1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09\b13178\b13178\b13178.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\Arrays\Complex1\Complex1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\thiscall\_relthisnull\_relthisnull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\backwardleaveincatch_d\backwardleaveincatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\223862\conv_opt\conv_opt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\range\_il_relint32_1\_il_relint32_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V2.0-Beta2\b423721\b423721\b423721.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\basic\_opt_dbgrefarg_o\_opt_dbgrefarg_o.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\leaveintotrybody_r\leaveintotrybody_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\rethrow\Rethrow2\Rethrow2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\opt\Inline\tests\Inline_STARG\Inline_STARG.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\GaussJordan\classarr_cs_r\classarr_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\branchoutofnestedtryfinally_r\branchoutofnestedtryfinally_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Arrays\huge\_il_relhuge_i4\_il_relhuge_i4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh08_large\eh08_large.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_dbgi_box\_il_dbgi_box.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\vswhidbey\148190\baduwinfo1\baduwinfo1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\cg\cgstress\CgStress2_do\CgStress2_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b92066\b92066\b92066.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1a_cs_ro\25param1a_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\localvarincatch_r\localvarincatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\regress\asurt\141358\uncaughtException_ro\uncaughtException_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\disconnected\tryfinallyincatchtry_r\tryfinallyincatchtry_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\nested\general\throwinnestedcatch_r\throwinnestedcatch_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\ELEMENT_TYPE_IU\_il_reli_fld\_il_reli_fld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b78694\b78694\b78694.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\Swap\Swap.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\apps\bouncingball_cs_ro\bouncingball_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate007\Delegate007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\266693\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\_XModuletest2-xmod\_XModuletest2-xmod.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\ConstrainedCall\vt1_cs_r\vt1_cs_r.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\misc\_relbinop\_relbinop.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\interactions\switchinfinally_d\switchinfinally_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\shift\int32_do\int32_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\eh\leaves\nonlocalexitfromnestedcatch_d\nonlocalexitfromnestedcatch_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\r8\r8_cs_d\r8_cs_d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\casts\coverage\_dbgcastclass_ldloc\_dbgcastclass_ldloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\Instantiation\delegates\Delegate014\Delegate014.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\25params\25param1a_cs_do\25param1a_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\ldelemnullarr2\ldelemnullarr2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\eh\Leaves\nonlocalexitfromnestedcatch\nonlocalexitfromnestedcatch.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\MDArray\basics\classarr_cs_ro\classarr_cs_ro.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\doublearray\dblarray1_cs_do\dblarray1_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\cmov\Float_Or_Op_cs_do\Float_Or_Op_cs_do.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\pinvoke\static02\static02.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\sin\sin.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\pinvoke\instance01\instance01.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-RTM\b286991\b286991\b286991.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\clr-x64-JIT\v2.1\b173569\b173569\b173569.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b28901\b28901\b28901.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\pinvoke\static01\static01.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\286991\test\test.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\pinvoke\instance02\instance02.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\pinvoke\calli_excep\calli_excep.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Generics\pinvoke\instance03\instance03.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-05_cs_ro\5w1d-05_cs_ro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh04_dynamic\eh04_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\bug619534\ILStackAllocRepro\ILStackAllocRepro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind02_dynamic\unwind02_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh11_large\eh11_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call05_small\call05_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind05_large\unwind05_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72164\b72164\b72164.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind06_large\unwind06_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh13_dynamic\eh13_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\4\localloc\localloc.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\CodeGenBringUpTests\LocallocLarge\LocallocLarge.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\zeroinit\zeroinit01_large\zeroinit01_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv1_cs_r\callconv1_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call06_dynamic\call06_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv2_cs_d\callconv2_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop2_cs_r\loop2_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh03_small\eh03_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv2_cs_r\callconv2_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh02_small\eh02_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh04_small\eh04_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind01_dynamic\unwind01_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\193825\193825_uro\193825_uro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\560402\opmul\opmul.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind06_dynamic\unwind06_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind04_dynamic\unwind04_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind01_large\unwind01_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\560402\opadd\opadd.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-01_cs_r\200w1d-01_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh11_small\eh11_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\objectmodel\localloc\localloc.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b14324\b14324\b14324.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh09_large\eh09_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\call\call01_small\call01_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call07_dynamic\call07_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind02_large\unwind02_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh03_dynamic\eh03_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M01\b10852\b10852\b10852.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\localloc\localloc3_cs_do\localloc3_cs_do.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53547\b53547\b53547.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv1_cs_do\callconv1_cs_do.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop2_cs_d\loop2_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b72986\b72986\b72986.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-05_cs_do\5w1d-05_cs_do.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b87285\b87285\b87285.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\localloc\localloc3_cs_ro\localloc3_cs_ro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind03_small\unwind03_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\2\localloc\localloc.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh09_small\eh09_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh13_large\eh13_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind04_large\unwind04_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind02_small\unwind02_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind05_dynamic\unwind05_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call07_small\call07_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\zeroinit\zeroInit01_large\zeroInit01_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind05_small\unwind05_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh04_large\eh04_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh12_large\eh12_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh02_dynamic\eh02_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call06_large\call06_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call03_large\call03_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\localloc\localloc3_cs_d\localloc3_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv1_cs_ro\callconv1_cs_ro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\gc\misc\alloca3\alloca3.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call04_large\call04_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call05_dynamic\call05_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\zeroinit\zeroInit01_small\zeroInit01_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh01_dynamic\eh01_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh09_dynamic\eh09_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv1_cs_d\callconv1_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind01_small\unwind01_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv1_cs_r\callconv1_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-05_cs_r\5w1d-05_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh12_small\eh12_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh13_small\eh13_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\volatile\1\localloc\localloc.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b14355\b14355\b14355.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh01_large\eh01_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b60600\b60600\b60600.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv1_cs_d\callconv1_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh03_large\eh03_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-01_cs_ro\200w1d-01_cs_ro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\unaligned\1\localloc\localloc.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\localloc\zeroinit\zeroinit01_small\zeroinit01_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop2_cs_do\loop2_cs_do.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind04_small\unwind04_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\directed\heap_ovf\heap_ovf.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv1_cs_ro\callconv1_cs_ro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57952\b57952\b57952.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\5w1d-05_cs_d\5w1d-05_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call04_dynamic\call04_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh11_dynamic\eh11_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-01_cs_d\200w1d-01_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\UnrollLoop\loop2_cs_ro\loop2_cs_ro.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call04_small\call04_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\regress\vsw\560402\opsub\opsub.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind03_large\unwind03_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind06_small\unwind06_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\opt\regress\vswhidbey\193825\193825_udo\193825_udo.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b80764\b80764\b80764.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv1_cs_do\callconv1_cs_do.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call05_large\call05_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv2_cs_r\callconv2_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\ehverify\eh12_dynamic\eh12_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call03_dynamic\call03_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\localloc\localloc3_cs_r\localloc3_cs_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call06_small\call06_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\unwind\unwind03_dynamic\unwind03_dynamic.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh01_small\eh01_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\eh\eh02_large\eh02_large.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\PREFIX\PrimitiveVT\callconv2_cs_d\callconv2_cs_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv3_il_d\callconv3_il_d.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\call\call03_small\call03_small.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\fp\exgen\200w1d-01_cs_do\200w1d-01_cs_do.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\perffix\primitivevt\callconv3_il_r\callconv3_il_r.cmd" >
+             <Issue>4182</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_relldobj_R4\_il_relldobj_R4.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\lcs\lcs.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_double_1_r\expl_gc_double_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_int_1_r\expl_gc_int_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_byte_1_r\seq_gc_byte_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_relstress1\_relstress1.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_obj_1_d\expl_obj_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_speed_relnested\_speed_relnested.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\flowgraph\dev10_bug679008\fgloop\fgloop.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_speed_relgc_nested\_speed_relgc_nested.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_double_1_d\seq_gc_double_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_long_1_d\seq_gc_long_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_float_1_d\expl_float_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_int_1_r\expl_int_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_float_1_r\seq_gc_float_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_float_1_d\seq_float_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\format\format.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_val_1_d\expl_val_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_double_1_r\seq_gc_double_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_byte_1_r\seq_byte_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_relvirtcall\_speed_relvirtcall.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_dbgvirtcall\_dbgvirtcall.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_long_1_r\seq_gc_long_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b52840\b52840\b52840.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_int_1_r\seq_int_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_dbgstress1\_speed_dbgstress1.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_int_1_d\seq_gc_int_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_val_1_d\seq_val_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_byte_1_d\seq_gc_byte_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_short_1_d\expl_gc_short_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_long_1_d\expl_long_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_double_1_d\seq_double_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relarray3\_il_relarray3.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_float_1_r\seq_float_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_rellcs\_il_rellcs.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_int_1_r\seq_gc_int_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_int_1_d\seq_int_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\array2\array2.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_long_1_r\expl_long_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_val_1_d\expl_gc_val_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_short_1_d\expl_short_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_short_1_d\seq_gc_short_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relarray2\_il_relarray2.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_val_1_r\seq_gc_val_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_relvirtcall\_relvirtcall.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relseq\_il_relseq.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_double_1_d\expl_double_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\array1\array1.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_val_1_d\seq_gc_val_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_byte_1_r\expl_byte_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\etc\_il_relnested\_il_relnested.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_val_1_r\seq_val_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_double_1_r\seq_double_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_reltypedref\_reltypedref.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_float_1_d\seq_gc_float_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_byte_1_r\expl_gc_byte_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_double_1_r\expl_double_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_long_1_r\seq_long_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_obj_1_r\expl_gc_obj_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\operand\_speed_relrefanyval\_speed_relrefanyval.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_dbgstress1\_dbgstress1.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b52593\b52593\b52593.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relarray1\_il_relarray1.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_byte_1_d\expl_gc_byte_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-Beta1\b301479\b301479\b301479.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_float_1_r\expl_float_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_float_1_d\expl_gc_float_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_obj_1_r\expl_obj_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_double_1_d\expl_gc_double_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_obj_1_r\seq_gc_obj_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\virtcall\virtcall.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_byte_1_d\expl_byte_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_relldobj_U2\_il_relldobj_U2.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_obj_1_d\seq_obj_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_long_1_d\expl_gc_long_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_short_1_d\seq_short_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_short_1_r\seq_gc_short_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_gc_obj_1_d\seq_gc_obj_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_obj_1_r\seq_obj_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_dbgvirtcall\_speed_dbgvirtcall.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_val_1_r\expl_gc_val_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_long_1_r\expl_gc_long_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_short_1_r\expl_gc_short_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_long_1_d\seq_long_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_obj_1_d\expl_gc_obj_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\TypedReference\TypedReference\TypedReference.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_int_1_d\expl_gc_int_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_short_1_r\seq_short_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_int_1_d\expl_int_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_relldobj_R8\_il_relldobj_R8.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_val_1_r\expl_val_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\seq_byte_1_d\seq_byte_1_d.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\ldobj\_il_relldobj_I\_il_relldobj_I.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_speed_relstress1\_speed_relstress1.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_short_1_r\expl_short_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\explicit\coverage\expl_gc_float_1_r\expl_gc_float_1_r.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b52733\b52733\b52733.cmd" >
+             <Issue>4183</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_odbgsin_cs_cs\_odbgsin_cs_cs.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\xlang\_orelsin_cs_cs\_orelsin_cs_cs.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_relsin_il\_relsin_il.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_odbgsin_cs\_odbgsin_cs.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\morph\_odbgsin_cs\_odbgsin_cs.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\morph\_orelsin_cs\_orelsin_cs.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\functional\_orelsin_cs\_orelsin_cs.cmd" >
+             <Issue>4184</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgdeep_inst\_il_dbgdeep_inst.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgdeep_virt\_il_dbgdeep_virt.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relvirtftn_t\_il_relvirtftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgreference_i\_il_dbgreference_i.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfault_tail\_il_relcatchfault_tail.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumps3\_il_dbgjumps3.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b26957\b26957\b26957.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reldeep_gc\_il_reldeep_gc.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b102518\b102518\b102518.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_2a\_il_dbgtest_2a.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgrecurse_tail_call\_il_dbgrecurse_tail_call.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reldeep_inst\_il_reldeep_inst.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgdeep_value\_il_dbgdeep_value.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumps2\_il_reljumps2.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relinstftn_t\_il_relinstftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbginstftn_t\_il_dbginstftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumps2\_il_dbgjumps2.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgdeep_gc\_il_dbgdeep_gc.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_switch\_il_dbgtest_switch.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_relindcall\_il_relindcall.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_2c\_il_reltest_2c.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relrecurse_tail_calli\_il_relrecurse_tail_calli.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_switch\_il_reltest_switch.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfault_tail\_il_dbgcatchfault_tail.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\PInvokeTail\TailWinApi\TailWinApi.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relcompat_i4_u\_il_relcompat_i4_u.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-Beta2\b356258\b356258\b356258.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relftn_t\_il_relftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_reltailjump_il\_reltailjump_il.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reldeep_virt\_il_reldeep_virt.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Coverage\hole\hole.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_virt\_il_dbgtest_virt.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_2a\_il_reltest_2a.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b17904\b17904\b17904.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_2b\_il_reltest_2b.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_2c\_il_dbgtest_2c.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbggcval_sideeffect\_il_dbggcval_sideeffect.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_enum\_il_dbgcompat_enum.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Boxing\misc\_dbgtailjump_il\_dbgtailjump_il.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reldeep_array_nz\_il_reldeep_array_nz.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\refany\_il_dbgindcall\_il_dbgindcall.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbggcval_nested\_il_dbggcval_nested.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_relcatchfinally_tail\_il_relcatchfinally_tail.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_i4_u\_il_dbgcompat_i4_u.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_obj\_il_dbgcompat_obj.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relreference_i\_il_relreference_i.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgdeep_array_nz\_il_dbgdeep_array_nz.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumps4\_il_reljumps4.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_virt\_il_reltest_virt.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\JitBlue\devdiv_902271\DevDiv_902271\DevDiv_902271.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgftn_t\_il_dbgftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgcompat_v\_il_dbgcompat_v.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgrecurse_tail_calli\_il_dbgrecurse_tail_calli.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgvalftn_t\_il_dbgvalftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_2b\_il_dbgtest_2b.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V1.2-M02\b102844\b102844\b102844.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reldeep_value\_il_reldeep_value.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_relrecurse_ep\_il_relrecurse_ep.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\Tailcall\jitTailcall1\jitTailcall1.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\Desktop\callipinvoke_il_d\callipinvoke_il_d.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgtest_mutual_rec\_il_dbgtest_mutual_rec.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b84586\b84586\b84586.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\tailcall_d\tailcall_d.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b10894\b10894\b10894.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_reljumps3\_il_reljumps3.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\VT\callconv\_il_dbgjumps4\_il_dbgjumps4.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\SEH\_il_dbgcatchfinally_tail\_il_dbgcatchfinally_tail.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b06020\b06020\b06020.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\PInvokeTail\PInvokeTail\PInvokeTail.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\mutualrecur-tailcall\MutualRecur-TailCall\MutualRecur-TailCall.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relvalftn_t\_il_relvalftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\Desktop\callipinvoke_il_r\callipinvoke_il_r.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reldeep_array\_il_reldeep_array.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbggcval\_il_dbggcval.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\nonvirtualcall\tailcall_r\tailcall_r.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M10\b02043\b02043\b02043.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\oldtests\callipinvoke\callipinvoke.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_reltest_mutual_rec\_il_reltest_mutual_rec.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_relrecurse_tail_call\_il_relrecurse_tail_call.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall_v4\delegatetail\delegatetail.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\Invoke\fptr\_il_dbgvirtftn_t\_il_dbgvirtftn_t.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgrecurse_ep\_il_dbgrecurse_ep.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\tailcall\_il_dbgdeep_array\_il_dbgdeep_array.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\IL\Tailcall\JitTailcall2\JitTailcall2.cmd" >
+             <Issue>4185</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\Dev11\External\dev11_149090\GCHole1\GCHole1.cmd" >
+             <Issue>4186</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_rels_addsub\_speed_rels_addsub.cmd" >
+             <Issue>4593</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b36274\b36274\b36274.cmd" >
+             <Issue>4593</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_speed_dbgs_addsub\_speed_dbgs_addsub.cmd" >
+             <Issue>4593</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_dbgs_addsub\_dbgs_addsub.cmd" >
+             <Issue>4593</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_rels_addsub\_il_rels_addsub.cmd" >
+             <Issue>4593</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_rels_addsub\_rels_addsub.cmd" >
+             <Issue>4593</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b92614\b92614\b92614.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\v2.1\b610750\b610750\b610750.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_reladdsub\_speed_reladdsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\signed\_il_dbgs_addsub\_il_dbgs_addsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b25458\b25458\b25458.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16500\b16500\b16500.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_speed_dbgaddsub\_speed_dbgaddsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b31150\b31150\b31150.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41126\b41126\b41126.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b37215\b37215\b37215.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b16399\b16399\b16399.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\shl_u8\shl_u8.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\M00\b80738\b80738\b80738.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\shr_u8\shr_u8.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b27658\b27658\b27658.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M11-Beta1\b41278\b41278\b41278.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_dbgaddsub\_il_dbgaddsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_speed_relsizeof64\_speed_relsizeof64.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorDot_ro\VectorDot_ro.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_reladdsub\_reladdsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16886\b16886\b16886.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\VS-ia64-JIT\V2.0-RTM\b460385\b460385\b460385.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b53995\b53995\b53995.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b14770\b14770\b14770.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b74937\b74937\b74937.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1.2-M01\b02762\b02762\b02762.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16345\b16345\b16345.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\shr_i8\shr_i8.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M12-Beta2\b57516\b57516\b57516.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M13-RTM\b113239\b113239\b113239.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\xxobj\sizeof\_speed_dbgsizeof64\_speed_dbgsizeof64.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_il_reladdsub\_il_reladdsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\int64\unsigned\_dbgaddsub\_dbgaddsub.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\Regression\CLR-x86-JIT\V1-M09.5-PDC\b16071\b16071\b16071.cmd" >
+             <Issue>needs triage</Issue>
+        </ExcludeList>
+                <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\interlock\interlock.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\bestfit-finalize\bestfit-finalize.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\bestfit-threaded\bestfit-threaded.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\bestfit_1\bestfit_1.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\TotalMemory2\TotalMemory2.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\ServerModel\servermodel\servermodel.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\TotalMemory\TotalMemory.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\gettotalmemory\gettotalmemory.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetTotalMemory\GetTotalMemory.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\LargeObjectAlloc\LargeObjectAlloc.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta2\445488\445488\445488.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\bestfit\bestfit.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\plug\plug.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\LeakWheel\leakwheel\leakwheel.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\LOHCompaction\lohcompactapi\lohcompactapi.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Dynamo\dynamo\dynamo.cmd" >
+             <Issue>4168</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\keepalive\keepalive.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\Allocation\largeexceptiontest\largeexceptiontest.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\API\gc\suppressfinalize\suppressfinalize.cmd" >
+             <Issue>4169</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Alloc_neg2\Alloc_neg2.cmd" >
+             <Issue>4170</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\pow3\pow3.cmd" >
+             <Issue>4171</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta2\471729\471729\471729.cmd" >
+             <Issue>4172</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\CompEx\CompEx.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGeneration_box\GetGeneration_box.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\RemoveUsageTest\RemoveUsageTest.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\AddMemoryPressureTest\AddMemoryPressureTest.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\RemoveMemoryPressureTest\RemoveMemoryPressureTest.cmd" >
+             <Issue>4173</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\ReadWrite\ReadWriteByte\ReadWriteByte.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02c_seq_ser\Base02c_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopyByteArray\CopyByteArray.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\expl_double\expl_double\expl_double.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class02_auto\class02_auto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface07\NestedInterface07.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\ReadWrite\ReadWriteInt32\ReadWriteInt32.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\ReadWrite\ReadWriteInt16\ReadWriteInt16.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct02_auto\struct02_auto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopyCharArray\CopyCharArray.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Miscellaneous\MarshalClassTests\MarshalClassTests.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedClass02\NestedClass02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\ReadWrite\ReadWriteInt64\ReadWriteInt64.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\NativeCallable\NativeCallableTest\NativeCallableTest.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\UnsafeAddrOfPinnedArrayElement\UnsafeAddrOfPinnedArrayElement\UnsafeAddrOfPinnedArrayElement.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\ArrayMarshalling\ByValArray\MarshalArrayByValTest\MarshalArrayByValTest.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopyInt64Array\CopyInt64Array.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\GetNativeVariantForObject\GetNativeVariantForObject\GetNativeVariantForObject.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopySingleArray\CopySingleArray.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\ICastable\Castable\Castable.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\OffsetOf\OffsetOf\OffsetOf.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\GetObjectsForNativeVariants\GetObjectsForNativeVariants\GetObjectsForNativeVariants.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\GetObjectForNativeVariant\GetObjectForNativeVariant\GetObjectForNativeVariant.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopyDoubleArray\CopyDoubleArray.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopyInt16Array\CopyInt16Array.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase01\AbstractBase01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\Copy\CopyInt32Array\CopyInt32Array.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01b_auto_ser\Base01b_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\managed\Compilation\Compilation\Compilation.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedClass01\NestedClass01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-3-1\L-2-3-1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\14610\TestObjectGetTypeVirtual\TestObjectGetTypeVirtual.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedBaseClass02\NestedBaseClass02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\BinTree\thdtreelivingobj\thdtreelivingobj.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\coreclr\exec16\exec16.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct02_seq_ser\struct02_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\CollectionCountTest\CollectionCountTest.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface08\NestedInterface08.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01b_seq_ser\Base01b_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\Unbox005\Unbox005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\IsInst003\IsInst003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\BinTree\thdtree\thdtree.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandleCollector\CtorsAndProperties\CtorsAndProperties.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedBaseClass06\NestedBaseClass06.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\IsInst005\IsInst005.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\IsInst002\IsInst002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class01_auto\class01_auto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\CastClass004\CastClass004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\CastClass001\CastClass001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02a_auto_ser\Base02a_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct02_seq\struct02_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta2\462651\462651\462651.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-5-1\L-2-5-1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase02\AbstractBase02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\CoreCLR\Method001\Method001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedStruct02\NestedStruct02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-5-3\L-2-5-3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\BinTree\thdtreegrowingobj\thdtreegrowingobj.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-11-3\L-2-11-3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedClass03\NestedClass03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface06\NestedInterface06.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct02_auto_ser\struct02_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Methods\Method001\Method001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedStruct01\NestedStruct01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct01_seq_ser\struct01_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\Unbox006\Unbox006.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\regressions\classloader\main\main.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-6-3\L-2-6-3.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\SameMethodImpl\Override\HelloWorld\HelloWorld.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01c_seq_ser\Base01c_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\dd95372\dd95372\dd95372.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedClass04\NestedClass04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\208900\bug\bug.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase07\AbstractBase07.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedStruct04\NestedStruct04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedBaseClass05\NestedBaseClass05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Delegates\Delegates001\Delegates001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Interfaces\Interfaces002\Interfaces002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02a_auto\Base02a_auto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\vsw111021\main\main.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class02_auto_ser\class02_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class01_seq_ser\class01_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_443322\dev10_443322\dev10_443322.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedBaseClass04\NestedBaseClass04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\Unbox001\Unbox001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\CctorThrowMethodAccess\CctorThrowMethodAccess.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02b_auto_ser\Base02b_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface05\NestedInterface05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\Dev12_518401\dev12_518401\dev12_518401.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\vsw305955\GenericAssertin\GenericAssertin.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_720779\dev10_720779\dev10_720779.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02a_seq_ser\Base02a_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct01_seq\struct01_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02a_seq\Base02a_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01a_auto\Base01a_auto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\CollapsedInterfaces\HelloWorld\HelloWorld.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class01_auto_ser\class01_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Recursion\genrecur\genrecur.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02b_seq\Base02b_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class02_seq_ser\class02_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02b_seq_ser\Base02b_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface01\NestedInterface01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\IsInst004\IsInst004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface04\NestedInterface04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-11-1\L-2-11-1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface03\NestedInterface03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase04\AbstractBase04.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedBaseClass03\NestedBaseClass03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev11_95728\dev11_95728\dev11_95728.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01a_auto_ser\Base01a_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01d_seq_ser\Base01d_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\vsw188290\vsw188290\vsw188290.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase05\AbstractBase05.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct01_auto_ser\struct01_auto_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01b_seq\Base01b_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedInterface02\NestedInterface02.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedStruct03\NestedStruct03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01a_seq_ser\Base01a_seq_ser.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\struct01_auto\struct01_auto.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\class01_seq\class01_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\NestedBaseClass01\NestedBaseClass01.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-4-1\L-2-4-1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_710121\dev10_710121\dev10_710121.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase06\AbstractBase06.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\Unbox004\Unbox004.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\Unbox002\Unbox002.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\Unbox003\Unbox003.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\dev10_393447\dev10_393447\dev10_393447.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\AbstractBase03\AbstractBase03.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base01a_seq\Base01a_seq.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\IsInst001\IsInst001.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_398410\dev10_398410\dev10_398410.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\111021\main\main.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-6-1\L-2-6-1.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\369794\repro369794\repro369794.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\IsInst006\IsInst006.cmd" >
+             <Issue>4179</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_fail\Collect_fail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\testInterface\testInterface.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method005\method005.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Exceptions\Finalization\Finalizer\Finalizer.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\date\date.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\LeakGen\leakgen\leakgen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\MinLeakGen\minleakgen\minleakgen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\181424\test5\test5.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\testClass\testClass.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Resurrection\continue\continue.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\DisableTransparencyEnforcement\DisableTransparencyEnforcement.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\ArrayCopy\ArrayCopy.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\MaxGeneration\MaxGeneration.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\coreclr\0014\avtest\avtest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\ThreadCulture\ThreadCulture.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta1\289745\302560\302560.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\assemblyref\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\avtest\avtest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test23\test23.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\Marshal\Marshal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\RefInt\RefIntTest\RefIntTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\test1307\test1307.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\PrimitiveMarshalling\EnumMarshalling\EnumTest\EnumTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\AddrOfPinnedObject\AddrOfPinnedObject.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\Unsafe\Unsafe.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-5-1\L-1-5-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\ToLower\ToLower.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_Default_3\Collect_Default_3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\StringMarshalling\LPTSTR\LPTSTRTest\LPTSTRTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\doublinknoleak2\doublinknoleak2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\readytorun\mainv1\mainv1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\SuppressFinalize_Null\SuppressFinalize_Null.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\FunctionPointer\FunctionPtrTest\FunctionPtrTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlbigleakthd\dlbigleakthd.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\StructMarshalling\PInvoke\MarshalStructAsLayoutExp\MarshalStructAsLayoutExp.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\FinalizeTimeout\FinalizeTimeout\FinalizeTimeout.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-1-6e-two\RMV-4-1-6e-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\FuncPtrAsDelegateParam\FuncPtrAsDelegateParam\FuncPtrAsDelegateParam.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\IsAllocated\IsAllocated.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-20-one\RMV-2-8-20-one.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\AddrOfPinnedObject_neg\AddrOfPinnedObject_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_403582\dev10_403582\dev10_403582.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\KeepAlive\KeepAlive.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\readytorun\mainv2\mainv2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param05\param05.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\RefCharArray\RefCharArrayTest\RefCharArrayTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\SimpleStruct\SimpleStruct\SimpleStruct.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\variantlinklist\variantlinklist.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\methodoverriding\regressions\549411\exploit\exploit.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\StructMarshalling\PInvoke\MarshalStructAsLayoutSeq\MarshalStructAsLayoutSeq.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeother\finalizeinherit\finalizeinherit.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\MarshalAPI\IUnknown\IUnknownTest\IUnknownTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\Regressions\pressureoverflow\pressureoverflow.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Positive008\Positive008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlbigleak\dlbigleak.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect0\Collect0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\LargeMemory\Regressions\largearraytest\largearraytest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\doublinkstay\doublinkstay.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\vsw307137\vsw307137\vsw307137.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract07\abstract07.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivehandle\keepalivehandle.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-41g-two\RMV-2-13-41g-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivefinalize\keepalivefinalize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Negative_ExplicitGen\Negative_ExplicitGen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\GCBase1\gc_base1_1\gc_base1_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param02\param02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Finalize\Finalize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\FragMan\fragman\fragman.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract08\abstract08.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeother\finalizeexcep\finalizeexcep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Struct_ExplicitOverrideVirtualNewslot\Struct_ExplicitOverrideVirtualNewslot.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\Finalizer\Finalizer.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case5\case5.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\variantint\variantint.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\StringCreator\stringcreator\stringcreator.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\General\Base02d_seq_ser\Base02d_seq_ser.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-3-1\L-1-3-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\Inlining\GenTypeInlined\GenTypeInlined.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\doublinkgen\doublinkgen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect1\Collect1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-3-4\RMV-4-3-4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract04\abstract04.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\Variance1\Variance1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\vsw237932\repro237932\repro237932.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Alloc_neg\Alloc_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\536564\vsw536564\vsw536564.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-1-6d-two\RMV-4-1-6d-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\395780\testExplicitOverride\testExplicitOverride.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedHandle\PinnedHandle.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_493135\dev10_493135\dev10_493135.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\CollapsedMethods\Override\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Negative004\Negative004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\109968\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Constraints\Regressions\ddb62403\bug62403\bug62403.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001\method001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\359519\test359519\test359519.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-40a-two\RMV-2-13-40a-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\MethodImpl\self_override1\self_override1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\Target\Target.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-11-3\L-1-11-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGeneration_fail\GetGeneration_fail.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\Statics\Regressions\484837\Enum_ValueField\Enum_ValueField.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR2\GetGenerationWR2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\coreclr\nesting4\nesting4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\gcvariant4\gcvariant4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface09\MultipleInterface09.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\FinalNStruct\nstructtun\nstructtun.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase3\TestCase3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\KeepAliveRecur\KeepAliveRecur.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case2\case2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-6-1\L-1-6-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_neg\Collect_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract06\abstract06.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedMultiple\PinnedMultiple.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Free\Free.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-1-3\L-1-1-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001g\method001g.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\IsAlive_neg\IsAlive_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-8-3\L-1-8-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Free_neg\Free_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorThreeThreads01BFI\CircularCctorThreeThreads01BFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\SingLinkList\singlinkstay\singlinkstay.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\pluggaps\pluggaps.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Casting\Casting.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\LOHCompaction\lohcompactapi_exceptions\lohcompactapi_exceptions.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlstack\dlstack.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\395780\testExplicitOverride2\testExplicitOverride2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\LeakGen\leakgenthrd\leakgenthrd.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-3-two\RMV-2-8-3-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\PinObj_neg\PinObj_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface13\MultipleInterface13.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\Variance\Variant_CollapsedInterfaces\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\FinalNStruct\finalnstruct\finalnstruct.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\vsw543506\vsw543506.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\AddUsageTest\AddUsageTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\THDList\thdlist\thdlist.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method009\method009.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect\Collect.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Delegates\Delegates002\Delegates002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Target_neg\Target_neg.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-3-7-two\RMV-4-3-7-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\CctorOpenFile\CctorOpenFile.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\IsAlive\IsAlive.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-31-two\RMV-2-8-31-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\WeakReference\weakreffinal\weakreffinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Regressions\common\AboveStackLimit\AboveStackLimit.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-2-4\RMV-4-2-4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\Inlining\GenMethInlined\GenMethInlined.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\arrcpy\arrcpy.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta1\149926\149926\149926.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test10\test10.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\multipleWRs_1\multipleWRs_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\IL\InterfaceInheritanceTest2\InterfaceInheritanceTest2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\RanCollect\rancollect\rancollect.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivescope\keepalivescope.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCSettings\InputValidation\InputValidation.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Alloc\Alloc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\FinalNStruct\nstructresur\nstructresur.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandleCollector\Usage\Usage.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\CollapsedMethods\InterfaceImplementation\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\THDChaos\thdchaos\thdchaos.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Positive009\Positive009.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandleCollector\NegTests\NegTests.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\vsw531159\vsw531159\vsw531159.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\347422\b347422\b347422.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\ToFromIntPtr\ToFromIntPtr.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\Regressions\dev10_602978\MainApp\MainApp.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\HandleCopy\HandleCopy.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_788724\dev10_788724\dev10_788724.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\gcvariant\gcvariant.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Misc\TestWithManyParams\TestWithManyParams.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev11_11333\dev11_11333\dev11_11333.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\GCBench\gcbench\gcbench.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\methodoverriding\regressions\576621\VSW576621\VSW576621.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\gcvariant2\gcvariant2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeother\finalizearray\finalizearray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\coreclr\nesting31\nesting31.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeother\finalizedest\finalizedest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\Tests\nesting7\nesting7.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method006\method006.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\Finalize\Finalize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\515341\vsw515341\vsw515341.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Struct_ExplicitOverrideVirtualNewslotFinal\Struct_ExplicitOverrideVirtualNewslotFinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\delete_next_card_table\delete_next_card_table.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\vararystress\vararystress.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Equality\Equality.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-2-1\L-1-2-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlbigleakthd_v2\dlbigleakthd_v2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method015\method015.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001h\method001h.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Rootmem\rootmem\rootmem.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_813331\Case3\Case3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\LOHCompaction\lohpin\lohpin.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta2\426480\426480\426480.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase7\TestCase7.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Coverage\LargeObjectAlloc2\LargeObjectAlloc2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\coreclr\VSW491577\VSW491577.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Samples\gc\gc.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\CctorThrowStaticField\CctorThrowStaticField.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-9-1\L-1-9-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\asurt150271\test23\test23.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta1\289745\289745\289745.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedInt\PinnedInt.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Constraints\Regressions\532403\VSW532403\VSW532403.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\asurt150271\test3\test3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\AddThresholdTest\AddThresholdTest.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\PrivateInterfaceImpl\Test6_ImplementingClass\Test6_ImplementingClass.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\simpvariant\simpvariant.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-11-1\L-1-11-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\KeepAliveNull\KeepAliveNull.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedCollect\PinnedCollect.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\NDPin\ndpinfinal\ndpinfinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-1-6b\RMV-4-1-6b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\ReRegisterForFinalize_null\ReRegisterForFinalize_null.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract01\abstract01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\ReflectObj\reflectobj\reflectobj.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedMany\PinnedMany.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\GCBase1\gc_base1\gc_base1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\NDPin\ndpin\ndpin.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\NativeLibs\FromNativePaths\FromNativePaths.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Pinning\PinningOther\PinnedObject\PinnedObject.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test2\test2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Struct_ImplicitOverrideVirtualNewslotFinal\Struct_ImplicitOverrideVirtualNewslotFinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\SingLinkList\singlinkgen\singlinkgen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\TrackResurrection\TrackResurrection.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test13\test13.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\ResetGlobalFields\ResetGlobalFields.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\ReRegisterForFinalize\ReRegisterForFinalize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Struct_ImplicitOverrideVirtualNewslot\Struct_ImplicitOverrideVirtualNewslot.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-beta2\452950\452950\452950.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case3\case3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\Finalize2\Finalize2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\188892\test188892\test188892.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\expandheap\expandheap.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method013\method013.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeother\finalizearraysleep\finalizearraysleep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeother\finalizenested\finalizenested.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\137310\test137310\test137310.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\GCStress\gcstress\gcstress.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method002\method002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_Default_1\Collect_Default_1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\405223\vsw405223\vsw405223.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\Boxing\gcvariant3\gcvariant3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGenerationWR\GetGenerationWR.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_813331\Case1\Case1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Weak\Weak.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivedirectedgraph\keepalivedirectedgraph.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Recursion\GenTypeItself\GenTypeItself.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\CollapsedMethods\InterfaceDefinition\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class_ExplicitOverrideVirtualNewslotFinal\Class_ExplicitOverrideVirtualNewslotFinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\Finalizer\finalizeio\finalizeio\finalizeio.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivetry\keepalivetry.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\vsw514968\vsw514968\vsw514968.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandleCollector\Count\Count.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\Variance\Variant_InherittedCollision\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivearray\keepalivearray.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\341477\Test\Test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\KeepAlive\keepaliveother\keepalivetypes\keepalivetypes.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Scenarios\DoublinkList\dlcollect\dlcollect.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Target\Target.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\NullHandle\NullHandle.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-10-1\L-1-10-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Normal\Normal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-rtm\544701\544701\544701.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\523654\test532654_b\test532654_b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_Default_2\Collect_Default_2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\GetGeneration\GetGeneration.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Features\HeapExpansion\Handles\Handles.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-15-12b\RMV-2-15-12b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\SuppressFinalize\SuppressFinalize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract10\abstract10.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\WeakReference\multipleWRs\multipleWRs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CoreCLR\CctorThrowStaticFieldBFI\CctorThrowStaticFieldBFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GCHandle\Pinned\Pinned.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface04\MultipleInterface04.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-5-3\L-1-5-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\434481\b434481_GenericRecurInit\b434481_GenericRecurInit.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param06\param06.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class_ImplicitOverrideVirtualNewslotFinal\Class_ImplicitOverrideVirtualNewslotFinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-15-two\RMV-2-13-15-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\139056\Foo\Foo.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test3\test3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-4-1\L-1-4-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-6-3\L-1-6-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-5-8-two\RMV-2-5-8-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case6\case6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-8-1\L-1-8-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\448208\b448208\b448208.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\Tests\nesting63\nesting63.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-7-two\RMV-2-8-7-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method016\method016.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorThreeThreads03BFI\CircularCctorThreeThreads03BFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\coreclr\nesting18\nesting18.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-7-1\L-1-7-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\methodoverriding\regressions\577403\vsw577403\vsw577403.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\CctorThrowInlinedStatic\CctorThrowInlinedStatic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Statics\Regressions\524571\StaticsProblem5\StaticsProblem5.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\regressions\polyrec\Polyrec\Polyrec.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\MethodImpl\override_override1\override_override1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-2-4-two\RMV-4-2-4-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\MethodImpl\self_override3\self_override3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method008\method008.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-25-five\RMV-2-13-25-five.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-1-6e\RMV-4-1-6e.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-2-3\L-1-2-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Methods\Method003\Method003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\SequentialLayout\Regress\217070\t2\t2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001d\method001d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\TypeLoadInitExcepBFI\TypeLoadInitExcepBFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\451034\LoadType\LoadType.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test14\test14.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Recursion\Struct_ImplementMscorlibGenInterface\Struct_ImplementMscorlibGenInterface.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case1\case1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\452707\b452707\b452707.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\methodoverriding\regressions\593884\vsw593884\vsw593884.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-11-6-two\RMV-2-11-6-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-10-3\L-1-10-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001b\method001b.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param01\param01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorThreeThreads02\CircularCctorThreeThreads02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\vsw524571\StaticsProblem5\StaticsProblem5.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase0\TestCase0.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_724989\dev10_724989\dev10_724989.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract02\abstract02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class2_ImplicitOverrideVirtual\Class2_ImplicitOverrideVirtual.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001c\method001c.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\421439\Test\Test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method003\method003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param08\param08.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\vsw529206\vsw529206ModuleCctor\vsw529206ModuleCctor.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\163172\MethodImplFinal\MethodImplFinal.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\DD117522\Test\Test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-10-3\L-2-10-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_526434\dev10_526434\dev10_526434.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Nesting\NestedGenericStructs\NestedGenericStructs.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_813331\Case2\Case2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class_ExplicitOverrideVirtualNewslot\Class_ExplicitOverrideVirtualNewslot.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\misc\derivedExplicitClass\derivedExplicitClass.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_897464\dev10_897464\dev10_897464.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-9-3\L-1-9-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-20-two\RMV-2-8-20-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001j\method001j.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\SequentialLayout\Regress\217070\t1\t1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorFourThreads\CircularCctorFourThreads.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_889822\dev10_889822\dev10_889822.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case11\case11.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-12-1\L-1-12-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test16\test16.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test21\test21.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\Inlining\Inlined\Inlined.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Constraints\Recursion\RecursiveConstraints\RecursiveConstraints.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CoreCLR\CircularCctorThreeThreads03\CircularCctorThreeThreads03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorThreeThreads03\CircularCctorThreeThreads03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method007\method007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param07\param07.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface12\MultipleInterface12.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase6\TestCase6.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Misc\ConstraintsAndInheritance\ConstraintsAndInheritance.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test15\test15.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface07\MultipleInterface07.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\Inlining\Inlined_Multinested\Inlined_Multinested.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dd116295\dd116295\dd116295.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\123712\repro123712\repro123712.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\ThisNulllPointer\CctorZeroVal03\CctorZeroVal03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\226741\test3\test3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001a\method001a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-30-two\RMV-2-8-30-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\Type_ofT_Inherit_FromT\Type_ofT_Inherit_FromT.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface06\MultipleInterface06.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\307137\vsw307137\vsw307137.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test11\test11.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\Ambiguous\Ambiguous.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\RecursiveGen\RecursiveGen.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_813331\Case4\Case4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\TypeLoadInitExcep\TypeLoadInitExcep.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorThreeThreads01\CircularCctorThreeThreads01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\Inlining\GenTypeInlined_Multinested\GenTypeInlined_Multinested.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase2\TestCase2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\583649\vsw583649\vsw583649.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Positive010\Positive010.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method004\method004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-1-6d\RMV-4-1-6d.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\Tests\nesting4\nesting4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\CctorThrowStaticFieldBFI\CctorThrowStaticFieldBFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case14\case14.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-6b-two\RMV-2-13-6b-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\433497\vsw433497\vsw433497.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param04\param04.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase4\TestCase4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test9\test9.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\test24\test24.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract05\abstract05.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class2_ImplicitOverrideVirtual_Interface\Class2_ImplicitOverrideVirtual_Interface.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-1-6a\RMV-4-1-6a.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-12-1\L-2-12-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Statics\Regressions\524571\StaticsProblem2\StaticsProblem2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case15\case15.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-3-8\RMV-4-3-8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\SealedTypes\SealedTypes.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-3-4-two\RMV-4-3-4-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorFourThreadsBFI\CircularCctorFourThreadsBFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-7-3\L-1-7-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface02\MultipleInterface02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\334376\b334376\b334376.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Regressions\dev10_468712\dev10_468712\dev10_468712.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case8\case8.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface11\MultipleInterface11.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-25-9-two\RMV-2-25-9-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001i\method001i.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase5\TestCase5.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface08\MultipleInterface08.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CircularCctors\CircularCctorThreeThreads02BFI\CircularCctorThreeThreads02BFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-10-1\L-2-10-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-5-5-two\RMV-2-5-5-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\MethodCalls\MethodCalls.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\101904\test\test.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-12-3\L-2-12-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Negative002\Negative002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\InterfaceFolding\TestCase1\TestCase1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract03\abstract03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-26-two\RMV-2-13-26-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001f\method001f.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-1-1\L-1-1-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\Statics\Misc\LiteralStatic\LiteralStatic.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\CoreCLR\Method003\Method003.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Methods\Method002\Method002.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\144257\vsw144257\vsw144257.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\298006\explicitStruct_oddSize\explicitStruct_oddSize.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\arity01\arity01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\methodoverriding\regressions\dev10_432038\dev10_432038\dev10_432038.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Interfaces\Interfaces001\Interfaces001.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method011\method011.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method010\method010.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-7-two\RMV-2-13-7-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\ddb3422\ddb3422\ddb3422.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\backpatching\test1\test1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class2_ImplicitOverrideVirtualNewslot_Interface\Class2_ImplicitOverrideVirtualNewslot_Interface.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Statics\Regressions\524571\StaticsProblem4\StaticsProblem4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dd52\dd52\dd52.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface03\MultipleInterface03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\Inlining\GenMethInlined_Multinested\GenMethInlined_Multinested.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\UntrustedCodeBFI\UntrustedCodeBFI.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_851479\dev10_851479\dev10_851479.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Statics\Regressions\524571\StaticsProblem1\StaticsProblem1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\237932\repro237932\repro237932.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class2_ImplicitOverrideVirtualNewslot\Class2_ImplicitOverrideVirtualNewslot.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method012\method012.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Constraints\General\ManyGenConstraints\ManyGenConstraints.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_715437\dev10_715437\dev10_715437.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\abstract09\abstract09.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-28-two\RMV-2-8-28-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface14\MultipleInterface14.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Variance\Methods\Method004\Method004.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface01\MultipleInterface01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Regressions\607\DevDiv607\DevDiv607.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\529206\vsw529206StaticCctor\vsw529206StaticCctor.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\dev10_531793\dev10_531793\dev10_531793.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method014\method014.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case12\case12.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Layout\Specific\Positive007\Positive007.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\regressions\classloader\vsw307137\vsw307137.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\VSD\Class_ImplicitOverrideVirtualNewslot\Class_ImplicitOverrideVirtualNewslot.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Negative\param03\param03.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\CctorsWithSideEffects\CctorThrowLDFTNStaticMethod\CctorThrowLDFTNStaticMethod.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface05\MultipleInterface05.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-39g-two\RMV-2-8-39g-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\SameMethodImpl\CollapsedInterfaces\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\Variance\Covariant_CollapsedInterfaces\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-9-3\L-2-9-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Nesting\NestedGenericClasses\NestedGenericClasses.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case4\case4.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\91888\pumpFromCctor\pumpFromCctor.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-2-9-1\L-2-9-1.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\regressions\vsw395780\testExplicitOverride2\testExplicitOverride2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Statics\Regressions\524571\StaticsProblem3\StaticsProblem3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\nesting\coreclr\exec3\exec3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\ThisNulllPointer\CctorZeroVal02\CctorZeroVal02.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\Regressions\ASURT\ASURT150271\bigdat\bigdat.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Constraints\Regressions\dev10_512868\dev10_512868\dev10_512868.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_630250\dev10_630250\dev10_630250.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case7\case7.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TSAmbiguities\Variance\Covariant_InherittedCollision\HelloWorld\HelloWorld.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\ConstrainedMethods\ConstrainedMethods.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\GenericMethods\method001e\method001e.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Constraints\Regressions\vsw609874\vsw609874\vsw609874.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\v1\Beta1\Layout\Matrix\cs\L-1-12-3\L-1-12-3.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-4-3-7\RMV-4-3-7.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-8-33-two\RMV-2-8-33-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\objrefandnonobjrefoverlap\case9\case9.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-41a-two\RMV-2-13-41a-two.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\rmv\il\RMV-2-13-22-three\RMV-2-13-22-three.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\generics\Instantiation\Positive\MultipleInterface10\MultipleInterface10.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\explicitlayout\misc\case10\case10.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\TypeInitialization\ThisNulllPointer\CctorZeroVal01\CctorZeroVal01.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\529206\vsw529206ModuleCctor\vsw529206ModuleCctor.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_568786\4_Misc\Variance2\Variance2.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\245191\nullenum1000\nullenum1000.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\Regressions\v2.0-rtm\494226\494226\494226.cmd" >
+             <Issue>4180</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Exceptions\ForeignThread\ForeignThreadExceptions\ForeignThreadExceptions.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\PrimitiveMarshalling\UIntPtr\PInvokeUIntPtrTest\PInvokeUIntPtrTest.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\StringMarshalling\LPSTR\LPSTRTest\LPSTRTest.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\ArrayMarshalling\BoolArray\MarshalBoolArrayTest\MarshalBoolArrayTest.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Interop\PrimitiveMarshalling\Bool\BoolTest\BoolTest.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_Forced_3\Collect_Forced_3.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_Forced_2\Collect_Forced_2.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\GC\API\GC\Collect_Forced_1\Collect_Forced_1.cmd" >
+             <Issue>4181</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_794943\dev10_794943\dev10_794943.cmd" >
+             <Issue>4186</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_add_ovf_i8\ldc_add_ovf_i8.cmd" >
+             <Issue>4596</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_sub_ovf_i8\ldc_sub_ovf_i8.cmd" >
+             <Issue>4596</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\add_ovf_i8\add_ovf_i8.cmd" >
+             <Issue>4596</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\sub_ovf_i8\sub_ovf_i8.cmd" >
+             <Issue>4596</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\sub_ovf\sub_ovf.cmd" >
+             <Issue>4596</Issue>
         </ExcludeList>
     </ItemGroup>
 </Project>

--- a/tests/x86/ryujit_x86_testenv.cmd
+++ b/tests/x86/ryujit_x86_testenv.cmd
@@ -1,0 +1,10 @@
+@REM -------------------------------------------------------------------------
+@REM 
+@REM  This script provides x86 Ryujit test environment settings
+@REM
+@REM -------------------------------------------------------------------------
+
+set COMPLUS_AltJit=*
+set COMPLUS_AltJitName=protojit.dll
+set COMPLUS_NoGuiOnAssert=1
+set COMPLUS_AltJitAssertOnNYI=1


### PR DESCRIPTION
This change adds exclusions with their issue numbers for the x86 RyuJIT
bring up. Additionally, this change adds the x86 TestEnv script for
running runtests.cmd with protojit.dll.

Also fixes the indentation for one excluded file in issues.targets.