### PR TITLE
Inliner: implement FullPolicy

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8594,8 +8594,10 @@ public:
     static fgWalkPreFn      gsMarkPtrsAndAssignGroups;  // Shadow param analysis tree-walk
     static fgWalkPreFn      gsReplaceShadowParams;      // Shadow param replacement tree-walk
 
-#define DEFAULT_MAX_INLINE_SIZE         100         // Method with >  DEFAULT_MAX_INLINE_SIZE IL bytes will never be inlined.
+#define DEFAULT_MAX_INLINE_SIZE         100         // Methods with >  DEFAULT_MAX_INLINE_SIZE IL bytes will never be inlined.
                                                     // This can be overwritten by setting complus_JITInlineSize env variable.
+
+#define DEFAULT_MAX_INLINE_DEPTH         20         // Methods at more than this level deep will not be inlined
                                          
 private:
 #ifdef FEATURE_JIT_METHOD_PERF

--- a/src/jit/flowgraph.cpp
+++ b/src/jit/flowgraph.cpp
@@ -21329,7 +21329,7 @@ void Compiler::fgRemoveContainedEmbeddedStatements(GenTreePtr tree, GenTreeStmt*
 
 //------------------------------------------------------------------------
 // fgCheckForInlineDepthAndRecursion: compute depth of the candidate, and
-// check for recursion and excessive depth
+// check for recursion.
 //
 // Return Value:
 //    The depth of the inline candidate. The root method is a depth 0, top-level
@@ -21350,13 +21350,11 @@ unsigned     Compiler::fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo)
 
     // There should be a context for all candidates.
     assert(inlineContext != nullptr);
-
-    const DWORD MAX_INLINING_RECURSION_DEPTH = 20;
-    DWORD depth = 0;
+    int depth = 0;
 
     for (; inlineContext != nullptr; inlineContext = inlineContext->GetParent())
     {
-        // Hard limit just to catch pathological cases
+
         depth++;
 
         if (inlineContext->GetCode() == candidateCode)
@@ -21367,9 +21365,8 @@ unsigned     Compiler::fgCheckInlineDepthAndRecursion(InlineInfo* inlineInfo)
             break;
         }
 
-        if (depth > MAX_INLINING_RECURSION_DEPTH)
+        if (depth > InlineStrategy::IMPLEMENTATION_MAX_INLINE_DEPTH)
         {
-            inlineResult->NoteFatal(InlineObservation::CALLSITE_IS_TOO_DEEP);
             break;
         }
     }

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -670,6 +670,12 @@ public:
         return m_MaxInlineSize;
     }
 
+    // Get depth of maximum allowable inline
+    unsigned GetMaxInlineDepth()
+    {
+        return m_MaxInlineDepth;
+    }
+
     // Number of successful inlines into the root.
     unsigned GetInlineCount()
     {
@@ -701,7 +707,8 @@ public:
     enum
     {
         ALWAYS_INLINE_SIZE = 16,
-        IMPLEMENTATION_MAX_INLINE_SIZE= _UI16_MAX
+        IMPLEMENTATION_MAX_INLINE_SIZE = _UI16_MAX,
+        IMPLEMENTATION_MAX_INLINE_DEPTH = 1000
     };
 
 private:
@@ -731,8 +738,8 @@ private:
     int EstimateSize(InlineContext* context);
 
 #if defined(DEBUG) || defined(INLINE_DATA)
-    static bool    s_DumpDataHeader;
-    static bool    s_DumpXmlHeader;
+    static bool    s_HasDumpedDataHeader;
+    static bool    s_HasDumpedXmlHeader;
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
     Compiler*      m_Compiler;
@@ -742,6 +749,7 @@ private:
     unsigned       m_InlineAttemptCount;
     unsigned       m_InlineCount;
     unsigned       m_MaxInlineSize;
+    unsigned       m_MaxInlineDepth;
     int            m_InitialTimeBudget;
     int            m_InitialTimeEstimate;
     int            m_CurrentTimeBudget;

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -11,9 +11,14 @@
 //
 // LegalPolicy         - partial class providing common legality checks
 // LegacyPolicy        - policy that provides legacy inline behavior
+//
+// These experimental policies are available only in
+// DEBUG or release+INLINE_DATA builds of the jit.
+//
 // RandomPolicy        - randomized inlining
 // DiscretionaryPolicy - legacy variant with uniform size policy
 // ModelPolicy         - policy based on statistical modelling
+// FullPolicy          - inlines everything up to size and depth limits
 
 #ifndef _INLINE_POLICY_H_
 #define _INLINE_POLICY_H_
@@ -290,6 +295,26 @@ public:
 
     // Miscellaneous
     const char* GetName() const override { return "ModelPolicy"; }
+};
+
+// FullPolicy is an experimental policy that will always inline if
+// possible, subject to externally settable depth and size limits.
+//
+// It's useful for unconvering the full set of possible inlines for
+// methods.
+
+class FullPolicy : public DiscretionaryPolicy
+{
+public:
+
+    // Construct a ModelPolicy
+    FullPolicy(Compiler* compiler, bool isPrejitRoot);
+
+    // Policy determinations
+    void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
+
+    // Miscellaneous
+    const char* GetName() const override { return "FullPolicy"; }
 };
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -57,6 +57,7 @@ CONFIG_INTEGER(JitHashHalt, W("JitHashHalt"), -1) // Same as JitHalt, but for a 
 CONFIG_INTEGER(JitInlineAdditionalMultiplier, W("JitInlineAdditionalMultiplier"), 0)
 CONFIG_INTEGER(JitInlinePrintStats, W("JitInlinePrintStats"), 0)
 CONFIG_INTEGER(JitInlineSize, W("JITInlineSize"), DEFAULT_MAX_INLINE_SIZE)
+CONFIG_INTEGER(JitInlineDepth, W("JITInlineDepth"), DEFAULT_MAX_INLINE_DEPTH)
 CONFIG_INTEGER(JitLargeBranches, W("JitLargeBranches"), 0) // Force using the largest conditional branch format
 CONFIG_INTEGER(JitMaxTempAssert, W("JITMaxTempAssert"), 1)
 CONFIG_INTEGER(JitMaxUncheckedOffset, W("JitMaxUncheckedOffset"), 8)
@@ -195,6 +196,7 @@ CONFIG_INTEGER(JitInlineDumpXml, W("JitInlineDumpXml"), 0)
 CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
+CONFIG_INTEGER(JitInlinePolicyFull, W("JitInlinePolicyFull"), 0)
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
 #undef CONFIG_INTEGER


### PR DESCRIPTION
The FullPolicy will be used to grow maximal potential inline trees
for methods. It inlines all legal candidates subject to depth and
size limits. Add a config flag to select this as the policy to use.

Also add a config flag so the inline depth limit becomes adjustable,
and rework the code so that checking this limit is now a matter of
policy.  Add in an implementation max depth limit of 1000.

Revise names of some statics to make their intent clearer, and add some
missing header comments.