### PR TITLE
Scripts: verify compiler definitions of native and managed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -574,3 +574,5 @@ if(NOT DEFINED CLR_CROSS_COMPONENTS_BUILD AND CLR_CROSS_COMPONENTS_BUILD_ENABLED
     INSTALL_DIR $ENV{__CMakeBinDir}/${CLR_CROSS_BUILD_HOST_ARCH}
   )
 endif()
+
+include(definitionsconsistencycheck.cmake)

--- a/definitionsconsistencycheck.cmake
+++ b/definitionsconsistencycheck.cmake
@@ -1,0 +1,11 @@
+get_directory_property( DirDefs COMPILE_DEFINITIONS )
+
+# Reset the definition file
+file(WRITE cmake.definitions "")
+foreach( d ${DirDefs} )
+    if($ENV{VERBOSE})
+        message( STATUS "Compiler Definition: " ${d} )
+    endif($ENV{VERBOSE})
+    file(APPEND cmake.definitions ${d})
+    file(APPEND cmake.definitions "\n")
+endforeach()

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -177,7 +177,10 @@
   <Target Name="CDefineChecker" BeforeTargets="Build">
     <!-- Compiler Definition Verification -->
     <Message Importance="High" Text="============" />
-    <Exec Command='python $(MSBuildThisFileDirectory)../scripts/check-definitions.py $(MSBuildThisFileDirectory)../../cmake.definitions "$(DefineConstants)"' />
+    <PropertyGroup>
+      <IgnoreDefineConstants>FEATURE_IMPLICIT_TLS;FEATURE_HIJACK</IgnoreDefineConstants>
+    </PropertyGroup>
+    <Exec Command='python $(MSBuildThisFileDirectory)../scripts/check-definitions.py $(MSBuildThisFileDirectory)../../cmake.definitions "$(DefineConstants)" "$(IgnoreDefineConstants)" ' />
     <Message Importance="High" Text="============" />
   </Target>
 

--- a/src/mscorlib/System.Private.CoreLib.csproj
+++ b/src/mscorlib/System.Private.CoreLib.csproj
@@ -173,6 +173,14 @@
       <ResGenDefines>$(DefineConstants)</ResGenDefines>
     </SplitTextStringResource>
   </ItemGroup>
+
+  <Target Name="CDefineChecker" BeforeTargets="Build">
+    <!-- Compiler Definition Verification -->
+    <Message Importance="High" Text="============" />
+    <Exec Command='python $(MSBuildThisFileDirectory)../scripts/check-definitions.py $(MSBuildThisFileDirectory)../../cmake.definitions "$(DefineConstants)"' />
+    <Message Importance="High" Text="============" />
+  </Target>
+
   <ItemGroup>
     <EmbeddedResource Include="$(NlpObjDir)\charinfo.nlp">
       <LogicalName>charinfo.nlp</LogicalName>

--- a/src/scripts/check-definitions.py
+++ b/src/scripts/check-definitions.py
@@ -9,13 +9,17 @@
 # CoreCLR
 #
 # Usage:
-#   $ ./check-definitions.py Definition_File String_of_Definitions
+#   $ ./check-definitions.py Definition_File String_of_Definitions [String_of_Ignored_Definitions]
 #
 #      Definition_File: the filename of a file containing the list of
 #          compiler definitions of CMAKE, seperated by line.
 #          (Mandatory)
 #      String_of_Definitions: the list of managed code compiler
-#          definitions, seperated by semicolon.
+#          definitions, seperated by semicolon without spaces.
+#          (Mandatory)
+#      String_of_Ignored_Definitions: the list of compiler definitions
+#          to be suppressed from emitting warnings, seperated by semicolon without spaces.
+#          (Optional)
 #
 # (c) 2016 MyungJoo Ham <myungjoo.ham@samsung.com>
 
@@ -96,15 +100,25 @@ def getDiff(arrNative, arrManaged):
     return result
 
 
-def printPotentiallyCritical(arrDefinitions, referencedFilename):
+def printPotentiallyCritical(arrDefinitions, referencedFilename, arrIgnore):
     f = open(referencedFilename, 'r')
     content = f.read()
     f.close()
     for keyword in arrDefinitions:
