### PR TITLE
[x64 Unix] Avoid SIMD types returned in two return registers from requiring to go through memory.

### DIFF
--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -13551,25 +13551,8 @@ GenTreePtr Compiler::impAssignStructClassToVar(GenTreePtr op, CORINFO_CLASS_HAND
     // This code will be called only if the struct return has not been normalized (i.e. 2 eightbytes - max allowed.)
     assert(IsMultiRegReturnedType(hClass));
 
-    // The return value is based on eightbytes, so all the fields need to be on stack
-    // before loading the eightbyte in the corresponding return register.
-    //
-    // TODO-Amd64-Unix-CQ: Right now codegen assumes that tmpNum lcl var is on stack and 
-    // and does not live in a register.  For example, consider a case where Vector3/4
-    // return value of a call is assigned to tmpNum.  In such a case tmpNum will be of
-    // SIMD type and will be allocated a register unless explicitly marked as DoNotEnregister.
-    // Code quality can be improved by not marking enregistrable struct type tmpNum
-    // as DoNotEnregister=true.
-
-    // Mark the var so that fields are not promoted and stay together
+    // Mark the var so that fields are not promoted and stay together.
     lvaTable[tmpNum].lvIsMultiRegArgOrRet = true;
-
-    // For now to workaround codegen limitation marking tmpNum as DoNotEnregister
-    // if it can be enregistered.
-    if (varTypeIsEnregisterableStruct(op))
-    {
-        lvaTable[tmpNum].lvDoNotEnregister = true;
-    }
 #endif // defined(FEATURE_UNIX_AMD64_STRUCT_PASSING)
 
     return ret;

--- a/src/jit/lowerxarch.cpp
+++ b/src/jit/lowerxarch.cpp
@@ -326,15 +326,15 @@ void Lowering::TreeNodeInfoInit(GenTree* stmt)
                     // op1 has to be either an lclvar or a multi-reg returning call
                     if (op1->OperGet() == GT_LCL_VAR)
                     {
-                        GenTreeLclVarCommon* lclVarPtr = op1->AsLclVarCommon();
-                        LclVarDsc* varDsc = &(compiler->lvaTable[lclVarPtr->gtLclNum]);
+                        GenTreeLclVarCommon* lclVarCommon = op1->AsLclVarCommon();
+                        LclVarDsc* varDsc = &(compiler->lvaTable[lclVarCommon->gtLclNum]);
                         assert(varDsc->lvIsMultiRegArgOrRet);
-                        varDsc->lvDoNotEnregister = true;
 
-                        // If this is a two eightbyte return, make the var
-                        // contained by the return expression. Codegen will put
-                        // the values in the right registers for return.
-                        MakeSrcContained(tree, op1);
+                        // Mark var as contained if not enregistrable.
+                        if (!varTypeIsEnregisterableStruct(op1))
+                        {
+                            MakeSrcContained(tree, op1);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
IR forms :
var = GT_CALL 
GT_RETURN(var)

Current codegen implementation requires that 'var' be marked as lvDoNotEnregister=1.  As a result SIMD types returned in two return registers will have to go through memory.  These code changes address that limitation.

case of var = GT_CALL:
In this case return value is in two xmm registers and needs to be assembled in target xmm reg.

case of GT_RETURN(var):
In this case return value is in a single xmm register and needs to be split into two ABI return regs.

Also, happened to notice that GT_RETURN(call) is not handling GT_COPY/GT_RELOAD of a multi-reg call and fixed that as well.

Fixes #4628 
Fixes #4629 


