### PR TITLE
Fix handling of FP args on stack in the ArgIterator

### DIFF
--- a/src/vm/callingconvention.h
+++ b/src/vm/callingconvention.h
@@ -954,8 +954,8 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
     m_fArgInRegisters = true;
 
     int cFPRegs = 0;
+    int cGenRegs = 0;
     int cbArg = StackElemSize(argSize);
-    int cGenRegs = cbArg / 8; // GP reg size
 
     switch (argType)
     {
@@ -1027,6 +1027,7 @@ int ArgIteratorTemplate<ARGITERATOR_BASE>::GetNextOffset()
     }
 
     default:
+        cGenRegs = cbArg / 8; // GP reg size
         break;
     }
 


### PR DESCRIPTION
This change fixes a bug in the ArgIterator that resulted in assigning
floating point arguments that didn't fit to the xmm registers to general
purpose registers in the ArgIterator if there were some general purpose
registers available.