### PR TITLE
Mark some GC tests incompatible with GCStress

### DIFF
--- a/tests/src/GC/API/GC/AddMemoryPressureTest.csproj
+++ b/tests/src/GC/API/GC/AddMemoryPressureTest.csproj
@@ -31,6 +31,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddMemoryPressureTest.cs" />

--- a/tests/src/GC/API/GC/AddThresholdTest.csproj
+++ b/tests/src/GC/API/GC/AddThresholdTest.csproj
@@ -31,6 +31,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddThresholdTest.cs" />

--- a/tests/src/GC/API/GC/AddUsageTest.csproj
+++ b/tests/src/GC/API/GC/AddUsageTest.csproj
@@ -31,6 +31,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AddUsageTest.cs" />

--- a/tests/src/GC/API/GC/RemoveUsageTest.csproj
+++ b/tests/src/GC/API/GC/RemoveUsageTest.csproj
@@ -31,6 +31,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="RemoveUsageTest.cs" />

--- a/tests/src/GC/API/GCHandleCollector/Usage.csproj
+++ b/tests/src/GC/API/GCHandleCollector/Usage.csproj
@@ -31,6 +31,7 @@
     <DebugType>PdbOnly</DebugType>
     <NoLogo>True</NoLogo>
     <DefineConstants>$(DefineConstants);DESKTOP</DefineConstants>
+    <GCStressIncompatible>true</GCStressIncompatible>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Usage.cs" />

--- a/tests/src/GC/Regressions/v2.0-beta2/452950/452950.csproj
+++ b/tests/src/GC/Regressions/v2.0-beta2/452950/452950.csproj
@@ -24,6 +24,9 @@
       <Visible>False</Visible>
     </CodeAnalysisDependentAssemblyPaths>
   </ItemGroup>
+  <PropertyGroup>
+    <GCStressIncompatible>true</GCStressIncompatible>
+  </PropertyGroup>
   <ItemGroup>
     <!-- Add Compile Object Here -->
     <Compile Include="452950.cs" />


### PR DESCRIPTION
These tests rely on GC.CollectionCount, which is unreliable
(or at best different than what the test expects) under GCStress.