-        if (((keyword[-2:] == "=1") and (re.search("[^\\w]"+keyword[:-2]+"[^\\w]", content))) or 
-            (re.search("[^\\w]"+keyword+"[^\\w]", content))):
-            print(keyword)
+        skip = 0
 
+        if (keyword[-2:] == "=1"):
+            key = keyword[:-2]
+        else:
+            key = keyword
+
+        if re.search("[^\\w]"+key+"[^\\w]", content):
+            for ign in arrIgnore:
+                if key == ign:
+                    skip = 1
+                    break
+            if skip == 0:
+                print(keyword)
 
 # MAIN SCRIPT
 if len(sys.argv) < 3:
@@ -121,16 +135,20 @@ string = sys.argv[2]
 
 arrayNative = loadDefinitionFile(filename)
 arrayManaged = loadDefinitionString(string)
+arrayIgnore = []
+
+if len(sys.argv) > 3:
+    arrayIgnore = loadDefinitionString(sys.argv[3])
 
 arrays = getDiff(arrayNative, arrayManaged)
 # arrays[0] = array of added in managed
 # arrays[1] = array of omitted in managed (added in native)
 
 print "Potentially Dangerous Compiler Definitions in clrdefinitions.cmake (omitted in native build):"
-printPotentiallyCritical(arrays[0], "../../clrdefinitions.cmake")
+printPotentiallyCritical(arrays[0], "../../clrdefinitions.cmake", arrayIgnore)
 
 print "Potentially Dangerous Compiler Definitions in clr.defines.targets (omitted in managed build):"
-printPotentiallyCritical(arrays[1], "../../clr.defines.targets")
+printPotentiallyCritical(arrays[1], "../../clr.defines.targets", arrayIgnore)
 
 print "Definition Check Completed."
 

