### PR TITLE
Mark EDX as trashed by the no-gc helper calls

### DIFF
--- a/src/jit/target.h
+++ b/src/jit/target.h
@@ -558,7 +558,7 @@ typedef unsigned short          regPairNoSmall; // arm: need 12 bits
   // We don't allow using ebp as a source register. Maybe we should only prevent this for ETW_EBP_FRAMED (but that is always set right now).
   #define RBM_WRITE_BARRIER_SRC    (RBM_EAX|RBM_ECX|RBM_EBX|RBM_ESI|RBM_EDI)
 
-  #define RBM_CALLEE_TRASH_NOGC    RBM_NONE
+  #define RBM_CALLEE_TRASH_NOGC    RBM_EDX
 #endif // NOGC_WRITE_BARRIERS
 
   // IL stub's secret parameter (CORJIT_FLG_PUBLISH_SECRET_PARAM)

--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -413,9 +413,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\stringintern\test1-xassem\test1-xassem.cmd">
              <Issue>3554</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Linq\Linq\Linq.cmd">
-             <Issue>4666</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Performance\CodeQuality\Serialization\Serialize\Serialize.cmd">
              <Issue>3597</Issue>
         </ExcludeList>


### PR DESCRIPTION
Fixes #4666

@CarolEidt @adiaaida PTAL
/cc @dotnet/jit-contrib 