### PR TITLE
Match Inconsistent CMake/MSBuild Compiler Definitions 2

### DIFF
--- a/src/inc/winrt/paraminstanceapi.h
+++ b/src/inc/winrt/paraminstanceapi.h
@@ -78,7 +78,7 @@ namespace Ro { namespace detail {
     // Debugging aide.  Set breakpoint on _FailedHR 
     //  to see HRESULT propagation.
     // 
-    #ifdef DBG
+    #ifdef DEBUG
     inline HRESULT __declspec(noinline) _FailedHR(HRESULT hr) { static HRESULT _hr = hr; return hr; }
     #else
     inline HRESULT _FailedHR(HRESULT hr) { return hr; }


### PR DESCRIPTION
Similar with #4709, which addresses omitted definitions from mscorlib/msbuild,
This addresses omitted definitions from native/cmake.

The utility of WIP-PR #4675 is used to find such inconsistency.

Fix #4712 

ps. Note that I have test with ARM-LINUX-DEBUG build only.
There might be other inconsistency in different build configurations.
(You may find it with the script fo #4675)