### PR TITLE
RyuJIT - throughput improvements, PInvoke transitions tweaks:

### DIFF
--- a/src/jit/codegenxarch.cpp
+++ b/src/jit/codegenxarch.cpp
@@ -5870,21 +5870,7 @@ void CodeGen::genCallInstruction(GenTreePtr node)
         else
         {
             // Direct call to a non-virtual user function.
-            CORINFO_ACCESS_FLAGS  aflags = CORINFO_ACCESS_ANY;
-            if (call->IsSameThis())
-            {
-                aflags = (CORINFO_ACCESS_FLAGS)(aflags | CORINFO_ACCESS_THIS);
-            }
-
-            if ((call->NeedsNullCheck()) == 0)
-            {
-                aflags = (CORINFO_ACCESS_FLAGS)(aflags | CORINFO_ACCESS_NONNULL);
-            }
-
-            CORINFO_CONST_LOOKUP addrInfo;
-            compiler->info.compCompHnd->getFunctionEntryPoint(methHnd, &addrInfo, aflags);
-
-            addr = addrInfo.addr;
+            addr = call->gtDirectCallAddress;
         }
 
         // Non-virtual direct calls to known addresses

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3141,7 +3141,7 @@ private:
 
     void                impMarkInlineCandidate(GenTreePtr call,
                                                CORINFO_CONTEXT_HANDLE exactContextHnd,
-                                               CORINFO_CALL_INFO * callInfo);
+                                               CORINFO_CALL_INFO* callInfo);
 
     bool                impTailCallRetTypeCompatible(var_types callerRetType, 
                                                      CORINFO_CLASS_HANDLE callerRetTypeClass,

--- a/src/jit/compiler.h
+++ b/src/jit/compiler.h
@@ -3138,9 +3138,11 @@ private:
                                                 GenTreePtr additionalTreesToBeEvaluatedBefore,
                                                 GenTreePtr variableBeingDereferenced,
                                                 InlArgInfo * inlArgInfo);
-    void                impMarkInlineCandidate(GenTreePtr call, CORINFO_CONTEXT_HANDLE exactContextHnd);
 
-    
+    void                impMarkInlineCandidate(GenTreePtr call,
+                                               CORINFO_CONTEXT_HANDLE exactContextHnd,
+                                               CORINFO_CALL_INFO * callInfo);
+
     bool                impTailCallRetTypeCompatible(var_types callerRetType, 
                                                      CORINFO_CLASS_HANDLE callerRetTypeClass,
                                                      var_types calleeRetType,

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2884,10 +2884,10 @@ struct GenTreeCall final : public GenTree
         // only used for CALLI unmanaged calls (CT_INDIRECT)
         GenTreePtr      gtCallCookie;           
         // gtInlineCandidateInfo is only used when inlining methods 
-        InlineCandidateInfo * gtInlineCandidateInfo;
-        void *  gtStubCallStubAddr;             // GTF_CALL_VIRT_STUB - these are never inlined                
+        InlineCandidateInfo* gtInlineCandidateInfo;
+        void* gtStubCallStubAddr;             // GTF_CALL_VIRT_STUB - these are never inlined                
         CORINFO_GENERIC_HANDLE compileTimeHelperArgumentHandle; // Used to track type handle argument of dynamic helpers
-        void * gtDirectCallAddress; // Used to pass direct call address between lower and codegen
+        void* gtDirectCallAddress; // Used to pass direct call address between lower and codegen
     };
 
     // expression evaluated after args are placed which determines the control target

--- a/src/jit/gentree.h
+++ b/src/jit/gentree.h
@@ -2887,6 +2887,7 @@ struct GenTreeCall final : public GenTree
         InlineCandidateInfo * gtInlineCandidateInfo;
         void *  gtStubCallStubAddr;             // GTF_CALL_VIRT_STUB - these are never inlined                
         CORINFO_GENERIC_HANDLE compileTimeHelperArgumentHandle; // Used to track type handle argument of dynamic helpers
+        void * gtDirectCallAddress; // Used to pass direct call address between lower and codegen
     };
 
     // expression evaluated after args are placed which determines the control target

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -16461,7 +16461,7 @@ BOOL                Compiler::impInlineIsGuaranteedThisDerefBeforeAnySideEffects
 
 void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, 
                                                CORINFO_CONTEXT_HANDLE exactContextHnd, 
