### PR TITLE
Increase a test timeout

### DIFF
--- a/tests/longRunningGcTests.txt
+++ b/tests/longRunningGcTests.txt
@@ -7,3 +7,4 @@ GC/Features/PartialCompaction/partialcompactiontest/partialcompactiontest.sh
 GC/Features/PartialCompaction/partialcompactionwloh/partialcompactionwloh.sh
 GC/Features/SustainedLowLatency/sustainedlowlatency_race_reverse/sustainedlowlatency_race_reverse.sh
 GC/Features/SustainedLowLatency/sustainedlowlatency_race/sustainedlowlatency_race.sh
+GC/Regressions/v2.0-beta2/462651/462651/462651.sh

--- a/tests/src/GC/Regressions/v2.0-beta2/462651/462651.csproj
+++ b/tests/src/GC/Regressions/v2.0-beta2/462651/462651.csproj
@@ -13,6 +13,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\11.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <IsLongRunningGCTest>true</IsLongRunningGCTest>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
Test case tests/src/GC/Regressions/v2.0-beta2/462651 occasionally fails
due to time out (see issue #3691). Mark it with IsLongRunningGCTest.