### PR TITLE
Use Buffer.BlockCopy in System.Reflection.Emit

### DIFF
--- a/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilder.cs
@@ -399,7 +399,7 @@ namespace System.Reflection.Emit
                     else if (attribute.m_con.DeclaringType == typeof(SecurityRulesAttribute))
                     {
                         securityRulesBlob = new byte[attribute.m_blob.Length];
-                        Array.Copy(attribute.m_blob, securityRulesBlob, securityRulesBlob.Length);
+                        Buffer.BlockCopy(attribute.m_blob, 0, securityRulesBlob, 0, securityRulesBlob.Length);
                     }
                     else if (attribute.m_con.DeclaringType == typeof(SecurityTreatAsSafeAttribute))
                     {
@@ -411,7 +411,7 @@ namespace System.Reflection.Emit
                     {
                         assemblyFlags |= DynamicAssemblyFlags.Aptca;
                         aptcaBlob = new byte[attribute.m_blob.Length];
-                        Array.Copy(attribute.m_blob, aptcaBlob, aptcaBlob.Length);
+                        Buffer.BlockCopy(attribute.m_blob, 0, aptcaBlob, 0, aptcaBlob.Length);
                     }
 #endif // FEATURE_APTCA
                 }
@@ -1460,7 +1460,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(Environment.GetResourceString("Argument_NativeResourceAlreadyDefined"));
             
             m_assemblyData.m_resourceBytes = new byte[resource.Length];
-            System.Array.Copy(resource, m_assemblyData.m_resourceBytes, resource.Length);
+            Buffer.BlockCopy(resource, 0, m_assemblyData.m_resourceBytes, 0, resource.Length);
         }
 
         [System.Security.SecuritySafeCritical]  // auto-generated

