### PR TITLE
Remove --infer-runtimes restore argument

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -111,7 +111,6 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) "$(DotnetToolCommand)"</DnuRestoreCommand> 
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('\\'))"</DnuRestoreCommand>
-    <DnuRestoreCommand Condition="'$(InferRuntimes)'!='false'">$(DnuRestoreCommand) --infer-runtimes</DnuRestoreCommand>
   </PropertyGroup>
   
   <!--

--- a/tests/dir.props
+++ b/tests/dir.props
@@ -104,7 +104,6 @@
     <DnuRestoreCommand>$(DnuRestoreCommand) "$(DotnetToolCommand)"</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) restore</DnuRestoreCommand>
     <DnuRestoreCommand>$(DnuRestoreCommand) --packages "$(PackagesDir.TrimEnd('/\'.ToCharArray()))" $(DnuRestoreSource)</DnuRestoreCommand>
-    <DnuRestoreCommand Condition="'$(InferRuntimes)'!='false'">$(DnuRestoreCommand) --infer-runtimes</DnuRestoreCommand>
   </PropertyGroup>
 
   <!-- Create a collection of all project.json files for dependency updates. -->

--- a/tests/src/Loader/classloader/PrivateInterfaceImpl/project.json
+++ b/tests/src/Loader/classloader/PrivateInterfaceImpl/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/Statics/ComplexScenarios/project.json
+++ b/tests/src/Loader/classloader/Statics/ComplexScenarios/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/Statics/Misc/project.json
+++ b/tests/src/Loader/classloader/Statics/Misc/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TSAmbiguities/CollapsedMethods/InterfaceImplementation/project.json
+++ b/tests/src/Loader/classloader/TSAmbiguities/CollapsedMethods/InterfaceImplementation/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TypeInitialization/CctorsWithSideEffects/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/CctorsWithSideEffects/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TypeInitialization/CircularCctors/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/CircularCctors/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TypeInitialization/CoreCLR/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/CoreCLR/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TypeInitialization/Inlining/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/Inlining/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TypeInitialization/ThisNulllPointer/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/ThisNulllPointer/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/TypeInitialization/backpatching/project.json
+++ b/tests/src/Loader/classloader/TypeInitialization/backpatching/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/explicitlayout/Regressions/298006/project.json
+++ b/tests/src/Loader/classloader/explicitlayout/Regressions/298006/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/explicitlayout/Regressions/369794/project.json
+++ b/tests/src/Loader/classloader/explicitlayout/Regressions/369794/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Constraints/General/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/General/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Constraints/Recursion/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Recursion/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/532403/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/532403/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/ddb62403/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/ddb62403/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/dev10_512868/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/dev10_512868/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Constraints/Regressions/vsw609874/project.json
+++ b/tests/src/Loader/classloader/generics/Constraints/Regressions/vsw609874/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/GenericMethods/project.json
+++ b/tests/src/Loader/classloader/generics/GenericMethods/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Instantiation/Negative/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Negative/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Instantiation/Nesting/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Nesting/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Instantiation/Positive/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Positive/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Instantiation/Recursion/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Recursion/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Instantiation/Regressions/607/project.json
+++ b/tests/src/Loader/classloader/generics/Instantiation/Regressions/607/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Layout/General/project.json
+++ b/tests/src/Loader/classloader/generics/Layout/General/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Layout/Specific/project.json
+++ b/tests/src/Loader/classloader/generics/Layout/Specific/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Misc/project.json
+++ b/tests/src/Loader/classloader/generics/Misc/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Statics/Regressions/524571/project.json
+++ b/tests/src/Loader/classloader/generics/Statics/Regressions/524571/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/VSD/project.json
+++ b/tests/src/Loader/classloader/generics/VSD/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Variance/CoreCLR/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/CoreCLR/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Variance/Delegates/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/Delegates/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Variance/IL/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/IL/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Variance/Interfaces/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/Interfaces/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Variance/Methods/project.json
+++ b/tests/src/Loader/classloader/generics/Variance/Methods/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/Visibility/project.json
+++ b/tests/src/Loader/classloader/generics/Visibility/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/123712/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/123712/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/137310/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/137310/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/188892/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/188892/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/237932/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/237932/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/334376/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/334376/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/341477/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/341477/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/395780/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/395780/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/433497/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/433497/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/448208/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/448208/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/515341/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/515341/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/536564/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/536564/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/DD117522/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/DD117522/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/dd95372/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/dd95372/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/ddb3422/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/ddb3422/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/generics/regressions/vsw578898/project.json
+++ b/tests/src/Loader/classloader/generics/regressions/vsw578898/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/methodoverriding/regressions/576621/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/576621/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/methodoverriding/regressions/dev10_432038/project.json
+++ b/tests/src/Loader/classloader/methodoverriding/regressions/dev10_432038/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/nesting/Regressions/dev10_602978/project.json
+++ b/tests/src/Loader/classloader/nesting/Regressions/dev10_602978/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/nesting/Tests/project.json
+++ b/tests/src/Loader/classloader/nesting/Tests/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/101682/project.json
+++ b/tests/src/Loader/classloader/regressions/101682/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/106647/project.json
+++ b/tests/src/Loader/classloader/regressions/106647/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/111021/project.json
+++ b/tests/src/Loader/classloader/regressions/111021/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/14610/project.json
+++ b/tests/src/Loader/classloader/regressions/14610/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/208900/project.json
+++ b/tests/src/Loader/classloader/regressions/208900/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/307137/project.json
+++ b/tests/src/Loader/classloader/regressions/307137/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/347422/project.json
+++ b/tests/src/Loader/classloader/regressions/347422/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/348842/project.json
+++ b/tests/src/Loader/classloader/regressions/348842/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/451034/project.json
+++ b/tests/src/Loader/classloader/regressions/451034/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/523654/project.json
+++ b/tests/src/Loader/classloader/regressions/523654/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/529206/project.json
+++ b/tests/src/Loader/classloader/regressions/529206/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/583649/project.json
+++ b/tests/src/Loader/classloader/regressions/583649/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/91888/project.json
+++ b/tests/src/Loader/classloader/regressions/91888/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/Dev12_518401/project.json
+++ b/tests/src/Loader/classloader/regressions/Dev12_518401/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dd116295/project.json
+++ b/tests/src/Loader/classloader/regressions/dd116295/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dd52/project.json
+++ b/tests/src/Loader/classloader/regressions/dd52/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_398410/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_398410/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_526434/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_526434/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_568786/4_Misc/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_568786/4_Misc/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_630250/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_630250/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_724989/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_724989/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_794943/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_794943/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_813331/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_813331/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev10_897464/project.json
+++ b/tests/src/Loader/classloader/regressions/dev10_897464/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev11_256384/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_256384/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev11_38348/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_38348/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev11_383846/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_383846/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/dev11_95728/project.json
+++ b/tests/src/Loader/classloader/regressions/dev11_95728/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/vsw529206/project.json
+++ b/tests/src/Loader/classloader/regressions/vsw529206/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/regressions/vsw531159/project.json
+++ b/tests/src/Loader/classloader/regressions/vsw531159/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/v1/Beta1/Layout/Matrix/cs/project.json
+++ b/tests/src/Loader/classloader/v1/Beta1/Layout/Matrix/cs/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/v1/M10/Acceptance/project.json
+++ b/tests/src/Loader/classloader/v1/M10/Acceptance/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }

