### PR TITLE
Fix incremental build restore: move generated test_runtime project.json to bin

### DIFF
--- a/tests/dir.props
+++ b/tests/dir.props
@@ -112,9 +112,7 @@
 
   <!-- Create a collection of all project.json files for dependency updates. -->
   <ItemGroup>
-    <!-- Skip validation of the test_runtime project created by the test build. -->
-    <ProjectJsonFiles Include="$(SourceDir)**\project.json"
-                      Exclude="$(SourceDir)Common\test_runtime\project.json" />
+    <ProjectJsonFiles Include="$(SourceDir)**\project.json" />
   </ItemGroup>
 
   <!-- Which tests shall we build? Default: Priority 0 tests.

--- a/tests/helix.targets
+++ b/tests/helix.targets
@@ -25,6 +25,7 @@
     </PropertyGroup>
     <ItemGroup>
       <TestNugetProjectLockFile Include="$(SourceDir)$(Category)\**\project.lock.json"/>
+      <TestNugetProjectLockFile Include="$(TestRuntimeProjectLockJson)"/>
     </ItemGroup>
   </Target>
 

--- a/tests/helixperftasks.targets
+++ b/tests/helixperftasks.targets
@@ -15,8 +15,8 @@
     </GetPerfTestAssemblies>
 
     <PropertyGroup>
-      <TestRuntimeDependenciesJson>$(SourceDir)Common\test_runtime\project.json</TestRuntimeDependenciesJson>
-      <TestRuntimeProjectLockJson>$(SourceDir)Common\test_runtime\project.lock.json</TestRuntimeProjectLockJson>
+      <TestRuntimeDependenciesJson>$(TestRuntimeProjectJson)</TestRuntimeDependenciesJson>
+      <TestRuntimeProjectLockJson>$(TestRuntimeProjectLockJson)</TestRuntimeProjectLockJson>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/helixperftasks.targets
+++ b/tests/helixperftasks.targets
@@ -14,17 +14,12 @@
       <Output TaskParameter="PerfTestAssemblies" ItemName="CoreCLRPerfTest" />
     </GetPerfTestAssemblies>
 
-    <PropertyGroup>
-      <TestRuntimeDependenciesJson>$(TestRuntimeProjectJson)</TestRuntimeDependenciesJson>
-      <TestRuntimeProjectLockJson>$(TestRuntimeProjectLockJson)</TestRuntimeProjectLockJson>
-    </PropertyGroup>
-
     <ItemGroup>
      <DnuSourceList Include="$(CORE_ROOT)\.nuget\pkg" />
     </ItemGroup>
 
     <!-- Restore the runtime dependencies -->
-    <Exec Command="$(DnuRestoreCommand) &quot;$(TestRuntimeDependenciesJson)&quot;"
+    <Exec Command="$(DnuRestoreCommand) &quot;$(TestRuntimeProjectJson)&quot;"
            StandardOutputImportance="Low"
            CustomErrorRegularExpression="^Unable to resolve .*"
            IgnoreExitCode="true"

--- a/tests/runtest.proj
+++ b/tests/runtest.proj
@@ -382,9 +382,11 @@ namespace $([System.String]::Copy($(Category)).Replace(".","_").Replace("\","").
       </TestRuntimeJsonContents>
     </PropertyGroup>
 
+    <MakeDir Directories="$(TestRuntimeProjectJsonDir)" Condition="!Exists('$(TestRuntimeProjectJsonDir)')" />
+
     <!-- Write the file -->
     <WriteLinesToFile
-      File="src\Common\test_runtime\project.json"
+      File="$(TestRuntimeProjectJson)"
       Lines="$(TestRuntimeJsonContents)"
       Overwrite="true" />
 

--- a/tests/src/Common/test_runtime/test_runtime.csproj
+++ b/tests/src/Common/test_runtime/test_runtime.csproj
@@ -12,7 +12,7 @@
      <DnuSourceList Include="$(CORE_ROOT)\.nuget\pkg" /> 
   </ItemGroup>
   <ItemGroup>
-    <None Include="project.json" />
+    <None Include="$(TestRuntimeProjectJson)" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
   <Target Name="Build" /> 

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -51,6 +51,12 @@
     <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)/</TestPath>
   </PropertyGroup>
 
+  <!-- Setup the output location for the project.json generated for the local CoreCLR build. -->
+  <PropertyGroup>
+    <TestRuntimeProjectJsonDir>$(BaseOutputPath)\test_runtime</TestRuntimeProjectJsonDir>
+    <TestRuntimeProjectJson>$(TestRuntimeProjectJsonDir)\project.json</TestRuntimeProjectJson>
+  </PropertyGroup>
+
   <!-- Default priority building values. -->
   <PropertyGroup>
     <CLRTestKind Condition="'$(CLRTestKind)' == ' '">BuildAndRun</CLRTestKind>

--- a/tests/src/dir.common.props
+++ b/tests/src/dir.common.props
@@ -55,6 +55,7 @@
   <PropertyGroup>
     <TestRuntimeProjectJsonDir>$(BaseOutputPath)\test_runtime</TestRuntimeProjectJsonDir>
     <TestRuntimeProjectJson>$(TestRuntimeProjectJsonDir)\project.json</TestRuntimeProjectJson>
+    <TestRuntimeProjectLockJson>$(TestRuntimeProjectJsonDir)\project.lock.json</TestRuntimeProjectLockJson>
   </PropertyGroup>
 
   <!-- Default priority building values. -->


### PR DESCRIPTION
In some cases incremental builds didn't work because package restore fails on the generated test_runtime project.json. From my email:

> That project.json is generated by `tests\runtest.proj` to contain a dependency on the currently built CoreCLR package, and `runtest.proj` also restores it, using the local package output dir as the package source. Unfortunately, the generated project.json is left in the `tests\src\` tree, so it’s picked up by any recursive restores in later builds. If the packages dir is cleared and that generated project.json is still there, the restore will try to find the package on MyGet, and it will either hit that error or find a “matching” `-00` version.

The restore error is "`Unable to resolve 'Microsoft.NETCore.Runtime.CoreCLR (>= 1.0.2-rc3-24103-0)`"

This change moves the generated project.json into `bin/tests/test_runtime`. I've only done a tiny amount of local testing because the test build is going extremely slow for me. This PR will not fix existing repros, but should prevent this issue from reproing again in the future.

/cc @BruceForstall @geoffkizer @rahku @janvorli 