### PR TITLE
Implement JitNoInlineRange

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -7737,12 +7737,12 @@ public :
         const char*     compFullName;
 #endif // defined(DEBUG) || defined(LATE_DISASM)
 
-#ifdef DEBUG
+#if defined(DEBUG) || defined(INLINE_DATA)
         // Method hash is logcally const, but computed
         // on first demand.
         mutable unsigned compMethodHashPrivate;
         unsigned         compMethodHash() const;
-#endif
+#endif // defined(DEBUG) || defined(INLINE_DATA)
 
 #ifdef PSEUDORANDOM_NOP_INSERTION
         // things for pseudorandom nop insertion

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -16553,10 +16553,17 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
     GenTreeCall* call = callNode->AsCall();
     InlineResult inlineResult(this, call, "impMarkInlineCandidate");
     
-    /* Don't inline if not optimized code */
-    if  (opts.compDbgCode)
+    // Don't inline if not optimizing root method
+    if (opts.compDbgCode)
     {
         inlineResult.NoteFatal(InlineObservation::CALLER_DEBUG_CODEGEN);
+        return;
+    }
+
+    // Don't inline if inlining into root method is disabled.
+    if (InlineStrategy::IsNoInline(info.compCompHnd, info.compMethodHnd))
+    {
+        inlineResult.NoteFatal(InlineObservation::CALLER_IS_JIT_NOINLINE);
         return;
     }
 

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -99,6 +99,7 @@ INLINE_OBSERVATION(UNSUPPORTED_OPCODE,        bool,   "unsupported opcode",     
 // ------ Caller Corectness ------- 
 
 INLINE_OBSERVATION(DEBUG_CODEGEN,             bool,   "debug codegen",                 FATAL,       CALLER)
+INLINE_OBSERVATION(IS_JIT_NOINLINE,           bool,   "noinline per JitNoInlineRange", FATAL,       CALLER)
 INLINE_OBSERVATION(NEEDS_SECURITY_CHECK,      bool,   "needs security check",          FATAL,       CALLER)
 
 // ------ Call Site Correctness ------- 

--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -689,6 +689,9 @@ public:
     // time budget.
     bool BudgetCheck(unsigned ilSize);
 
+    // Check if this method is not allowing inlines.
+    static bool IsNoInline(ICorJitInfo* info, CORINFO_METHOD_HANDLE method);
+
 #if defined(DEBUG) || defined(INLINE_DATA)
 
     // Dump textual description of inlines done so far.

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -197,6 +197,7 @@ CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 CONFIG_INTEGER(JitInlinePolicyFull, W("JitInlinePolicyFull"), 0)
+CONFIG_STRING(JitNoInlineRange, W("JitNoInlineRange"))
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 
 #undef CONFIG_INTEGER


### PR DESCRIPTION
Rework and cleanup ConfigMethodRange. Give it a configurable size. Do
some error detection when parsing the range string. Update comments
and add notes at existing usage sites about the behavior when the
range string is not specified.

Use ConfigMethodRange to implement a JitNoInlineRange option that
suppresses inlining in a specified set of methods. Set this up so
inlning still happens if the range string is empty. Choose capacity so
it can hold the entire range string's set of ranges. Add a new
observation for the cases where enabling this JIT option disables
inlines.

Make compMethodHash available for INLINE_DATA builds. Report this hash
in the Xml inline dumps, so it can provide hash values to feed into
JitNoInlineRange strings.