### PR TITLE
Use current stack trace in ExceptionDispatchInfo when Exception lacks one

### DIFF
--- a/src/mscorlib/src/System/Runtime/ExceptionServices/ExceptionServicesCommon.cs
+++ b/src/mscorlib/src/System/Runtime/ExceptionServices/ExceptionServicesCommon.cs
@@ -104,7 +104,19 @@ namespace System.Runtime.ExceptionServices {
                 throw new ArgumentNullException("source", Environment.GetResourceString("ArgumentNull_Obj"));
             }
             
-            return new ExceptionDispatchInfo(source);
+            var edi = new ExceptionDispatchInfo(source);
+
+            // If there's no stack trace stored in the ExceptionDispatchInfo, use the current stack.
+            if (edi.m_remoteStackTrace == null && edi.m_stackTrace == null)
+            {
+                edi.m_remoteStackTrace = 
+                    Environment.StackTrace +
+                    Environment.NewLine + 
+                    Environment.GetResourceString("Exception_EndStackTraceFromPreviousCapture") +
+                    Environment.NewLine;
+            }
+
+            return edi;
         }
     
         // Return the exception object represented by this ExceptionDispatchInfo instance

--- a/src/mscorlib/src/mscorlib.txt
+++ b/src/mscorlib/src/mscorlib.txt
@@ -42,6 +42,7 @@ Exception_WasThrown = Exception of type '{0}' was thrown.
 
 ; The following are used in the implementation of ExceptionDispatchInfo
 Exception_EndStackTraceFromPreviousThrow = --- End of stack trace from previous location where exception was thrown ---
+Exception_EndStackTraceFromPreviousCapture = --- End of stack trace from previous location where exception was captured ---
 
 Arg_ParamName_Name = Parameter name: {0}
 ArgumentOutOfRange_ActualValue = Actual value was {0}.


### PR DESCRIPTION
(@gkhanna79, @ericeil, @jkotas, any thoughts on this approach?  I'm not tied to it, but I was hoping to find some solution.)

When implementing a component based on Tasks and wrapping a native asynchronous API, it's common to have code that manually completes tasks using TaskCompletionSources, e.g.
```C#
var tcs = new TaskCompletionSource<int>();
InvokeSomeNativeApi(result => tcs.SetResult(result), hr => tcs.SetException(GetExceptionFromHr(hr)));
return tcs.Task;
```
When an error occurs, typically an Exception is created for that native error, but the Exception isn't thrown and thus the Exception object doesn't contain a good stack trace.  Instead, the Exception is stored into the TaskCompletionSource with SetException.  SetException in turn uses ExceptionDispatchInfo.Capture to extract the relevant data from the Exception so that it can be restored and appended later when the exception is propagated.  Since there's no stack trace stored in the exception, when the Exception gets thrown later via ExceptionDispatchInfo.Throw, there's nothing for the EDI to append and the propagated exception lacks any information about the original source location.

This commit attempts to mitigate the problem by having the ExceptionDispatchInfo use the stack trace at the point of Capture if there's no other stack trace information already stored in the Exception.  Since it's typical for the Exception in such situations to be constructed in the same general vicinity as where it's then Capture'd, this provides more relevant information than an empty stack trace.