### PR TITLE
Set overflow flag for add/sub hi on x86 TYP_LONG

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -1464,7 +1464,12 @@ void CodeGen::genCodeForBinary(GenTree* treeNode)
 
     if (treeNode->gtOverflowEx())
     {
+#if !defined(_TARGET_64BIT_)
+        assert(oper == GT_ADD || oper == GT_SUB ||
+               oper == GT_ADD_HI || oper == GT_SUB_HI);
+#else
         assert(oper == GT_ADD || oper == GT_SUB);
+#endif
         genCheckOverflow(treeNode);
     }
     genProduceReg(treeNode);

--- a/src/jit/compiler.hpp
+++ b/src/jit/compiler.hpp
@@ -1525,9 +1525,16 @@ bool                GenTree::IsVarAddr() const
 inline
 bool                GenTree::gtOverflow() const
 {
+#if !defined(_TARGET_64BIT_) && !defined(LEGACY_BACKEND)
+    assert(gtOper == GT_MUL      || gtOper == GT_CAST     ||
+           gtOper == GT_ADD      || gtOper == GT_SUB      ||
+           gtOper == GT_ASG_ADD  || gtOper == GT_ASG_SUB  ||
+           gtOper == GT_ADD_HI   || gtOper == GT_SUB_HI);
+#else
     assert(gtOper == GT_MUL      || gtOper == GT_CAST     ||
            gtOper == GT_ADD      || gtOper == GT_SUB      ||
            gtOper == GT_ASG_ADD  || gtOper == GT_ASG_SUB);
+#endif
 
     if (gtFlags & GTF_OVERFLOW)
     {
@@ -1546,6 +1553,9 @@ bool                GenTree::gtOverflowEx() const
 {
     if   ( gtOper == GT_MUL      || gtOper == GT_CAST     ||
            gtOper == GT_ADD      || gtOper == GT_SUB      ||
+#if !defined(_TARGET_64BIT_) && !defined(LEGACY_BACKEND)
+           gtOper == GT_ADD_HI   || gtOper == GT_SUB_HI   ||
+#endif
            gtOper == GT_ASG_ADD  || gtOper == GT_ASG_SUB)
     {
         return gtOverflow();

--- a/src/jit/lower.cpp
+++ b/src/jit/lower.cpp
@@ -469,6 +469,18 @@ void Lowering::DecomposeNode(GenTreePtr* pTree, Compiler::fgWalkData* data)
             hiOp2->gtNext      = hiResult;
             hiResult->gtPrev   = hiOp2;
 
+            if (oper == GT_ADD || oper == GT_SUB)
+            {
+                if (loResult->gtOverflow())
+                {
+                    hiResult->gtFlags |= GTF_OVERFLOW;
+                    loResult->gtFlags &= ~GTF_OVERFLOW;
+                }
+                if (loResult->gtFlags & GTF_UNSIGNED)
+                {
+                    hiResult->gtFlags |= GTF_UNSIGNED;
+                }
+            }
             // Below, we'll put the loResult and hiResult trees together, using the more
             // general fgInsertTreeInListAfter() method.
         }

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -428,21 +428,6 @@
     <!-- The following x86 failures only occur with RyuJIT/x86 -->
 
     <ItemGroup Condition="'$(XunitTestBinBase)' != '' and '$(BuildArch)' == 'x86'">
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\sub_ovf\sub_ovf.cmd">
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\add_ovf_i8\add_ovf_i8.cmd">
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_add_ovf_i8\ldc_add_ovf_i8.cmd">
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_sub_ovf_i8\ldc_sub_ovf_i8.cmd">
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\sub_ovf_i8\sub_ovf_i8.cmd">
-             <Issue>4596</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\AsgOp\i8\i8_cs_d\i8_cs_d.cmd">
              <Issue>4659</Issue>
         </ExcludeList>

--- a/tests/ryujit_x86_no_fallback_issues.targets
+++ b/tests/ryujit_x86_no_fallback_issues.targets
@@ -16515,20 +16515,11 @@
         <ExcludeList Include="$(XunitTestBinBase)\Loader\classloader\regressions\dev10_794943\dev10_794943\dev10_794943.cmd" >
              <Issue>4186</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_add_ovf_i8\ldc_add_ovf_i8.cmd" >
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\ldc_sub_ovf_i8\ldc_sub_ovf_i8.cmd" >
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\add_ovf_i8\add_ovf_i8.cmd" >
-             <Issue>4596</Issue>
-        </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\sub_ovf_i8\sub_ovf_i8.cmd" >
-             <Issue>4596</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Base\sub_ovf\sub_ovf.cmd" >
-             <Issue>4596</Issue>
+             <Issue>4751</Issue>
+        </ExcludeList>
+        <ExcludeList Include="$(XunitTestBinBase)\JIT\SIMD\VectorHWAccel_ro\VectorHWAccel_ro.cmd" >
+            <Issue>needs triage</Issue>
         </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\rtchecks\overflow\overflow01_add\overflow01_add.cmd">
              <Issue></Issue>


### PR DESCRIPTION
When we create the hi operation for add and sub on TYP_LONG, we don't
carry the overflow flag to the hi operation. This change sets the overflow
flag on hiResult in lower if it was set on loResult, and adds GT_ADD_HI
and GT_SUB_HI to the operations that can have overflow. We also need to
pass the unsigned flag to the high part in the instance that we are
dealing with an add or subtract with overflow. Fixes #4596.