### PR TITLE
Mark LotsOfInlines tests as optimization-sensitive

### DIFF
--- a/tests/src/JIT/opt/Inline/tests/LotsOfInlines.csproj
+++ b/tests/src/JIT/opt/Inline/tests/LotsOfInlines.csproj
@@ -32,6 +32,7 @@
     <NoStandardLib>True</NoStandardLib>
     <Noconfig>True</Noconfig>
     <DefineConstants>$(DefineConstants);CORECLR</DefineConstants>
+    <JitOptimizationSensitive>true</JitOptimizationSensitive>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="LotsOfInlines.cs" />


### PR DESCRIPTION
The LotsOfInlines test times out under COMPlus_JitStress=1.
(http://dotnet-ci.cloudapp.net/job/dotnet_coreclr/job/master/job/x64_checked_windows_nt_jitstress1/48/testReport/).
This change disables it from running under JitStress modes that might
affect optimizations required for it to run in reasonable time.