### PR TITLE
ARM64: Enable Struct Promotion for most Mutireg structs

### DIFF
--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -6445,6 +6445,7 @@ CodeGen::genIntrinsic(GenTreePtr treeNode)
 //
 void CodeGen::genPutArgStk(GenTreePtr treeNode)
 {
+    assert(treeNode->OperGet() == GT_PUTARG_STK);
     var_types targetType = treeNode->TypeGet();
     emitter *emit = getEmitter();
 
@@ -6493,8 +6494,9 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
     {
         varNum = compiler->lvaOutgoingArgSpaceVar;
     }
+    bool isStruct = (targetType == TYP_STRUCT) || (data->OperGet() == GT_LIST);
 
-    if (targetType != TYP_STRUCT)   // a normal non-Struct argument
+    if (!isStruct)   // a normal non-Struct argument
     {
         instruction storeIns  = ins_Store(targetType);  
         emitAttr    storeAttr = emitTypeSize(targetType);
@@ -6512,7 +6514,7 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
             emit->emitIns_S_R(storeIns, storeAttr, data->gtRegNum, varNum, argOffset);
         }
     }
-    else  // We have a TYP_STRUCT argument (it also must be a 16-byte multi-reg struct)
+    else  // We have a TYP_STRUCT argument (it currently must be a 16-byte multi-reg struct)
     {
         // We will use two store instructions that each write a register sized value
 
@@ -6520,12 +6522,14 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
         assert(curArgTabEntry->numSlots == 2);
         assert(data->isContained());    // We expect that this node was marked as contained in LowerArm64
 
-        // In lowerArm64 we reserved two internal integer registers for this 16-byte TYP_STRUCT
         regNumber loReg = REG_NA;
         regNumber hiReg = REG_NA;
-        genGetRegPairFromMask(treeNode->gtRsvdRegs, &loReg, &hiReg);
-        assert(loReg != REG_NA);
-        assert(hiReg != REG_NA);
+
+        if (data->OperGet() != GT_LIST)
+        {
+            // In lowerArm64 we reserved two internal integer registers for this 16-byte TYP_STRUCT
+            genGetRegPairFromMask(treeNode->gtRsvdRegs, &loReg, &hiReg);
+        }
 
         // We will need to record the GC type used by each of the load instructions
         //  so that we use the same type in each of the store instructions
@@ -6697,6 +6701,31 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
                 }
             }
         }
+        else if (data->OperGet() == GT_LIST)
+        {
+            // Deal with multi register passed struct args.
+            GenTreeArgList* argListPtr = data->AsArgList();
+            unsigned iterationNum = 0;
+            for (; argListPtr != nullptr; argListPtr = argListPtr->Rest(), iterationNum++)
+            {
+                GenTreePtr nextArgNode = argListPtr->gtOp.gtOp1;
+                genConsumeReg(nextArgNode);
+
+                if (iterationNum == 0)
+                {
+                    // record loReg and type0 for the store to the out arg space
+                    loReg = nextArgNode->gtRegNum;
+                    type0 = nextArgNode->TypeGet();
+                }
+                else
+                {
+                    assert(iterationNum == 1);
+                    // record hiReg and type1 for the store to the out arg space
+                    hiReg = nextArgNode->gtRegNum;;
+                    type1 = nextArgNode->TypeGet();
+                }
+            }
+        }
 
         if ((data->OperGet() == GT_LCL_VAR) || (data->OperGet() == GT_LCL_VAR_ADDR))
         {
@@ -6718,6 +6747,10 @@ void CodeGen::genPutArgStk(GenTreePtr treeNode)
             emit->emitIns_R_S(ins_Load(type0), emitTypeSize(type0), loReg, varNum, 0);
             emit->emitIns_R_S(ins_Load(type1), emitTypeSize(type1), hiReg, varNum, TARGET_POINTER_SIZE);
         }
