### PR TITLE
ARM: Fix compiler definition inconsistency

### DIFF
--- a/clr.coreclr.props
+++ b/clr.coreclr.props
@@ -88,7 +88,7 @@
     <FeaturePal>true</FeaturePal>
     <FeatureXplatEventSource>true</FeatureXplatEventSource>
 
-    <FeatureStubsAsIL>true</FeatureStubsAsIL>
+    <FeatureStubsAsIL Condition="'$(TargetArch)' != 'arm'">true</FeatureStubsAsIL>
 
     <!-- Windows specific features -->
     <FeatureWin32Registry>false</FeatureWin32Registry>


### PR DESCRIPTION
Fix the following inconsistency
CoreCLR-Native @ Linux/ARM: FEATURE_STUBS_AS_IL not defined
CoreCLR-Managed @ Linux/ARM: FEATURE_STUBS_AS_IL defined

This _partially_ fixes #3635

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>