### PR TITLE
Fixing issue with perf targets restoring test runtime

### DIFF
--- a/tests/helixperftasks.targets
+++ b/tests/helixperftasks.targets
@@ -19,6 +19,10 @@
       <TestRuntimeProjectLockJson>$(SourceDir)Common\test_runtime\project.lock.json</TestRuntimeProjectLockJson>
     </PropertyGroup>
 
+    <ItemGroup>
+     <DnuSourceList Include="$(CORE_ROOT)\.nuget\pkg" />
+    </ItemGroup>
+
     <!-- Restore the runtime dependencies -->
     <Exec Command="$(DnuRestoreCommand) &quot;$(TestRuntimeDependenciesJson)&quot;"
            StandardOutputImportance="Low"


### PR DESCRIPTION
Adding the Product package path to the dnu source list so that the perf targets can correctly restore runtime
@lt72 @rahku 