### PR TITLE
Fix class names for benchmarks

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/MatInv4/MatInv4.cs
@@ -10,7 +10,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-public static class LLoops
+public static class MatInv4
 {
 #if DEBUG
     public const int Iterations = 1;

--- a/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
+++ b/tests/src/JIT/Performance/CodeQuality/BenchF/Regula/Regula.cs
@@ -12,7 +12,7 @@ using Xunit;
 [assembly: OptimizeForBenchmarks]
 [assembly: MeasureInstructionsRetired]
 
-public static class Adams
+public static class Regula
 {
 #if DEBUG
     public const int Iterations = 1;


### PR DESCRIPTION
Fix a couple of class names for benchmarks so they more accurately
describe the benchmark.