### PR TITLE
Buffer.BlockCopy: Avoid double-typechecks for arrays of same type

### DIFF
--- a/src/vm/comutilnative.cpp
+++ b/src/vm/comutilnative.cpp
@@ -1454,10 +1454,13 @@ FCIMPL5(VOID, Buffer::BlockCopy, ArrayBase *src, int srcOffset, ArrayBase *dst, 
     }
     else
     {
-        const CorElementType dstET = dst->GetArrayElementType();
-        if (!CorTypeInfo::IsPrimitiveType_NoThrow(dstET))
-            FCThrowArgumentVoid(W("dest"), W("Arg_MustBePrimArray"));
         dstLen = dst->GetNumComponents() * dst->GetComponentSize();
+        if (dst->GetMethodTable() != src->GetMethodTable())
+        {
+            const CorElementType dstET = dst->GetArrayElementType();
+            if (!CorTypeInfo::IsPrimitiveType_NoThrow(dstET))
+                FCThrowArgumentVoid(W("dest"), W("Arg_MustBePrimArray"));
+        }
     }
 
     if (srcOffset < 0 || dstOffset < 0 || count < 0) {


### PR DESCRIPTION
Small optimization in `Buffer.BlockCopy`: we don't need to perform another type check if the source/destination method tables are the same (which I'm assuming correspond to the same instance if the arrays are of the same type). This helps for copying between non-byte arrays of the same type, e.g.

```cs
var src = new char[3] { 'A', 'B', 'C' };
var dest = new char[3];
Buffer.BlockCopy(src, 0, dest, 0, src.Length * sizeof(char));
```

cc @jkotas