### PR TITLE
Load JIT from custom location for Crossgen

### DIFF
--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -134,7 +134,11 @@ add_definitions(-DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE)
 # TODO_DJIT: Remove this "set" to commence loading JIT dynamically.
 if(NOT WIN32)
   set(FEATURE_MERGE_JIT_AND_ENGINE 1)
+elseif (CLR_CMAKE_TARGET_ARCH_ARM64)
+  # TODO_DJIT: Remove this as part of enabling cross-compiling standalone JIT binary.
+  set(FEATURE_MERGE_JIT_AND_ENGINE 1)
 endif(NOT WIN32)
+
 if(FEATURE_MERGE_JIT_AND_ENGINE)
   # Disable the following for UNIX altjit on Windows
   add_definitions(-DFEATURE_MERGE_JIT_AND_ENGINE)

--- a/src/inc/zapper.h
+++ b/src/inc/zapper.h
@@ -124,6 +124,9 @@ class Zapper
     SString                 m_platformWinmdPaths;
 #endif // FEATURE_CORECLR || CROSSGEN_COMPILE
 
+#if defined(FEATURE_CORECLR) && !defined(FEATURE_MERGE_JIT_AND_ENGINE)
+    SString                 m_CLRJITPath;
+#endif // defined(FEATURE_CORECLR) && !defined(FEATURE_MERGE_JIT_AND_ENGINE)
     bool                    m_fForceFullTrust;
 
     SString                 m_outputFilename;
@@ -444,6 +447,10 @@ class Zapper
     void SetPlatformWinmdPaths(LPCWSTR pwzPlatformWinmdPaths);
     void SetForceFullTrust(bool val);
 #endif // FEATURE_CORECLR || CROSSGEN_COMPILE
+
+#if defined(FEATURE_CORECLR) && !defined(FEATURE_MERGE_JIT_AND_ENGINE)
+    void SetCLRJITPath(LPCWSTR pwszCLRJITPath);
+#endif // defined(FEATURE_CORECLR) && !defined(FEATURE_MERGE_JIT_AND_ENGINE)
 
     void SetOutputFilename(LPCWSTR pwszOutputFilename);
     SString GetOutputFileName();


### PR DESCRIPTION
Enable crossgen to take a custom JIT location using command line. This will be helpful when we have to make changes in CLI to consume crossgen.

@jkotas PTAL