### PR TITLE
Fix COMPlus_JitFunctionTrace=1 to work better with NYI

### DIFF
--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -8238,6 +8238,9 @@ public:
 #endif // DEBUG
 #endif // MEASURE_MEM_ALLOC
 
+    void                compFunctionTraceStart();
+    void                compFunctionTraceEnd(void* methodCodePtr, ULONG methodCodeSize, bool isNYI);
+
 protected:
 
     unsigned            compMaxUncheckedOffsetForNullObject; 

--- a/src/jit/error.cpp
+++ b/src/jit/error.cpp
@@ -170,6 +170,15 @@ void notYetImplemented(const char * msg, const char * filename, unsigned line)
 #endif // !DEBUG
 #endif // FUNC_INFO_LOGGING
 
+#ifdef DEBUG
+    Compiler* pCompiler = JitTls::GetCompiler();
+    if (pCompiler != nullptr)
+    {
+        // Assume we're within a compFunctionTrace boundary, which might not be true.
+        pCompiler->compFunctionTraceEnd(nullptr, 0, true);
+    }
+#endif // DEBUG 
+
     DWORD value = JitConfig.AltJitAssertOnNYI();
 
     // 0 means just silently skip


### PR DESCRIPTION
When we hit an NYI, do the "end" processing for a compilation, to avoid continuing to nest deeper. Also, indicate in the JitFunctionTrace that an NYI was hit.

@dotnet/jit-contrib PTAL
