### PR TITLE
ARM64: Enable Tail Call with Vararg

### DIFF
--- a/src/jit/block.h
+++ b/src/jit/block.h
@@ -925,14 +925,12 @@ typedef unsigned weight_t;             // Type used to hold block and edge weigh
 
     bool endsWithJmpMethod(Compiler *comp);
 
-#if FEATURE_FASTTAILCALL
     bool endsWithTailCall(Compiler* comp, bool fastTailCallsOnly, bool tailCallsConvertibleToLoopOnly, GenTree** tailCall);
 
     bool endsWithTailCallOrJmp(Compiler *comp, 
                                bool fastTailCallsOnly = false);
 
     bool endsWithTailCallConvertibleToLoop(Compiler *comp, GenTree** tailCall);
-#endif // FEATURE_FASTTAILCALL
 
 #if JIT_FEATURE_SSA_SKIP_DEFS
     // Returns the first statement in the statement list of "this" that is

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -4675,8 +4675,6 @@ inline bool         BasicBlock::endsWithJmpMethod(Compiler *comp)
     return false;
 }
 
-#if FEATURE_FASTTAILCALL
-
 // Returns true if the basic block ends with either
 //  i) GT_JMP or
 // ii) tail call (implicit or explicit)
@@ -4783,8 +4781,6 @@ inline bool BasicBlock::endsWithTailCallConvertibleToLoop(Compiler* comp, GenTre
     bool tailCallsConvertibleToLoopOnly = true;
     return endsWithTailCall(comp, fastTailCallsOnly, tailCallsConvertibleToLoopOnly, tailCall);
 }
-
-#endif // FEATURE_FASTTAILCALL
 
 // Returns the last top level stmt of a given basic block.
 // Returns nullptr if the block is empty.

--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -1166,7 +1166,6 @@ void                emitter::dispIns(instrDesc* id)
 #if     EMIT_TRACK_STACK_DEPTH
     assert((int)emitCurStackLvl >= 0);
 #endif
-
     size_t  sz = emitSizeOfInsDsc(id);
     assert(id->idDebugOnlyInfo()->idSize == sz); 
 #endif  // DEBUG

--- a/src/jit/emitarm64.cpp
+++ b/src/jit/emitarm64.cpp
@@ -80,11 +80,11 @@ size_t              emitter::emitSizeOfInsDsc(instrDesc *id)
     assert((unsigned)id->idInsFmt() < emitFmtCount);
 
     ID_OPS idOp         = (ID_OPS) emitFmtToOps[id->idInsFmt()];
