### PR TITLE
Modify some test cases for <2GB RAM testing environments

### DIFF
--- a/tests/src/GC/LargeMemory/API/gc/collect.cs
+++ b/tests/src/GC/LargeMemory/API/gc/collect.cs
@@ -68,19 +68,25 @@ public sealed class CollectTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-            size = UInt32.Parse(args[0]);
+            sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
             if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-                Console.WriteLine("args: uint - number of GB to allocate");
+                Console.WriteLine("args: uint - number of MB to allocate");
                 return 0;
             }
             throw;
         }
 
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
+
         CollectTest test = new CollectTest();
-        test.size = size;
+        test.size = sizeInMB;
 
         if (test.RunTests()) {
             Console.WriteLine("Test passed");

--- a/tests/src/GC/LargeMemory/API/gc/collect.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/collect.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/API/gc/getgeneration.cs
+++ b/tests/src/GC/LargeMemory/API/gc/getgeneration.cs
@@ -81,19 +81,25 @@ public sealed class GetGenerationTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-            size = UInt32.Parse(args[0]);
+            sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
             if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-                Console.WriteLine("args: uint - number of GB to allocate");
+                Console.WriteLine("args: uint - number of MB to allocate");
                 return 0;
             }
             throw;
         }
 
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
+
         GetGenerationTest test = new GetGenerationTest();
