### PR TITLE
Let all signals be unblocked on Unix

### DIFF
--- a/src/pal/src/exception/signal.cpp
+++ b/src/pal/src/exception/signal.cpp
@@ -171,8 +171,6 @@ void SEHCleanupSignals()
 {
     TRACE("Restoring default signal handlers\n");
 
-    // Do not remove handlers for SIGUSR1 and SIGUSR2. They must remain so threads can be suspended
-    // during cleanup after this function has been called.
     restore_signal(SIGILL, &g_previous_sigill);
     restore_signal(SIGTRAP, &g_previous_sigtrap);
     restore_signal(SIGFPE, &g_previous_sigfpe);

--- a/src/pal/src/include/pal/threadsusp.hpp
+++ b/src/pal/src/include/pal/threadsusp.hpp
@@ -360,11 +360,6 @@ namespace CorUnix
                 DWORD *pdwSuspendCount
             );
 
-#if !HAVE_MACH_EXCEPTIONS
-            static 
-            VOID InitializeSignalSets();
-#endif // !HAVE_MACH_EXCEPTIONS
-
             VOID InitializeSuspensionLock();
 
             void SetBlockingPipe(

--- a/src/pal/src/thread/thread.cpp
+++ b/src/pal/src/thread/thread.cpp
@@ -1783,14 +1783,6 @@ CorUnix::InitializeGlobalThreadData(
         InternalFree(pszStackSize);
     }
 
-#if !HAVE_MACH_EXCEPTIONS
-    //
-    // Initialize the thread suspension signal sets.
-    //
-    
-    CThreadSuspensionInfo::InitializeSignalSets();
-#endif // !HAVE_MACH_EXCEPTIONS
-
     return palError;
 }
 


### PR DESCRIPTION
This change removes blocking of all of the 17 signals that we were
blocking. I have looked at the default behavior of their handlers
and we should be fine with it.