--- a/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilderData.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/AssemblyBuilderData.cs
@@ -77,7 +77,7 @@ namespace System.Reflection.Emit {
             if (m_iCABuilder == m_CABuilders.Length)
             {
                 CustomAttributeBuilder[]  tempCABuilders = new CustomAttributeBuilder[m_iCABuilder * 2];
-                Array.Copy(m_CABuilders, tempCABuilders, m_iCABuilder);
+                Array.Copy(m_CABuilders, 0, tempCABuilders, 0, m_iCABuilder);
                 m_CABuilders = tempCABuilders;            
             }
             m_CABuilders[m_iCABuilder] = customBuilder;
@@ -110,7 +110,7 @@ namespace System.Reflection.Emit {
             }
 
             byte[] attrs = new byte[binaryAttribute.Length];
-            Array.Copy(binaryAttribute, attrs, binaryAttribute.Length);
+            Buffer.BlockCopy(binaryAttribute, 0, attrs, 0, binaryAttribute.Length);
             m_CABytes[m_iCAs] = attrs;
             m_CACons[m_iCAs] = con;
             m_iCAs++;
@@ -449,7 +449,7 @@ namespace System.Reflection.Emit {
             if (m_iPublicComTypeCount == m_publicComTypeList.Length)
             {
                 Type[]  tempTypeList = new Type[m_iPublicComTypeCount * 2];
-                Array.Copy(m_publicComTypeList, tempTypeList, m_iPublicComTypeCount);
+                Array.Copy(m_publicComTypeList, 0, tempTypeList, 0, m_iPublicComTypeCount);
                 m_publicComTypeList = tempTypeList;            
             }
         }

--- a/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/CustomAttributeBuilder.cs
@@ -130,7 +130,7 @@ namespace System.Reflection.Emit {
             // Cache information used elsewhere.
             m_con = con;
             m_constructorArgs = new Object[constructorArgs.Length];
-            Array.Copy(constructorArgs, m_constructorArgs, constructorArgs.Length);
+            Array.Copy(constructorArgs, 0, m_constructorArgs, 0, constructorArgs.Length);
 
             Type[] paramTypes;
             int i;

--- a/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/DynamicMethod.cs
@@ -915,7 +915,7 @@ namespace System.Reflection.Emit
             public override ParameterInfo[] GetParameters() {
                 ParameterInfo[] privateParameters = LoadParameters();
                 ParameterInfo[] parameters = new ParameterInfo[privateParameters.Length];
-                Array.Copy(privateParameters, parameters, privateParameters.Length);
+                Array.Copy(privateParameters, 0, parameters, 0, privateParameters.Length);
                 return parameters;
             }
             

--- a/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ILGenerator.cs
@@ -28,44 +28,37 @@ namespace System.Reflection.Emit
         #endregion
 
         #region Internal Statics
-        internal static int[] EnlargeArray(int[] incoming)
+        internal static T[] EnlargeArray<T>(T[] incoming)
+        {
+            return EnlargeArray(incoming, incoming.Length * 2);
+        }
+        
+        internal static T[] EnlargeArray<T>(T[] incoming, int requiredSize)
         {
             Contract.Requires(incoming != null);
-            Contract.Ensures(Contract.Result<int[]>() != null);
-            Contract.Ensures(Contract.Result<int[]>().Length > incoming.Length);
-            int[] temp = new int [incoming.Length*2];
-            Array.Copy(incoming, temp, incoming.Length);
+            Contract.Ensures(Contract.Result<T[]>() != null);
+            Contract.Ensures(Contract.Result<T[]>().Length == requiredSize);
+            
+            T[] temp = new T[requiredSize];
+            Array.Copy(incoming, 0, temp, 0, incoming.Length);
             return temp;
         }
-
+        
         private static byte[] EnlargeArray(byte[] incoming)
         {
-            byte [] temp = new byte [incoming.Length*2];
-            Array.Copy(incoming, temp, incoming.Length);
-            return temp;
+            return EnlargeArray(incoming, incoming.Length * 2);
         }
 
         private static byte[] EnlargeArray(byte[] incoming, int requiredSize)
         {
-            byte [] temp = new byte [requiredSize];
-            Array.Copy(incoming, temp, incoming.Length);
+            Contract.Requires(incoming != null);
+            Contract.Ensures(Contract.Result<byte[]>() != null);
+            Contract.Ensures(Contract.Result<byte[]>().Length == requiredSize);
+            
+            byte[] temp = new byte[requiredSize];
+            Buffer.BlockCopy(incoming, 0, temp, 0, incoming.Length);
             return temp;
         }
-
-        private static __FixupData[] EnlargeArray(__FixupData[] incoming)
-        {
-            __FixupData [] temp = new __FixupData[incoming.Length*2];
-            //Does arraycopy work for value classes?
-            Array.Copy(incoming, temp, incoming.Length);
-            return temp;
-        }
-
-        private static __ExceptionInfo[] EnlargeArray(__ExceptionInfo[] incoming)
-        {
-            __ExceptionInfo[] temp = new __ExceptionInfo[incoming.Length*2];
-            Array.Copy(incoming, temp, incoming.Length);
-            return temp;
-        }        
         #endregion
 
         #region Internal Data Members
@@ -244,7 +237,7 @@ namespace System.Reflection.Emit
 
             int newSize;
             int updateAddr;
-            byte []newBytes;
+            byte[] newBytes;
 
             if (m_currExcStackCount != 0)
             {
@@ -260,7 +253,7 @@ namespace System.Reflection.Emit
             newBytes = new byte[newSize];
 
             //Copy the data from the old array
-            Array.Copy(m_ILStream, newBytes, newSize);
+            Buffer.BlockCopy(m_ILStream, 0, newBytes, 0, newSize);
 
             //Do the fixups.
             //This involves iterating over all of the labels and
@@ -313,7 +306,7 @@ namespace System.Reflection.Emit
             }
             
             temp = new __ExceptionInfo[m_exceptionCount];
-            Array.Copy(m_exceptions, temp, m_exceptionCount);
+            Array.Copy(m_exceptions, 0, temp, 0, m_exceptionCount);
             SortExceptions(temp);
             return temp;
         }
@@ -426,7 +419,7 @@ namespace System.Reflection.Emit
             }
 
             int[] narrowTokens = new int[m_RelocFixupCount];
-            Array.Copy(m_RelocFixupList, narrowTokens, m_RelocFixupCount);
+            Array.Copy(m_RelocFixupList, 0, narrowTokens, 0, m_RelocFixupCount);
             return narrowTokens;
         }
         #endregion
@@ -1459,13 +1452,6 @@ namespace System.Reflection.Emit
             m_currentState = State_Try;
         }
 
-        private static Type[] EnlargeArray(Type[] incoming)
-        {
-            Type[] temp = new Type[incoming.Length * 2];
-            Array.Copy(incoming, temp, incoming.Length);
-            return temp;
-        }
-
         private void MarkHelper(
             int         catchorfilterAddr,      // the starting address of a clause
             int         catchEndAddr,           // the end address of a previous catch clause. Only use when finally is following a catch
@@ -1476,7 +1462,7 @@ namespace System.Reflection.Emit
                 m_filterAddr=ILGenerator.EnlargeArray(m_filterAddr);
                 m_catchAddr=ILGenerator.EnlargeArray(m_catchAddr);
                 m_catchEndAddr=ILGenerator.EnlargeArray(m_catchEndAddr);
-                m_catchClass=__ExceptionInfo.EnlargeArray(m_catchClass);
+                m_catchClass=ILGenerator.EnlargeArray(m_catchClass);
                 m_type = ILGenerator.EnlargeArray(m_type);
             }
             if (type == Filter)
