### PR TITLE
ARM64: Update FP-context-pointer in ExceptionFrame

### DIFF
--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -734,10 +734,8 @@ void FaultingExceptionFrame::UpdateRegDisplay(const PREGDISPLAY pRD)
     pRD->pCurrentContextPointers->X26 = (PDWORD64)&m_ctx.X26;
     pRD->pCurrentContextPointers->X27 = (PDWORD64)&m_ctx.X27;
     pRD->pCurrentContextPointers->X28 = (PDWORD64)&m_ctx.X28;
-    pRD->pCurrentContextPointers->Fp = NULL;
-    pRD->pCurrentContextPointers->Lr = NULL;
-
-
+    pRD->pCurrentContextPointers->Fp = (PDWORD64)&m_ctx.Fp;
+    pRD->pCurrentContextPointers->Lr = (PDWORD64)&m_ctx.Lr;
 
     pRD->IsCallerContextValid = FALSE;
     pRD->IsCallerSPValid      = FALSE;        // Don't add usage of this field.  This is only temporary.


### PR DESCRIPTION
Update the CurrentContextPointers for FP and LR registers
in FaultingExceptionFrame::UpdateRegDisplay()

This change fixes a few GCStress=0xC failures on ARM64.