### PR TITLE
Improve ArraySegment's override of GetHashCode

### DIFF
--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -118,8 +118,8 @@ namespace System
             }
             
             int hash = 5381;
-            hash = System.Numerics.HashHelpers.Combine(hash, _offset);
-            hash = System.Numerics.HashHelpers.Combine(hash, _count);
+            hash = System.Numerics.Hashing.HashHelpers.Combine(hash, _offset);
+            hash = System.Numerics.Hashing.HashHelpers.Combine(hash, _count);
             
             // The array hash is expected to be an evenly-distributed mixture of bits,
             // so rather than adding the cost of another rotation we just xor it.

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -117,23 +117,14 @@ namespace System
                 return 0;
             }
             
-#if !FEATURE_CORECLR
-            // Old implementation: Xor everything.
-            // This isn't optimal since it treats _offset and _count interchangeably,
-            // but we keep it around in the full framework for compat.
-            return _array.GetHashCode() ^ _offset ^ _count;
-#else
-            // Modified Bernstein hash: start with 5381,
-            // multiply by 33, xor with the next hash.
-            // NOTE: (hash << 5) + hash is equal to hash * 33.
+            int hash = 5381;
+            hash = System.Numerics.HashHelpers.Combine(hash, _offset);
+            hash = System.Numerics.HashHelpers.Combine(hash, _count);
             
-            int hash = (33 * 5381) ^ _offset;
-            hash = ((hash << 5) + hash) ^ _count;
-            
-            // Finally, xor in the array's hash
+            // The array hash is expected to be an evenly-distributed mixture of bits,
+            // so rather than adding the cost of another rotation we just xor it.
             hash ^= _array.GetHashCode();
             return hash;
-#endif // !FEATURE_CORECLR
         }
 
         public override bool Equals(Object obj)

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -112,9 +112,23 @@ namespace System
         
         public override int GetHashCode()
         {
-            return null == _array
-                        ? 0
-                        : _array.GetHashCode() ^ _offset ^ _count;
+            if (_array == null)
+            {
+                return 0;
+            }
+            
+#if !FEATURE_CORECLR
+            // Old implementation: Xor everything.
+            // This isn't optimal since it treats _offset and _count interchangeably,
+            // but we keep it around in the full framework for compat.
+            return _array.GetHashCode() ^ _offset ^ _count;
+#else
+            // Taken from ValueTuple.CombineHashCodes
+            int hash = _array.GetHashCode();
+            hash = ((hash << 5) + hash) ^ _offset;
+            hash = ((hash << 5) + hash) ^ _count;
+            return hash;
+#endif // !FEATURE_CORECLR
         }
 
         public override bool Equals(Object obj)

--- a/src/mscorlib/src/System/ArraySegment.cs
+++ b/src/mscorlib/src/System/ArraySegment.cs
@@ -130,21 +130,6 @@ namespace System
             int hash = (33 * 5381) ^ _offset;
             hash = ((hash << 5) + hash) ^ _count;
             
-            // Move the lower 8 bits to the top.
-            
-            // EXPLANATION:
-            // Since as it currently stands object.GetHashCode
-            // only returns 26 bits in the return value (the top
-            // 6 are zero), and since _offset and _count are
-            // typically low, simply xoring with the array's hash
-            // would usually leave the top bits wasted.
-            
-            // Transferring the lower bits of hash to the top
-            // here allows us to not waste those upper bits,
-            // while also being resilient if Object's hash
-            // code algorithm changes in the future.
-            hash = (hash << 24) | (hash >> 8);
-            
             // Finally, xor in the array's hash
             hash ^= _array.GetHashCode();
             return hash;


### PR DESCRIPTION
This changes `ArraySegment`'s implementation of `GetHashCode` to follow the one in [`ValueTuple`](https://github.com/dotnet/corefx/blob/master/src/System.ValueTuple/src/System/ValueTuple/ValueTuple.cs#L248), which is order-sensitive and hopefully has put more thought into it. As a result, `_offset` and `_count` should no longer be treated interchangeably, e.g. the following won't print `True`:

```cs
var array = new byte[1];
var segment = new ArraySegment<byte>(array, 0, 1);
var segment2 = new ArraySegment<byte>(array, 1, 0);
Console.WriteLine(segment.GetHashCode() == segment2.GetHashCode());
```

Addresses #4550 

cc @JonHanna