### PR TITLE
Inliner: initial version of SizePolicy

### DIFF
--- a/src/jit/inline.h
+++ b/src/jit/inline.h
@@ -656,7 +656,7 @@ public:
                               InlineResult*   inlineResult);
 
     // Compiler associated with this strategy
-    Compiler* GetCompiler()
+    Compiler* GetCompiler() const
     {
         return m_Compiler;
     }
@@ -665,21 +665,33 @@ public:
     InlineContext* GetRootContext();
 
     // Get IL size for maximum allowable inline
-    unsigned GetMaxInlineILSize()
+    unsigned GetMaxInlineILSize() const
     {
         return m_MaxInlineSize;
     }
 
     // Get depth of maximum allowable inline
-    unsigned GetMaxInlineDepth()
+    unsigned GetMaxInlineDepth() const
     {
         return m_MaxInlineDepth;
     }
 
-    // Number of successful inlines into the root.
-    unsigned GetInlineCount()
+    // Number of successful inlines into the root
+    unsigned GetInlineCount() const
     {
         return m_InlineCount;
+    }
+
+    // Return the current code size estimate for this method
+    int GetCurrentSizeEstimate() const
+    {
+        return m_CurrentSizeEstimate;
+    }
+
+    // Return the initial code size estimate for this method
+    int GetInitialSizeEstimate() const
+    {
+        return m_InitialSizeEstimate;
     }
 
     // Inform strategy that there's a new inline candidate.

--- a/src/jit/inlinepolicy.h
+++ b/src/jit/inlinepolicy.h
@@ -19,6 +19,7 @@
 // DiscretionaryPolicy - legacy variant with uniform size policy
 // ModelPolicy         - policy based on statistical modelling
 // FullPolicy          - inlines everything up to size and depth limits
+// SizePolicy          - tries not to increase method sizes
 
 #ifndef _INLINE_POLICY_H_
 #define _INLINE_POLICY_H_
@@ -307,7 +308,7 @@ class FullPolicy : public DiscretionaryPolicy
 {
 public:
 
-    // Construct a ModelPolicy
+    // Construct a FullPolicy
     FullPolicy(Compiler* compiler, bool isPrejitRoot);
 
     // Policy determinations
@@ -316,6 +317,27 @@ public:
     // Miscellaneous
     const char* GetName() const override { return "FullPolicy"; }
 };
+
+// SizePolicy is an experimental policy that will inline as much
+// as possible without increasing the (estimated) method size.
+//
+// It may be useful down the road as a policy to use for methods
+// that are rarely executed (eg class constructors).
+
+class SizePolicy : public DiscretionaryPolicy
+{
+public:
+
+    // Construct a SizePolicy
+    SizePolicy(Compiler* compiler, bool isPrejitRoot);
+
+    // Policy determinations
+    void DetermineProfitability(CORINFO_METHOD_INFO* methodInfo) override;
+
+    // Miscellaneous
+    const char* GetName() const override { return "SizePolicy"; }
+};
+
 
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 

--- a/src/jit/jitconfigvalues.h
+++ b/src/jit/jitconfigvalues.h
@@ -197,6 +197,7 @@ CONFIG_INTEGER(JitInlineLimit, W("JitInlineLimit"), -1)
 CONFIG_INTEGER(JitInlinePolicyDiscretionary, W("JitInlinePolicyDiscretionary"), 0)
 CONFIG_INTEGER(JitInlinePolicyModel, W("JitInlinePolicyModel"), 0)
 CONFIG_INTEGER(JitInlinePolicyFull, W("JitInlinePolicyFull"), 0)
+CONFIG_INTEGER(JitInlinePolicySize, W("JitInlinePolicySize"), 0)
 CONFIG_STRING(JitNoInlineRange, W("JitNoInlineRange"))
 #endif // defined(DEBUG) || defined(INLINE_DATA)
 

--- a/tests/src/JIT/jit64/regress/ddb/87766/ddb87766.cs
+++ b/tests/src/JIT/jit64/regress/ddb/87766/ddb87766.cs
@@ -2,23 +2,27 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-
 using System;
+using System.Runtime.CompilerServices;
 
 public class VInline
 {
     private int _fi1;
     private int _fi2;
+
     public VInline(int ival)
     {
         _fi1 = ival;
         _fi2 = 0;
     }
-    [System.Runtime.CompilerServices.MethodImplAttribute(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
     private void GetI1(ref int i)
     {
         i = _fi1;
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public int Accumulate(int a)
     {
         int i = 0;


### PR DESCRIPTION
Add a new inline policy that tries to inline as much as possible
without increasing method size.

Fix one test that had an expected inline that doesn't happen under
the SizePolicy, by marking a method with AggressiveInline.