### PR TITLE
Port from tfs: onload exception debugger crash fix

### DIFF
--- a/src/debug/ee/amd64/dbghelpers.S
+++ b/src/debug/ee/amd64/dbghelpers.S
@@ -45,6 +45,13 @@ NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
         // So we allocate 4 stack slots as the outgoing argument home and just copy the 
         // arguments set up by DacDbi into these stack slots.  We will take a perf hit,
         // but this is not a perf critical code path anyway.
+
+        // There is an additional dependency on this alloc_stack: the
+        // ExceptionHijackPersonalityRoutine assumes that it can find
+        // the first argument to HijackWorker in the stack frame of
+        // ExceptionHijack, at an offset of exactly 0x20 bytes from
+        // ExceptionHijackWorker's stack frame. Therefore it is
+        // important that we move the stack pointer by the same amount.
         alloc_stack 0x20
         END_PROLOGUE
 
@@ -53,6 +60,11 @@ NESTED_ENTRY ExceptionHijack, _TEXT, UnhandledExceptionHandlerUnix
         // stack for us.  However, the Orcas compilers don't like a 0-sized frame, so 
         // we need to allocate something here and then just copy the stack arguments to 
         // their new argument homes.
+
+        // In x86, ExceptionHijackWorker is marked STDCALL, so it finds
+        // its arguments on the stack. In x64, it gets its arguments in
+        // registers (set up for us by DacDbiInterfaceImpl::Hijack),
+        // and this stack space may be reused.
         mov     rax, [rsp + 20h]
         mov     [rsp], rax
         mov     rax, [rsp + 28h]


### PR DESCRIPTION
The ExceptionHijackPersonalityRoutine was retrieving a context from a
particular stack frame, but the calling conventions for the function
executing in that frame allow it to overwrite the context. This was
causing the debugger to crash for exceptions thrown from the onload
method in winforms on x64.

The fix is to instead retrieve the context from the previous stack
frame, whose layout is set up explicitly in ExceptionHijack.