### PR TITLE
Specify the signedness of 'char' in HFA testcases

### DIFF
--- a/tests/src/JIT/jit64/hfa/main/dll/hfa_native.cpp
+++ b/tests/src/JIT/jit64/hfa/main/dll/hfa_native.cpp
@@ -319,60 +319,60 @@ HFADLL_API FLOATTYPE  sum3_HFA19(float v1, __int64 v2, HFA19 hfa) {
 }
 
 
-HFADLL_API FLOATTYPE  sum5_HFA01(__int64 v1, double v2, short v3, char v4, HFA01 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA01(__int64 v1, double v2, short v3, signed char v4, HFA01 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA01(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum5_HFA02(__int64 v1, double v2, short v3, char v4, HFA02 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA02(__int64 v1, double v2, short v3, signed char v4, HFA02 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA02(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum5_HFA03(__int64 v1, double v2, short v3, char v4, HFA03 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA03(__int64 v1, double v2, short v3, signed char v4, HFA03 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA03(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum5_HFA05(__int64 v1, double v2, short v3, char v4, HFA05 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA05(__int64 v1, double v2, short v3, signed char v4, HFA05 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA05(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum5_HFA08(__int64 v1, double v2, short v3, char v4, HFA08 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA08(__int64 v1, double v2, short v3, signed char v4, HFA08 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA08(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum5_HFA11(__int64 v1, double v2, short v3, char v4, HFA11 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA11(__int64 v1, double v2, short v3, signed char v4, HFA11 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA11(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum5_HFA19(__int64 v1, double v2, short v3, char v4, HFA19 hfa) {
+HFADLL_API FLOATTYPE  sum5_HFA19(__int64 v1, double v2, short v3, signed char v4, HFA19 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + EXPRESSION_SUM_HFA19(hfa);
 }
 
 
-HFADLL_API FLOATTYPE  sum8_HFA01(float v1, double v2, __int64 v3, char v4, double v5, HFA01 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA01(float v1, double v2, __int64 v3, signed char v4, double v5, HFA01 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA01(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum8_HFA02(float v1, double v2, __int64 v3, char v4, double v5, HFA02 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA02(float v1, double v2, __int64 v3, signed char v4, double v5, HFA02 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA02(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum8_HFA03(float v1, double v2, __int64 v3, char v4, double v5, HFA03 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA03(float v1, double v2, __int64 v3, signed char v4, double v5, HFA03 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA03(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum8_HFA05(float v1, double v2, __int64 v3, char v4, double v5, HFA05 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA05(float v1, double v2, __int64 v3, signed char v4, double v5, HFA05 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA05(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum8_HFA08(float v1, double v2, __int64 v3, char v4, double v5, HFA08 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA08(float v1, double v2, __int64 v3, signed char v4, double v5, HFA08 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA08(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum8_HFA11(float v1, double v2, __int64 v3, char v4, double v5, HFA11 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA11(float v1, double v2, __int64 v3, signed char v4, double v5, HFA11 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA11(hfa);
 }
 
-HFADLL_API FLOATTYPE  sum8_HFA19(float v1, double v2, __int64 v3, char v4, double v5, HFA19 hfa) {
+HFADLL_API FLOATTYPE  sum8_HFA19(float v1, double v2, __int64 v3, signed char v4, double v5, HFA19 hfa) {
 	return static_cast<FLOATTYPE>(v1) + static_cast<FLOATTYPE>(v2) + static_cast<FLOATTYPE>(v3) + static_cast<FLOATTYPE>(v4) + static_cast<FLOATTYPE>(v5) + EXPRESSION_SUM_HFA19(hfa);
 }
 

--- a/tests/src/JIT/jit64/hfa/main/dll/hfa_native.h
+++ b/tests/src/JIT/jit64/hfa/main/dll/hfa_native.h
@@ -174,21 +174,21 @@ HFADLL_API FLOATTYPE  sum3_HFA08(float v1, __int64 v2, HFA08 hfa);
 HFADLL_API FLOATTYPE  sum3_HFA11(float v1, __int64 v2, HFA11 hfa);
 HFADLL_API FLOATTYPE  sum3_HFA19(float v1, __int64 v2, HFA19 hfa);
 
-HFADLL_API FLOATTYPE  sum5_HFA01(__int64 v1, double v2, short v3, char v4, HFA01 hfa);
-HFADLL_API FLOATTYPE  sum5_HFA02(__int64 v1, double v2, short v3, char v4, HFA02 hfa);
-HFADLL_API FLOATTYPE  sum5_HFA03(__int64 v1, double v2, short v3, char v4, HFA03 hfa);
-HFADLL_API FLOATTYPE  sum5_HFA05(__int64 v1, double v2, short v3, char v4, HFA05 hfa);
-HFADLL_API FLOATTYPE  sum5_HFA08(__int64 v1, double v2, short v3, char v4, HFA08 hfa);
-HFADLL_API FLOATTYPE  sum5_HFA11(__int64 v1, double v2, short v3, char v4, HFA11 hfa);
-HFADLL_API FLOATTYPE  sum5_HFA19(__int64 v1, double v2, short v3, char v4, HFA19 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA01(__int64 v1, double v2, short v3, signed char v4, HFA01 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA02(__int64 v1, double v2, short v3, signed char v4, HFA02 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA03(__int64 v1, double v2, short v3, signed char v4, HFA03 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA05(__int64 v1, double v2, short v3, signed char v4, HFA05 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA08(__int64 v1, double v2, short v3, signed char v4, HFA08 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA11(__int64 v1, double v2, short v3, signed char v4, HFA11 hfa);
+HFADLL_API FLOATTYPE  sum5_HFA19(__int64 v1, double v2, short v3, signed char v4, HFA19 hfa);
 
-HFADLL_API FLOATTYPE  sum8_HFA01(float v1, double v2, __int64 v3, char v4, double v5, HFA01 hfa);
-HFADLL_API FLOATTYPE  sum8_HFA02(float v1, double v2, __int64 v3, char v4, double v5, HFA02 hfa);
-HFADLL_API FLOATTYPE  sum8_HFA03(float v1, double v2, __int64 v3, char v4, double v5, HFA03 hfa);
-HFADLL_API FLOATTYPE  sum8_HFA05(float v1, double v2, __int64 v3, char v4, double v5, HFA05 hfa);
-HFADLL_API FLOATTYPE  sum8_HFA08(float v1, double v2, __int64 v3, char v4, double v5, HFA08 hfa);
-HFADLL_API FLOATTYPE  sum8_HFA11(float v1, double v2, __int64 v3, char v4, double v5, HFA11 hfa);
-HFADLL_API FLOATTYPE  sum8_HFA19(float v1, double v2, __int64 v3, char v4, double v5, HFA19 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA01(float v1, double v2, __int64 v3, signed char v4, double v5, HFA01 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA02(float v1, double v2, __int64 v3, signed char v4, double v5, HFA02 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA03(float v1, double v2, __int64 v3, signed char v4, double v5, HFA03 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA05(float v1, double v2, __int64 v3, signed char v4, double v5, HFA05 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA08(float v1, double v2, __int64 v3, signed char v4, double v5, HFA08 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA11(float v1, double v2, __int64 v3, signed char v4, double v5, HFA11 hfa);
+HFADLL_API FLOATTYPE  sum8_HFA19(float v1, double v2, __int64 v3, signed char v4, double v5, HFA19 hfa);
 
 HFADLL_API FLOATTYPE  sum11_HFA01(double v1, float v2, float v3, int v4, float v5, __int64 v6, double v7, float v8, HFA01 hfa);
 HFADLL_API FLOATTYPE  sum11_HFA02(double v1, float v2, float v3, int v4, float v5, __int64 v6, double v7, float v8, HFA02 hfa);


### PR DESCRIPTION
In C#, sbyte always represents 8-bit signed interger.

However, the signedness of char in C is undefined, and the default
signedness of char in ARM is unsigned.

The native code for HFA test does not specify the signedness of char,
and thus the native code assumes that it is unsigned, but the managed
code assumes that it is signed, which leads to unittest failure in ARM.

This commit specifies the signedness of 'char' in order to fix #4639.