### PR TITLE
Generalize Buffer.BlockCopy optimization for either src or dst

### DIFF
--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1442,7 +1442,7 @@ FCIMPL5(VOID, Buffer::BlockCopy, ArrayBase *src, int srcOffset, ArrayBase *dst, 
             FCThrowArgumentVoid(W("src"), W("Arg_MustBePrimArray"));
     }
     
-    // Optimization: If copying to/fro the same array, then
+    // Optimization: If copying to/from the same array, then
     // we know that dstLen and srcLen must be the same.
     if (src == dst)
     {

--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1424,28 +1424,40 @@ FCIMPL5(VOID, Buffer::BlockCopy, ArrayBase *src, int srcOffset, ArrayBase *dst, 
 
     MethodTable * pByteArrayMT = g_pByteArrayMT;
     _ASSERTE(pByteArrayMT != NULL);
-    if (src->GetMethodTable() == pByteArrayMT &&  dst->GetMethodTable() == pByteArrayMT)
+    
+    // Optimization: If src is a byte array, we can
+    // simply set srcLen to GetNumComponents, without having
+    // to call GetComponentSize or verifying GetArrayElementType
+    if (src->GetMethodTable() == pByteArrayMT)
     {
         srcLen = src->GetNumComponents();
-        dstLen = dst->GetNumComponents();
     }
     else
     {
-        // Size of the Arrays in bytes
         srcLen = src->GetNumComponents() * src->GetComponentSize();
-        dstLen = srcLen;
 
         // We only want to allow arrays of primitives, no Objects.
         const CorElementType srcET = src->GetArrayElementType();
         if (!CorTypeInfo::IsPrimitiveType_NoThrow(srcET))
             FCThrowArgumentVoid(W("src"), W("Arg_MustBePrimArray"));
-
-        if (src != dst) {
-            const CorElementType dstET = dst->GetArrayElementType();
-            if (!CorTypeInfo::IsPrimitiveType_NoThrow(dstET))
-                FCThrowArgumentVoid(W("dest"), W("Arg_MustBePrimArray"));
-            dstLen = dst->GetNumComponents() * dst->GetComponentSize();
-        }
+    }
+    
+    // Optimization: If copying to/fro the same array, then
+    // we know that dstLen and srcLen must be the same.
+    if (src == dst)
+    {
+        dstLen = srcLen;
+    }
+    else if (dst->GetMethodTable() == pByteArrayMT)
+    {
+        dstLen = dst->GetNumComponents();
+    }
+    else
+    {
+        const CorElementType dstET = dst->GetArrayElementType();
+        if (!CorTypeInfo::IsPrimitiveType_NoThrow(dstET))
+            FCThrowArgumentVoid(W("dest"), W("Arg_MustBePrimArray"));
+        dstLen = dst->GetNumComponents() * dst->GetComponentSize();
     }
 
     if (srcOffset < 0 || dstOffset < 0 || count < 0) {


### PR DESCRIPTION
Don't have that much experience in native programming, but here it goes...

I noticed from #3118 that an optimization was added in the case where both `src` and `dst` were byte arrays, but not when only one of them was. Therefore, the optimization would not apply to code like this:

```cs
var bytes = new byte[4] { 1, 2, 3, 4 };
var shorts = new shorts[2];
Buffer.BlockCopy(bytes, 0, shorts, 0, bytes.Length);
```

This PR changes that so the optimization runs if either the `src` or `dst` arrays is a byte array, otherwise falling back to the default implementation as usual.

cc @jkotas 