### PR TITLE
Make Delegate BeginInvoke/EndInvoke throw PlatformNotSupportedException

### DIFF
--- a/src/vm/comdelegate.cpp
+++ b/src/vm/comdelegate.cpp
@@ -2412,7 +2412,7 @@ PCODE COMDelegate::GetInvokeMethodStub(EEImplMethodDesc* pMD)
         STANDARD_VM_CHECK;
         POSTCONDITION(RETVAL != NULL);
 
-        INJECT_FAULT(COMPlusThrowOM()); 
+        INJECT_FAULT(COMPlusThrowOM());
     }
     CONTRACT_END;
 
@@ -2459,7 +2459,7 @@ PCODE COMDelegate::GetInvokeMethodStub(EEImplMethodDesc* pMD)
         // If the call was indeed for async delegate invocation, we will just throw an exception.
         if ((pMD == pClass->m_pBeginInvokeMethod) || (pMD == pClass->m_pEndInvokeMethod))
         {
-            COMPlusThrow(kNotSupportedException);
+            COMPlusThrow(kPlatformNotSupportedException);
         }
 
 #endif //FEATURE_REMOTING
@@ -2468,7 +2468,7 @@ PCODE COMDelegate::GetInvokeMethodStub(EEImplMethodDesc* pMD)
         COMPlusThrow(kInvalidProgramException);
     }
 
-    RETURN ret;    
+    RETURN ret;
 }
 
 FCIMPL1(Object*, COMDelegate::InternalAlloc, ReflectClassBaseObject * pTargetUNSAFE)

--- a/tests/src/baseservices/threading/delegate/BeginInvokeEndInvoke.cs
+++ b/tests/src/baseservices/threading/delegate/BeginInvokeEndInvoke.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System;
+using System.Threading;
+
+namespace DelegateTest
+{
+    class DelegateCommon
+    {
+        public static string TestMethod(int input)
+        {
+            return input.ToString();
+        }
+    }
+
+    class BeginInvokeEndInvokeTest
+    {
+        public delegate string AsyncMethodCaller(int input);
+        static int Main(string[] args)
+        {
+            IAsyncResult result = null;
+            AsyncMethodCaller caller = new AsyncMethodCaller(DelegateCommon.TestMethod);
+
+            try
+            {
+                result = caller.BeginInvoke(123, null, null);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Expected
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("BeginInvoke resulted in unexpected exception: {0}", ex.ToString());
+                Console.WriteLine("FAILED!");
+                return -1;
+            }
+
+            try
+            {
+                caller.EndInvoke(result);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Expected
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("EndInvoke resulted in unexpected exception: {0}", ex.ToString());
+                Console.WriteLine("FAILED!");
+                return -1;
+            }
+
+            return 100;
+        }
+    }
+}

--- a/tests/src/baseservices/threading/delegate/BeginInvokeEndInvoke.csproj
+++ b/tests/src/baseservices/threading/delegate/BeginInvokeEndInvoke.csproj
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{c485e164-f82c-4a4f-a02e-bc711827e5be}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <ReferenceLocalMscorlib>false</ReferenceLocalMscorlib>
+    <CLRTestKind>BuildAndRun</CLRTestKind>
+    <CLRTestPriority>1</CLRTestPriority>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+  </PropertyGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="BeginInvokeEndInvoke.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+  <PropertyGroup Condition=" '$(MsBuildProjectDirOverride)' != '' ">
+  </PropertyGroup>
+</Project>

--- a/tests/src/baseservices/threading/delegate/project.json
+++ b/tests/src/baseservices/threading/delegate/project.json
@@ -1,0 +1,44 @@
+{
+  "dependencies": {
+    "Microsoft.NETCore.Platforms": "1.0.1-rc2-23816",
+    "System.Collections": "4.0.10-rc2-23816",
+    "System.Collections.NonGeneric": "4.0.1-rc2-23816",
+    "System.Collections.Specialized": "4.0.1-rc2-23816",
+    "System.ComponentModel": "4.0.1-rc2-23816",
+    "System.Console": "4.0.0-rc2-23816",
+    "System.Diagnostics.Process": "4.0.0-rc2-23816",
+    "System.Globalization": "4.0.10-rc2-23816",
+    "System.Globalization.Calendars": "4.0.0-rc2-23816",
+    "System.IO": "4.0.10-rc2-23816",
+    "System.IO.FileSystem": "4.0.0-rc2-23816",
+    "System.IO.FileSystem.Primitives": "4.0.0-rc2-23816",
+    "System.Linq": "4.0.1-rc2-23816",
+    "System.Linq.Queryable": "4.0.1-rc2-23816",
+    "System.Reflection": "4.0.10-rc2-23816",
+    "System.Reflection.Primitives": "4.0.0-rc2-23816",
+    "System.Runtime": "4.0.20-rc2-23816",
+    "System.Runtime.Extensions": "4.0.10-rc2-23816",
+    "System.Runtime.Handles": "4.0.0-rc2-23816",
+    "System.Runtime.InteropServices": "4.0.20-rc2-23816",
+    "System.Runtime.Loader": "4.0.0-rc2-23816",
+    "System.Text.Encoding": "4.0.10-rc2-23816",
+    "System.Threading": "4.0.10-rc2-23816",
+    "System.Threading.AccessControl": "4.0.0-rc2-23816",
+    "System.Xml.ReaderWriter": "4.0.11-rc2-23816",
+    "System.Xml.XDocument": "4.0.11-rc2-23816",
+    "System.Xml.XmlDocument": "4.0.1-rc2-23816",
+    "System.Xml.XmlSerializer": "4.0.11-rc2-23816"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  },
+  "runtimes": {
+    "win7-x86": {},
+    "win7-x64": {},
+    "ubuntu.14.04-x64": {},
+    "osx.10.10-x64": {},
+    "centos.7-x64": {},
+    "rhel.7-x64": {},
+    "debian.8.2-x64": {}
+  }
+}


### PR DESCRIPTION
Make BeginInvoke/EndInvoke throw PlatformNotSupportedException instead of NotSupportedException.

Addresses #3811. 

cc: @KrzysztofCwalina @stephentoub @jkotas 