-    bool   isCallIns    = (id->idIns() == INS_bl) || (id->idIns() == INS_blr);
-    bool   maybeCallIns = (id->idIns() == INS_b)  || (id->idIns() == INS_br);
-
-    // A call instruction (ID_OP_CALL) may use a "fat" call descriptor
-    // A local call to a label (i.e. call to a finally) cannot use a fat" call descriptor
+    bool   isCallIns    = (id->idIns() == INS_bl)
+        || (id->idIns() == INS_blr)
+        || (id->idIns() == INS_b_tail)
+        || (id->idIns() == INS_br_tail);
+    bool   maybeCallIns = (id->idIns() == INS_b) || (id->idIns() == INS_br);
 
     switch (idOp)
     {
@@ -6888,7 +6888,7 @@ void                emitter::emitIns_Call(EmitCallType  callType,
 
             if (isJump)
             {
-                ins = INS_br;      // INS_br  Reg
+                ins = INS_br_tail; // INS_br_tail  Reg
             }
             else
             {
@@ -6918,14 +6918,13 @@ void                emitter::emitIns_Call(EmitCallType  callType,
 
         if (isJump)
         {
-            ins = INS_b;      // INS_b imm28
-            fmt = IF_BI_0A;
+            ins = INS_b_tail; // INS_b_tail imm28
         }
         else
         {
             ins = INS_bl;     // INS_bl imm28
-            fmt = IF_BI_0C;
         }
+        fmt = IF_BI_0C;
 
         id->idIns(ins);
         id->idInsFmt(fmt); 
@@ -8246,7 +8245,6 @@ size_t              emitter::emitOutputInstr(insGroup  *ig,
     case IF_BI_0B:    // BI_0B   ......iiiiiiiiii iiiiiiiiiii.....               simm19:00
         assert(id->idGCref() == GCT_NONE);
         assert(id->idIsBound());
-
         dst = emitOutputLJ(ig, dst, id);
         sz = sizeof(instrDescJmp);
         break;

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -9358,7 +9358,7 @@ RET:
                 break;
 
         case CEE_JMP:
-            
+
             assert(!compIsForInlining());
 
             if (tiVerificationNeeded)
@@ -9392,7 +9392,7 @@ RET:
                 BADCODE("Incompatible target for CEE_JMPs");
             }
 
-#if defined(_TARGET_XARCH_) || defined(_TARGET_ARM_)
+#if defined(_TARGET_XARCH_) || defined(_TARGET_ARMARCH_)
 
             op1 = new (this, GT_JMP) GenTreeVal(GT_JMP, TYP_VOID, (size_t) resolvedToken.hMethod);
 
@@ -9409,7 +9409,7 @@ RET:
                         
             goto APPEND;
 
-#else // !_TARGET_X86_ && !_TARGET_ARM_
+#else // !_TARGET_XARCH_ && !_TARGET_ARMARCH_
 
             // Import this just like a series of LDARGs + tail. + call + ret
 
@@ -9446,7 +9446,7 @@ RET:
             // And finish with the ret
             goto RET;
 
-#endif // _TARGET_XXX
+#endif // _TARGET_XARCH_ || _TARGET_ARMARCH_
 
         case CEE_LDELEMA :
             assertImp(sz == sizeof(unsigned));

--- a/src/jit/instrsarm64.h
+++ b/src/jit/instrsarm64.h
@@ -590,7 +590,10 @@ INST1(adrp,    "adrp",   0, 0, IF_DI_1E,  0x90000000)
 
 INST1(b,       "b",      0, 0, IF_BI_0A,  0x14000000)
                                    //  b       simm26               BI_0A  000101iiiiiiiiii iiiiiiiiiiiiiiii   1400 0000   simm26:00
-   
+
+INST1(b_tail,  "b",      0, 0, IF_BI_0C,  0x14000000)
+                                   //  b       simm26               BI_0A  000101iiiiiiiiii iiiiiiiiiiiiiiii   1400 0000   simm26:00, same as b representing a tail call of bl.
+
 INST1(bl_local,"bl",     0, 0, IF_BI_0A,  0x94000000)
                                    //  bl      simm26               BI_0A  100101iiiiiiiiii iiiiiiiiiiiiiiii   9400 0000   simm26:00, same as bl, but with a BasicBlock target.
    
@@ -599,6 +602,9 @@ INST1(bl,      "bl",     0, 0, IF_BI_0C,  0x94000000)
 
 INST1(br,      "br",     0, 0, IF_BR_1B,  0xD61F0000)
                                    //  br      Rn                   BR_1B  1101011000011111 000000nnnnn00000   D61F 0000
+
+INST1(br_tail, "br",     0, 0, IF_BR_1B,  0xD61F0000)
+                                   //  br      Rn                   BR_1B  1101011000011111 000000nnnnn00000   D61F 0000, same as br representing a tail call of blr.
 
 INST1(blr,     "blr",    0, 0, IF_BR_1B,  0xD63F0000)
                                    //  blr     Rn                   BR_1B  1101011000111111 000000nnnnn00000   D63F 0000

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -2672,9 +2672,7 @@ void Lowering::InsertPInvokeMethodEpilog(BasicBlock *returnBB
     // Method doing Pinvoke calls has exactly one return block unless it has "jmp" or tail calls.
 #ifdef DEBUG
     bool endsWithTailCallOrJmp = false;
-#if FEATURE_FASTTAILCALL
     endsWithTailCallOrJmp = returnBB->endsWithTailCallOrJmp(comp);
-#endif // FEATURE_FASTTAILCALL
     assert(((returnBB == comp->genReturnBB) && (returnBB->bbJumpKind == BBJ_RETURN)) || endsWithTailCallOrJmp);
 #endif // DEBUG
 

--- a/src/jit/lowerarm64.cpp
+++ b/src/jit/lowerarm64.cpp
@@ -722,17 +722,14 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
 
                 // If it is a fast tail call, it is already preferenced to use IP0.
                 // Therefore, no need set src candidates on call tgt again.
-                if (tree->gtCall.IsVarargs() && 
-                    callHasFloatRegArgs &&                 
+                if (tree->gtCall.IsVarargs() &&
+                    callHasFloatRegArgs &&
                     !tree->gtCall.IsFastTailCall() &&
                     (ctrlExpr != nullptr))
                 {
                     // Don't assign the call target to any of the argument registers because
                     // we will use them to also pass floating point arguments as required
                     // by Arm64 ABI.
-                    
-                    NYI_ARM64("Lower - IsVarargs");
-
                     ctrlExpr->gtLsraInfo.setSrcCandidates(l, l->allRegs(TYP_INT) & ~(RBM_ARG_REGS));
                 }
             }

--- a/tests/arm64/Tests.lst
+++ b/tests/arm64/Tests.lst
@@ -11659,7 +11659,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i03\mcc_i03.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i03
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i04.cmd_1696]
 RelativePath=JIT\jit64\mcc\interop\mcc_i04\mcc_i04.cmd
@@ -11715,7 +11715,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i13\mcc_i13.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i13
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_2989
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i14.cmd_1704]
 RelativePath=JIT\jit64\mcc\interop\mcc_i14\mcc_i14.cmd
@@ -11771,7 +11771,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i33\mcc_i33.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i33
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_2989
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i34.cmd_1712]
 RelativePath=JIT\jit64\mcc\interop\mcc_i34\mcc_i34.cmd
@@ -11827,7 +11827,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i53\mcc_i53.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i53
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_2989
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i54.cmd_1720]
 RelativePath=JIT\jit64\mcc\interop\mcc_i54\mcc_i54.cmd
@@ -11883,7 +11883,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i63\mcc_i63.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i63
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_2989
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i64.cmd_1728]
 RelativePath=JIT\jit64\mcc\interop\mcc_i64\mcc_i64.cmd
