### PR TITLE
Load JIT from a custom location

### DIFF
--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -132,7 +132,9 @@ add_definitions(-DFEATURE_MAIN_CLR_MODULE_USES_CORE_NAME)
 add_definitions(-DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE)
 
 # TODO_DJIT: Remove this "set" to commence loading JIT dynamically.
-set(FEATURE_MERGE_JIT_AND_ENGINE 1)
+if(NOT WIN32)
+  set(FEATURE_MERGE_JIT_AND_ENGINE 1)
+endif(NOT WIN32)
 if(FEATURE_MERGE_JIT_AND_ENGINE)
   # Disable the following for UNIX altjit on Windows
   add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)

--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -132,6 +132,11 @@ static void ConvertConfigPropertiesToUnicode(
     *propertyValuesWRef = propertyValuesW;
 }
 
+#if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
+// Reference to the global holding the path to the JIT
+extern "C" LPCWSTR g_CLRJITPath;
+#endif // !defined(FEATURE_MERGE_JIT_AND_ENGINE)
+
 //
 // Initialize the CoreCLR. Creates and starts CoreCLR host and creates an app domain
 //
@@ -188,6 +193,11 @@ int coreclr_initialize(
 
     // This will take ownership of propertyKeysWTemp and propertyValuesWTemp
     Configuration::InitializeConfigurationKnobs(propertyCount, propertyKeysW, propertyValuesW);
+
+#if !defined(FEATURE_MERGE_JIT_AND_ENGINE)
+    // Fetch the path to JIT binary, if specified
+    g_CLRJITPath = Configuration::GetKnobStringValue(W("JIT_PATH"));
+#endif // !defined(FEATURE_MERGE_JIT_AND_ENGINE)
 
     STARTUP_FLAGS startupFlags;
     InitializeStartupFlags(&startupFlags);

--- a/src/vm/codeman.h
+++ b/src/vm/codeman.h
@@ -1168,7 +1168,6 @@ public:
 #endif //ALLOW_SXS_JIT
 };
 
-
 //*****************************************************************************
 //
 // This class manages IJitManagers and ICorJitCompilers.  It has only static

--- a/src/zap/zapper.cpp
+++ b/src/zap/zapper.cpp
@@ -696,9 +696,9 @@ void Zapper::LoadAndInitializeJITForNgen(LPCWSTR pwzJitName, OUT HINSTANCE* phJi
     HRESULT hr = E_FAIL;
 
 #if defined(FEATURE_CORECLR) || defined(FEATURE_MERGE_JIT_AND_ENGINE)
-    // TODO_DJIT: Currently, we are looking up the JIT from the same location as CoreCLR. The path needs to be passed by the caller.
-    //
     // Note: FEATURE_MERGE_JIT_AND_ENGINE is defined for the Desktop crossgen compilation as well.
+    //
+    // For Crossgen, we always look up the JIT from the same location as CoreCLR. 
     PathString CoreClrFolder;
     extern HINSTANCE g_hThisInst;
     if (WszGetModuleFileName(g_hThisInst, CoreClrFolder))


### PR DESCRIPTION
With this change:

1) On Windows, we will always load JIT dynamically for both runtime and crossgen scenarios.
2) Unix version of CoreRun is updated (and manually tested) to pass the path to JIT using JIT_PATH to coreclr_initialize
3) Crossgen will always expect the JIT binary to be present next to it.
4) Fixed a regression introduced by https://github.com/dotnet/coreclr/commit/b100ceb285829d7101c1a6f97375dc6a6734aa56#diff-61d8744ed872dcb468235cd86a642b14

@jkotas @janvorli PTAL.

CC @pgavlin 