### PR TITLE
Fix regression in internal Cobol test

### DIFF
--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -9523,7 +9523,7 @@ NO_MUL_64RSLT:
             if (((op2->gtOper == GT_CNS_INT) && (op2->gtIntConCommon.IconValue() == 1))
                 || ((op2->gtOper == GT_CNS_LNG) && (op2->gtIntConCommon.LngValue() == 1)))
             {
-                GenTreePtr zeroNode = new(this, GT_CNS_INT) GenTreeIntCon(typ, 0);
+                GenTreePtr zeroNode = gtNewZeroConNode(typ);
 #ifdef DEBUG
                 zeroNode->gtFlags |= GTF_MORPHED;
 #endif


### PR DESCRIPTION
The x86 (legacy backend) JIT was asserting because an optimization created the wrong size int constant node.

This was a regression introduced with https://github.com/dotnet/coreclr/pull/3385