--- a/tests/src/Loader/classloader/v1/Stress/Beta1/CLStressA/project.json
+++ b/tests/src/Loader/classloader/v1/Stress/Beta1/CLStressA/project.json
@@ -31,5 +31,14 @@
   },
   "frameworks": {
     "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
   }
 }


### PR DESCRIPTION
I don't think that [`src/.nuget/init/project.json`](https://github.com/dotnet/coreclr/blob/master/src/.nuget/init/project.json) needs any runtimes, so we can remove `--infer-runtimes` from `dir.props`.

Runtimes have been added to the test project.json files now (thanks to https://github.com/dotnet/coreclr/pull/4308), so we can also remove `--infer-runtimes` in `tests\dir.props`.

When I tried building I got some warnings, but I didn't completely clean my repo so it may be old generated files causing them. (These could be some warnings that were fixed in 4308.) For example:

> C:\git\coreclr\tests\publishdependency.targets(32,5): warning : Your project.json doesn't have a runtimes section. You should add '"runtimes": { "win7-x64": { } }' to your project.json and then re-run NuGet restore. [C:\git\coreclr\tests\runtest.proj]

I'm doing a cleaner build now, but I'd rather not block on that before I try to pass this through CI.

CoreFX `--infer-runtimes` removal: https://github.com/dotnet/corefx/pull/8107

/cc @weshaggard @ericstj @joperezr 