### PR TITLE
Update RyuJIT/x86 XMM register definitions and usage

### DIFF
--- a/src/jit/register.h
+++ b/src/jit/register.h
@@ -65,7 +65,11 @@ REGALIAS(EDI, RDI)
 
 #endif // !defined(_TARGET_X86_)
 
-#ifndef LEGACY_BACKEND
+#ifdef LEGACY_BACKEND
+
+REGDEF(STK,     8,   0x00, "STK"   )
+
+#else // !LEGACY_BACKEND
 
 #ifdef _TARGET_AMD64_
 #define XMMBASE 16
@@ -83,6 +87,10 @@ REGDEF(XMM4,    4+XMMBASE,  XMMMASK(4),   "mm4"  )
 REGDEF(XMM5,    5+XMMBASE,  XMMMASK(5),   "mm5"  )
 REGDEF(XMM6,    6+XMMBASE,  XMMMASK(6),   "mm6"  )
 REGDEF(XMM7,    7+XMMBASE,  XMMMASK(7),   "mm7"  )
+
+#ifdef _TARGET_X86_
+REGDEF(STK,     8+XMMBASE,  0x0000,       "STK"  )
+#else // !_TARGET_X86_
 REGDEF(XMM8,    8+XMMBASE,  XMMMASK(8),   "mm8"  )
 REGDEF(XMM9,    9+XMMBASE,  XMMMASK(9),   "mm9"  )
 REGDEF(XMM10,  10+XMMBASE,  XMMMASK(10),  "mm10" )
@@ -91,14 +99,10 @@ REGDEF(XMM12,  12+XMMBASE,  XMMMASK(12),  "mm12" )
 REGDEF(XMM13,  13+XMMBASE,  XMMMASK(13),  "mm13" )
 REGDEF(XMM14,  14+XMMBASE,  XMMMASK(14),  "mm14" )
 REGDEF(XMM15,  15+XMMBASE,  XMMMASK(15),  "mm15" )
-REGDEF(STK,    16+XMMBASE,  0x0000,       "STK"   )
+REGDEF(STK,    16+XMMBASE,  0x0000,       "STK"  )
+#endif // !_TARGET_X86_
 
-
-#else // LEGACY_BACKEND
-
-REGDEF(STK,     8,   0x00, "STK"   )
-
-#endif // LEGACY_BACKEND
+#endif // !LEGACY_BACKEND
 
 #elif defined(_TARGET_ARM_)
  #include "registerarm.h"

--- a/src/jit/registerxmm.h
+++ b/src/jit/registerxmm.h
@@ -8,6 +8,10 @@
 #error  Must define REGDEF macro before including this file
 #endif
 
+#ifndef LEGACY_BACKEND
+#error This file is only used for the LEGACY_BACKEND build.
+#endif
+
 #if defined(_TARGET_XARCH_)
 
 #define XMMMASK(x) (unsigned(1) << (x-1))

--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -412,7 +412,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   #define REG_PREV(reg)           ((regNumber)((unsigned)(reg) - 1))
 
   #define REG_FP_FIRST             REG_XMM0
-  #define REG_FP_LAST              REG_XMM15
+  #define REG_FP_LAST              REG_XMM7
   #define FIRST_FP_ARGREG          REG_XMM0
   #define LAST_FP_ARGREG           REG_XMM3
   #define REG_FLTARG_0             REG_XMM0


### PR DESCRIPTION
Change the register definition to not include XMM8 through XMM15,
which are not available on x86.

Also, put a few things previously under _TARGET_AMD64_ instead
under !LEGACY_BACKEND to make them available for RyuJIT/x86.

There are more things to do to enable AVX. For example, size_t is
used for code bytes, but expects to be able to store >32 bits. This
work is just a start.