### PR TITLE
ARM: Fix SOS stack dump command failure

### DIFF
--- a/src/ToolBox/SOS/Strike/disasm.cpp
+++ b/src/ToolBox/SOS/Strike/disasm.cpp
@@ -888,7 +888,7 @@ BOOL PrintCallInfo(DWORD_PTR vEBP, DWORD_PTR IP, DumpStackFlag& DSFlag, BOOL bSy
     {
         bOutput = TRUE;
         if (!bSymbolOnly)
-            DMLOut("%p %s ", (ULONG64)vEBP, DMLIP(IP));
+            DMLOut("%p %s ", SOS_PTR(vEBP), DMLIP(IP));
         DMLOut("(MethodDesc %s ", DMLMethodDesc(methodDesc));    
         
         // TODO: Microsoft, more checks to make sure method is not eeimpl, etc. Add this field to MethodDesc
@@ -918,7 +918,7 @@ BOOL PrintCallInfo(DWORD_PTR vEBP, DWORD_PTR IP, DumpStackFlag& DSFlag, BOOL bSy
             bOutput = TRUE;
             const char *name;
             if (!bSymbolOnly)
-                DMLOut("%p %s ", (ULONG64)vEBP, DMLIP(IP));
+                DMLOut("%p %s ", SOS_PTR(vEBP), DMLIP(IP));
 
             // if AMD64 ever becomes a cross platform target this must be resolved through
             // virtual dispatch rather than conditional compilation
@@ -1030,9 +1030,9 @@ void DumpStackWorker (DumpStackFlag &DSFlag)
                     ExtOut(" ====> Exception ");
                     if (exrAddr)
                         ExtOut("Code %x ", exr.ExceptionCode);
-                    ExtOut ("cxr@%p", (ULONG64)cxrAddr);
+                    ExtOut ("cxr@%p", SOS_PTR(cxrAddr));
                     if (exrAddr)
-                        ExtOut(" exr@%p", (ULONG64)exrAddr);
+                        ExtOut(" exr@%p", SOS_PTR(exrAddr));
                     ExtOut("\n");
                 }
             }

--- a/src/ToolBox/SOS/Strike/disasmX86.cpp
+++ b/src/ToolBox/SOS/Strike/disasmX86.cpp
@@ -383,7 +383,7 @@ void HandleCall(TADDR callee, Register *reg)
         if (MethodDescData.Request(g_sos, TO_CDADDR(methodDesc)) == S_OK)
         {
             NameForMD_s(methodDesc, g_mdName,mdNameLen);                    
-            ExtOut(" (%S, mdToken: %p)", g_mdName, (UINT64)MethodDescData.MDToken);
+            ExtOut(" (%S, mdToken: %p)", g_mdName, SOS_PTR(MethodDescData.MDToken));
             return;
         }
     }
@@ -414,7 +414,7 @@ void HandleCall(TADDR callee, Register *reg)
             if (MethodDescData.Request(g_sos, md) == S_OK)
             {
                 NameForMD_s(md, g_mdName,mdNameLen);
-                ExtOut(" (%S, mdToken: %p)", g_mdName, (UINT64)MethodDescData.MDToken);
+                ExtOut(" (%S, mdToken: %p)", g_mdName, SOS_PTR(MethodDescData.MDToken));
                 return;
             }
         }

--- a/src/ToolBox/SOS/Strike/dllsext.cpp
+++ b/src/ToolBox/SOS/Strike/dllsext.cpp
@@ -86,7 +86,7 @@ static void DllsNameFromPeb(
     if (FAILED(g_ExtData->ReadVirtual(ProcessPeb+Offset_Ldr, &peb.Ldr,
                                       sizeof(peb.Ldr), NULL)))
     {
-        ExtOut ( "    Unable to read PEB_LDR_DATA address at %p\n", (ULONG64)(ProcessPeb+Offset_Ldr));
+        ExtOut ( "    Unable to read PEB_LDR_DATA address at %p\n", SOS_PTR(ProcessPeb+Offset_Ldr));
         return;
     }
 
@@ -123,7 +123,7 @@ static void DllsNameFromPeb(
                                       sizeof(Ldr.InMemoryOrderModuleList),
                                       NULL)))
     {
-        ExtOut ( "    Unable to read InMemoryOrderModuleList address at %p\n", OrderModuleListStart);
+        ExtOut ( "    Unable to read InMemoryOrderModuleList address at %p\n", SOS_PTR(OrderModuleListStart));
         return;
     }
     Next = (ULONG64)Ldr.InMemoryOrderModuleList.Flink;
@@ -201,7 +201,7 @@ static void DllsNameFromPeb(
             {
 #if 0
                 ExtOut ( "    Unable to read FullDllName.Buffer address at %p\n",
-                         (ULONG64)FullDllName.Buffer);
+                         SOS_PTR(FullDllName.Buffer));
 #endif
                 ZeroMemory( dllName, MAX_LONGPATH * sizeof (WCHAR) );
             }

--- a/src/ToolBox/SOS/Strike/eeheap.cpp
+++ b/src/ToolBox/SOS/Strike/eeheap.cpp
@@ -447,7 +447,7 @@ void GCPrintGenerationInfo(const DacpGcHeapDetails &heap)
         if (IsInterrupt())
             return;
         ExtOut("generation %d starts at 0x%p\n",
-                 n, (ULONG64)heap.generation_table[n].allocation_start);
+                 n, SOS_PTR(heap.generation_table[n].allocation_start));
     }
 
     // We also need to look at the gen0 alloc context.
@@ -455,8 +455,8 @@ void GCPrintGenerationInfo(const DacpGcHeapDetails &heap)
     if (heap.generation_table[0].allocContextPtr)
     {
         ExtOut("(0x%p, 0x%p)\n",
-            (ULONG64) heap.generation_table[0].allocContextPtr,
-            (ULONG64) (heap.generation_table[0].allocContextLimit + Align(min_obj_size)));       
+            SOS_PTR(heap.generation_table[0].allocContextPtr),
+            SOS_PTR(heap.generation_table[0].allocContextLimit + Align(min_obj_size)));
     }
     else
     {
@@ -479,11 +479,11 @@ void GCPrintSegmentInfo(const DacpGcHeapDetails &heap, DWORD_PTR &total_size)
             return;
         if (segment.Request(g_sos, dwAddrSeg, heap) != S_OK)
         {
-            ExtOut("Error requesting heap segment %p\n", (ULONG64)dwAddrSeg);
+            ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
             return;
         }
-        ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", (ULONG64)dwAddrSeg,
-                 (ULONG64)segment.mem, (ULONG64)segment.allocated,
+        ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", SOS_PTR(dwAddrSeg),
+                 SOS_PTR(segment.mem), SOS_PTR(segment.allocated),
                  (ULONG_PTR)(segment.allocated - segment.mem),
                  (ULONG_PTR)(segment.allocated - segment.mem));
         total_size += (DWORD_PTR) (segment.allocated - segment.mem);
@@ -492,13 +492,13 @@ void GCPrintSegmentInfo(const DacpGcHeapDetails &heap, DWORD_PTR &total_size)
 
     if (segment.Request(g_sos, dwAddrSeg, heap) != S_OK)
     {
-        ExtOut("Error requesting heap segment %p\n",(ULONG64)dwAddrSeg);
+        ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
         return;
     }
     
     DWORD_PTR end = (DWORD_PTR)heap.alloc_allocated;
-    ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", (ULONG64)dwAddrSeg,
-             (ULONG64)segment.mem, (ULONG64)end,
+    ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", SOS_PTR(dwAddrSeg),
+             SOS_PTR(segment.mem), SOS_PTR(end),
              (ULONG_PTR)(end - (DWORD_PTR)segment.mem),
              (ULONG_PTR)(end - (DWORD_PTR)segment.mem));
     
@@ -521,11 +521,11 @@ void GCPrintLargeHeapSegmentInfo(const DacpGcHeapDetails &heap, DWORD_PTR &total
             return;
         if (segment.Request(g_sos, dwAddrSeg, heap) != S_OK)
         {
-            ExtOut("Error requesting heap segment %p\n", (ULONG64)dwAddrSeg);
+            ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddrSeg));
             return;
         }