@@ -1763,15 +1749,15 @@ namespace System.Reflection.Emit
                 // It would probably be simpler to just use Lists here.
                 int newSize = checked(m_iCount * 2);
                 int[] temp = new int[newSize];
-                Array.Copy(m_iOffsets, temp, m_iCount);
+                Array.Copy(m_iOffsets, 0, temp, 0, m_iCount);
                 m_iOffsets = temp;
 
                 ScopeAction[] tempSA = new ScopeAction[newSize];
-                Array.Copy(m_ScopeActions, tempSA, m_iCount);
+                Array.Copy(m_ScopeActions, 0, tempSA, 0, m_iCount);
                 m_ScopeActions = tempSA;
 
                 LocalSymInfo[] tempLSI = new LocalSymInfo[newSize];
-                Array.Copy(m_localSymInfos, tempLSI, m_iCount);
+                Array.Copy(m_localSymInfos, 0, tempLSI, 0, m_iCount);
                 m_localSymInfos = tempLSI;
             }
         }
@@ -1883,7 +1869,7 @@ namespace System.Reflection.Emit
             {
                 // the arrays are full. Enlarge the arrays
                 REDocument[] temp = new REDocument [m_DocumentCount * 2];
-                Array.Copy(m_Documents, temp, m_DocumentCount);
+                Array.Copy(m_Documents, 0, temp, 0, m_DocumentCount);
                 m_Documents = temp;
             }
         }
@@ -1961,23 +1947,23 @@ namespace System.Reflection.Emit
                 // It would probably be simpler to just use Lists here
                 int newSize = checked(m_iLineNumberCount * 2);
                 int[] temp = new int [newSize];
-                Array.Copy(m_iOffsets, temp, m_iLineNumberCount);
+                Array.Copy(m_iOffsets, 0, temp, 0, m_iLineNumberCount);
                 m_iOffsets = temp;
 
                 temp = new int [newSize];
-                Array.Copy(m_iLines, temp, m_iLineNumberCount);
+                Array.Copy(m_iLines, 0, temp, 0, m_iLineNumberCount);
                 m_iLines = temp;
 
                 temp = new int [newSize];
-                Array.Copy(m_iColumns, temp, m_iLineNumberCount);
+                Array.Copy(m_iColumns, 0, temp, 0, m_iLineNumberCount);
                 m_iColumns = temp;
 
                 temp = new int [newSize];
-                Array.Copy(m_iEndLines, temp, m_iLineNumberCount);
+                Array.Copy(m_iEndLines, 0, temp, 0, m_iLineNumberCount);
                 m_iEndLines = temp;
 
                 temp = new int [newSize];
-                Array.Copy(m_iEndColumns, temp, m_iLineNumberCount);
+                Array.Copy(m_iEndColumns, 0, temp, 0, m_iLineNumberCount);
                 m_iEndColumns = temp;
             }
         }
@@ -1997,19 +1983,19 @@ namespace System.Reflection.Emit
                 return;
             // reduce the array size to be exact
             iOffsetsTemp = new int [m_iLineNumberCount];
-            Array.Copy(m_iOffsets, iOffsetsTemp, m_iLineNumberCount);
+            Array.Copy(m_iOffsets, 0, iOffsetsTemp, 0, m_iLineNumberCount);
 
             iLinesTemp = new int [m_iLineNumberCount];
-            Array.Copy(m_iLines, iLinesTemp, m_iLineNumberCount);
+            Array.Copy(m_iLines, 0, iLinesTemp, 0, m_iLineNumberCount);
 
             iColumnsTemp = new int [m_iLineNumberCount];
-            Array.Copy(m_iColumns, iColumnsTemp, m_iLineNumberCount);
+            Array.Copy(m_iColumns, 0, iColumnsTemp, 0, m_iLineNumberCount);
 
             iEndLinesTemp = new int [m_iLineNumberCount];
-            Array.Copy(m_iEndLines, iEndLinesTemp, m_iLineNumberCount);
+            Array.Copy(m_iEndLines, 0, iEndLinesTemp, 0, m_iLineNumberCount);
 
             iEndColumnsTemp = new int [m_iLineNumberCount];
