### PR TITLE
Linux/ARM: fix stack alignment breaks

### DIFF
--- a/src/vm/arm/ehhelpers.S
+++ b/src/vm/arm/ehhelpers.S
@@ -129,7 +129,6 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
 
         PROLOG_PUSH  "{r7, lr}"
         PROLOG_STACK_SAVE r7
-        alloc_stack  4
 
         // On entry:
         //
@@ -143,7 +142,6 @@ OFFSET_OF_FRAME=(4 + SIZEOF__GSCookie)
         // Invoke the filter funclet
         blx r2
 
-        free_stack   4
         EPILOG_POP   "{r7, pc}"
 
         NESTED_END CallEHFilterFunclet, _TEXT

--- a/src/vm/arm/memcpy.S
+++ b/src/vm/arm/memcpy.S
@@ -22,9 +22,9 @@
         ldr r3, [r0]
         ldr r3, [r1]
         
-        push {lr}
+        push {r7, lr} // r7 as a dummy to make SP aligned
         blx C_FUNC(memcpy)
-        pop {lr}
+        pop {r7, lr}
 
 LOCAL_LABEL(GC_POLL):
         ldr r0, =g_TrapReturningThreads


### PR DESCRIPTION
ehhelper.S: the function no more requires dummy stack add.
memcpy.S: C_FUNC(memcpy) has misaligned stack.
  (memcpy.S is not directly related with the issue #4779.
  However, this requires the same fix with ehhelper.S)

We need to align SP by 8 bytes for function calls.

Fix #4779

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>