### PR TITLE
ildasm: incorrect signess usage with char

### DIFF
--- a/compileoptions.cmake
+++ b/compileoptions.cmake
@@ -42,6 +42,10 @@ if (CLR_CMAKE_PLATFORM_UNIX)
   # may not generate the same object layout as MSVC.
   add_compile_options(-Wno-incompatible-ms-struct)
 
+  # Some architectures (e.g., ARM) assume char type is unsigned while CoreCLR assumes char is signed
+  # as x64 does. It has been causing issues in ARM (https://github.com/dotnet/coreclr/issues/4746)
+  add_compile_options(-fsigned-char)
+
 endif(CLR_CMAKE_PLATFORM_UNIX)
 
 if(CLR_CMAKE_PLATFORM_UNIX_ARM)


### PR DESCRIPTION
Treat pCode signed. It is originally BYTE, not unsigned char.

Fix #4746

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

The incorrect branch reference of CoreCLR Unit Test Case `loopEH.cs` is cured with this:
```
   IL_0039:  brtrue.s   IL_012a
```
is corrected as:
```
   IL_0039:  brtrue.s   IL_002a
```
as supposed.
