### PR TITLE
Fix issue #4298 "SIGSEGV_libcoreclr.so!Debugger::GetArgCount"

### DIFF
--- a/src/debug/di/dbgtransportpipeline.cpp
+++ b/src/debug/di/dbgtransportpipeline.cpp
@@ -111,6 +111,13 @@ public:
     // Terminate the debuggee process.
     virtual BOOL TerminateProcess(UINT32 exitCode);
 
+#ifdef FEATURE_PAL
+    virtual void CleanupTargetProcess()
+    {
+        m_pTransport->CleanupTargetProcess();
+    }
+#endif
+
 private:
     // Return TRUE if the transport is up and runnning
     BOOL IsTransportRunning()

--- a/src/debug/di/nativepipeline.h
+++ b/src/debug/di/nativepipeline.h
@@ -167,6 +167,14 @@ public:
     {
         return S_FALSE;
     } 
+
+#ifdef FEATURE_PAL
+    // Used by debugger side (RS) to cleanup the target (LS) named pipes 
+    // and semaphores when the debugger detects the debuggee process  exited.
+    virtual void CleanupTargetProcess()
+    {
+    }
+#endif
 };
 
 //

--- a/src/debug/inc/dbgtransportsession.h
+++ b/src/debug/inc/dbgtransportsession.h
@@ -319,7 +319,7 @@ public:
     // may be delivered once the session is established.
 #ifdef RIGHT_SIDE_COMPILE
     HRESULT Init(DWORD pid, HANDLE hProcessExited);
-#else // RIGHT_SIDE_COMPILE
+#else
     HRESULT Init(DebuggerIPCControlBlock * pDCB, AppDomainEnumerationIPCBlock * pADB);
 #endif // RIGHT_SIDE_COMPILE
 
@@ -331,10 +331,16 @@ public:
     // Init() may be called again to start over from the beginning).
     void Shutdown();
 
+#ifdef RIGHT_SIDE_COMPILE
+    // Used by debugger side (RS) to cleanup the target (LS) named pipes 
+    // and semaphores when the debugger detects the debuggee process  exited.
+    void CleanupTargetProcess();
+#else
     // Cleans up the named pipe connection so no tmp files are left behind. Does only
     // the minimum and must be safe to call at any time. Called during PAL ExitProcess,
     // TerminateProcess and for unhandled native exceptions and asserts.
     void AbortConnection();
+#endif // RIGHT_SIDE_COMPILE
 
     LONG AddRef()
     {

--- a/src/debug/inc/twowaypipe.h
+++ b/src/debug/inc/twowaypipe.h
@@ -73,6 +73,10 @@ public:
         return m_state;
     }
 
+    // Used by debugger side (RS) to cleanup the target (LS) named pipes 
+    // and semaphores when the debugger detects the debuggee process  exited.
+    void CleanupTargetProcess();
+
 private:
 
     State m_state;
@@ -82,12 +86,13 @@ private:
 
     static const int MaxPipeNameLength = 64;
 
-    static void GetPipeName(char *name, DWORD id, const char *suffix);
+    void GetPipeName(char *name, DWORD id, const char *suffix);
 
-    int m_id;                              //id that was passed to CreateServer() or Connect()
-    int m_inboundPipe, m_outboundPipe;     //two one sided pipes used for communication
-    char m_inPipeName[MaxPipeNameLength];  //filename of the inbound pipe
-    char m_outPipeName[MaxPipeNameLength]; //filename of the outbound pipe
+    int m_id;                               // id that was passed to CreateServer() or Connect()
+    int m_inboundPipe, m_outboundPipe;      // two one sided pipes used for communication
+    UINT64 m_disambiguationKey;             // key to make the names more unique
+    char m_inPipeName[MaxPipeNameLength];   // filename of the inbound pipe
+    char m_outPipeName[MaxPipeNameLength];  // filename of the outbound pipe
 
 #else
     // Connects to a one sided pipe previously created by CreateOneWayPipe.

--- a/src/pal/inc/pal.h
+++ b/src/pal/inc/pal.h
@@ -582,6 +582,13 @@ PALAPI
 PAL_NotifyRuntimeStarted();
 
 PALIMPORT
+VOID
+PALAPI
+PAL_CleanupTargetProcess(
+    IN int pid, 
+    IN UINT64 disambiguationKey);
+
+PALIMPORT
 void
 PALAPI
 PAL_InitializeDebug(

--- a/src/vm/ceemain.cpp
+++ b/src/vm/ceemain.cpp
@@ -1965,12 +1965,6 @@ void STDMETHODCALLTYPE EEShutDownHelper(BOOL fIsDllUnloading)
         
         FastInterlockExchange((LONG*)&g_fForbidEnterEE, TRUE);
 
-#if defined(DEBUGGING_SUPPORTED) && defined(FEATURE_PAL)
-        // Terminate the debugging services in the first phase for PAL based platforms
-        // because EEDllMain's DLL_PROCESS_DETACH is NOT going to be called.
-        TerminateDebugger();
-#endif // DEBUGGING_SUPPORTED && FEATURE_PAL
-
         if (g_fProcessDetach)
         {
             ThreadStore::TrapReturningThreads(TRUE);


### PR DESCRIPTION
The fix is to remove the call to TerminateDebugger in the EE shutdown
path. The reason was to clean up the transport pipe files but that
still happens in coreclr_uninitialize called by the host.

Also added code to clean up the transport named pipes and semaphores
on the debugger side when it detects that the target process has
terminated before it sends the ExitProcess notification.

Plumbed the cleanup call from dbi's ExitProcess code through the
native pipe line to the transport and then to pipe code.

Add PAL_CleanupTargetProcess for the "continue" named semaphore cleanup.

Found and fixed a minor race in dbgshim register runtime startup.