### PR TITLE
Linux Mint support for mscorlib.dll build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -217,6 +217,9 @@ isMSBuildOnNETCoreSupported()
                 __OSVersion=$(lsb_release -rs)
                 if [ "$__OSVersion" == "14.04" ]; then
                     __isMSBuildOnNETCoreSupported=1
+                elif [ "$(cat /etc/*-release | grep -cim1 14.04)" -eq 1 ]; then
+                    # Linux Mint based on Ubuntu 14.04
+                    __isMSBuildOnNETCoreSupported=1
                 fi
             elif [ "$__DistroName" == "rhel" ]; then
                 __isMSBuildOnNETCoreSupported=1


### PR DESCRIPTION
This patch enables mscorlib.dll build on linux mint based on ubuntu 14.04 LTS 