-                                               CORINFO_CALL_INFO * callInfo)
+                                               CORINFO_CALL_INFO* callInfo)
 {
     if  (!opts.OptEnabled(CLFLG_INLINING))
     {                 

--- a/src/jit/importer.cpp
+++ b/src/jit/importer.cpp
@@ -6541,8 +6541,8 @@ var_types           Compiler::impImportCall (OPCODE         opcode,
                 
             if (!bIntrinsicImported)
             {
-                // Is it an inline candidate?        
-               impMarkInlineCandidate(call, exactContextHnd);       
+                // Is it an inline candidate?
+                impMarkInlineCandidate(call, exactContextHnd, callInfo);
             }
 
             // append the call node.
@@ -6758,7 +6758,7 @@ DONE_CALL:
         }
 
         // Is it an inline candidate?        
-        impMarkInlineCandidate(call, exactContextHnd); 
+        impMarkInlineCandidate(call, exactContextHnd, callInfo);
     }
 
     // Push or append the result of the call
@@ -16459,7 +16459,9 @@ BOOL                Compiler::impInlineIsGuaranteedThisDerefBeforeAnySideEffects
 // otherwise build tree context) so when we do the inlining pass we
 // can capture these reasons
 
-void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONTEXT_HANDLE exactContextHnd)
+void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, 
+                                               CORINFO_CONTEXT_HANDLE exactContextHnd, 
+                                               CORINFO_CALL_INFO * callInfo)
 {
     if  (!opts.OptEnabled(CLFLG_INLINING))
     {                 
@@ -16541,11 +16543,18 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
      * restricts the inliner to non-expanding inlines.  I removed the check to allow for non-expanding
      * inlining in throw blocks.  I should consider the same thing for catch and filter regions. */
 
+    CORINFO_METHOD_HANDLE fncHandle = call->gtCallMethHnd;
     unsigned methAttr;
-    CORINFO_METHOD_HANDLE fncHandle;
 
-    fncHandle = call->gtCallMethHnd;
-    methAttr = info.compCompHnd->getMethodAttribs(fncHandle);
+    // Reuse method flags from the original callInfo if possible
+    if (fncHandle == callInfo->hMethod)
+    {
+        methAttr = callInfo->methodFlags;
+    }
+    else
+    {
+        methAttr = info.compCompHnd->getMethodAttribs(fncHandle);
+    }
 
 #ifdef DEBUG
     if (compStressCompile(STRESS_FORCE_INLINE, 0))
@@ -16607,13 +16616,7 @@ void          Compiler::impMarkInlineCandidate(GenTreePtr callNode, CORINFO_CONT
         return;
     }
 
-    /* Cannot inline native or synchronized methods */
-
-    if  (methAttr & CORINFO_FLG_NATIVE)
-    {
-        inlineResult.NoteFatal(InlineObservation::CALLEE_IS_NATIVE);
-        return;
-    }
+    /* Cannot inline synchronized methods */
 
     if  (methAttr & CORINFO_FLG_SYNCH)
     {

--- a/src/jit/inline.def
+++ b/src/jit/inline.def
@@ -44,7 +44,6 @@ INLINE_OBSERVATION(HAS_PINNED_LOCALS,         bool,   "has pinned locals",      
 INLINE_OBSERVATION(IS_ARRAY_METHOD,           bool,   "is array method",               FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_GENERIC_VIRTUAL,        bool,   "generic virtual",               FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_JIT_NOINLINE,           bool,   "noinline per JitNoinline",      FATAL,       CALLEE)
-INLINE_OBSERVATION(IS_NATIVE,                 bool,   "is implemented natively",       FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_NOINLINE,               bool,   "noinline per IL/cached result", FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_SYNCHRONIZED,           bool,   "is synchronized",               FATAL,       CALLEE)
 INLINE_OBSERVATION(IS_VM_NOINLINE,            bool,   "noinline per VM",               FATAL,       CALLEE)

--- a/src/jit/morph.cpp
+++ b/src/jit/morph.cpp
@@ -2696,12 +2696,12 @@ GenTreeCall* Compiler::fgMorphArgs(GenTreeCall* callNode)
         // convention for x86/SSE.
         if (!lateArgsComputed)
         {
-            if (call->IsUnmanaged())
+            if (call->IsUnmanaged() && !opts.ShouldUsePInvokeHelpers())
             {
                 assert(!call->gtCallCookie);
                 // Add a conservative estimate of the stack size in a special parameter (r11) at the call site.
                 // It will be used only on the intercepted-for-host code path to copy the arguments.             
-                
+
                 GenTree* cns = new (this, GT_CNS_INT) GenTreeIntCon(TYP_I_IMPL, fgEstimateCallStackSize(call));
                 call->gtCallArgs = gtNewListNode(cns, call->gtCallArgs);
                 NonStandardArg nsa = {REG_PINVOKE_COOKIE_PARAM, cns};


### PR DESCRIPTION
- Minor compilation throughput improvements:
     - Avoid redundant calls to getMethodAttribs in impMarkInlineCandidate by reusing the value from CALL_INFO
     - Avoid redundant calls to getFunctionEntryPoint in codegen by reusing the value computed during lower
     - Stop checking CORINFO_FLG_NATIVE flag for inliner observations. It is dead flag, not set anywhere
- Tweaks for helper-based PInvoke transitions (used CoreRT only today):
     - Stop emitting CORINFO_HELP_INIT_PINVOKE_FRAME. Just having the two simple begin/end helpers is better.
     - Stop passing size of arguments in secret register.
     - Enable direct calls for PInvoke targets