### PR TITLE
StringBuilder: Supplant use of Array.Copy w/ BlockCopy

### DIFF
--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -304,16 +304,7 @@ namespace System.Text {
                 {
                     int newLen = value - m_ChunkOffset;
                     char[] newArray = new char[newLen];
-                    
-                    unsafe
-                    {
-                        fixed (char* psrc = m_ChunkChars) fixed (char* pdest = newArray)
-                        {
-                            int byteCount = m_ChunkLength * sizeof(char);
-                            Buffer.MemoryCopy(psrc, pdest, byteCount, byteCount);
-                        }
-                    }
-                    
+                    Buffer.BlockCopy(m_ChunkChars, 0, newArray, 0, m_ChunkLength * sizeof(char));
                     m_ChunkChars = newArray;
                 }
             }
@@ -511,15 +502,7 @@ namespace System.Text {
                         char[] newArray = new char[newLen];
 
                         Contract.Assert(newLen > chunk.m_ChunkChars.Length, "the new chunk should be larger than the one it is replacing");
-                        
-                        unsafe
-                        {
-                            fixed (char* psrc = chunk.m_ChunkChars) fixed (char* pdest = newArray)
-                            {
-                                int byteCount = chunk.m_ChunkLength * sizeof(char);
-                                Buffer.MemoryCopy(psrc, pdest, byteCount, byteCount);
-                            }
-                        }
+                        Buffer.BlockCopy(chunk.m_ChunkChars, 0, newArray, 0, chunk.m_ChunkLength * sizeof(char));
                         
                         m_ChunkChars = newArray;
                         m_ChunkPrevious = chunk.m_ChunkPrevious;                        
@@ -1552,14 +1535,7 @@ namespace System.Text {
                     else if (replacementsCount >= replacements.Length)
                     {
                         int[] newArray = new int[replacements.Length * 3 / 2 + 4];     // grow by 1.5X but more in the begining
-                        unsafe
-                        {
-                            fixed (int* psrc = replacements) fixed (int* pdest = newArray)
-                            {
-                                int byteCount = replacements.Length * sizeof(int);
-                                Buffer.MemoryCopy(psrc, pdest, byteCount, byteCount);
-                            }
-                        }
+                        Buffer.BlockCopy(replacements, 0, newArray, 0, replacements.Length * sizeof(int));
                         replacements = newArray;
                     }
                     replacements[replacementsCount++] = indexInChunk;

--- a/src/mscorlib/src/System/Text/StringBuilder.cs
+++ b/src/mscorlib/src/System/Text/StringBuilder.cs
@@ -304,7 +304,7 @@ namespace System.Text {
                 {
                     int newLen = value - m_ChunkOffset;
                     char[] newArray = new char[newLen];
-                    Buffer.BlockCopy(m_ChunkChars, 0, newArray, 0, m_ChunkLength * sizeof(char));
+                    Buffer.InternalBlockCopy(m_ChunkChars, 0, newArray, 0, m_ChunkLength * sizeof(char));
                     m_ChunkChars = newArray;
                 }
             }
@@ -502,7 +502,7 @@ namespace System.Text {
                         char[] newArray = new char[newLen];
 
                         Contract.Assert(newLen > chunk.m_ChunkChars.Length, "the new chunk should be larger than the one it is replacing");
-                        Buffer.BlockCopy(chunk.m_ChunkChars, 0, newArray, 0, chunk.m_ChunkLength * sizeof(char));
+                        Buffer.InternalBlockCopy(chunk.m_ChunkChars, 0, newArray, 0, chunk.m_ChunkLength * sizeof(char));
                         
                         m_ChunkChars = newArray;
                         m_ChunkPrevious = chunk.m_ChunkPrevious;                        
@@ -1535,7 +1535,7 @@ namespace System.Text {
                     else if (replacementsCount >= replacements.Length)
                     {
                         int[] newArray = new int[replacements.Length * 3 / 2 + 4];     // grow by 1.5X but more in the begining
-                        Buffer.BlockCopy(replacements, 0, newArray, 0, replacements.Length * sizeof(int));
+                        Buffer.InternalBlockCopy(replacements, 0, newArray, 0, replacements.Length * sizeof(int));
                         replacements = newArray;
                     }
                     replacements[replacementsCount++] = indexInChunk;


### PR DESCRIPTION
Recently noticed that `StringBuilder` had a few places where it was using `Array.Copy` as opposed to `Buffer.BlockCopy`, although the latter is supposed to be faster/more optimized for primitive types since IIRC it has a giant switch-case for small numbers of bytes. This PR changes those places to use `BlockCopy` and `sizeof`, since the places in question are dealing with primitive types (chars, ints).

Other notes:

- I initially started off this PR using `Buffer.MemoryCopy`, but decided against it since 1) it proved to be *slower* than `Array.Copy` (possibly due to the redundant `destinationSizeInBytes` parameter, or the fact that the method only accepts longs) and 2) was more verbose/error-prone; I had to add two levels of indentation for `fixed` and `unsafe` blocks, and forgot to check for null/0-length arrays beforehand.

- Benchmarks:

  - [Buffer.BlockCopy](https://gist.github.com/jamesqo/9da3bd56d7cb4de34f43e0ccb662a207)
  - [Array.Copy](https://gist.github.com/jamesqo/7cc31fe30ad5cb9850ee54d9c26a53d7)
  - [Buffer.MemoryCopy](https://gist.github.com/jamesqo/d1d0c7ced5cc3b00c5b4aaf8467a0c2f) (slowest)
  - [Source code](https://gist.github.com/jamesqo/926bf0e60054e6d0a9c6aee9e4c7120b) (only tests `Capacity`)

- Couldn't resist making a couple of formatting changes to the `Capacity` method as well, even though it's not really relevant to this PR. I'll revert them if you want me to.

cc @mikedn @jkotas 

**edit:** Using `Buffer.InternalBlockCopy` seems to [speed it up](https://gist.github.com/jamesqo/0b3f397cc820a44bf7a5b5991f07f110) a bit more, about 1/10 of a second.