### PR TITLE
Fix conv_ovf_i8_i test

### DIFF
--- a/tests/issues.targets
+++ b/tests/issues.targets
@@ -43,9 +43,6 @@
         <ExcludeList Include="$(XunitTestBinBase)\JIT\Directed\coverage\importer\Desktop\bleref_il_r\bleref_il_r.cmd" >
              <Issue>2414</Issue>
         </ExcludeList>
-        <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i8_i\conv_ovf_i8_i.cmd" >
-             <Issue>2414</Issue>
-        </ExcludeList>
         <ExcludeList Include="$(XunitTestBinBase)\JIT\jit64\localloc\verify\verify01_dynamic\verify01_dynamic.cmd" >
              <Issue>2414</Issue>
         </ExcludeList>

--- a/tests/src/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.il
+++ b/tests/src/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.il
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 .assembly extern legacy library mscorlib {}
 
 
@@ -167,13 +170,13 @@ END2:
 	ldc.i8			0xFFFFFFFF80000000
 	ldc.i4			0x80000000
 	call		int32 conv_ovf_i4::conv_un(int64,int32)
-	ldc.i4			0x11111111
+	ldc.i4			0xEEEEEEEE
 	ceq
 	brfalse			FAIL
 	ldc.i8			0xFFFFFFFFFFFFFFFF
 	ldc.i4			0xFFFFFFFF
 	call		int32 conv_ovf_i4::conv_un(int64,int32)
-	ldc.i4			0x11111111
+	ldc.i4			0xEEEEEEEE
 	ceq
 	brfalse			FAIL
 	ldc.i8			0x0000000000000000
@@ -196,7 +199,7 @@ END2:
 	brfalse			FAIL
 
 PASS:
-	ldc.i4	0xAAAA
+	ldc.i4	100
 	br		END
 
 FAIL:

--- a/tests/src/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.ilproj
+++ b/tests/src/JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i.ilproj
@@ -14,6 +14,8 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT	.0\UITestExtensionPackages</ReferencePath>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>7a9bfb7d</NuGetPackageImportStamp>
+    <DisableProjectBuild Condition="'$(Platform)' == 'x64'">true</DisableProjectBuild>
+    <DisableProjectBuild Condition="'$(Platform)' == 'arm64'">true</DisableProjectBuild>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/tests/src/JIT/IL_Conformance/Old/Conformance_Base/rem_r4.il
+++ b/tests/src/JIT/IL_Conformance/Old/Conformance_Base/rem_r4.il
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 .assembly extern System.Console
 {

--- a/tests/testsFailingOutsideWindows.txt
+++ b/tests/testsFailingOutsideWindows.txt
@@ -40,7 +40,6 @@ JIT/Directed/pinning/object-pin/object-pin/object-pin.sh
 JIT/Directed/pinvoke/preemptive_cooperative/preemptive_cooperative.sh
 JIT/Directed/tls/mutualrecurthd-tls/mutualrecurthd-tls.sh
 JIT/Directed/tls/test-tls/test-tls.sh
-JIT/IL_Conformance/Old/Conformance_Base/conv_ovf_i8_i/conv_ovf_i8_i.sh
 JIT/jit64/localloc/verify/verify01_dynamic/verify01_dynamic.sh
 JIT/jit64/localloc/verify/verify01_large/verify01_large.sh
 JIT/jit64/localloc/verify/verify01_small/verify01_small.sh

--- a/tests/x86_legacy_backend_issues.targets
+++ b/tests/x86_legacy_backend_issues.targets
@@ -307,9 +307,6 @@
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\cctor\misc\tail_il_r\tail_il_r.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>
-    <ExcludeList Include="$(XunitTestBinBase)\JIT\IL_Conformance\Old\Conformance_Base\conv_ovf_i8_i\conv_ovf_i8_i.cmd">
-      <Issue>needs triage</Issue>
-    </ExcludeList>
     <ExcludeList Include="$(XunitTestBinBase)\JIT\Methodical\varargs\seh\filter_il_d\filter_il_d.cmd">
       <Issue>needs triage</Issue>
     </ExcludeList>


### PR DESCRIPTION
Test has at least four problems:
- It assumes native int = int32, so disable it for 64-bit
- It is just wrong in a couple of its assumptions about when overflow
  happens during unsigned conversions.
- On success, it returns 0xAAAA instead of the commonly accepted 100
- It has no copyright header

Also piggybacking a copyright fix for rem_r4.il that I missed earlier

Fixes #4850