### PR TITLE
Disable FEATURE_MERGE_JIT_AND_ENGINE on *nix.

### DIFF
--- a/clrdefinitions.cmake
+++ b/clrdefinitions.cmake
@@ -132,13 +132,10 @@ add_definitions(-DFEATURE_MANAGED_ETW_CHANNELS)
 add_definitions(-DFEATURE_MAIN_CLR_MODULE_USES_CORE_NAME)
 add_definitions(-DFEATURE_MERGE_CULTURE_SUPPORT_AND_ENGINE)
 
-# TODO_DJIT: Remove this "set" to commence loading JIT dynamically.
-if(NOT WIN32)
-  set(FEATURE_MERGE_JIT_AND_ENGINE 1)
-elseif (CLR_CMAKE_TARGET_ARCH_ARM64)
+if(CLR_CMAKE_TARGET_ARCH_ARM64)
   # TODO_DJIT: Remove this as part of enabling cross-compiling standalone JIT binary.
   set(FEATURE_MERGE_JIT_AND_ENGINE 1)
-endif(NOT WIN32)
+endif(CLR_CMAKE_TARGET_ARCH_ARM64)
 
 if(FEATURE_MERGE_JIT_AND_ENGINE)
   # Disable the following for UNIX altjit on Windows

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -438,7 +438,7 @@ Parameters :
 static void inject_activation_handler(int code, siginfo_t *siginfo, void *context)
 {
     // Only accept activations from the current process
-    if (siginfo->si_pid == getpid() && g_activationFunction != NULL)
+    if (g_activationFunction != NULL && siginfo->si_pid == getpid())
     {
         _ASSERTE(g_safeActivationCheckFunction != NULL);
 

--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -94,6 +94,10 @@ struct sigaction g_previous_sigint;
 struct sigaction g_previous_sigquit;
 struct sigaction g_previous_sigterm;
 
+#ifdef INJECT_ACTIVATION_SIGNAL
+struct sigaction g_previous_activation;
+#endif
+
 /* public function definitions ************************************************/
 
 /*++
@@ -135,7 +139,7 @@ BOOL SEHInitializeSignals()
     handle_signal(SIGTERM, sigterm_handler, &g_previous_sigterm);
 
 #ifdef INJECT_ACTIVATION_SIGNAL
-    handle_signal(INJECT_ACTIVATION_SIGNAL, inject_activation_handler, NULL);
+    handle_signal(INJECT_ACTIVATION_SIGNAL, inject_activation_handler, &g_previous_activation);
 #endif
 
     /* The default action for SIGPIPE is process termination.
@@ -179,6 +183,10 @@ void SEHCleanupSignals()
     restore_signal(SIGINT, &g_previous_sigint);
     restore_signal(SIGQUIT, &g_previous_sigquit);
     restore_signal(SIGTERM, &g_previous_sigterm);
+
+#ifdef INJECT_ACTIVATION_SIGNAL
+    restore_signal(INJECT_ACTIVATION_SIGNAL, &g_previous_activation);
+#endif
 }
 
 /* internal function definitions **********************************************/
@@ -430,28 +438,29 @@ Parameters :
 static void inject_activation_handler(int code, siginfo_t *siginfo, void *context)
 {
     // Only accept activations from the current process
-    if (siginfo->si_pid == getpid())
+    if (siginfo->si_pid == getpid() && g_activationFunction != NULL)
     {
-        if (g_activationFunction != NULL)
+        _ASSERTE(g_safeActivationCheckFunction != NULL);
+
+        native_context_t *ucontext = (native_context_t *)context;
+
+        CONTEXT winContext;
+        CONTEXTFromNativeContext(
+            ucontext, 
+            &winContext, 
+            CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
+
+        if (g_safeActivationCheckFunction(CONTEXTGetPC(&winContext), /* checkingCurrentThread */ TRUE))
         {
-            _ASSERTE(g_safeActivationCheckFunction != NULL);
-
-            native_context_t *ucontext = (native_context_t *)context;
-
-            CONTEXT winContext;
-            CONTEXTFromNativeContext(
-                ucontext, 
-                &winContext, 
-                CONTEXT_CONTROL | CONTEXT_INTEGER | CONTEXT_FLOATING_POINT);
-
-            if (g_safeActivationCheckFunction(CONTEXTGetPC(&winContext), /* checkingCurrentThread */ TRUE))
-            {
-                g_activationFunction(&winContext);
-            }
-
-            // Activation function may have modified the context, so update it.
-            CONTEXTToNativeContext(&winContext, ucontext);
+            g_activationFunction(&winContext);
         }
+
+        // Activation function may have modified the context, so update it.
+        CONTEXTToNativeContext(&winContext, ucontext);
+    }
+    else if (g_previous_activation.sa_sigaction != NULL)
+    {
+        g_previous_activation.sa_sigaction(code, siginfo, context);
     }
 }
 #endif


### PR DESCRIPTION
Now that #3058 has been fixed, the JIT can be consumed as a dynamic
library on all platforms.