-        ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", (ULONG64)dwAddrSeg,
-                 (ULONG64)segment.mem, (ULONG64)segment.allocated,
+        ExtOut("%p  %p  %p  0x%" POINTERSIZE_TYPE "x(%" POINTERSIZE_TYPE "d)\n", SOS_PTR(dwAddrSeg),
+                 SOS_PTR(segment.mem), SOS_PTR(segment.allocated),
                  (ULONG_PTR)(segment.allocated - segment.mem),
                  segment.allocated - segment.mem);
         total_size += (DWORD_PTR) (segment.allocated - segment.mem);
@@ -539,7 +539,7 @@ void GCHeapInfo(const DacpGcHeapDetails &heap, DWORD_PTR &total_size)
     ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "size");
     GCPrintSegmentInfo(heap, total_size);
     ExtOut("Large object heap starts at 0x%p\n",
-                  (ULONG64)heap.generation_table[GetMaxGeneration()+1].allocation_start);
+                  SOS_PTR(heap.generation_table[GetMaxGeneration()+1].allocation_start));
     ExtOut("%" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s  %" POINTERSIZE "s\n", "segment", "begin", "allocated", "size");
     GCPrintLargeHeapSegmentInfo(heap,total_size);
 }
@@ -588,7 +588,7 @@ BOOL GCObjInSegment(TADDR taddrObj, const DacpGcHeapDetails &heap,
             return FALSE;
         if (dacpSeg.Request(g_sos, taddrSeg, heap) != S_OK)
         {
-            ExtOut("Error requesting heap segment %p\n", (ULONG64)taddrSeg);
+            ExtOut("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
             return FALSE;
         }
         if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj < TO_TADDR(dacpSeg.allocated))
@@ -606,7 +606,7 @@ BOOL GCObjInSegment(TADDR taddrObj, const DacpGcHeapDetails &heap,
     // the ephemeral segment
     if (dacpSeg.Request(g_sos, taddrSeg, heap) != S_OK)
     {
-        ExtOut("Error requesting heap segment %p\n", (ULONG64)taddrSeg);
+        ExtOut("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
         return FALSE;
     }
 
@@ -637,7 +637,7 @@ BOOL GCObjInLargeSegment(TADDR taddrObj, const DacpGcHeapDetails &heap, TADDR_SE
             return FALSE;
         if (dacpSeg.Request(g_sos, taddrSeg, heap) != S_OK)
         {
-            ExtOut("Error requesting heap segment %p\n",(ULONG64)taddrSeg);
+            ExtOut("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
             return FALSE;
         }
         if (taddrObj >= TO_TADDR(dacpSeg.mem) && taddrObj && taddrObj < TO_TADDR(dacpSeg.allocated))
@@ -705,7 +705,7 @@ void GCGenUsageStats(TADDR start, TADDR end, const std::unordered_set<TADDR> &li
                 if (taddrObj == (TADDR)pAllocInfo->array[i].alloc_ptr)
                 {
                     ExtDbgOut("Skipping allocation context: [%#p-%#p)\n", 
-                        (ULONG64)pAllocInfo->array[i].alloc_ptr, (ULONG64)pAllocInfo->array[i].alloc_limit);
+                        SOS_PTR(pAllocInfo->array[i].alloc_ptr), SOS_PTR(pAllocInfo->array[i].alloc_limit));
                     taddrObj =
                         (TADDR)pAllocInfo->array[i].alloc_limit + Align(min_obj_size);
                     break;
@@ -739,7 +739,7 @@ void GCGenUsageStats(TADDR start, TADDR end, const std::unordered_set<TADDR> &li
         BOOL bMTOk = GetSizeEfficient(taddrObj, taddrMT, bLarge, objSize, bContainsPointers);
         if (!bMTOk)
         {
-            ExtErr("bad object: %#p - bad MT %#p\n", (ULONG64) taddrObj, (ULONG64) taddrMT);
+            ExtErr("bad object: %#p - bad MT %#p\n", SOS_PTR(taddrObj), SOS_PTR(taddrMT));
             // set objSize to size_t to look for the next valid MT
             objSize = sizeof(TADDR);
             continue;
@@ -792,7 +792,7 @@ BOOL GCHeapUsageStats(const DacpGcHeapDetails& heap, BOOL bIncUnreachable, HeapU
 
         if (dacpSeg.Request(g_sos, taddrSeg, heap) != S_OK)
         {
-            ExtErr("Error requesting heap segment %p\n", (ULONG64)taddrSeg);
+            ExtErr("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
             return FALSE;
         }
         GCGenUsageStats((TADDR)dacpSeg.mem, (TADDR)dacpSeg.allocated, liveObjs, heap, FALSE, &allocInfo, &hpUsage->genUsage[2]);
@@ -803,7 +803,7 @@ BOOL GCHeapUsageStats(const DacpGcHeapDetails& heap, BOOL bIncUnreachable, HeapU
     // 1b. now handle the ephemeral segment
     if (dacpSeg.Request(g_sos, taddrSeg, heap) != S_OK)
     {
-        ExtErr("Error requesting heap segment %p\n", (ULONG64)taddrSeg);
+        ExtErr("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
         return FALSE;
     }
 
@@ -836,7 +836,7 @@ BOOL GCHeapUsageStats(const DacpGcHeapDetails& heap, BOOL bIncUnreachable, HeapU
 
         if (dacpSeg.Request(g_sos, taddrSeg, heap) != S_OK)
         {
-            ExtErr("Error requesting heap segment %p\n",(ULONG64)taddrSeg);
+            ExtErr("Error requesting heap segment %p\n", SOS_PTR(taddrSeg));
             return FALSE;
         }
 
@@ -928,8 +928,8 @@ void GatherOneHeapFinalization(DacpGcHeapDetails& heapDetails, HeapStat *stat, B
                 (SegQueueLimit(heapDetails,gen_segment(m)) - SegQueue(heapDetails,gen_segment(m))) / sizeof(size_t));
             
             ExtOut ("(%p->%p)\n",
-                (ULONG64) SegQueue(heapDetails,gen_segment(m)),
-                (ULONG64) SegQueueLimit(heapDetails,gen_segment(m)));    
+                SOS_PTR(SegQueue(heapDetails,gen_segment(m))),
+                SOS_PTR(SegQueueLimit(heapDetails,gen_segment(m))));
         }
     }
 #ifndef FEATURE_PAL
@@ -951,9 +951,9 @@ void GatherOneHeapFinalization(DacpGcHeapDetails& heapDetails, HeapStat *stat, B
     {
         ExtOut ("Ready for finalization %d objects ",
                 (SegQueueLimit(heapDetails,FinalizerListSeg)-SegQueue(heapDetails,CriticalFinalizerListSeg)) / sizeof(size_t));
-        ExtOut ("(%p->%p)\n",                    
-                (ULONG64) SegQueue(heapDetails,CriticalFinalizerListSeg),
-                (ULONG64) SegQueueLimit(heapDetails,FinalizerListSeg));            
+        ExtOut ("(%p->%p)\n",
+                SOS_PTR(SegQueue(heapDetails,CriticalFinalizerListSeg)),
+                SOS_PTR(SegQueueLimit(heapDetails,FinalizerListSeg)));
     }
 
     // if bAllReady we only count objects that are ready for finalization,
@@ -1002,7 +1002,7 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
 
     if (segment.Request(g_sos, dwAddr, heap) != S_OK)
     {
-        ExtOut("Error requesting heap segment %p\n", (ULONG64)dwAddr);
+        ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddr));
         return FALSE;
     }    
     
@@ -1033,9 +1033,9 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
             if (dwAddrCurrObj > (DWORD_PTR)end_of_segment)
             {
                 ExtOut ("curr_object: %p > heap_segment_allocated (seg: %p)\n",
-                         (ULONG64)dwAddrCurrObj, (ULONG64)dwAddrSeg);
+                         SOS_PTR(dwAddrCurrObj), SOS_PTR(dwAddrSeg));
                 if (dwAddrPrevObj) {
-                    ExtOut ("Last good object: %p\n", (ULONG64)dwAddrPrevObj);
+                    ExtOut ("Last good object: %p\n", SOS_PTR(dwAddrPrevObj));
                 }
                 return FALSE;
             }
@@ -1045,7 +1045,7 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
                 dwAddr = dwAddrSeg;
                 if (segment.Request(g_sos, dwAddr, heap) != S_OK)
                 {
-                    ExtOut("Error requesting heap segment %p\n", (ULONG64)dwAddr);
+                    ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddr));
                     return FALSE;
                 }
                 dwAddrCurrObj = (DWORD_PTR)segment.mem;
@@ -1062,7 +1062,7 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
             {
                 // prev_object length is too long
                 ExtOut("curr_object: %p > end_youngest: %p\n",
-                         (ULONG64)dwAddrCurrObj, (ULONG64)end_youngest);
+                         SOS_PTR(dwAddrCurrObj), SOS_PTR(end_youngest));
                 if (dwAddrPrevObj) {
                     DMLOut("Last good object: %s\n", DMLObject(dwAddrPrevObj));
                 }
@@ -1132,7 +1132,7 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
     
     if (segment.Request(g_sos, dwAddr, heap) != S_OK)
     {
-        ExtOut("Error requesting heap segment %p\n",(ULONG64)dwAddr);
+        ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddr));
         return FALSE;
     }
 
@@ -1156,9 +1156,9 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
             if (dwAddrCurrObj > (DWORD_PTR)end_of_segment)
             {
                 ExtOut("curr_object: %p > heap_segment_allocated (seg: %p)\n",
-                         (ULONG64)dwAddrCurrObj, (ULONG64)dwAddrSeg);
+                         SOS_PTR(dwAddrCurrObj), SOS_PTR(dwAddrSeg));
                 if (dwAddrPrevObj) {
-                    ExtOut("Last good object: %p\n", (ULONG64)dwAddrPrevObj);
+                    ExtOut("Last good object: %p\n", SOS_PTR(dwAddrPrevObj));
                 }
                 return FALSE;
             }
@@ -1168,7 +1168,7 @@ BOOL GCHeapTraverse(const DacpGcHeapDetails &heap, AllocInfo* pallocInfo, VISITG
                 dwAddr = dwAddrSeg;
                 if (segment.Request(g_sos, dwAddr, heap) != S_OK)
                 {
-                    ExtOut("Error requesting heap segment %p\n", (ULONG64)dwAddr);
+                    ExtOut("Error requesting heap segment %p\n", SOS_PTR(dwAddr));
                     return FALSE;
                 }
                 dwAddrCurrObj = (DWORD_PTR)segment.mem;
@@ -1481,7 +1481,7 @@ BOOL GCHeapSnapshot::AddSegments(DacpGcHeapDetails& details)
             // See code:ClrDataAccess::RequestGCHeapSegment for details. 
             if (segment.Request(g_sos, AddrSeg, details) != S_OK)
             {
-                ExtOut("Error requesting heap segment %p\n", (ULONG64)AddrSeg);
+                ExtOut("Error requesting heap segment %p\n", SOS_PTR(AddrSeg));
                 return FALSE;
             }
             if (n++ > nMaxHeapSegmentCount) // that would be insane
@@ -1552,7 +1552,7 @@ int GCHeapSnapshot::GetGeneration(CLRDATA_ADDRESS objectPointer)
     DacpGcHeapDetails *pDetails = GetHeap(objectPointer);
     if (pDetails == NULL)
     {
-        ExtOut("Object %p has no generation\n", (ULONG64)objectPointer);
+        ExtOut("Object %p has no generation\n", SOS_PTR(objectPointer));
         return 0;
     }
 
@@ -1601,7 +1601,7 @@ void LoaderHeapTraverse(CLRDATA_ADDRESS blockData,size_t blockSize,BOOL blockIsC
     }
     
     g_trav_totalSize += curSize;
-    ExtOut("%p(%x:%x) ", (ULONG64)blockData, blockSize, curSize);
+    ExtOut("%p(%x:%x) ", SOS_PTR(blockData), blockSize, curSize);
 }
 
 /**********************************************************************\
@@ -1696,7 +1696,7 @@ DWORD_PTR JitHeapInfo()
                     else if (codeHeapInfo[iHeaps].codeHeapType == CODEHEAP_HOST)
                     {
                         ExtOut("HostCodeHeap:      ");
-                        ExtOut("%p ", (ULONG64)codeHeapInfo[iHeaps].HostData.baseAddr);
+                        ExtOut("%p ", SOS_PTR(codeHeapInfo[iHeaps].HostData.baseAddr));
                         DWORD dwSize = (DWORD)(codeHeapInfo[iHeaps].HostData.currentAddr - codeHeapInfo[iHeaps].HostData.baseAddr);
                         PrintHeapSize(dwSize, 0);
                         totalSize += dwSize;
@@ -1890,7 +1890,7 @@ DWORD_PTR PrintModuleHeapInfo(__out_ecount(count) DWORD_PTR *moduleList, int cou
             DacpModuleData dmd;
             if (dmd.Request(g_sos, addr) != S_OK)
             {
-                ExtOut("Unable to read module %p\n", (ULONG64)addr);
+                ExtOut("Unable to read module %p\n", SOS_PTR(addr));
             }
             else
             {

--- a/src/ToolBox/SOS/Strike/gchist.cpp
+++ b/src/ToolBox/SOS/Strike/gchist.cpp
@@ -295,8 +295,8 @@ DECLARE_API(HistStats)
                 {
                     if (Iter->Root == innerIter->Root)
                     {
-                        ExtOut ("Root %p promoted multiple times in gc %d\n", 
-                            (ULONG64) Iter->Root, 
+                        ExtOut ("Root %p promoted multiple times in gc %d\n",
+                            SOS_PTR(Iter->Root),
                             GCCount);
                         bErrorFound = TRUE;
                     }
@@ -317,8 +317,8 @@ DECLARE_API(HistStats)
                 {
                     if (Iter->Root == innerIter->Root)
                     {
-                        ExtOut ("Root %p relocated multiple times in gc %d\n", 
-                            (ULONG64) Iter->Root, 
+                        ExtOut ("Root %p relocated multiple times in gc %d\n",
+                            SOS_PTR(Iter->Root),
                             GCCount);
                         bErrorFound = TRUE;
                     }
@@ -417,8 +417,8 @@ DECLARE_API(HistRoot)
             bBoringPeople = false;
             
             ExtOut ("%8d %p %p %9s ", GCCount,
-                (ULONG64) pRelocRec->NewValue, 
-                (ULONG64) pRelocRec->methodTable,
+                SOS_PTR(pRelocRec->NewValue),
+                SOS_PTR(pRelocRec->methodTable),
                 pPromoteRec ? "yes" : "no");
             if (pPromoteRec != NULL)
             {
@@ -499,10 +499,10 @@ DECLARE_API(HistObjFind)
             if (pPtr->Value  == curAddress)
             {
                 bBoringPeople = false;
-                ExtOut ("%8d %p ", GCCount, (ULONG64) curAddress);
-                ExtOut ("Promotion for root %p (MT = %p)\n", 
-                    (ULONG64) pPtr->Root, 
-                    (ULONG64) pPtr->methodTable);
+                ExtOut ("%8d %p ", GCCount, SOS_PTR(curAddress));
+                ExtOut ("Promotion for root %p (MT = %p)\n",
+                    SOS_PTR(pPtr->Root),
+                    SOS_PTR(pPtr->methodTable));
             }
             pPtr = pPtr->next;
         }
@@ -512,12 +512,12 @@ DECLARE_API(HistObjFind)
         {
             if (pReloc->NewValue == curAddress ||
                 pReloc->PrevValue == curAddress)
-            {              
+            {
                 bBoringPeople = false;
-                ExtOut ("%8d %p ", GCCount, (ULONG64) curAddress);
-                ExtOut ("Relocation %s for root %p\n", 
+                ExtOut ("%8d %p ", GCCount, SOS_PTR(curAddress));
+                ExtOut ("Relocation %s for root %p\n",
                     (pReloc->NewValue == curAddress) ? "NEWVALUE" : "PREVVALUE",
-                    (ULONG64) pReloc->Root);
+                    SOS_PTR(pReloc->Root));
             }
             pReloc = pReloc->next;
         }
@@ -571,7 +571,7 @@ DECLARE_API(HistObj)
         
         UINT GCCount = (UINT) g_records[i].GCCount;
 
-        ExtOut ("%8d %p ", GCCount, (ULONG64) curAddress);
+        ExtOut ("%8d %p ", GCCount, SOS_PTR(curAddress));
 
         RelocRecord *pReloc = g_records[i].RelocList;
         size_t candidateCurAddress = curAddress;
@@ -580,7 +580,7 @@ DECLARE_API(HistObj)
         {
             if (pReloc->NewValue == curAddress)
             {
-                ExtOut ("%p, ", (ULONG64) pReloc->Root);
+                ExtOut ("%p, ", SOS_PTR(pReloc->Root));
                 if (bFirstReloc)
                 {
                     candidateCurAddress = pReloc->PrevValue;

--- a/src/ToolBox/SOS/Strike/gcroot.cpp
+++ b/src/ToolBox/SOS/Strike/gcroot.cpp
@@ -452,12 +452,12 @@ void GCRootImpl::ReportOnePath(DWORD thread, const SOSStackRefData &stackRef, Ro
         if (stackRef.SourceType == SOS_StackSourceIP)
         {
             WString methodName = MethodNameFromIP(stackRef.Source);
-            ExtOut("    %p %p %S\n", stackRef.StackPointer, stackRef.Source, methodName.c_str());
+            ExtOut("    %p %p %S\n", SOS_PTR(stackRef.StackPointer), SOS_PTR(stackRef.Source), methodName.c_str());
         }
         else
         {
             WString frameName = GetFrameFromAddress(TO_TADDR(stackRef.Source));
-            ExtOut("    %p %S\n", stackRef.Source, frameName.c_str());
+            ExtOut("    %p %S\n", SOS_PTR(stackRef.Source), frameName.c_str());
         }
     }
     
@@ -525,8 +525,8 @@ int GCRootImpl::PrintRootsInOlderGen()
             return 0;
         }
 
-        ExtDbgOut("internal_root_array = %#p\n", analyzeData.internal_root_array);
-        ExtDbgOut("internal_root_array_index = %#p\n", analyzeData.internal_root_array_index);
+        ExtDbgOut("internal_root_array = %#p\n", SOS_PTR(analyzeData.internal_root_array));
+        ExtDbgOut("internal_root_array_index = %#p\n", SOS_PTR(analyzeData.internal_root_array_index));
         
         TADDR start = TO_TADDR(analyzeData.internal_root_array);
         TADDR stop = TO_TADDR(analyzeData.internal_root_array + sizeof(TADDR) * (size_t)analyzeData.internal_root_array_index);
@@ -567,8 +567,8 @@ int GCRootImpl::PrintRootsInOlderGen()
                 continue;
             }
 
-            ExtDbgOut("internal_root_array = %#p\n", analyzeData.internal_root_array);
-            ExtDbgOut("internal_root_array_index = %#p\n", analyzeData.internal_root_array_index);
+            ExtDbgOut("internal_root_array = %#p\n", SOS_PTR(analyzeData.internal_root_array));
+            ExtDbgOut("internal_root_array_index = %#p\n", SOS_PTR(analyzeData.internal_root_array_index));
             
             TADDR start = TO_TADDR(analyzeData.internal_root_array);
             TADDR stop = TO_TADDR(analyzeData.internal_root_array + sizeof(TADDR) * (size_t)analyzeData.internal_root_array_index);
@@ -1639,7 +1639,7 @@ BOOL FindSegment(const DacpGcHeapDetails &heap, DacpHeapSegmentData &seg, CLRDAT
     // Request the inital segment.
     if (seg.Request(g_sos, dwAddrSeg, heap) != S_OK)
     {
-        ExtOut("Error requesting heap segment %p.\n", (ULONG64)dwAddrSeg);
+        ExtOut("Error requesting heap segment %p.\n", SOS_PTR(dwAddrSeg));
         return FALSE;
     }
 
@@ -1656,7 +1656,7 @@ BOOL FindSegment(const DacpGcHeapDetails &heap, DacpHeapSegmentData &seg, CLRDAT
 
         if (seg.Request(g_sos, dwAddrSeg, heap) != S_OK)
         {
-            ExtOut("Error requesting heap segment %p.\n", (ULONG64)dwAddrSeg);
+            ExtOut("Error requesting heap segment %p.\n", SOS_PTR(dwAddrSeg));
             return FALSE;
         }
     }
@@ -2339,7 +2339,7 @@ bool sos::ObjectIterator::VerifyObjectMembers(char *reason, size_t count) const
                          (GetSizeEfficient(dwAddr1, dwAddrMethTable, FALSE, s, bPointers) == FALSE)) 
                     {
                         BuildError(reason, count, "object %s: bad member %p at %p", DMLObject(objAddr),
-                               (size_t)dwAddr1, (size_t)(objAddr+(size_t)parm-objAddr));
+                               SOS_PTR(dwAddr1), SOS_PTR(objAddr+(size_t)parm-objAddr));
 
                         return false;
                     }
@@ -2347,7 +2347,7 @@ bool sos::ObjectIterator::VerifyObjectMembers(char *reason, size_t count) const
                     if (IsMTForFreeObj(dwAddrMethTable))
                     {
                         sos::Throw<HeapCorruption>("object %s contains free object %p at %p", DMLObject(objAddr),
-                               (ULONG64)dwAddr1, (ULONG64)(objAddr+(size_t)parm-objAddr));
+                               SOS_PTR(dwAddr1), SOS_PTR(objAddr+(size_t)parm-objAddr));
                     }
                
                     // verify card table
@@ -2356,7 +2356,7 @@ bool sos::ObjectIterator::VerifyObjectMembers(char *reason, size_t count) const
                     {
                         BuildError(reason, count, "Object %s: %s missing card_table entry for %p",
                                 DMLObject(objAddr), (dwChild == dwAddr1)? "" : " maybe",
-                               (size_t)(objAddr+(size_t)parm-objAddr));
+                                SOS_PTR(objAddr+(size_t)parm-objAddr));
 
                         return false;
                     }
@@ -2414,8 +2414,8 @@ bool sos::ObjectIterator::VerifyObjectMembers(char *reason, size_t count) const
                              if (FAILED(GetMTOfObject(dwAddr1, &dwAddrMethTable)) ||
                                   (GetSizeEfficient(dwAddr1, dwAddrMethTable, FALSE, s, bPointers) == FALSE)) 
                              {
-                                 BuildError(reason, count, "Object %s: Bad member %p at %p.\n", DMLObject(objAddr), 
-                                         (size_t)dwAddr1, (size_t)(objAddr+(size_t)parm-objAddr));
+                                 BuildError(reason, count, "Object %s: Bad member %p at %p.\n", DMLObject(objAddr),
+                                         SOS_PTR(dwAddr1), SOS_PTR(objAddr+(size_t)parm-objAddr));
 
                                  return false;
                              }
@@ -2423,7 +2423,7 @@ bool sos::ObjectIterator::VerifyObjectMembers(char *reason, size_t count) const
                              if (IsMTForFreeObj(dwAddrMethTable))
                              {
                                  BuildError(reason, count, "Object %s contains free object %p at %p.", DMLObject(objAddr),
-                                        (size_t)dwAddr1, (size_t)(objAddr+(size_t)parm-objAddr));
+                                        SOS_PTR(dwAddr1), SOS_PTR(objAddr+(size_t)parm-objAddr));
                                  return false;
                              }
 
@@ -2433,7 +2433,7 @@ bool sos::ObjectIterator::VerifyObjectMembers(char *reason, size_t count) const
                              {
                                  BuildError(reason, count, "Object %s:%s missing card_table entry for %p",
                                         DMLObject(objAddr), (dwChild == dwAddr1) ? "" : " maybe",
-                                        (size_t)(objAddr+(size_t)parm-objAddr));
+                                        SOS_PTR(objAddr+(size_t)parm-objAddr));
 
                                  return false;
                              }

--- a/src/ToolBox/SOS/Strike/sildasm.cpp
+++ b/src/ToolBox/SOS/Strike/sildasm.cpp
@@ -272,7 +272,7 @@ HRESULT DecodeILFromAddress(IMetaDataImport *pImport, TADDR ilAddr)
         return Status;
     }
 
-    ExtOut("ilAddr = %p\n", (ULONG64) ilAddr);
+    ExtOut("ilAddr = %p\n", SOS_PTR(ilAddr));
 
     // Read the memory into a local buffer
     ArrayHolder<BYTE> pArray = new BYTE[Size];
@@ -493,13 +493,13 @@ void DisassembleToken(DacpObjectData& tokenArray,
     case mdtSignature:
     case mdtTypeRef:
         {
-            printf ("%x (%p)", token, (ULONG64) GetObj(tokenArray, RidFromToken(token)));
+            printf ("%x (%p)", token, SOS_PTR(GetObj(tokenArray, RidFromToken(token))));
         }
         break;
 
     case mdtFieldDef:
         {
-            printf ("%x (%p)", token, (ULONG64) GetObj(tokenArray, RidFromToken(token)));
+            printf ("%x (%p)", token, SOS_PTR(GetObj(tokenArray, RidFromToken(token))));
         }
         break;
 
@@ -523,7 +523,7 @@ void DisassembleToken(DacpObjectData& tokenArray,
 
     case mdtMemberRef:
         {
-            printf ("%x (%p)", token, (ULONG64) GetObj(tokenArray, RidFromToken(token)));
+            printf ("%x (%p)", token, SOS_PTR(GetObj(tokenArray, RidFromToken(token))));
         }
         break;
     case mdtString:

--- a/src/ToolBox/SOS/Strike/strike.cpp
+++ b/src/ToolBox/SOS/Strike/strike.cpp
@@ -865,7 +865,7 @@ DECLARE_API(DumpIL)
         DacpMethodDescData MethodDescData;
         if (MethodDescData.Request(g_sos, TO_CDADDR(dwStartAddr)) != S_OK)
         {
-            ExtOut("%p is not a MethodDesc\n", (ULONG64)dwStartAddr);
+            ExtOut("%p is not a MethodDesc\n", SOS_PTR(dwStartAddr));
             return Status;
         }
 
@@ -874,7 +874,7 @@ DECLARE_API(DumpIL)
             dwDynamicMethodObj = TO_TADDR(MethodDescData.managedDynamicMethodObject);
             if (dwDynamicMethodObj == NULL)
             {
-                ExtOut("Unable to print IL for DynamicMethodDesc %p\n", (ULONG64) dwDynamicMethodObj);
+                ExtOut("Unable to print IL for DynamicMethodDesc %p\n", SOS_PTR(dwDynamicMethodObj));
                 return Status;
             }
         }
@@ -1679,7 +1679,7 @@ HRESULT PrintPermissionSet (TADDR p_PermSet)
         return S_FALSE;
     }
 
-    ExtOut("PermissionSet object: %p\n", (ULONG64)p_PermSet);
+    ExtOut("PermissionSet object: %p\n", SOS_PTR(p_PermSet));
     
     // Print basic info
 
@@ -2732,7 +2732,7 @@ DECLARE_API(PrintException)
 
             if (Status != S_OK)
             {
-                ExtOut("Error retrieving nested exception info %p\n", (ULONG64)currentNested);
+                ExtOut("Error retrieving nested exception info %p\n", SOS_PTR(currentNested));
                 return Status;
             }
 
@@ -3371,7 +3371,7 @@ DECLARE_API(EEHeap)
                     return Status;
                 }
                 ExtOut("------------------------------\n");
-                ExtOut("Heap %d (%p)\n", n, (ULONG64)heapAddrs[n]);
+                ExtOut("Heap %d (%p)\n", n, SOS_PTR(heapAddrs[n]));
                 DWORD_PTR heapSize = 0;
                 GCHeapInfo (heapDetails, heapSize);
                 totalSize += heapSize;
@@ -4012,7 +4012,7 @@ private:
             {
                 DMLOut("%s %s %8d", DMLObject(itr->GetAddress()), DMLDumpHeapMT(itr->GetMT()), itr->GetSize());
                 ExtOut(" ThinLock owner %x (%p) Recursive %x\n", lockInfo.ThreadId,
-                                        (ULONG64)lockInfo.ThreadPtr, lockInfo.Recursion);
+                                        SOS_PTR(lockInfo.ThreadPtr), lockInfo.Recursion);
 
                 count++;
             }
@@ -4360,7 +4360,7 @@ DECLARE_API(VerifyObj)
     if (FAILED(GetMTOfObject(taddrObj, &taddrMT)) ||
         !GetSizeEfficient(taddrObj, taddrMT, FALSE, objSize, bContainsPointers))
     {
-        ExtOut("object %#p does not have valid method table\n", (ULONG64)taddrObj);
+        ExtOut("object %#p does not have valid method table\n", SOS_PTR(taddrObj));
         goto Exit;
     }
 
@@ -4376,7 +4376,7 @@ DECLARE_API(VerifyObj)
 Exit:
     if (bValid)
     {
-        ExtOut("object %#p is a valid object\n", (ULONG64) taddrObj);
+        ExtOut("object %#p is a valid object\n", SOS_PTR(taddrObj));
     }
 
     return Status;
@@ -4437,7 +4437,7 @@ DECLARE_API(ListNearObj)
     DacpGcHeapDetails *heap = g_snapshot.GetHeap(taddrArg);
     if (heap == NULL)
     {
-        ExtOut("Address %p does not lie in the managed heap\n", (ULONG64) taddrObj);
+        ExtOut("Address %p does not lie in the managed heap\n", SOS_PTR(taddrObj));
         return Status;
     }
 
@@ -4448,7 +4448,7 @@ DECLARE_API(ListNearObj)
     if (!GCObjInHeap(taddrObj, *heap, trngSeg, gen, allocCtx, bLarge))
     {
         ExtOut("Failed to find the segment of the managed heap where the object %p resides\n", 
-            (ULONG64) taddrObj);
+            SOS_PTR(taddrObj));
         return Status;
     }
 
@@ -4552,8 +4552,8 @@ DECLARE_API(ListNearObj)
     if (bCur)
         LNODisplayOutput(W("Before: "), curMT, taddrCur, curSize);
     else
-        ExtOut("Before: couldn't find any object between %#p and %#p\n", 
-            (ULONG64)trngSeg.start, (ULONG64)taddrArg);
+        ExtOut("Before: couldn't find any object between %#p and %#p\n",
+            SOS_PTR(trngSeg.start), SOS_PTR(taddrArg));
 
     if (bObj)
         LNODisplayOutput(W("Current:"), objMT, taddrObj, objSize);
@@ -4561,8 +4561,8 @@ DECLARE_API(ListNearObj)
     if (bNxt)
         LNODisplayOutput(W("After:  "), nxtMT, taddrNxt, nxtSize);
     else
-        ExtOut("After:  couldn't find any object between %#p and %#p\n", 
-            (ULONG64)taddrArg, (ULONG64)trngSeg.end);
+        ExtOut("After:  couldn't find any object between %#p and %#p\n",
+            SOS_PTR(taddrArg), SOS_PTR(trngSeg.end));
 
     if (bCur && bNxt && 
         (((taddrCur+curSize == taddrObj) && (taddrObj+objSize == taddrNxt)) || (taddrCur+curSize == taddrNxt)))
@@ -5250,7 +5250,7 @@ DECLARE_API(DumpModule)
     DacpModuleData module;
     if ((Status=module.Request(g_sos, TO_CDADDR(p_ModuleAddr)))!=S_OK)
     {
-        ExtOut("Fail to fill Module %p\n", (ULONG64) p_ModuleAddr);
+        ExtOut("Fail to fill Module %p\n", SOS_PTR(p_ModuleAddr));
         return Status;
     }
     
@@ -5269,17 +5269,17 @@ DECLARE_API(DumpModule)
     
     DMLOut("Assembly:   %s\n", DMLAssembly(module.Assembly));
 
-    ExtOut("LoaderHeap:              %p\n", (ULONG64)module.pLookupTableHeap);
-    ExtOut("TypeDefToMethodTableMap: %p\n", (ULONG64)module.TypeDefToMethodTableMap);
-    ExtOut("TypeRefToMethodTableMap: %p\n", (ULONG64)module.TypeRefToMethodTableMap);
-    ExtOut("MethodDefToDescMap:      %p\n", (ULONG64)module.MethodDefToDescMap);
-    ExtOut("FieldDefToDescMap:       %p\n", (ULONG64)module.FieldDefToDescMap);
-    ExtOut("MemberRefToDescMap:      %p\n", (ULONG64)module.MemberRefToDescMap);
-    ExtOut("FileReferencesMap:       %p\n", (ULONG64)module.FileReferencesMap);
-    ExtOut("AssemblyReferencesMap:   %p\n", (ULONG64)module.ManifestModuleReferencesMap);
+    ExtOut("LoaderHeap:              %p\n", SOS_PTR(module.pLookupTableHeap));
+    ExtOut("TypeDefToMethodTableMap: %p\n", SOS_PTR(module.TypeDefToMethodTableMap));
+    ExtOut("TypeRefToMethodTableMap: %p\n", SOS_PTR(module.TypeRefToMethodTableMap));
+    ExtOut("MethodDefToDescMap:      %p\n", SOS_PTR(module.MethodDefToDescMap));
+    ExtOut("FieldDefToDescMap:       %p\n", SOS_PTR(module.FieldDefToDescMap));
+    ExtOut("MemberRefToDescMap:      %p\n", SOS_PTR(module.MemberRefToDescMap));
+    ExtOut("FileReferencesMap:       %p\n", SOS_PTR(module.FileReferencesMap));
+    ExtOut("AssemblyReferencesMap:   %p\n", SOS_PTR(module.ManifestModuleReferencesMap));
 
     if (module.ilBase && module.metadataStart)
-        ExtOut("MetaData start address:  %p (%d bytes)\n", (ULONG64)module.metadataStart, module.metadataSize);
+        ExtOut("MetaData start address:  %p (%d bytes)\n", SOS_PTR(module.metadataStart), module.metadataSize);
 
     if (bMethodTables)
     {
@@ -5407,7 +5407,7 @@ DECLARE_API(DumpDomain)
 
         if ((Status=appDomain.Request(g_sos, pArray[n])) != S_OK)
         {
-            ExtOut("Failed to get appdomain %p, error %lx\n", (ULONG64)pArray[n], Status);
+            ExtOut("Failed to get appdomain %p, error %lx\n", SOS_PTR(pArray[n]), Status);
             return Status;
         }
 
@@ -7284,7 +7284,7 @@ DECLARE_API(bpmd)
                     {
                         continue;
                     }
-                    ExtOut("MethodDesc = %p\n", (ULONG64) pMDs[i]);
+                    ExtOut("MethodDesc = %p\n", SOS_PTR(pMDs[i]));
                 }
             }
 
@@ -7316,10 +7316,10 @@ DECLARE_API(bpmd)
         INIT_API_DAC();
 
         DacpMethodDescData MethodDescData;
-        ExtOut("MethodDesc = %p\n", (ULONG64) pMD);
+        ExtOut("MethodDesc = %p\n", SOS_PTR(pMD));
         if (MethodDescData.Request(g_sos, TO_CDADDR(pMD)) != S_OK)
         {
-            ExtOut("%p is not a valid MethodDesc\n", (ULONG64)pMD);
+            ExtOut("%p is not a valid MethodDesc\n", SOS_PTR(pMD));
             return Status;
         }
         
@@ -7361,7 +7361,7 @@ DECLARE_API(bpmd)
             // Must issue a pending breakpoint.
             if (g_sos->GetMethodDescName(pMD, mdNameLen, FunctionName, NULL) != S_OK)
             {
-                ExtOut("Unable to get method name for MethodDesc %p\n", (ULONG64)pMD);
+                ExtOut("Unable to get method name for MethodDesc %p\n", SOS_PTR(pMD));
                 return Status;
             }
 
@@ -7451,10 +7451,10 @@ DECLARE_API(ThreadPool)
             }
 
             if (workRequestData.Function == threadpool.AsyncTimerCallbackCompletionFPtr)
-                ExtOut ("    AsyncTimerCallbackCompletion TimerInfo@%p\n", (ULONG64)workRequestData.Context);
+                ExtOut ("    AsyncTimerCallbackCompletion TimerInfo@%p\n", SOS_PTR(workRequestData.Context));
             else
-                ExtOut ("    Unknown Function: %p  Context: %p\n", (ULONG64)workRequestData.Function,
-                    (ULONG64)workRequestData.Context);
+                ExtOut ("    Unknown Function: %p  Context: %p\n", SOS_PTR(workRequestData.Function),
+                    SOS_PTR(workRequestData.Context));
 
             workRequestPtr = workRequestData.NextWorkRequest;
         }
@@ -7564,7 +7564,7 @@ DECLARE_API(FindAppDomain)
     
     if ((p_Object == 0) || !sos::IsObject(p_Object))
     {
-        ExtOut("%p is not a valid object\n", (ULONG64) p_Object);
+        ExtOut("%p is not a valid object\n", SOS_PTR(p_Object));
         return Status;
     }
     
@@ -7596,7 +7596,7 @@ DECLARE_API(FindAppDomain)
             if ((domain.Request(g_sos, appDomain) != S_OK) ||
                 (g_sos->GetAppDomainName(appDomain,mdNameLen,g_mdName, NULL)!=S_OK))
             {
-                ExtOut("Error getting AppDomain %p.\n", (ULONG64) appDomain);
+                ExtOut("Error getting AppDomain %p.\n", SOS_PTR(appDomain));
                 return Status;
             }
 
@@ -7661,7 +7661,7 @@ DECLARE_API(COMState)
         g_ExtSystem->SetCurrentThreadId(ids[i]);
         CLRDATA_ADDRESS cdaTeb;
         g_ExtSystem->GetCurrentThreadTeb(&cdaTeb);
-        ExtOut("%3d %4x %p", ids[i], sysIds[i], CDA_TO_UL64(cdaTeb));
+        ExtOut("%3d %4x %p", ids[i], sysIds[i], SOS_PTR(CDA_TO_UL64(cdaTeb)));
         // Apartment state
         TADDR OleTlsDataAddr;
         if (SafeReadMemory(TO_TADDR(cdaTeb) + offsetof(TEB,ReservedForOle),
@@ -7707,10 +7707,10 @@ DECLARE_API(COMState)
                 if (SafeReadMemory(OleTlsDataAddr+offsetof(SOleTlsData,pCurrentCtx),
                                    &Context,
                                    sizeof(Context), NULL)) {
-                    ExtOut(" %p", (ULONG64)Context);
+                    ExtOut(" %p", SOS_PTR(Context));
                 }
                 else
-                    ExtOut(" %p", (ULONG64)0);
+                    ExtOut(" %p", SOS_PTR(0));
 
             }
             else
@@ -7844,7 +7844,7 @@ DECLARE_API(EHInfo)
     DacpMethodDescData MD;
     if ((tmpAddr == 0) || (MD.Request(g_sos, TO_CDADDR(tmpAddr)) != S_OK))
     {
-        ExtOut("%p is not a MethodDesc\n", (ULONG64)tmpAddr);
+        ExtOut("%p is not a MethodDesc\n", SOS_PTR(tmpAddr));
         return Status;
     }
 
@@ -7925,7 +7925,7 @@ DECLARE_API(GCInfo)
     DacpMethodDescData MD;
     if ((tmpAddr == 0) || (MD.Request(g_sos, TO_CDADDR(tmpAddr)) != S_OK))
     {
-        ExtOut("%p is not a valid MethodDesc\n", (ULONG64)taStartAddr);
+        ExtOut("%p is not a valid MethodDesc\n", SOS_PTR(taStartAddr));
         return Status;
     }
 
@@ -7977,7 +7977,7 @@ DECLARE_API(GCInfo)
 
     taGCInfoAddr = TO_TADDR(codeHeaderData.GCInfo);
 
-    ExtOut("GC info %p\n", (ULONG64)taGCInfoAddr);
+    ExtOut("GC info %p\n", SOS_PTR(taGCInfoAddr));
 
     // assume that GC encoding table is never more than
     // 40 + methodSize * 2
@@ -7999,7 +7999,7 @@ DECLARE_API(GCInfo)
     // We avoid using move here, because we do not want to return
     if (!SafeReadMemory(taGCInfoAddr, table, tableSize, NULL))
     {
-        ExtOut("Could not read memory %p\n", (ULONG64)taGCInfoAddr);
+        ExtOut("Could not read memory %p\n", SOS_PTR(taGCInfoAddr));
         return Status;
     }
 
@@ -8247,12 +8247,12 @@ DECLARE_API(u)
     if (codeHeaderData.ColdRegionStart != NULL)
     {
         ExtOut("Begin %p, size %x. Cold region begin %p, size %x\n",
-            (ULONG64)codeHeaderData.MethodStart, codeHeaderData.HotRegionSize,
-            (ULONG64)codeHeaderData.ColdRegionStart, codeHeaderData.ColdRegionSize);
+            SOS_PTR(codeHeaderData.MethodStart), codeHeaderData.HotRegionSize,
+            SOS_PTR(codeHeaderData.ColdRegionStart), codeHeaderData.ColdRegionSize);
     }
     else
     {
-        ExtOut("Begin %p, size %x\n", (ULONG64)codeHeaderData.MethodStart, codeHeaderData.MethodSize);    
+        ExtOut("Begin %p, size %x\n", SOS_PTR(codeHeaderData.MethodStart), codeHeaderData.MethodSize);
     }
 
 #if !defined(FEATURE_PAL)
@@ -8294,7 +8294,7 @@ DECLARE_API(u)
         // We avoid using move here, because we do not want to return
         if (!SafeReadMemory(TO_TADDR(codeHeaderData.GCInfo), gcEncodingInfo.table, tableSize, NULL))
         {
-            ExtOut("Could not read memory %p\n", (ULONG64)codeHeaderData.GCInfo);
+            ExtOut("Could not read memory %p\n", SOS_PTR(codeHeaderData.GCInfo));
             return Status;
         }
 
@@ -9639,8 +9639,8 @@ DECLARE_API(GCWhere)
         if(FAILED(GetMTOfObject(taddrObj, &taddrMT)) ||
            !GetSizeEfficient(taddrObj, taddrMT, FALSE, size, bContainsPointers))
         {
-            ExtWarn("Couldn't get size for object %#p: possible heap corruption.\n", 
-                taddrObj);
+            ExtWarn("Couldn't get size for object %#p: possible heap corruption.\n",
+                SOS_PTR(taddrObj));
         }
     }
 
@@ -9657,7 +9657,7 @@ DECLARE_API(GCWhere)
         {
             ExtOut("Address   " WIN64_8SPACES " Gen   Heap   segment   " WIN64_8SPACES " begin     " WIN64_8SPACES " allocated  " WIN64_8SPACES " size\n");
             ExtOut("%p   %d     %2d     %p   %p   %p    0x%x(%d)\n",
-                (ULONG64)taddrObj, gen, 0, (ULONG64)trngSeg.segAddr, (ULONG64)trngSeg.start, (ULONG64)trngSeg.end, size, size);
+                SOS_PTR(taddrObj), gen, 0, SOS_PTR(trngSeg.segAddr), SOS_PTR(trngSeg.start), SOS_PTR(trngSeg.end), size, size);
             bFound = TRUE;
         }
     }
@@ -9698,7 +9698,7 @@ DECLARE_API(GCWhere)
             {
                 ExtOut("Address " WIN64_8SPACES " Gen Heap segment " WIN64_8SPACES " begin   " WIN64_8SPACES " allocated" WIN64_8SPACES " size\n");
                 ExtOut("%p   %d     %2d     %p   %p   %p    0x%x(%d)\n",
-                    (ULONG64)taddrObj, gen, n, (ULONG64)trngSeg.segAddr, (ULONG64)trngSeg.start, (ULONG64)trngSeg.end, size, size);
+                    SOS_PTR(taddrObj), gen, n, SOS_PTR(trngSeg.segAddr), SOS_PTR(trngSeg.start), SOS_PTR(trngSeg.end), size, size);
                 bFound = TRUE;
                 break;
             }
@@ -9707,7 +9707,7 @@ DECLARE_API(GCWhere)
 
     if (!bFound)
     {
-        ExtOut("Address %#p not found in the managed heap.\n", (ULONG64)taddrObj);
+        ExtOut("Address %#p not found in the managed heap.\n", SOS_PTR(taddrObj));
     }
 
     return Status;
@@ -9800,7 +9800,7 @@ DECLARE_API(FindRoots)
 
         if (g_snapshot.GetHeap(taObj) == NULL)
         {
-            ExtOut("Address %#p is not in the managed heap.\n", (ULONG64) taObj);
+            ExtOut("Address %#p is not in the managed heap.\n", SOS_PTR(taObj));
             return Status;
         }
 
@@ -9808,7 +9808,7 @@ DECLARE_API(FindRoots)
         if (ogen > CNotification::GetCondemnedGen())
         {
             DMLOut("Object %s will survive this collection:\n\tgen(%#p) = %d > %d = condemned generation.\n",
-                DMLObject(taObj), (ULONG64)taObj, ogen, CNotification::GetCondemnedGen());
+                DMLObject(taObj), SOS_PTR(taObj), ogen, CNotification::GetCondemnedGen());
             return Status;
         }
 
@@ -10663,7 +10663,7 @@ DECLARE_API(GCHandleLeaks)
     ExtOut("Found %d handles:\n",iFinal);
     for (i=1;i<=iFinal;i++)
     {
-        ExtOut("%p\t",(ULONG64)array[i-1]);
+        ExtOut("%p\t", SOS_PTR(array[i-1]));
         if ((i % 4) == 0)
             ExtOut("\n");
     }
@@ -10721,14 +10721,14 @@ DECLARE_API(GCHandleLeaks)
             {
                 if (IsInterrupt())
                 {
-                    ExtOut("Quitting at %p due to user abort\n",(ULONG64)memIter);
+                    ExtOut("Quitting at %p due to user abort\n", SOS_PTR(memIter));
                     bAbort = TRUE;
                     break;
                 }
 
                 if ((memIter % 0x10000000)==0x0)
                 {
-                    ExtOut("Searching %p...\n",(ULONG64)memIter);
+                    ExtOut("Searching %p...\n", SOS_PTR(memIter));
                 }
                 
                 ULONG size = 0;
@@ -10750,11 +10750,11 @@ DECLARE_API(GCHandleLeaks)
                             {
                                 if (stressLog.IsInStressLog (addrInDebugee))
                                 {
-                                    ExtOut("Found %p in stress log at location %p, reference not counted\n", (ULONG64)value, addrInDebugee);
+                                    ExtOut("Found %p in stress log at location %p, reference not counted\n", SOS_PTR(value), addrInDebugee);
                                 }
                                 else
                                 {
-                                    ExtOut("Found %p at location %p\n",(ULONG64)value, addrInDebugee);
+                                    ExtOut("Found %p at location %p\n", SOS_PTR(value), addrInDebugee);
                                     array[i] |= 0x1;
                                 }
                             }
@@ -10765,7 +10765,7 @@ DECLARE_API(GCHandleLeaks)
                 {
                     if (size > 0)
                     {
-                        ExtOut("only read %x bytes at %p\n",size,(ULONG64)memIter);
+                        ExtOut("only read %x bytes at %p\n", size, SOS_PTR(memIter));
                     }
                 }
             }
@@ -10780,7 +10780,7 @@ DECLARE_API(GCHandleLeaks)
         if ((array[i] & 0x1) == 0)
         {
             numNotFound++;
-            // ExtOut("WARNING: %p not found\n",(ULONG64)array[i]);
+            // ExtOut("WARNING: %p not found\n", SOS_PTR(array[i]));
         }
     }
 
@@ -10801,11 +10801,11 @@ DECLARE_API(GCHandleLeaks)
         for (i=0;i<iFinal;i++)
         {
             if ((array[i] & 0x1) == 0)
-            {             
+            {
                 numPrinted++;
-                ExtOut("%p\t",(ULONG64)array[i]);
+                ExtOut("%p\t", SOS_PTR(array[i]));
                 if ((numPrinted % 4) == 0)
-                    ExtOut("\n");            
+                    ExtOut("\n");
             }
         }   
         ExtOut("\n");
@@ -12369,7 +12369,7 @@ private:
                     }
                     else
                     {
-                        ExtOut("(0x%p) ", CDA_TO_UL64(addr));
+                        ExtOut("(0x%p) ", SOS_PTR(CDA_TO_UL64(addr)));
                     }
                     fPrintedLocation = TRUE;
                 }
@@ -12409,7 +12409,7 @@ private:
                     if (outVar)
                         DMLOut("0x%s\n", DMLObject(outVar));
                     else
-                        ExtOut("0x%p\n", (ULONG64)outVar);
+                        ExtOut("0x%p\n", SOS_PTR(outVar));
                 }
                 
             }
@@ -12462,7 +12462,7 @@ private:
                     }
                     else
                     {
-                        ExtOut("0x%p ", CDA_TO_UL64(addr));
+                        ExtOut("0x%p ", SOS_PTR(CDA_TO_UL64(addr)));
                     }
                 }
 
@@ -12503,7 +12503,7 @@ private:
                     if (outVar)
                         DMLOut("0x%s\n", DMLObject(outVar));
                     else
-                        ExtOut("0x%p\n", (ULONG64)outVar);
+                        ExtOut("0x%p\n", SOS_PTR(outVar));
                 }
             }
             else
@@ -12856,14 +12856,14 @@ DECLARE_API(SaveModule)
     }
     else
     {
-        ExtOut ("%p is not a Module or base address\n", (ULONG64)moduleAddr);
+        ExtOut ("%p is not a Module or base address\n", SOS_PTR(moduleAddr));
         return Status;
     }
 
     MEMORY_BASIC_INFORMATION64 mbi;
     if (FAILED(g_ExtData2->QueryVirtual(TO_CDADDR(dllBase), &mbi)))
     {
-        ExtOut("Failed to retrieve information about segment %p", (ULONG64)dllBase);
+        ExtOut("Failed to retrieve information about segment %p", SOS_PTR(dllBase));
         return Status;
     }
 
@@ -13849,7 +13849,7 @@ DECLARE_API(VerifyStackTrace)
             return Status;
         }
 
-        ExtOut("_EFN_GetManagedExcepStack(%P, wszStr, sizeof(wszStr)) returned:\n", (ULONG64) taExc);
+        ExtOut("_EFN_GetManagedExcepStack(%P, wszStr, sizeof(wszStr)) returned:\n", SOS_PTR(taExc));
         ExtOut("%S\n", wszStr);
 
         if (ImplementEFNGetManagedExcepStack((ULONG64)NULL, wszStr, cchStr) != S_OK)
@@ -13993,9 +13993,9 @@ DECLARE_API(VerifyStackTrace)
         }
         for (size_t j=0; j < contextLength; j++)
         {
-            ExtOut("%p %p %p\n", (ULONG64) pSimple[j].FrameOffset,
-                    (ULONG64) pSimple[j].StackOffset,
-                    (ULONG64) pSimple[j].InstructionOffset);
+            ExtOut("%p %p %p\n", SOS_PTR(pSimple[j].FrameOffset),
+                    SOS_PTR(pSimple[j].StackOffset),
+                    SOS_PTR(pSimple[j].InstructionOffset));
         }
         delete [] pSimple;
         delete[] wszBuffer;

--- a/src/ToolBox/SOS/Strike/strike.h
+++ b/src/ToolBox/SOS/Strike/strike.h
@@ -104,6 +104,12 @@
 #define INITGUID
 #include "guiddef.h"
 
+#ifdef FEATURE_PAL
+#define SOS_PTR(x) (size_t)(x)
+#else // FEATURE_PAL
+#define SOS_PTR(x) (unsigned __int64)(x)
+#endif // FEATURE_PAL else
+
 #include "exts.h"
 
 //Alignment constant for allocation
@@ -124,12 +130,6 @@
 
 #define plug_skew           SIZEOF_OBJHEADER
 #define min_obj_size        (sizeof(BYTE*)+plug_skew+sizeof(size_t))
-
-#ifdef FEATURE_PAL
-#define SOS_PTR(x) (size_t)(x)
-#else // FEATURE_PAL
-#define SOS_PTR(x) (unsigned __int64)(x)
-#endif // FEATURE_PAL else
 
 extern BOOL CallStatus;
 

--- a/src/ToolBox/SOS/Strike/util.cpp
+++ b/src/ToolBox/SOS/Strike/util.cpp
@@ -2113,9 +2113,9 @@ HRESULT FileNameForModule (DacpModuleData *pModule, __out_ecount (MAX_LONGPATH) 
 
 void AssemblyInfo(DacpAssemblyData *pAssembly)
 {
-    ExtOut("ClassLoader:        %p\n", (ULONG64)pAssembly->ClassLoader);
+    ExtOut("ClassLoader:        %p\n", SOS_PTR(pAssembly->ClassLoader));
     if ((ULONG64)pAssembly->AssemblySecDesc != NULL)
-        ExtOut("SecurityDescriptor: %p\n", (ULONG64)pAssembly->AssemblySecDesc);
+        ExtOut("SecurityDescriptor: %p\n", SOS_PTR(pAssembly->AssemblySecDesc));
     ExtOut("  Module Name\n");
     
     ArrayHolder<CLRDATA_ADDRESS> Modules = new CLRDATA_ADDRESS[pAssembly->ModuleCount];
@@ -2194,12 +2194,12 @@ const char *GetStageText(DacpAppDomainDataStage stage)
 \**********************************************************************/
 void DomainInfo (DacpAppDomainData *pDomain)
 {
-    ExtOut("LowFrequencyHeap:   %p\n", (ULONG64)pDomain->pLowFrequencyHeap);
-    ExtOut("HighFrequencyHeap:  %p\n", (ULONG64)pDomain->pHighFrequencyHeap);
-    ExtOut("StubHeap:           %p\n", (ULONG64)pDomain->pStubHeap);
+    ExtOut("LowFrequencyHeap:   %p\n", SOS_PTR(pDomain->pLowFrequencyHeap));
+    ExtOut("HighFrequencyHeap:  %p\n", SOS_PTR(pDomain->pHighFrequencyHeap));
+    ExtOut("StubHeap:           %p\n", SOS_PTR(pDomain->pStubHeap));
     ExtOut("Stage:              %s\n", GetStageText(pDomain->appDomainStage));
     if ((ULONG64)pDomain->AppSecDesc != NULL)
-        ExtOut("SecurityDescriptor: %p\n", (ULONG64)pDomain->AppSecDesc);
+        ExtOut("SecurityDescriptor: %p\n", SOS_PTR(pDomain->AppSecDesc));
     ExtOut("Name:               ");
 
     if (g_sos->GetAppDomainName(pDomain->AppDomainPtr, mdNameLen, g_mdName, NULL)!=S_OK)
@@ -2274,7 +2274,7 @@ BOOL NameForMD_s (DWORD_PTR pMD, __out_ecount (capacity_mdName) WCHAR *mdName, s
     //
     if (!IsMiniDumpFile() && MethodDescData.Request(g_sos,StartAddr) != S_OK)
     {
-        ExtOut("%p is not a MethodDesc\n", (ULONG64)StartAddr);
+        ExtOut("%p is not a MethodDesc\n", SOS_PTR(StartAddr));
         return FALSE;
     }
 

--- a/src/ToolBox/SOS/Strike/util.h
+++ b/src/ToolBox/SOS/Strike/util.h
@@ -692,7 +692,7 @@ namespace Output
             {
                 if (mFormat == Formats::Default || mFormat == Formats::Pointer)
                 {
-                    ExtOut("%p", (__int64)mValue);
+                    ExtOut("%p", SOS_PTR(mValue));
                 }
                 else
                 {

--- a/src/ToolBox/SOS/Strike/vm.cpp
+++ b/src/ToolBox/SOS/Strike/vm.cpp
@@ -695,9 +695,9 @@ Return Value:
 
         ExtOut(
             "%p-%p %p  %-13s %-13s %-8s %-8s\n",
-            (ULONG64) memInfo.BaseAddress,
-            (ULONG64)((ULONG_PTR)memInfo.BaseAddress + memInfo.RegionSize - 1),
-            (ULONG64)memInfo.RegionSize,
+            SOS_PTR(memInfo.BaseAddress),
+            SOS_PTR(((ULONG_PTR)memInfo.BaseAddress + memInfo.RegionSize - 1)),
+            SOS_PTR(memInfo.RegionSize),
             VmProtectToString( memInfo.AllocationProtect, aprotectStr, _countof(aprotectStr) ),
             VmProtectToString( memInfo.Protect, protectStr, _countof(protectStr)  ),
             VmStateToString( memInfo.State, stateStr, _countof(stateStr) ),


### PR DESCRIPTION
Dumping address pointer for 32bit system needs adjusting for current implementation
while it assumes %p argument is 64bit. This patch changes (ULONG64) casting to SOS_PTR()
so that it will be safe for both 64 and 32bit.
This will fix DumpStack and EEStack segmentation fault problem.

Related issue: #4672 

@mikem8361 , @janvorli  please take a look.