### PR TITLE
Fix 'runtest.sh' script

### DIFF
--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -429,17 +429,29 @@ declare -a playlistTests
 
 function load_unsupported_tests {
     # Load the list of tests that are not supported on this platform. These tests are disabled (skipped) permanently.
-    readarray -t unsupportedTests <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
+    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
+    # readarray -t unsupportedTests <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
+    while IFS='' read -r line || [ -n "$line" ]; do
+        unsupportedTests[${#unsupportedTests[@]}]=$line
+    done <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
 }
 
 function load_failing_tests {
     # Load the list of tests that fail on this platform. These tests are disabled (skipped) temporarily, pending investigation.
-    readarray -t failingTests <"$(dirname "$0")/testsFailingOutsideWindows.txt"
+    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
+    # readarray -t failingTests <"$(dirname "$0")/testsFailingOutsideWindows.txt"
+    while IFS='' read -r line || [ -n "$line" ]; do
+        failingTests[${#failingTests[@]}]=$line
+    done <"$(dirname "$0")/testsFailingOutsideWindows.txt"
 }
 
 function load_playlist_tests {
     # Load the list of tests that are enabled as a part of this test playlist.
-    readarray -t playlistTests <"${playlistFile}"
+    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
+    # readarray -t playlistTests <"${playlistFile}"
+    while IFS='' read -r line || [ -n "$line" ]; do
+        playlistTests[${#playlistTests[@]}]=$line
+    done <"${playlistFile}"
 }
 
 function is_unsupported_test {
@@ -639,7 +651,11 @@ function set_test_directories {
         exit_with_error "$errorSource" "Test directories file not found at $listFileName"
     fi
 
-    readarray -t testDirectories < "$listFileName"
+    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
+    # readarray -t testDirectories < "$listFileName"
+    while IFS='' read -r line || [ -n "$line" ]; do
+        testDirectories[${#testDirectories[@]}]=$line
+    done < "$listFileName"
 }
 
 function run_tests_in_directory {

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -429,25 +429,17 @@ declare -a playlistTests
 
 function load_unsupported_tests {
     # Load the list of tests that are not supported on this platform. These tests are disabled (skipped) permanently.
-    # 'readarray' is not used here, as it includes the trailing linefeed in lines placed in the array.
-    while IFS='' read -r line || [ -n "$line" ]; do
-        unsupportedTests[${#unsupportedTests[@]}]=$line
-    done <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
+    readarray -t unsupportedTests <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
 }
 
 function load_failing_tests {
     # Load the list of tests that fail on this platform. These tests are disabled (skipped) temporarily, pending investigation.
-    # 'readarray' is not used here, as it includes the trailing linefeed in lines placed in the array.
-    while IFS='' read -r line || [ -n "$line" ]; do
-        failingTests[${#failingTests[@]}]=$line
-    done <"$(dirname "$0")/testsFailingOutsideWindows.txt"
+    readarray -t failingTests <"$(dirname "$0")/testsFailingOutsideWindows.txt"
 }
 
 function load_playlist_tests {
     # Load the list of tests that are enabled as a part of this test playlist.
-    while IFS='' read -r line || [ -n "$line" ]; do
-        playlistTests[${#playlistTests[@]}]=$line
-    done <"${playlistFile}"
+    readarray -t playlistTests <"${playlistFile}"
 }
 
 function is_unsupported_test {
@@ -647,7 +639,7 @@ function set_test_directories {
         exit_with_error "$errorSource" "Test directories file not found at $listFileName"
     fi
 
-    readarray testDirectories < "$listFileName"
+    readarray -t testDirectories < "$listFileName"
 }
 
 function run_tests_in_directory {

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -322,9 +322,6 @@ function create_core_overlay {
     if [ ! -d "$coreClrBinDir" ]; then
         exit_with_error "$errorSource" "Directory specified by --coreClrBinDir does not exist: $coreClrBinDir"
     fi
-    if [ -z "$mscorlibDir" ]; then
-        mscorlibDir=$coreClrBinDir
-    fi
     if [ ! -f "$mscorlibDir/mscorlib.dll" ]; then
         exit_with_error "$errorSource" "mscorlib.dll was not found in: $mscorlibDir"
     fi
@@ -822,6 +819,9 @@ fi
 
 # Copy native interop test libraries over to the mscorlib path in
 # order for interop tests to run on linux.
+if [ -z "$mscorlibDir" ]; then
+	mscorlibDir=$coreClrBinDir
+fi
 if [ -d $mscorlibDir/bin ]; then
     cp $mscorlibDir/bin/* $mscorlibDir   
 fi

--- a/tests/runtest.sh
+++ b/tests/runtest.sh
@@ -424,31 +424,31 @@ declare -a failingTests
 declare -a playlistTests
 ((runFailingTestsOnly = 0))
 
+# Get an array of items by reading the specified file line by line.
+function read_array {
+    local theArray=()
+
+    # bash in Mac OS X doesn't support 'readarray', so using alternate way instead.
+    # readarray -t theArray < "$1"
+    while IFS='' read -r line || [ -n "$line" ]; do
+        theArray[${#theArray[@]}]=$line
+    done < "$1"
+    echo ${theArray[@]}
+}
+
 function load_unsupported_tests {
     # Load the list of tests that are not supported on this platform. These tests are disabled (skipped) permanently.
-    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
-    # readarray -t unsupportedTests <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
-    while IFS='' read -r line || [ -n "$line" ]; do
-        unsupportedTests[${#unsupportedTests[@]}]=$line
-    done <"$(dirname "$0")/testsUnsupportedOutsideWindows.txt"
+    unsupportedTests=($(read_array "$(dirname "$0")/testsUnsupportedOutsideWindows.txt"))
 }
 
 function load_failing_tests {
     # Load the list of tests that fail on this platform. These tests are disabled (skipped) temporarily, pending investigation.
-    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
-    # readarray -t failingTests <"$(dirname "$0")/testsFailingOutsideWindows.txt"
-    while IFS='' read -r line || [ -n "$line" ]; do
-        failingTests[${#failingTests[@]}]=$line
-    done <"$(dirname "$0")/testsFailingOutsideWindows.txt"
+    failingTests=($(read_array "$(dirname "$0")/testsFailingOutsideWindows.txt"))
 }
 
 function load_playlist_tests {
     # Load the list of tests that are enabled as a part of this test playlist.
-    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
-    # readarray -t playlistTests <"${playlistFile}"
-    while IFS='' read -r line || [ -n "$line" ]; do
-        playlistTests[${#playlistTests[@]}]=$line
-    done <"${playlistFile}"
+    playlistTests=($(read_array "${playlistFile}"))
 }
 
 function is_unsupported_test {
@@ -647,12 +647,7 @@ function set_test_directories {
     then
         exit_with_error "$errorSource" "Test directories file not found at $listFileName"
     fi
-
-    # bash in Mac OS X doesn't support 'readarray', so sing alternate way instead.
-    # readarray -t testDirectories < "$listFileName"
-    while IFS='' read -r line || [ -n "$line" ]; do
-        testDirectories[${#testDirectories[@]}]=$line
-    done < "$listFileName"
+    testDirectories=($(read_array "$listFileName"))
 }
 
 function run_tests_in_directory {


### PR DESCRIPTION
This change fixes a bug in the 'runtest.sh' that read test cases from file given by '--testDirFile=<path>' option.
Remove LF characters while reading each line to make test directory list array properly.
Also changes similar codes in other place to same simpler one.