### PR TITLE
Fix conditional in Unix build definition

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -1290,7 +1290,7 @@ combinedScenarios.each { scenario ->
                                 case 'x86ryujit':
                                 case 'x86lb':
                                     def arch = architecture
-                                    if (architecture != 'x86ryujit' || architecture == 'x86lb') {
+                                    if (architecture == 'x86ryujit' || architecture == 'x86lb') {
                                         arch = 'x86'
                                     }
                                 


### PR DESCRIPTION
This was causing us to pass x86 to all the Unix job definitions.