### PR TITLE
Fix a typo in GCMetrics that provides the wrong generation's statistics

### DIFF
--- a/tests/src/GC/Performance/Framework/Metrics/GCMetrics.cs
+++ b/tests/src/GC/Performance/Framework/Metrics/GCMetrics.cs
@@ -253,7 +253,7 @@ namespace GCPerfTestFramework.Metrics
 
         protected override double YieldMetric()
         {
-            return ProcessInfo.Generations[0].MeanPauseDurationMSec;
+            return ProcessInfo.Generations[1].MeanPauseDurationMSec;
         }
     }
     #endregion


### PR DESCRIPTION
This project currently doesn't build as a part of the managed test build.