### PR TITLE
Add fwrapv compile option

### DIFF
--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -7,6 +7,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   #-fms-compatibility      Enable full Microsoft Visual C++ compatibility
   #-fms-extensions         Accept some non-standard constructs supported by the Microsoft compiler
 
+  # Make signed arithmetic overflow of addition, subtraction, and multiplication wrap around
+  # using twos-complement representation (this is normally undefined according to the C++ spec).
+  add_compile_options(-fwrapv)
+
   if(CLR_CMAKE_PLATFORM_DARWIN)
     # We cannot enable "stack-protector-strong" on OS X due to a bug in clang compiler (current version 7.0.2)
     add_compile_options(-fstack-protector)

--- a/src/vm/gchelpers.cpp
+++ b/src/vm/gchelpers.cpp
@@ -350,28 +350,13 @@ OBJECTREF AllocateArrayEx(TypeHandle arrayType, INT32 *pArgs, DWORD dwNumArgs, B
                 lowerBound = pArgs[i];
                 i++;
             }
-
             int length = pArgs[i];
             if (length < 0)
                 COMPlusThrow(kOverflowException);
-
             if ((SIZE_T)length > MaxArrayLength(componentSize))
-            {
-                // This will cause us to throw below if we don't throw anything else before then.
                 maxArrayDimensionLengthOverflow = true;
-            }
-
-            if (length > 0)
-            {
-                int highestAllowableLowerBound = INT32_MAX - (length - 1);
-                if (lowerBound > highestAllowableLowerBound)
-                {
-                    // We throw because the lower bound is large enough that the sum of the 
-                    // dimension's length and the lower bound would exceed INT32_MAX.
-                    COMPlusThrow(kArgumentOutOfRangeException, W("ArgumentOutOfRange_ArrayLBAndLength"));
-                }
-            }
-
+            if ((length > 0) && (lowerBound + (length - 1) < lowerBound))
+                COMPlusThrow(kArgumentOutOfRangeException, W("ArgumentOutOfRange_ArrayLBAndLength"));
             safeTotalElements = safeTotalElements * S_UINT32(length);
             if (safeTotalElements.IsOverflow())
                 ThrowOutOfMemoryDimensionsExceeded();


### PR DESCRIPTION
The behavior of signed integer overflow is undefined per the C++ spec. This change adds the `fwrapv` option to compileoptions.cmake so that signed arithmetic overflow of addition, subtraction, and multiplication wraps around using twos-complement representation.

I've also reverted the previous fix for the bounds check in array allocation since adding this compile option means that it's no longer necessary.

@janvorli PTAL