+
+        // We are required to set these two values above
+        assert(loReg != REG_NA);
+        assert(hiReg != REG_NA);
 
         // We are required to set these two values above, so that the stores have the same GC type as the loads
         assert(type0 != TYP_UNKNOWN);

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -2031,6 +2031,7 @@ public:
     void                    gtGetArgMsg     (GenTreePtr             call,
                                              GenTreePtr             arg,
                                              unsigned               argNum,
+                                             int                    listCount,
                                              char*                  bufp,
                                              unsigned               bufLength);
     void                    gtGetLateArgMsg (GenTreePtr             call,
@@ -8817,7 +8818,7 @@ public:
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
     void          fgMorphMultiregStructArgs(GenTreeCall* call);
-    GenTreePtr    fgMorphMultiregStructArg (GenTreePtr   arg);
+    GenTreePtr    fgMorphMultiregStructArg (GenTreePtr   arg, fgArgTabEntryPtr fgEntryPtr);
 
 }; // end of class Compiler
 

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -15640,19 +15640,19 @@ void                Compiler::fgPromoteStructs()
 
                 if (varDsc->lvIsParam)
                 {
-#if FEATURE_MULTIREG_STRUCT_PROMOTE
-                   
-                    if (varDsc->lvIsMultiregStruct()        &&   // Is this a variable holding a value that is passed in multiple registers?
-                        (structPromotionInfo.fieldCnt != 2) &&   // An argument with two exactly two fields
-                        false)                                   // TODO-PERF - Disabled as this needs additional implementation:
-                                                                 //             it hits assert(lvFieldCnt==1) in lclvar.cpp line 4417
+#if FEATURE_MULTIREG_STRUCT_PROMOTE                   
+                    if (varDsc->lvIsMultiregStruct() &&         // Is this a variable holding a value that is passed in multiple registers?
+                        (structPromotionInfo.fieldCnt != 2))    // Does it have exactly two fields
                     {
-                        JITDUMP("Not promoting multireg struct local V%02u, because lvIsParam is true and #fields = %d.\n",
-                            lclNum, structPromotionInfo.fieldCnt);
+                        JITDUMP("Not promoting multireg struct local V%02u, because lvIsParam is true and #fields != 2\n",
+                                lclNum);
                         continue;
                     }
-                    else
 #endif  // !FEATURE_MULTIREG_STRUCT_PROMOTE
+
+                    // TODO-PERF - Implement struct promotion for incoming multireg structs
+                    //             Currently it hits assert(lvFieldCnt==1) in lclvar.cpp line 4417  
+
                     if (structPromotionInfo.fieldCnt != 1)
                     {
                         JITDUMP("Not promoting promotable struct local V%02u, because lvIsParam is true and #fields = %d.\n",

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -1450,7 +1450,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define FEATURE_WRITE_BARRIER    1       // Generate the proper WriteBarrier calls for GC    
   #define FEATURE_FIXED_OUT_ARGS   1       // Preallocate the outgoing arg area in the prolog
   #define FEATURE_STRUCTPROMOTE    1       // JIT Optimization to promote fields of structs into registers
-  #define FEATURE_MULTIREG_STRUCT_PROMOTE 0  // True when we want to promote fields of a multireg struct into registers
+  #define FEATURE_MULTIREG_STRUCT_PROMOTE 1  // True when we want to promote fields of a multireg struct into registers
   #define FEATURE_FASTTAILCALL     0       // Tail calls made as epilog+jmp
   #define FEATURE_TAILCALL_OPT     0       // opportunistic Tail calls (i.e. without ".tail" prefix) made as fast tail calls.
   #define FEATURE_SET_FLAGS        1       // Set to true to force the JIT to mark the trees with GTF_SET_FLAGS when the flags need to be set


### PR DESCRIPTION
Enable struct promotion for Multireg Struct on Arm64 (16-byte structs)
For the current level of support the struct must have exactly two fields and they must be on the natural alignment of 0 and 8.
If the struct is use as a parameter and it contains a floating point field then we force the promoted struct to be stack allocated in order to avoid LSRA limitations in this area.
If a promoted multireg struct is passed in the out going arg area we convert it to the GT_LIST form.
The optimizer phases can perform copy and constant prop into the promoted struct fields.
Support for the promotion of incoming multireg arguments is still disabled as additional work in required to enable this.

A lot of method showed very large improvemenst is the AsmDiffs.

Overall using we are seeing a 0.34% total size improvement with a lot of method showing 50% size reductions:

mscorlib.dasm                                          6852660     6831248       21412          0.31     38763
 573 functions improved (19428 total bytes improvement)
    Improvement # 1 goes from  3428 to  2216, diff of  1212 (35.36%) :: System.Runtime.Remoting.Activation.RemotingXmlConfigFileParser:ParseDefaultConfiguration():ref
    Improvement # 2 goes from   996 to   584, diff of   412 (41.37%) :: System.BCLDebug:.cctor()
    Improvement # 3 goes from   184 to    60, diff of   124 (67.39%) :: System.Internal:NullableHelper():long
    Improvement # 4 goes from   540 to   332, diff of   208 (38.52%) :: System.Decimal:.cctor()
    Improvement # 5 goes from   292 to   144, diff of   148 (50.68%) :: System.Internal:NullableHelper():ref
    Improvement # 6 goes from   104 to    28, diff of    76 (73.08%) :: System.ConfigNode:ReplaceAttribute(int,ref,ref):this
    Improvement # 7 goes from   144 to    60, diff of    84 (58.33%) :: System.Collections.Generic.Dictionary`2[EventCacheKey,EventCacheEntry][System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+NativeOrStaticEventRegistrationImpl+EventCacheKey,System.Runtime.InteropServices.WindowsRuntime.WindowsRuntimeMarshal+NativeOrStaticEventRegistrationImpl+EventCacheEntry]:System.Collections.Generic.ICollection<System.Collections.Generic.KeyValuePair<TKey,TValue>>.Add(struct):this
    Improvement # 8 goes from   184 to    92, diff of    92 (50.00%) :: System.Threading.CancellationTokenRegistration:Equals(struct):bool:this
    Improvement # 9 goes from   148 to    72, diff of    76 (51.35%) :: System.Threading.Tasks.ParallelLoopStateFlags64:get_NullableLowestBreakIteration():struct:this
    Improvement #10 goes from    96 to    36, diff of    60 (62.50%) :: System.Runtime.CompilerServices.ConfiguredTaskAwaitable:.ctor(ref,bool):this