-            Array.Copy(m_iEndColumns, iEndColumnsTemp, m_iLineNumberCount);
+            Array.Copy(m_iEndColumns, 0, iEndColumnsTemp, 0, m_iLineNumberCount);
 
             symWriter.DefineSequencePoints(m_document, iOffsetsTemp, iLinesTemp, iColumnsTemp, iEndLinesTemp, iEndColumnsTemp); 
         }

--- a/src/mscorlib/src/System/Reflection/Emit/LocalBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/LocalBuilder.cs
@@ -100,7 +100,7 @@ namespace System.Reflection.Emit
             // bit unfortunate, since it means that we need to allocate
             // yet another array of bytes...  
             mungedSig = new byte[sigLength - 1];
-            Array.Copy(signature, 1, mungedSig, 0, sigLength - 1);
+            Buffer.BlockCopy(signature, 1, mungedSig, 0, sigLength - 1);
             
             index = methodBuilder.GetILGenerator().m_ScopeTree.GetCurrentActiveScopeIndex();
             if (index == -1)

--- a/src/mscorlib/src/System/Reflection/Emit/MethodBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/MethodBuilder.cs
@@ -153,7 +153,7 @@ namespace System.Reflection.Emit
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
-                Array.Copy(parameterTypes, m_parameterTypes, parameterTypes.Length);
+                Array.Copy(parameterTypes, 0, m_parameterTypes, 0, parameterTypes.Length);
             }
             else
             {
@@ -831,7 +831,7 @@ namespace System.Reflection.Emit
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
-                Array.Copy (parameterTypes, m_parameterTypes, parameterTypes.Length);
+                Array.Copy (parameterTypes, 0, m_parameterTypes, 0, parameterTypes.Length);
             }
 
             m_returnTypeRequiredCustomModifiers = returnTypeRequiredCustomModifiers;
@@ -1085,7 +1085,7 @@ namespace System.Reflection.Emit
             }
 
             m_ubBody = new byte[count];
-            Array.Copy(il,m_ubBody,count);
+            Buffer.BlockCopy(il, 0, m_ubBody, 0, count);
 
             m_localSignature = null;
             m_exceptions = null;
@@ -1300,7 +1300,7 @@ namespace System.Reflection.Emit
             else if (m_iNameSpaceCount == m_namespace.Length)
             {
                 String [] strTemp = new String [checked(m_iNameSpaceCount * 2)];
-                Array.Copy(m_namespace, strTemp, m_iNameSpaceCount);
+                Array.Copy(m_namespace, 0, strTemp, 0, m_iNameSpaceCount);
                 m_namespace = strTemp;
             }
         }
@@ -1322,23 +1322,23 @@ namespace System.Reflection.Emit
                 // why aren't we just using lists here?
                 int newSize = checked(m_iLocalSymCount * 2);
                 int[] temp = new int [newSize];
-                Array.Copy(m_iLocalSlot, temp, m_iLocalSymCount);
+                Array.Copy(m_iLocalSlot, 0, temp, 0, m_iLocalSymCount);
                 m_iLocalSlot = temp;
 
                 temp = new int [newSize];
-                Array.Copy(m_iStartOffset, temp, m_iLocalSymCount);
+                Array.Copy(m_iStartOffset, 0, temp, 0, m_iLocalSymCount);
                 m_iStartOffset = temp;
 
                 temp = new int [newSize];
-                Array.Copy(m_iEndOffset, temp, m_iLocalSymCount);
+                Array.Copy(m_iEndOffset, 0, temp, 0, m_iLocalSymCount);
                 m_iEndOffset = temp;
 
                 String [] strTemp = new String [newSize];
-                Array.Copy(m_strName, strTemp, m_iLocalSymCount);
+                Array.Copy(m_strName, 0, strTemp, 0, m_iLocalSymCount);
                 m_strName = strTemp;
 
                 byte[][] ubTemp = new byte[newSize][];
-                Array.Copy(m_ubSignature, ubTemp, m_iLocalSymCount);
+                Array.Copy(m_ubSignature, 0, ubTemp, 0, m_iLocalSymCount);
                 m_ubSignature = ubTemp;
 
             }

--- a/src/mscorlib/src/System/Reflection/Emit/ModuleBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/ModuleBuilder.cs
@@ -1370,7 +1370,7 @@ namespace System.Reflection.Emit
                 throw new ArgumentException(Environment.GetResourceString("Argument_NativeResourceAlreadyDefined"));
                         
             m_moduleData.m_resourceBytes = new byte[resource.Length];
-            System.Array.Copy(resource, m_moduleData.m_resourceBytes, resource.Length);
+            Buffer.BlockCopy(resource, 0, m_moduleData.m_resourceBytes, 0, resource.Length);
         }
 
 #if FEATURE_CORECLR
