### PR TITLE
ARM64: Enabling Crossgen End-to-End Mscorlib

### DIFF
--- a/src/inc/clrnt.h
+++ b/src/inc/clrnt.h
@@ -985,6 +985,14 @@ RtlVirtualUnwind(
 #define IMAGE_REL_ARM64_BRANCH26        0x0003  // 26 bit offset << 2 & sign ext. for B & BL
 #endif
 
+#ifndef IMAGE_REL_ARM64_PAGEBASE_REL21
+#define IMAGE_REL_ARM64_PAGEBASE_REL21  0x0004  // ADRP 21 bit PC-relative page address
+#endif
+
+#ifndef IMAGE_REL_ARM64_PAGEOFFSET_12A
+#define IMAGE_REL_ARM64_PAGEOFFSET_12A  0x0006  // ADD 12 bit page offset
+#endif
+
 #endif
 
 #endif  // CLRNT_H_

--- a/src/inc/utilcode.h
+++ b/src/inc/utilcode.h
@@ -4526,9 +4526,29 @@ void PutThumb2BlRel24(UINT16 * p, INT32 imm24);
 INT32 GetArm64Rel28(UINT32 * pCode);
 
 //*****************************************************************************
+//  Extract the PC-Relative page address from an adrp instruction
+//*****************************************************************************
+INT32 GetArm64Rel21(UINT32 * pCode);
+
+//*****************************************************************************
+//  Extract the page offset from an add instruction
+//*****************************************************************************
+INT32 GetArm64Rel12(UINT32 * pCode);
+
+//*****************************************************************************
 //  Deposit the PC-Relative offset 'imm28' into a b or bl instruction 
 //*****************************************************************************
 void PutArm64Rel28(UINT32 * pCode, INT32 imm28);
+
+//*****************************************************************************
+//  Deposit the PC-Relative page address 'imm21' into an adrp instruction
+//*****************************************************************************
+void PutArm64Rel21(UINT32 * pCode, INT32 imm21);
+
+//*****************************************************************************
+//  Deposit the page offset 'imm12' into an add instruction
+//*****************************************************************************
+void PutArm64Rel12(UINT32 * pCode, INT32 imm12);
 
 //*****************************************************************************
 // Returns whether the offset fits into bl instruction
@@ -4544,6 +4564,22 @@ inline bool FitsInThumb2BlRel24(INT32 imm24)
 inline bool FitsInRel28(INT32 val32)
 {
     return (val32 >= -0x08000000) && (val32 < 0x08000000);
+}
+
+//*****************************************************************************
+// Returns whether the offset fits into an Arm64 adrp instruction
+//*****************************************************************************
+inline bool FitsInRel21(INT32 val32)
+{
+    return (val32 >= 0) && (val32 <= 0x001FFFFF);
+}
+
+//*****************************************************************************
+// Returns whether the offset fits into an Arm64 add instruction
+//*****************************************************************************
+inline bool FitsInRel12(INT32 val32)
+{
+    return (val32 >= 0) && (val32 <= 0x00000FFF);
 }
 
 //*****************************************************************************

--- a/src/jit/codegenarm64.cpp
+++ b/src/jit/codegenarm64.cpp
@@ -2157,12 +2157,11 @@ void                CodeGen::instGen_Set_Reg_To_Imm(emitAttr    size,
     {
         size = EA_SIZE(size);  // Strip any Reloc flags from size if we aren't doing relocs
     }
-    
+
     if (EA_IS_RELOC(size))
     {
-        // Emit a data section constant for a relocatable integer constant.
-        CORINFO_FIELD_HANDLE hnd = getEmitter()->emitLiteralConst(imm);
-        getEmitter()->emitIns_R_C(INS_ldr, size, reg, hnd, 0);    
+        // This emits a pair of adrp/add (two instructions) with fix-ups.
+        getEmitter()->emitIns_R_AI(INS_adrp, size, reg, imm);
     }
     else if (imm == 0)
     {
@@ -2252,7 +2251,7 @@ void                CodeGen::genSetRegToConst(regNumber targetReg, var_types tar
                 // We must load the FP constant from the constant pool
                 // Emit a data section constant for the float or double constant.
                 CORINFO_FIELD_HANDLE hnd = emit->emitFltOrDblConst(dblConst);
-                emit->emitIns_R_C(INS_ldr, size, targetReg, hnd, 0);        
+                emit->emitIns_R_C(INS_ldr, size, targetReg, hnd, 0);
             }
         }
         break;

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -4497,12 +4497,32 @@ unsigned            emitter::emitEndCodeGen(Compiler *comp,
     }
 #endif
 
+#ifdef _TARGET_ARM64_
+    // For arm64, we want to allocate JIT data always adjacent to code similar to what native compiler does.
+    // This way allows us to use a single `ldr` to access such data like float constant/jmp table.
+    if (emitTotalColdCodeSize > 0)
+    {
+        // JIT data might be far away from the cold code.
+        NYI_ARM64("Need to handle fix-up to data from cold code.");
+    }
+
+    emitCmpHandle->allocMem(emitTotalHotCodeSize + emitConsDsc.dsdOffs, emitTotalColdCodeSize,
+        0,
+        xcptnsCount,
+        allocMemFlag,
+        (void**)&codeBlock, (void**)&coldCodeBlock,
+        (void**)&consBlock);
+
+    consBlock = codeBlock + emitTotalHotCodeSize;
+
+#else
     emitCmpHandle->allocMem( emitTotalHotCodeSize, emitTotalColdCodeSize,
                              emitConsDsc.dsdOffs,
                              xcptnsCount,
                              allocMemFlag,
                              (void**)&codeBlock, (void**)&coldCodeBlock, 
                              (void**)&consBlock);
+#endif
 
 
 //  if  (emitConsDsc.dsdOffs) printf("Cons=%08X\n", consBlock);

--- a/src/jit/emit.h
+++ b/src/jit/emit.h
@@ -1131,6 +1131,7 @@ protected:
         bool            idIsDspReloc() const   { assert(!idIsTiny()); return _idDspReloc != 0;    }
         void            idSetIsDspReloc(bool val = true)
                                                { assert(!idIsTiny()); _idDspReloc = val;          }
+        bool            idIsReloc()            { return idIsDspReloc() || idIsCnsReloc();         }
         
 #endif
 

--- a/src/jit/emitfmtsarm64.h
+++ b/src/jit/emitfmtsarm64.h
@@ -121,7 +121,7 @@ IF_DEF(BI_1B,       IS_NONE,               JMP)      // BI_1B   B.......bbbbbiii
 IF_DEF(BR_1A,       IS_NONE,               CALL)     // BR_1A   ................ ......nnnnn.....         Rn                ret
 IF_DEF(BR_1B,       IS_NONE,               CALL)     // BR_1B   ................ ......nnnnn.....         Rn                br blr
 
-IF_DEF(LS_1A,       IS_NONE,               JMP)      // LS_1A   .X......iiiiiiii iiiiiiiiiiittttt      Rt    PC imm(1MB)
+IF_DEF(LS_1A,       IS_NONE,               JMP)      // LS_1A   XX...V..iiiiiiii iiiiiiiiiiittttt      Rt    PC imm(1MB)
 IF_DEF(LS_2A,       IS_NONE,               NONE)     // LS_2A   .X.......X...... ......nnnnnttttt      Rt Rn
 IF_DEF(LS_2B,       IS_NONE,               NONE)     // LS_2B   .X.......Xiiiiii iiiiiinnnnnttttt      Rt Rn    imm(0-4095)
 IF_DEF(LS_2C,       IS_NONE,               NONE)     // LS_2C   .X.......X.iiiii iiiiP.nnnnnttttt      Rt Rn    imm(-256..+255) pre/post inc

--- a/src/jit/instrsarm64.h
+++ b/src/jit/instrsarm64.h
@@ -91,7 +91,7 @@ INST5(ldr,     "ldr",    0,LD, IF_EN5A,   0xB9400000,  0xB9400000,  0xB8400000, 
                                    //  ldr     Rt,[Xn+pimm12]       LS_2B  1X11100101iiiiii iiiiiinnnnnttttt   B940 0000   imm(0-4095<<{2,3})
                                    //  ldr     Rt,[Xn+simm9]        LS_2C  1X111000010iiiii iiiiPPnnnnnttttt   B840 0000   [Xn imm(-256..+255) pre/post/no inc]
                                    //  ldr     Rt,[Xn,(Rm,ext,shl)] LS_3A  1X111000011mmmmm oooS10nnnnnttttt   B860 0800   [Xn, ext(Rm) LSL {0,2,3}]
-                                   //  ldr     Vt/Rt,[PC+simm19<<2] LS_1A  XX011000iiiiiiii iiiiiiiiiiittttt   1800 0000   [PC +- imm(1MB)]
+                                   //  ldr     Vt/Rt,[PC+simm19<<2] LS_1A  XX011V00iiiiiiii iiiiiiiiiiittttt   1800 0000   [PC +- imm(1MB)]
   
 INST5(ldrsw,   "ldrsw",  0,LD, IF_EN5A,   0xB9800000,  0xB9800000,  0xB8800000,  0xB8A00800,  0x98000000)
                                    //  ldrsw   Rt,[Xn]              LS_2A  1011100110000000 000000nnnnnttttt   B980 0000   

--- a/src/vm/arm64/asmhelpers.asm
+++ b/src/vm/arm64/asmhelpers.asm
@@ -16,6 +16,7 @@
     IMPORT PreStubWorker
     IMPORT NDirectImportWorker
     IMPORT VSD_ResolveWorker
+    IMPORT StubDispatchFixupWorker
     IMPORT JIT_InternalThrow
     IMPORT ComPreStubWorker
     IMPORT COMToCLRWorker
@@ -1175,7 +1176,6 @@ Fail
 
         NESTED_END
 
-		
 #ifdef FEATURE_READYTORUN
 
     NESTED_ENTRY DelayLoad_MethodCall
@@ -1221,5 +1221,28 @@ Fail
     DynamicHelper DynamicHelperFrameFlags_ObjectArg | DynamicHelperFrameFlags_ObjectArg2, _ObjObj
 #endif // FEATURE_READYTORUN		
         
+#ifdef FEATURE_PREJIT
+;; ------------------------------------------------------------------
+;; void StubDispatchFixupStub(args in regs x0-x7 & stack, x11:IndirectionCellAndFlags, x12:DispatchToken)
+;;
+;; The stub dispatch thunk which transfers control to StubDispatchFixupWorker.
+        NESTED_ENTRY StubDispatchFixupStub
+
+        PROLOG_WITH_TRANSITION_BLOCK
+
+        add x0, sp, #__PWTB_TransitionBlock ; pTransitionBlock
+        and x1, x11, #-4 ; Indirection cell
+        mov x2, #0 ; sectionIndex
+        mov x3, #0 ; pModule
+        bl StubDispatchFixupWorker
+        mov x9, x0
+
+        EPILOG_WITH_TRANSITION_BLOCK_TAILCALL
+
+        EPILOG_BRANCH_REG  x9
+
+        NESTED_END
+#endif
+
 ; Must be at very end of file
     END

--- a/src/vm/arm64/stubs.cpp
+++ b/src/vm/arm64/stubs.cpp
@@ -1046,13 +1046,6 @@ extern "C" void GenericComPlusCallStub(void)
 }
 #endif // FEATURE_COMINTEROP
 
-#ifdef FEATURE_PREJIT
-extern "C" void StubDispatchFixupStub()
-{
-    _ASSERTE(!"ARM64:NYI");
-}
-#endif
-
 //ARM64TODO: check if this should be amd64 and win64
 #ifdef _WIN64
 extern "C" void PInvokeStubForHostInner(DWORD dwStackSize, LPVOID pStackFrame, LPVOID pTarget)

--- a/src/vm/jitinterface.cpp
+++ b/src/vm/jitinterface.cpp
@@ -10762,6 +10762,32 @@ void CEEJitInfo::recordRelocation(void * location,
             PutArm64Rel28((UINT32*) fixupLocation, (INT32)delta);
         }
         break;
+
+    case IMAGE_REL_ARM64_PAGEBASE_REL21:
+        {
+            _ASSERTE(slot == 0);
+            _ASSERTE(addlDelta == 0);
+
+            // Write the 21 bits pc-relative page address into location.
+            INT64 targetPage = (INT64)target & 0xFFFFFFFFFFFFF000LL;
+            INT64 lcoationPage = (INT64)location & 0xFFFFFFFFFFFFF000LL;
+            INT64 relPage = (INT64)(targetPage - lcoationPage);
+            INT32 imm21 = (INT32)(relPage >> 12) & 0x1FFFFF;
+            PutArm64Rel21((UINT32 *)location, imm21);
+        }
+        break;
+
+    case IMAGE_REL_ARM64_PAGEOFFSET_12A:
+        {
+            _ASSERTE(slot == 0);
+            _ASSERTE(addlDelta == 0);
+
+            // Write the 12 bits page offset into location.
+            INT32 imm12 = (INT32)target & 0xFFFLL;
+            PutArm64Rel12((UINT32 *)location, imm12);
+        }
+        break;
+
 #endif // _TARGET_ARM64_
 
     default:

--- a/src/zap/zapinfo.cpp
+++ b/src/zap/zapinfo.cpp
@@ -2469,6 +2469,8 @@ void ZapInfo::recordRelocation(void *location, void *target,
 
 #if defined(_TARGET_ARM64_)
     case IMAGE_REL_ARM64_BRANCH26:
+    case IMAGE_REL_ARM64_PAGEBASE_REL21:
+    case IMAGE_REL_ARM64_PAGEOFFSET_12A:
         break;
 #endif
 
@@ -2582,6 +2584,17 @@ void ZapInfo::recordRelocation(void *location, void *target,
         if (!FitsInRel28(targetOffset))
             ThrowHR(COR_E_OVERFLOW);
         PutArm64Rel28((UINT32 *)location, targetOffset);
+        break;
+    case IMAGE_REL_ARM64_PAGEBASE_REL21:
+        if (!FitsInRel21(targetOffset))
+            ThrowHR(COR_E_OVERFLOW);
+        PutArm64Rel21((UINT32 *)location, targetOffset);
+        break;
+
+    case IMAGE_REL_ARM64_PAGEOFFSET_12A:
+        if (!FitsInRel12(targetOffset))
+            ThrowHR(COR_E_OVERFLOW);
+        PutArm64Rel12((UINT32 *)location, targetOffset);
         break;
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/4350
Fixes https://github.com/dotnet/coreclr/issues/4615

This is a bit large change across VM/Zap/JIT to properly support crossgen
scenario.
1. Fix incorrect `ldr` encoding with size.
2. Enforce JIT data following JIT code per method by allocating them together.
   This guarantees correct PC-relative encoding for such constant data access
   without fix-up.
3. For the general fix-up data acceess, use `adrp/add` instruction pairs with fix-ups.
   Two more relocations types are implemented in all sides.
4. Interface dispatch stub is now implemented which is needed for
interface call for crossgen.

I've verified hello world runs with mscorlib.ni.dll.