### PR TITLE
Revise CallEHFunclet not to overwrite the stack frame pointer

### DIFF
--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -114,7 +114,9 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         // Save the SP of this function
         str sp, [r3]
         // apply the non-volatiles corresponding to the CrawlFrame
-        ldm r2, {r4-r11}
+        ldm r2!, {r4-r6}
+        add r2, r2, #4
+        ldm r2!, {r8-r11}
         // Invoke the funclet
         blx r1
 


### PR DESCRIPTION
CallEHFunclet currently overwrites the stack frame pointer (R7) while
recovering the registers, which results in stack unwinding failure.

This commit revises CallEHFunclet not to overwrite the stack frame pointer 
(attempt to fix #4579)