--- a/src/scripts/check-definitions.py
+++ b/src/scripts/check-definitions.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+# Licensed to the .NET Foundation under one or more agreements.
+# The .NET Foundation licenses this file to you under the MIT license.
+# See the LICENSE file in the project root for more information.
+#
+# check-definitions.py
+#  This script checks the consistency between compiler definitions
+# of the native part of CoreCLR and managed part (mscorlib.dll) of
+# CoreCLR
+#
+# Usage:
+#   $ ./check-definitions.py Definition_File String_of_Definitions
+#
+#      Definition_File: the filename of a file containing the list of
+#          compiler definitions of CMAKE, seperated by line.
+#          (Mandatory)
+#      String_of_Definitions: the list of managed code compiler
+#          definitions, seperated by semicolon.
+#
+# (c) 2016 MyungJoo Ham <myungjoo.ham@samsung.com>
+
+import sys
+import re
+
+debug = 0
+
+# For the native part, return the sorted definition array.
+def loadDefinitionFile(filename):
+    result = []
+    f = open(filename, 'r')
+    for line in f:
+        theLine = line.rstrip("\r\n").strip()
+        if (len(theLine) > 0):
+            result.append(theLine)
+
+    f.close()
+    result = sorted(result)
+    return result
+
+
+# For the managed part, return the sorted definition array.
+def loadDefinitionString(string):
+    splitted = string.split(';')
+    result = []
+    for line in splitted:
+       theLine = line.strip()
+       if (len(theLine) > 0):
+           result.append(theLine)
+
+    result = sorted(result)
+    return result
+
+
+def getDiff(arrNative, arrManaged):
+    result = [[], []]
+    iF = 0 # From file (native)
+    nF = len(arrNative)
+
+    iS = 0 # From string (managed)
+    nS = len(arrManaged)
+
+    while (iS < nS) and (iF < nF):
+        if (arrNative[iF] == arrManaged[iS]):
+            if (debug == 1):
+                print("Both have " + arrNative[iF])
+            iF = iF + 1
+            iS = iS + 1
+        elif (arrNative[iF] == (arrManaged[iS] + "=1")):
+            if (debug == 1):
+                print("Both have " + arrNative[iF] + "(=1)")
+            iF = iF + 1
+            iS = iS + 1
+        elif (arrNative[iF] < arrManaged[iS]):
+            if (debug == 1):
+                print("--- Managed Omitted " + arrNative[iF])
+            result[1].append(arrNative[iF])
+            iF = iF + 1
+        elif (arrNative[iF] > arrManaged[iS]):
+            if (debug == 1):
+                print("+++ Managed Added " + arrManaged[iS])
+            result[0].append(arrManaged[iS])
+            iS = iS + 1
+
+    if (iS < nS):
+        while iS < nS:
+            if (debug == 1):
+                print("+++ Managed Added " + arrManaged[iS])
+            result[0].append(arrManaged[iS])
+            iS = iS + 1
+    elif (iF < nF):
+        while iF < nF:
+            if (debug == 1):
+                print("--- Managed Omitted " + arrNative[iF])
+            result[1].append(arrNative[iF])
+            iF = iF + 1
+    return result
+
+
+def printPotentiallyCritical(arrDefinitions, referencedFilename):
+    f = open(referencedFilename, 'r')
+    content = f.read()
+    f.close()
+    for keyword in arrDefinitions:
+        if (((keyword[-2:] == "=1") and (re.search("[^\\w]"+keyword[:-2]+"[^\\w]", content))) or 
+            (re.search("[^\\w]"+keyword+"[^\\w]", content))):
+            print(keyword)
+
+
+# MAIN SCRIPT
+if len(sys.argv) < 3:
+    print "\nUsage:"
+    print "$ check-definitions.py [Definition file] [String of definitions]"
+    print "    Definition file contains the list of cmake (native) compiler definitions"
+    print "      seperated by line."
+    print "    String of definitions contains the list of csproj (managed) definitions"
+    print "      seperated by semicolons."
+    sys.exit(-1)
+
+filename = sys.argv[1]
+string = sys.argv[2]
+
+arrayNative = loadDefinitionFile(filename)
+arrayManaged = loadDefinitionString(string)
+
+arrays = getDiff(arrayNative, arrayManaged)
+# arrays[0] = array of added in managed
+# arrays[1] = array of omitted in managed (added in native)
+
+print "Potentially Dangerous Compiler Definitions in clrdefinitions.cmake (omitted in native build):"
+printPotentiallyCritical(arrays[0], "../../clrdefinitions.cmake")
+
+print "Potentially Dangerous Compiler Definitions in clr.defines.targets (omitted in managed build):"
+printPotentiallyCritical(arrays[1], "../../clr.defines.targets")
+
+print "Definition Check Completed."
+


### PR DESCRIPTION
In order to find mismatch between native and managed,
we need to know the list of definitions of native.

The compiler definitions are stored at
cmake.definitions

If there are compiler definitions named confusingly (e.g., WIN32/WIN64 for mscorlib, which denotes word-length, not the OS (WIndows)), this script will say it's dangerous: for native, WIN32 denotes for Windows 32bit.

Fix #4674

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

