### PR TITLE
Add missing xunit performance attributes

### DIFF
--- a/tests/src/JIT/Performance/CodeQuality/SciMark/kernel.cs
+++ b/tests/src/JIT/Performance/CodeQuality/SciMark/kernel.cs
@@ -16,6 +16,9 @@
 using Microsoft.Xunit.Performance;
 using System;
 
+[assembly: OptimizeForBenchmarks]
+[assembly: MeasureInstructionsRetired]
+
 namespace SciMark2
 {
     public static class kernel

--- a/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
+++ b/tests/src/JIT/Performance/CodeQuality/V8/Crypto/Crypto.cs
@@ -43,6 +43,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 
+[assembly: OptimizeForBenchmarks]
+[assembly: MeasureInstructionsRetired]
+
 namespace Crypto
 {
     public class Support


### PR DESCRIPTION
We were not getting instructions retired data for these benchmarks
because the attribute to trigger measurement was missing.