@@ -11939,7 +11939,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i73\mcc_i73.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i73
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_2989
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i74.cmd_1736]
 RelativePath=JIT\jit64\mcc\interop\mcc_i74\mcc_i74.cmd
@@ -11995,7 +11995,7 @@ RelativePath=JIT\jit64\mcc\interop\mcc_i83\mcc_i83.cmd
 WorkingDir=JIT\jit64\mcc\interop\mcc_i83
 Expected=0
 MaxAllowedDurationSeconds=600
-Categories=Pri0;EXPECTED_FAIL;ISSUE_2989
+Categories=Pri0;EXPECTED_PASS
 HostStyle=0
 [mcc_i84.cmd_1744]
 RelativePath=JIT\jit64\mcc\interop\mcc_i84\mcc_i84.cmd


### PR DESCRIPTION
Fixes https://github.com/dotnet/coreclr/issues/4475
I've run into `IMPL_LIMITATION("varags + CEE_JMP doesn't work yet")` in
importer.cpp. This change enables ARM64 tail call path same as other
targets.
 1. Similar to amd64 `genFnEpilog`, I made the similar code under
 `!FEATURE_FASTTAILCALL`. Since `EC_FUNC_TOKEN_INDIR` is not defined for
 arm64, I've made NYI for such case.
 2. Added two pseudo branch instructions `b_tail` and `br_tail` which form
 jmp instruction encodings but follow call instruction semantics since
 they are used for tail-call.
 3. `GenJmpMethod` is enabled. Code is slightly changed to reflect correct
 float argument handlings.