@@ -2200,7 +2200,7 @@ namespace System.Reflection.Emit
             Contract.EndContractBlock();
 
             byte[] localSigBytes = new byte[sigBytes.Length];
-            Array.Copy(sigBytes, localSigBytes, sigBytes.Length);
+            Buffer.BlockCopy(sigBytes, 0, localSigBytes, 0, sigBytes.Length);
 
             return new SignatureToken(TypeBuilder.GetTokenFromSig(GetNativeHandle(), localSigBytes, sigLength), this);
         }

--- a/src/mscorlib/src/System/Reflection/Emit/SignatureHelper.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SignatureHelper.cs
@@ -648,7 +648,7 @@ namespace System.Reflection.Emit
                 requiredLength = inArray.Length*2;
 
             byte[] outArray = new byte[requiredLength];
-            Array.Copy(inArray, outArray, inArray.Length);
+            Buffer.BlockCopy(inArray, 0, outArray, 0, inArray.Length);
             return outArray;
         }
     
@@ -712,7 +712,7 @@ namespace System.Reflection.Emit
             //so we just copy that byte.  Then copy the rest of the array, shifting everything
             //to make room for the new number of elements.
             temp[0] = m_signature[0];
-            Array.Copy(m_signature, m_sizeLoc + 1, temp, m_sizeLoc + newSigSize, currSigHolder - (m_sizeLoc + 1));
+            Buffer.BlockCopy(m_signature, m_sizeLoc + 1, temp, m_sizeLoc + newSigSize, currSigHolder - (m_sizeLoc + 1));
             m_signature = temp;
             
             //Use the AddData method to add the number of elements appropriately compressed.
@@ -807,7 +807,7 @@ namespace System.Reflection.Emit
             else
                 throw new ArgumentException(Environment.GetResourceString("Argument_LargeInteger"));
             // copy the sig part of the sig
-            Array.Copy(m_signature, 2, temp, sigCopyIndex, currSigLength - 2);
+            Buffer.BlockCopy(m_signature, 2, temp, sigCopyIndex, currSigLength - 2);
             // mark the end of sig
             temp[newSigSize - 1] = (byte)CorElementType.End;
     
@@ -935,7 +935,7 @@ namespace System.Reflection.Emit
             if (m_signature.Length > m_currSig) 
             {
                 byte[] temp = new byte[m_currSig];
-                Array.Copy(m_signature, temp, m_currSig);
+                Array.Copy(m_signature, 0, temp, 0, m_currSig);
                 m_signature = temp;
             }
 

--- a/src/mscorlib/src/System/Reflection/Emit/SymbolMethod.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SymbolMethod.cs
@@ -44,7 +44,7 @@ namespace System.Reflection.Emit
             if (parameterTypes != null)
             {
                 m_parameterTypes = new Type[parameterTypes.Length];
-                Array.Copy(parameterTypes, m_parameterTypes, parameterTypes.Length);
+                Array.Copy(parameterTypes, 0, m_parameterTypes, 0, parameterTypes.Length);
             }
             else
             {

--- a/src/mscorlib/src/System/Reflection/Emit/SymbolType.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/SymbolType.cs
@@ -251,9 +251,9 @@ namespace System.Reflection.Emit
             {
                 // resize the bound array
                 int[]  iaTemp = new int[m_cRank * 2];
-                Array.Copy(m_iaLowerBound, iaTemp, m_cRank);
+                Array.Copy(m_iaLowerBound, 0, iaTemp, 0, m_cRank);
                 m_iaLowerBound = iaTemp;            
-                Array.Copy(m_iaUpperBound, iaTemp, m_cRank);
+                Array.Copy(m_iaUpperBound, 0, iaTemp, 0, m_cRank);
                 m_iaUpperBound = iaTemp;            
             }
 

--- a/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
+++ b/src/mscorlib/src/System/Reflection/Emit/TypeBuilder.cs
@@ -228,7 +228,7 @@ namespace System.Reflection.Emit {
             if (attr != null)
             {
                 localAttr = new byte[attr.Length];
-                Array.Copy(attr, localAttr, attr.Length);
+                Buffer.BlockCopy(attr, 0, localAttr, 0, attr.Length);
             }
 
             DefineCustomAttribute(module.GetNativeHandle(), tkAssociate, tkConstructor, 


### PR DESCRIPTION
Changes:

- `Buffer.BlockCopy` is used in favor of `Array.Copy` for byte arrays
- Remaining `Array.Copy` usages have been augmented with extra `0` args, to avoid calling `GetLowerBound` (see dotnet/corefx#3615)