### PR TITLE
Fix array allocation bounds checking on Unix

### DIFF
--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -350,13 +350,28 @@ OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, B
                 lowerBound = pArgs[i];
                 i++;
             }
+
             int length = pArgs[i];
             if (length < 0)
                 COMPlusThrow(kOverflowException);
+
             if ((SIZE_T)length > MaxArrayLength(componentSize))
+            {
+                // This will cause us to throw below if we don't throw anything else before then.
                 maxArrayDimensionLengthOverflow = true;
-            if ((length > 0) && (lowerBound + (length - 1) < lowerBound))
-                COMPlusThrow(kArgumentOutOfRangeException, W("ArgumentOutOfRange_ArrayLBAndLength"));
+            }
+
+            if (length > 0)
+            {
+                int highestAllowableLowerBound = INT32_MAX - (length - 1);
+                if (lowerBound > highestAllowableLowerBound)
+                {
+                    // We throw because the lower bound is large enough that the sum of the 
+                    // dimension's length and the lower bound would exceed INT32_MAX.
+                    COMPlusThrow(kArgumentOutOfRangeException, W("ArgumentOutOfRange_ArrayLBAndLength"));
+                }
+            }
+
             safeTotalElements = safeTotalElements * S_UINT32(length);
             if (safeTotalElements.IsOverflow())
                 ThrowOutOfMemoryDimensionsExceeded();


### PR DESCRIPTION
The overflow checking done in `AllocateArrayEx` was problematic when compiled on Clang with optimizations enabled. Since the behavior of signed integer overflow is undefined per the C++ spec, the generated code had the entire branch with the overflow check removed so we could never throw the `ArgumentOutOfRangeException` that we were supposed to in that case.

This change fixes the overflow checking so it can be done safely and without depending on undefined behavior.

#2835 

cc: @stephentoub @janvorli 