### PR TITLE
Remove an assert in AssemblySpec::EmitToken

### DIFF
--- a/src/vm/assemblyspec.cpp
+++ b/src/vm/assemblyspec.cpp
@@ -1551,7 +1551,6 @@ HRESULT AssemblySpec::EmitToken(
         NOTHROW;
         GC_NOTRIGGER;
         INJECT_FAULT(return E_OUTOFMEMORY;);
-        PRECONDITION(HasUniqueIdentity() || AppDomain::GetCurrentDomain()->IsCompilationDomain());
     }
     CONTRACTL_END;
 


### PR DESCRIPTION
AssemblySpec::EmitToken has a PRECONDITION that prohibits emitting AssemblyRef
tokens to WinMD files, except inside CrossGen. However, there are scenarios,
such as XML serialization, that need to emit such tokens. Thus this PRECONDITION
is removed.