### PR TITLE
Fix GC ref frame offset range assert

### DIFF
--- a/src/jit/emit.cpp
+++ b/src/jit/emit.cpp
@@ -2188,7 +2188,7 @@ void                emitter::emitSetFrameRangeGCRs(int offsLo, int offsHi)
             printf("-%04X ... %04X\n", -offsLo, offsHi);
 #else
             printf("-%04X ... -%04X\n", -offsLo, -offsHi);
-            assert(offsHi <  0);
+            assert(offsHi <= 0);
 #endif
           
         }


### PR DESCRIPTION
In emitSetFrameRangeGCRs(), on x86, there is the following assert:
```
  assert(offsHi <  0);
```
This is saying that the highest offset of a stack frame gc reference
is negative w.r.t. the frame pointer. This is not quite true: the
highest offset is exclusive of the range (the lowest offset is inclusive).
I found a test case where the 'this' pointer, a gc ref, was located
immediately below the frame pointer, in range [ebp-4,ebp), so offsHi==0.

The reason we don't hit this more is because this assert is only in
the JitDump code (under `#ifdef DEBUG` and `if (verbose)`). (This
also seems wrong.)

I changed the assert to (offsHi <= 0).