### PR TITLE
Fix Windows 'linuxmscorlib arm' build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -170,7 +170,7 @@ if %__TotalSpecifiedBuildArch% GTR 1 (
 
 if %__BuildArchX64%==1      set __BuildArch=x64
 if %__BuildArchX86%==1      set __BuildArch=x86
-if %__BuildArchArm%==1      set __BuildArch=arm 
+if %__BuildArchArm%==1      set __BuildArch=arm
 if %__BuildArchArm64%==1 (
     set __BuildArch=arm64
     set __CrossArch=x64


### PR DESCRIPTION
Windows build of linuxmscorlib for ARM has been broken by PR #4418. __BuildArch variable in build.cmd file got extra space after 'arm'. As result rc.exe gets option with unquoted path containing space and fails.
> 3>EXEC : fatal error RC1107: invalid usage; use RC /? for Help [C:\git\09d6a5d\coreclr\src\mscorlib\mscorlib.csproj]
> 3>C:\git\09d6a5d\coreclr\Tools\versioning.targets(310,5): error MSB3073: The command ""C:\Program Files (x86)\Windows Kits\8.1\bin\x86\rc.exe" /i C:\git\09d6a5d\coreclr\bin\obj/\Linux.arm .Debug\ /i \inc /i \Include /D _UNICODE /D UNICODE /l"0x0409" /r /fo "C:\git\09d6a5d\coreclr\bin\obj/\Linux.arm .Debug\/Native.res" "C:\git\09d6a5d\coreclr\Tools\NativeVersion.rc"" exited with code 1. [C:\git\09d6a5d\coreclr\src\mscorlib\mscorlib.csproj]