### PR TITLE
Faster short-circuiting in string.Concat for objects

### DIFF
--- a/src/mscorlib/src/System/String.cs
+++ b/src/mscorlib/src/System/String.cs
@@ -3078,29 +3078,34 @@ namespace System {
              return result;
         }
 
-        public static String Concat(Object arg0) {
+        public static String Concat(Object arg0)
+        {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
             if (arg0 == null)
             {
-                return String.Empty;
+                return string.Empty;
             }
+            
             return arg0.ToString();
         }
     
-        public static String Concat(Object arg0, Object arg1) {
+        public static String Concat(Object arg0, Object arg1)
+        {
             Contract.Ensures(Contract.Result<String>() != null);
             Contract.EndContractBlock();
 
             if (arg0 == null)
             {
-                arg0 = String.Empty;
+                return Concat(arg1);
             }
     
-            if (arg1==null) {
-                arg1 = String.Empty;
+            if (arg1 == null)
+            {
+                return Concat(arg0);
             }
+            
             return Concat(arg0.ToString(), arg1.ToString());
         }
     
@@ -3110,15 +3115,17 @@ namespace System {
 
             if (arg0 == null)
             {
-                arg0 = String.Empty;
+                return Concat(arg1, arg2);
             }
     
-            if (arg1==null) {
-                arg1 = String.Empty;
+            if (arg1 == null)
+            {
+                return Concat(arg0, arg2);
             }
     
-            if (arg2==null) {
-                arg2 = String.Empty;
+            if (arg2 == null)
+            {
+                return Concat(arg0, arg1);
             }
     
             return Concat(arg0.ToString(), arg1.ToString(), arg2.ToString());


### PR DESCRIPTION
Similar logic to what was used in #3280, except for `string.Concat(object)`. Not necessarily avoiding any allocations (the string-based overloads will short-circuit if one of the arguments is null/empty), but this change makes it so that we return early without having to ever call the string-based overload. Also cleaned up the code a bit.

@jkotas PTAL