### PR TITLE
Disable Vector3Interop until failures are addressed

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -358,6 +358,12 @@
         <ExcludeList Include="$(XunitTestBinBase)\baseservices\exceptions\regressions\Dev11\147911\test147911\*">
              <Issue>3651</Issue>
         </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Vector3Interop_r\Vector3Interop_r.cmd">
+             <Issue>4529</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\Vector3Interop_ro\Vector3Interop_ro.cmd">
+             <Issue>4529</Issue>
+        </ExcludeList>
     </ItemGroup>
 
     <!-- The following are baseline x86 failures -->
@@ -415,10 +421,10 @@
              <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_r\CircleInConvex_r.cmd">
-             <Issue>needs triage</Issue>
+             <Issue>3964</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\CircleInConvex_ro\CircleInConvex_ro.cmd">
-             <Issue>needs triage</Issue>
+             <Issue>3964</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\managed\Compilation\Compilation\Compilation.cmd">
              <Issue>needs triage</Issue>


### PR DESCRIPTION
This test is turning several lab runs red.  Disabling for now.