-        test.size = size;
+        test.size = sizeInMB;
         if (test.RunTests()) {
             Console.WriteLine("Test passed");
             return 100;

--- a/tests/src/GC/LargeMemory/API/gc/getgeneration.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/getgeneration.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/API/gc/gettotalmemory.cs
+++ b/tests/src/GC/LargeMemory/API/gc/gettotalmemory.cs
@@ -16,10 +16,10 @@ public sealed class GetTotalMemoryTest {
         try {
             LargeObject lo = new LargeObject(size);
             long mem  = GC.GetTotalMemory(false);
-            long delta = (long)(size*LargeObject.GB)/(long)10;
+            long delta = (long)(size*LargeObject.MB)/(long)10;
 
-            if ( (mem - size*LargeObject.GB)> delta) {
-                Console.WriteLine("{0} {1} {2}", mem, size*LargeObject.GB, delta);
+            if ( (mem - size*LargeObject.MB)> delta) {
+                Console.WriteLine("{0} {1} {2}", mem, size*LargeObject.MB, delta);
                 return false;
             }
 
@@ -40,19 +40,24 @@ public sealed class GetTotalMemoryTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-            size = UInt32.Parse(args[0]);
+            sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
             if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-                Console.WriteLine("args: uint - number of GB to allocate");
+                Console.WriteLine("args: uint - number of MB to allocate");
                 return 0;
             }
             throw;
         }
 
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
 
-        GetTotalMemoryTest test = new GetTotalMemoryTest(size);
+        GetTotalMemoryTest test = new GetTotalMemoryTest(sizeInMB);
         if (test.RunTests()) {
             Console.WriteLine("Test passed");
             return 100;

--- a/tests/src/GC/LargeMemory/API/gc/gettotalmemory.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/gettotalmemory.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/API/gc/keepalive.cs
+++ b/tests/src/GC/LargeMemory/API/gc/keepalive.cs
@@ -40,19 +40,24 @@ public sealed class KeepAliveTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-           size = UInt32.Parse(args[0]);
+           sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
            if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-               Console.WriteLine("args: uint - number of GB to allocate");
+               Console.WriteLine("args: uint - number of MB to allocate");
                return 0;
            }
            throw;
         }
 
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
 
-        KeepAliveTest test = new KeepAliveTest(size);
+        KeepAliveTest test = new KeepAliveTest(sizeInMB);
 
         if (test.RunTests()) {
             Console.WriteLine("Test passed");

--- a/tests/src/GC/LargeMemory/API/gc/keepalive.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/keepalive.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/API/gc/largeobject.cs
+++ b/tests/src/GC/LargeMemory/API/gc/largeobject.cs
@@ -8,26 +8,26 @@ using System;
 public sealed class LargeObject {
 
     private byte[][] data;
-    private uint sizeInGB;
+    private uint sizeInMB;
     private LargeObject next;
     public static int FinalizedCount = 0;
 
-    public const long GB = 1024*1024*1024;
+    public const long MB = 1024*1024;
 
-    public LargeObject(uint sizeInGB):this(sizeInGB, false)
+    public LargeObject(uint sizeInMB):this(sizeInMB, false)
     {
     }
 
-    public LargeObject(uint sizeInGB, bool finalize) {
-        this.sizeInGB = sizeInGB;
+    public LargeObject(uint sizeInMB, bool finalize) {
+        this.sizeInMB = sizeInMB;
 
         if (!finalize) {
             GC.SuppressFinalize(this);
         }
 
-        data = new byte[sizeInGB][];
-        for (int i=0; i<sizeInGB; i++) {
-            data[i] = new byte[GB];
+        data = new byte[sizeInMB][];
+        for (int i=0; i<sizeInMB; i++) {
+            data[i] = new byte[MB];
         }
     }
 
@@ -38,7 +38,7 @@ public sealed class LargeObject {
 
     public long Size {
         get {
-            return sizeInGB*GB;
+            return sizeInMB*MB;
         }
     }
 

--- a/tests/src/GC/LargeMemory/API/gc/memcheck.cs
+++ b/tests/src/GC/LargeMemory/API/gc/memcheck.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+public sealed class MemCheck {
+
+    public static int GetPhysicalMem() {
+        if(File.Exists("/proc/meminfo")){
+            string[] lines = System.IO.File.ReadAllLines("/proc/meminfo");
+            foreach(string line in lines){
+                if(line.StartsWith("MemAvailable")){
+                    int availableMem = Int32.Parse(Regex.Match(line, @"\d+").Value);
+                    return availableMem / 1024;
+                }
+            }
+        }
+        return -1;
+    }
+
+}
+

--- a/tests/src/GC/LargeMemory/API/gc/memcheck.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/memcheck.csproj
@@ -6,14 +6,14 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Add Compile Object Here -->
-    <Compile Include="LargeExceptionTest.cs" />
+    <Compile Include="MemCheck.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -37,10 +37,6 @@
     <ProjectJson>$(GCPackagesConfigFileDirectory)extra\project.json</ProjectJson>
     <ProjectLockJson>$(GCPackagesConfigFileDirectory)extra\project.lock.json</ProjectLockJson>
   </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="LargeObject.csproj" />
-    <ProjectReference Include="MemCheck.csproj" />
-  </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>

--- a/tests/src/GC/LargeMemory/API/gc/reregisterforfinalize.cs
+++ b/tests/src/GC/LargeMemory/API/gc/reregisterforfinalize.cs
@@ -46,19 +46,24 @@ public sealed class ReRegisterForFinalizeTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-           size = UInt32.Parse(args[0]);
+           sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
            if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-               Console.WriteLine("args: uint - number of GB to allocate");
+               Console.WriteLine("args: uint - number of MB to allocate");
                return 0;
            }
            throw;
         }
 
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
 
-        ReRegisterForFinalizeTest test = new ReRegisterForFinalizeTest(size);
+        ReRegisterForFinalizeTest test = new ReRegisterForFinalizeTest(sizeInMB);
 
         if (test.RunTests()) {
             Console.WriteLine("Test passed");

--- a/tests/src/GC/LargeMemory/API/gc/reregisterforfinalize.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/reregisterforfinalize.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/API/gc/suppressfinalize.cs
+++ b/tests/src/GC/LargeMemory/API/gc/suppressfinalize.cs
@@ -37,19 +37,24 @@ public sealed class SuppressFinalizeTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-           size = UInt32.Parse(args[0]);
+           sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
            if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-               Console.WriteLine("args: uint - number of GB to allocate");
+               Console.WriteLine("args: uint - number of MB to allocate");
                return 0;
            }
            throw;
         }
 
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
 
-        SuppressFinalizeTest test = new SuppressFinalizeTest(size);
+        SuppressFinalizeTest test = new SuppressFinalizeTest(sizeInMB);
 
         if (test.RunTests()) {
             Console.WriteLine("Test passed");

--- a/tests/src/GC/LargeMemory/API/gc/suppressfinalize.csproj
+++ b/tests/src/GC/LargeMemory/API/gc/suppressfinalize.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/Allocation/finalizertest.cs
+++ b/tests/src/GC/LargeMemory/Allocation/finalizertest.cs
@@ -10,13 +10,13 @@ public sealed class LargeObject2 {
 
     private byte[][] data;
 
-    public const long GB = 1024*1024*1024;
+    public const long MB = 1024*1024;
 
-    public LargeObject2(uint sizeInGB)
+    public LargeObject2(uint sizeInMB)
     {
-        data = new byte[sizeInGB][];
-        for (int i=0; i<sizeInGB; i++) {
-            data[i] = new byte[GB];
+        data = new byte[sizeInMB][];
+        for (int i=0; i<sizeInMB; i++) {
+            data[i] = new byte[MB];
         }
 
     }
@@ -31,9 +31,9 @@ public sealed class LargeObject2 {
 public sealed class FinalizerObject {
     uint size = 0;
 
-    public FinalizerObject(uint sizeInGB)
+    public FinalizerObject(uint sizeInMB)
     {
-        size = sizeInGB;
+        size = sizeInMB;
     }
 
     ~FinalizerObject() {
@@ -47,7 +47,7 @@ public sealed class FinalizerObject {
             return;
         } catch (Exception e) {
             Console.WriteLine("Unexpected Exception");
-            Console.WriteLine(e);
+            Console.WriteLine(e.ToString());
             return;
         }
 
@@ -94,7 +94,7 @@ public sealed class FinalizerTest {
             return false;
         } catch (Exception e) {
             Console.WriteLine("Unexpected Exception");
-            Console.WriteLine(e);
+            Console.WriteLine(e.ToString());
             return false;
         }
 
@@ -123,7 +123,7 @@ public sealed class FinalizerTest {
             return false;
         } catch (Exception e) {
             Console.WriteLine("Unexpected Exception");
-            Console.WriteLine(e);
+            Console.WriteLine(e.ToString());
             return false;
         }
 
@@ -131,11 +131,11 @@ public sealed class FinalizerTest {
         GC.WaitForPendingFinalizers();
         GC.Collect();
 
-        if (ObjectSize == size*LargeObject.GB) {
+        if (ObjectSize == size*LargeObject.MB) {
             Console.WriteLine("allocateInFinalizerTest passed");
             return true;
         }
-        Console.WriteLine("{0} {1}", ObjectSize, size*LargeObject.GB);
+        Console.WriteLine("{0} {1}", ObjectSize, size*LargeObject.MB);
         Console.WriteLine("allocateInFinalizerTest failed");
         return false;
 
@@ -159,19 +159,24 @@ public sealed class FinalizerTest {
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-            size = UInt32.Parse(args[0]);
+            sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
             if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-                Console.WriteLine("args: uint - number of GB to allocate");
+                Console.WriteLine("args: uint - number of MB to allocate");
                 return 0;
             }
             throw;
         }
 
-        FinalizerTest test = new FinalizerTest(size);
+        int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
 
+        FinalizerTest test = new FinalizerTest(sizeInMB);
 
         if (test.RunTests()) {
             Console.WriteLine("Test passed");

--- a/tests/src/GC/LargeMemory/Allocation/finalizertest.csproj
+++ b/tests/src/GC/LargeMemory/Allocation/finalizertest.csproj
@@ -13,7 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2</CLRTestExecutionArguments>
+    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="LargeObject.csproj" />
+    <ProjectReference Include="MemCheck.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/tests/src/GC/LargeMemory/Allocation/largeexceptiontest.cs
+++ b/tests/src/GC/LargeMemory/Allocation/largeexceptiontest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.IO;
 
 public sealed class LargeException : Exception
 {
@@ -16,9 +17,7 @@ public sealed class LargeException : Exception
     }
 }
 
-
 public sealed class LargeExceptionTest {
-
     private uint size = 0;
     public LargeExceptionTest(uint size) {
         this.size = size;
@@ -35,27 +34,31 @@ public sealed class LargeExceptionTest {
             return true;
         } catch (Exception e) {
             Console.WriteLine("Unexpected Exception");
-            Console.WriteLine(e);
+            Console.WriteLine(e.ToString());
             return false;
         }
-
     }
 
     public static int Main(string[] args) {
 
-        uint size = 0;
+        uint sizeInMB = 0;
         try {
-            size = UInt32.Parse(args[0]);
+            sizeInMB = UInt32.Parse(args[0]);
         } catch (Exception e) {
             if ( (e is IndexOutOfRangeException) || (e is FormatException) || (e is OverflowException) ) {
-                Console.WriteLine("args: uint - number of GB to allocate");
+                Console.WriteLine("args: uint - number of MB to allocate");
                 return 0;
             }
             throw;
         }
 
-        LargeExceptionTest test = new LargeExceptionTest(size);
+	int availableMem = MemCheck.GetPhysicalMem();
+        if (availableMem != -1 && availableMem < sizeInMB){
+            sizeInMB = (uint)(availableMem > 300 ? 300 : (availableMem / 2));
+            Console.WriteLine("Not enough memory. Allocating " + sizeInMB + "MB instead.");
+        }
 
+        LargeExceptionTest test = new LargeExceptionTest(sizeInMB);
 
         if (test.RunTests()) {
             Console.WriteLine("Test passed");

--- a/tests/src/GC/LargeMemory/Allocation/largeobject.cs
+++ b/tests/src/GC/LargeMemory/Allocation/largeobject.cs
@@ -8,26 +8,26 @@ using System;
 public sealed class LargeObject {
 
     private byte[][] data;
-    private uint sizeInGB;
+    private uint sizeInMB;
     private LargeObject next;
     public static int FinalizedCount = 0;
 
-    public const long GB = 1024*1024*1024;
+    public const long MB = 1024*1024;
 
-    public LargeObject(uint sizeInGB):this(sizeInGB, false)
+    public LargeObject(uint sizeInMB):this(sizeInMB, false)
     {
     }
 
-    public LargeObject(uint sizeInGB, bool finalize) {
-        this.sizeInGB = sizeInGB;
+    public LargeObject(uint sizeInMB, bool finalize) {
+        this.sizeInMB = sizeInMB;
 
         if (!finalize) {
             GC.SuppressFinalize(this);
         }
 
-        data = new byte[sizeInGB][];
-        for (int i=0; i<sizeInGB; i++) {
-            data[i] = new byte[GB];
+        data = new byte[sizeInMB][];
+        for (int i=0; i<sizeInMB; i++) {
+            data[i] = new byte[MB];
         }
     }
 
@@ -38,7 +38,7 @@ public sealed class LargeObject {
 
     public long Size {
         get {
-            return sizeInGB*GB;
+            return sizeInMB*MB;
         }
     }
 

--- a/tests/src/GC/LargeMemory/Allocation/memcheck.cs
+++ b/tests/src/GC/LargeMemory/Allocation/memcheck.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+
+public sealed class MemCheck {
+
+    public static int GetPhysicalMem() {
+        if(File.Exists("/proc/meminfo")){
+            string[] lines = System.IO.File.ReadAllLines("/proc/meminfo");
+            foreach(string line in lines){
+                if(line.StartsWith("MemAvailable")){
+                    int availableMem = Int32.Parse(Regex.Match(line, @"\d+").Value);
+                    return availableMem / 1024;
+                }
+            }
+        }
+        return -1;
+    }
+
+}
+

--- a/tests/src/GC/LargeMemory/Allocation/memcheck.csproj
+++ b/tests/src/GC/LargeMemory/Allocation/memcheck.csproj
@@ -6,14 +6,14 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{95DFC527-4DC1-495E-97D7-E94EE1F7140D}</ProjectGuid>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
-    <CLRTestExecutionArguments>2048</CLRTestExecutionArguments>
+    <CLRTestKind>BuildOnly</CLRTestKind>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Add Compile Object Here -->
-    <Compile Include="LargeExceptionTest.cs" />
+    <Compile Include="MemCheck.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
@@ -37,10 +37,6 @@
     <ProjectJson>$(GCPackagesConfigFileDirectory)extra\project.json</ProjectJson>
     <ProjectLockJson>$(GCPackagesConfigFileDirectory)extra\project.lock.json</ProjectLockJson>
   </PropertyGroup>
-  <ItemGroup>
-    <ProjectReference Include="LargeObject.csproj" />
-    <ProjectReference Include="MemCheck.csproj" />
-  </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>


### PR DESCRIPTION
Some test cases allocate 2GB space while some ARM testing environments cannot afford that much.

This PR changes those test cases so that  
1. For <2GB RAM UNIX machines, they allocate as much as half of available memory, up to 300MB.
2. Otherwise, they run as before. 

Fix #4714 