### PR TITLE
Inliner: add JitInlineLimit check to LegacyPolicy under debug

### DIFF
--- a/src/jit/inlinepolicy.cpp
+++ b/src/jit/inlinepolicy.cpp
@@ -736,6 +736,23 @@ int LegacyPolicy::DetermineCallsiteNativeSizeEstimate(CORINFO_METHOD_INFO* methI
 
 void LegacyPolicy::DetermineProfitability(CORINFO_METHOD_INFO* methodInfo)
 {
+
+#if defined(DEBUG)
+
+    // Punt if we're inlining and we've reached the acceptance limit.
+    int limit = JitConfig.JitInlineLimit();
+    unsigned current = m_RootCompiler->m_inlineStrategy->GetInlineCount();
+
+    if (!m_IsPrejitRoot &&
+        (limit >= 0) &&
+        (current >= static_cast<unsigned>(limit)))
+    {
+        SetFailure(InlineObservation::CALLSITE_OVER_INLINE_LIMIT);
+        return;
+    }
+
+#endif // defined(DEBUG)
+
     assert(InlDecisionIsCandidate(m_Decision));
     assert(m_Observation == InlineObservation::CALLEE_IS_DISCRETIONARY_INLINE);
 


### PR DESCRIPTION
Adds the ability to limit the number of inlines done by the LegacyPolicy.
Useful in trying to binary search for inlines that cause correctness
issues.

This limit impacts inlining in all methods, so effective isolation may
also require use of JitNoInlineRange to hone in on the root method that
is the source of problems.