---
Execution example with Linux/ARM cross build:
```
...
  ============
  DefineConstants = DBG;_DEBUG;_LOGGING;DEBUG;TRACE;WIN32;ARM;;_USE_NLS_PLUS_TABLE;RESOURCE_SATELLITE_CONFIG;INSIDE_CLR;CODE_ANALYSIS_BASELINE;FEATURE_APPDOMAIN_RESOURCE_MONITORING;FEATURE_ARRAYSTUB_AS_IL;FEATURE_STUBS_AS_IL;FEATURE_ASCII;FEATURE_BCL_FORMATTING;FEATURE_COLLECTIBLE_TYPES;FEATURE_CORECLR;FEATURE_COREFX_GLOBALIZATION;FEATURE_CORESYSTEM;FEATURE_CORRUPTING_EXCEPTIONS;FEATURE_ENCODINGNLS;FEATURE_EXCEPTIONDISPATCHINFO;FEATURE_HOST_ASSEMBLY_RESOLVER;FEATURE_HOSTED_BINDER;FEATURE_LATIN1;FEATURE_LOADER_OPTIMIZATION;FEATURE_MANAGED_ETW_CHANNELS;FEATURE_MAIN_CLR_MODULE_USES_CORE_NAME;FEATURE_NORM_IDNA_ONLY;FEATURE_PAL;FEATURE_EVENTSOURCE_XPLAT;FEATURE_RANDOMIZED_STRING_HASHING;FEATURE_STRONGNAME_MIGRATION;FEATURE_SYNTHETIC_CULTURES;FEATURE_UTF32;FEATURE_UTF7;FEATURE_VERSIONING;FEATURE_WINDOWSPHONE;FEATURE_WINMD_RESILIENT;PROFILING_SUPPORTED;FEATURE_USE_ASM_GC_WRITE_BARRIERS;FEATURE_SYMDIFF;FEATURE_READYTORUN;PLATFORM_UNIX;SIGNED
  Executing /source/tizen_3.0/dotnet/coreclr_upstreaming/src/mscorlib/../../scripts/check-definitions.pl /source/tizen_3.0/dotnet/coreclr_upstreaming/src/mscorlib/../../cmake.definitions "DBG;_DEBUG;_LOGGING;DEBUG;TRACE;WIN32;ARM;;_USE_NLS_PLUS_TABLE;RESOURCE_SATELLITE_CONFIG;INSIDE_CLR;CODE_ANALYSIS_BASELINE;FEATURE_APPDOMAIN_RESOURCE_MONITORING;FEATURE_ARRAYSTUB_AS_IL;FEATURE_STUBS_AS_IL;FEATURE_ASCII;FEATURE_BCL_FORMATTING;FEATURE_COLLECTIBLE_TYPES;FEATURE_CORECLR;FEATURE_COREFX_GLOBALIZATION;FEATURE_CORESYSTEM;FEATURE_CORRUPTING_EXCEPTIONS;FEATURE_ENCODINGNLS;FEATURE_EXCEPTIONDISPATCHINFO;FEATURE_HOST_ASSEMBLY_RESOLVER;FEATURE_HOSTED_BINDER;FEATURE_LATIN1;FEATURE_LOADER_OPTIMIZATION;FEATURE_MANAGED_ETW_CHANNELS;FEATURE_MAIN_CLR_MODULE_USES_CORE_NAME;FEATURE_NORM_IDNA_ONLY;FEATURE_PAL;FEATURE_EVENTSOURCE_XPLAT;FEATURE_RANDOMIZED_STRING_HASHING;FEATURE_STRONGNAME_MIGRATION;FEATURE_SYNTHETIC_CULTURES;FEATURE_UTF32;FEATURE_UTF7;FEATURE_VERSIONING;FEATURE_WINDOWSPHONE;FEATURE_WINMD_RESILIENT;PROFILING_SUPPORTED;FEATURE_USE_ASM_GC_WRITE_BARRIERS;FEATURE_SYMDIFF;FEATURE_READYTORUN;PLATFORM_UNIX;SIGNED"
  Managed omitted DEBUGGING_SUPPORTED, which might be critical.
  Managed omitted FEATURE_DBGIPC_TRANSPORT_DI, which might be critical.
  Managed omitted FEATURE_DBGIPC_TRANSPORT_VM, which might be critical.
  Managed omitted FEATURE_ICASTABLE, which might be critical.
  Managed omitted FEATURE_IMPLICIT_TLS, which might be critical.
  Managed omitted FEATURE_ISYM_READER, which might be critical.
  Managed omitted FEATURE_MANAGED_ETW, which might be critical.
  Managed omitted FEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE, which might be critical.
  Managed omitted FEATURE_MERGE_JIT_AND_ENGINE, which might be critical.
  Managed omitted FEATURE_MULTICOREJIT, which might be critical.
  Managed omitted FEATURE_PERFMAP, which might be critical.
  Managed omitted FEATURE_PREJIT, which might be critical.
  Managed omitted FEATURE_STANDALONE_SN, which might be critical.
  Managed omitted FEATURE_STRONGNAME_DELAY_SIGNING_ALLOWED, which might be critical.
  Managed omitted FEATURE_SVR_GC, which might be critical.
  Managed omitted FEATURE_WIN32_REGISTRY, which might be critical.
  Managed added WIN32 (Native omitted WIN32), which might be critical.
  ============
...
```

With "verbose" option applied to build.sh, it emits more messages about the compiler definitions (preprocessor defines).