### PR TITLE
[mscorlib] Improve perf for many Char methods

### DIFF
--- a/src/mscorlib/src/System/Char.cs
+++ b/src/mscorlib/src/System/Char.cs
@@ -212,16 +212,9 @@ namespace System {
       /*=================================CheckLetter=====================================
       ** Check if the specified UnicodeCategory belongs to the letter categories.
       ==============================================================================*/
-      internal static bool CheckLetter(UnicodeCategory uc) {                  
-          switch(uc) {
-              case (UnicodeCategory.UppercaseLetter):
-              case (UnicodeCategory.LowercaseLetter): 
-              case (UnicodeCategory.TitlecaseLetter): 
-              case (UnicodeCategory.ModifierLetter): 
-              case (UnicodeCategory.OtherLetter):
-                  return (true);
-          }
-          return (false);
+      internal static bool CheckLetter(UnicodeCategory uc) {
+          Contract.Assert(Enum.IsDefined(typeof(UnicodeCategory), uc));
+          return (uint)uc <= (uint)UnicodeCategory.OtherLetter;
       }
     
       /*=================================ISLETTER=====================================
@@ -253,10 +246,7 @@ namespace System {
             // U+000d = <control> CARRIAGE RETURN
             // U+0085 = <control> NEXT LINE
             // U+00a0 = NO-BREAK SPACE
-            if ((c == ' ') || (c >= '\x0009' && c <= '\x000d') || c == '\x00a0' || c == '\x0085') {
-                return (true);
-            }
-            return (false);
+            return IsSeparatorLatin1(c) || (uint)(c - '\u0009') <= (uint)('\u000d' - '\u0009') || c == '\u0085';
         }
     
     /*===============================ISWHITESPACE===================================
@@ -308,17 +298,8 @@ namespace System {
 
       internal static bool CheckPunctuation(UnicodeCategory uc)
       {
-          switch (uc) {
-              case UnicodeCategory.ConnectorPunctuation:
-              case UnicodeCategory.DashPunctuation:
-              case UnicodeCategory.OpenPunctuation:
-              case UnicodeCategory.ClosePunctuation:
-              case UnicodeCategory.InitialQuotePunctuation:
-              case UnicodeCategory.FinalQuotePunctuation:
-              case UnicodeCategory.OtherPunctuation:
-                  return (true);
-          }
-          return (false);
+          Contract.Assert(Enum.IsDefined(typeof(UnicodeCategory), uc));
+          return (uint)(uc - UnicodeCategory.ConnectorPunctuation) <= (uint)(UnicodeCategory.OtherPunctuation - UnicodeCategory.ConnectorPunctuation);
       }
 
     
@@ -339,16 +320,10 @@ namespace System {
       ** Check if the specified UnicodeCategory belongs to the letter or digit categories.
       ==============================================================================*/
       internal static bool CheckLetterOrDigit(UnicodeCategory uc) {
-          switch (uc) {
-              case UnicodeCategory.UppercaseLetter:
-              case UnicodeCategory.LowercaseLetter:
-              case UnicodeCategory.TitlecaseLetter:
-              case UnicodeCategory.ModifierLetter:
-              case UnicodeCategory.OtherLetter:
-              case UnicodeCategory.DecimalDigitNumber:
-                  return (true);
-          }
-          return (false);
+          Contract.Assert(Enum.IsDefined(typeof(UnicodeCategory), uc));
+          // TODO: See if we can come up with some bit-twiddling hack
+          // to avoid branching altogether here.
+          return CheckLetter(uc) || uc == UnicodeCategory.DecimalDigitNumber;
       }
     
         // Determines whether a character is a letter or a digit.
@@ -597,13 +572,8 @@ namespace System {
         ==============================================================================*/
 
         internal static bool CheckNumber(UnicodeCategory uc) {
-            switch (uc) {
-                case (UnicodeCategory.DecimalDigitNumber):
-                case (UnicodeCategory.LetterNumber):
-                case (UnicodeCategory.OtherNumber):
-                    return (true);
-            }
-            return (false);
+            Contract.Assert(Enum.IsDefined(typeof(UnicodeCategory), uc));
+            return (uint)(uc - UnicodeCategory.DecimalDigitNumber) <= (uint)(UnicodeCategory.OtherNumber - UnicodeCategory.DecimalDigitNumber);
         }
 
         public static bool IsNumber(char c)
@@ -665,19 +635,14 @@ namespace System {
 
         internal static bool CheckSeparator(UnicodeCategory uc)
         {
-            switch (uc) {
-                case UnicodeCategory.SpaceSeparator:
-                case UnicodeCategory.LineSeparator:
-                case UnicodeCategory.ParagraphSeparator:
-                    return (true);
-            }
-            return (false);
+            Contract.Assert(Enum.IsDefined(typeof(UnicodeCategory), uc));
+            return (uint)(uc - UnicodeCategory.SpaceSeparator) <= (uint)(UnicodeCategory.ParagraphSeparator - UnicodeCategory.SpaceSeparator);
         }
 
         private static bool IsSeparatorLatin1(char c) {
             // U+00a0 = NO-BREAK SPACE
             // There is no LineSeparator or ParagraphSeparator in Latin 1 range.
-            return (c == '\x0020' || c == '\x00a0');
+            return (c | '\u0080') == '\u00a0';
         }
 
         public static bool IsSeparator(char c)
@@ -706,7 +671,7 @@ namespace System {
         [Pure]
         public static bool IsSurrogate(char c)
         {
-            return (c >= HIGH_SURROGATE_START && c <= LOW_SURROGATE_END);
+            return (uint)(c - HIGH_SURROGATE_START) <= (uint)(LOW_SURROGATE_END - HIGH_SURROGATE_START);
         }
 
         [Pure]
@@ -727,14 +692,8 @@ namespace System {
         ==============================================================================*/
 
         internal static bool CheckSymbol(UnicodeCategory uc) {
-            switch (uc) {
-                case (UnicodeCategory.MathSymbol):
-                case (UnicodeCategory.CurrencySymbol): 
-                case (UnicodeCategory.ModifierSymbol): 
-                case (UnicodeCategory.OtherSymbol):            
-                    return (true);
-            }
-            return (false);
+            Contract.Assert(Enum.IsDefined(typeof(UnicodeCategory), uc));
+            return (uint)(uc - UnicodeCategory.MathSymbol) <= (uint)(UnicodeCategory.OtherSymbol - UnicodeCategory.MathSymbol);
         }
         
         public static bool IsSymbol(char c)
@@ -839,7 +798,7 @@ namespace System {
         ==============================================================================*/
         [Pure]
         public static bool IsHighSurrogate(char c) {
-            return ((c >= CharUnicodeInfo.HIGH_SURROGATE_START) && (c <= CharUnicodeInfo.HIGH_SURROGATE_END));
+            return (uint)(c - HIGH_SURROGATE_START) <= (uint)(HIGH_SURROGATE_END - HIGH_SURROGATE_START);
         } 
 
         [Pure]
@@ -847,7 +806,7 @@ namespace System {
             if (s == null) {
                 throw new ArgumentNullException("s");
             }
-            if (index < 0 || index >= s.Length) {
+            if ((uint)index >= s.Length) {
                 throw new ArgumentOutOfRangeException("index");
             }
             Contract.EndContractBlock();
@@ -859,7 +818,7 @@ namespace System {
         ==============================================================================*/
         [Pure]
         public static bool IsLowSurrogate(char c) {
-            return ((c >= CharUnicodeInfo.LOW_SURROGATE_START) && (c <= CharUnicodeInfo.LOW_SURROGATE_END));
+            return (uint)(c - LOW_SURROGATE_START) <= (uint)(LOW_SURROGATE_END - LOW_SURROGATE_START);
         }
 
         [Pure]
@@ -867,7 +826,7 @@ namespace System {
             if (s == null) {
                 throw new ArgumentNullException("s");
             }
-            if (index < 0 || index >= s.Length) {
+            if ((uint)index >= s.Length) {
                 throw new ArgumentOutOfRangeException("index");
             }
             Contract.EndContractBlock();
@@ -882,20 +841,19 @@ namespace System {
             if (s == null) {
                 throw new ArgumentNullException("s");
             }
-            if (index < 0 || index >= s.Length) {
+            if ((uint)index >= s.Length) {
                 throw new ArgumentOutOfRangeException("index");
             }
             Contract.EndContractBlock();
             if (index + 1 < s.Length) {
-                return (IsSurrogatePair(s[index], s[index+1]));
+                return (IsSurrogatePair(s[index], s[index + 1]));
             }
             return (false);
         }
 
         [Pure]
         public static bool IsSurrogatePair(char highSurrogate, char lowSurrogate) {
-            return ((highSurrogate >= CharUnicodeInfo.HIGH_SURROGATE_START && highSurrogate <= CharUnicodeInfo.HIGH_SURROGATE_END) &&
-                    (lowSurrogate >= CharUnicodeInfo.LOW_SURROGATE_START && lowSurrogate <= CharUnicodeInfo.LOW_SURROGATE_END));
+            return IsHighSurrogate(highSurrogate) && IsLowSurrogate(lowSurrogate);
         }
 
         internal const int UNICODE_PLANE00_END = 0x00ffff;
@@ -904,11 +862,11 @@ namespace System {
         // The end codepoint for Unicode plane 16.  This is the maximum code point value allowed for Unicode.
         // Plane 16 contains 0x100000 ~ 0x10ffff.
         internal const int UNICODE_PLANE16_END   = 0x10ffff;
-
-        internal const int HIGH_SURROGATE_START = 0x00d800;
-        internal const int LOW_SURROGATE_END    = 0x00dfff;
         
-
+        internal const int HIGH_SURROGATE_START = CharUnicodeInfo.HIGH_SURROGATE_START;
+        internal const int HIGH_SURROGATE_END = CharUnicodeInfo.HIGH_SURROGATE_END;
+        internal const int LOW_SURROGATE_START = CharUnicodeInfo.LOW_SURROGATE_START;
+        internal const int LOW_SURROGATE_END = CharUnicodeInfo.LOW_SURROGATE_END;
 
        /*================================= ConvertFromUtf32 ============================
         ** Convert an UTF32 value into a surrogate pair.
@@ -918,7 +876,7 @@ namespace System {
         {
             // For UTF32 values from U+00D800 ~ U+00DFFF, we should throw.  They
             // are considered as irregular code unit sequence, but they are not illegal.
-            if ((utf32 < 0 || utf32 > UNICODE_PLANE16_END) || (utf32 >= HIGH_SURROGATE_START && utf32 <= LOW_SURROGATE_END)) {
+            if ((uint)utf32 > UNICODE_PLANE16_END || (uint)(utf32 - HIGH_SURROGATE_START) <= (uint)(LOW_SURROGATE_END) - HIGH_SURROGATE_START) {
                 throw new ArgumentOutOfRangeException("utf32", Environment.GetResourceString("ArgumentOutOfRange_InvalidUTF32"));
             }
             Contract.EndContractBlock();
@@ -948,7 +906,7 @@ namespace System {
                 throw new ArgumentOutOfRangeException("lowSurrogate", Environment.GetResourceString("ArgumentOutOfRange_InvalidLowSurrogate"));
             }
             Contract.EndContractBlock();
-            return (((highSurrogate - CharUnicodeInfo.HIGH_SURROGATE_START) * 0x400) + (lowSurrogate - CharUnicodeInfo.LOW_SURROGATE_START) + UNICODE_PLANE01_START);
+            return (((highSurrogate - HIGH_SURROGATE_START) * 0x400) + (lowSurrogate - LOW_SURROGATE_START) + UNICODE_PLANE01_START);
         }
 
         /*=============================ConvertToUtf32===================================
@@ -964,35 +922,32 @@ namespace System {
                 throw new ArgumentNullException("s");
             }
 
-            if (index < 0 || index >= s.Length) {
+            if ((uint)index >= s.Length) {
                 throw new ArgumentOutOfRangeException("index", Environment.GetResourceString("ArgumentOutOfRange_Index"));
             }
             Contract.EndContractBlock();
             // Check if the character at index is a high surrogate.
-            int temp1 = (int)s[index] - CharUnicodeInfo.HIGH_SURROGATE_START;
-            if (temp1 >= 0 && temp1 <= 0x7ff) {
+            int temp1 = (int)s[index] - HIGH_SURROGATE_START;
+            if ((uint)temp1 <= 0x7ff) {
                 // Found a surrogate char.
                 if (temp1 <= 0x3ff) {
                     // Found a high surrogate.
                     if (index < s.Length - 1) {
-                        int temp2 = (int)s[index+1] - CharUnicodeInfo.LOW_SURROGATE_START;
-                        if (temp2 >= 0 && temp2 <= 0x3ff) {
+                        int temp2 = (int)s[index + 1] - LOW_SURROGATE_START;
+                        if ((uint)temp2 <= 0x3ff) {
                             // Found a low surrogate.
                             return ((temp1 * 0x400) + temp2 + UNICODE_PLANE01_START);
-                        } else {
-                            throw new ArgumentException(Environment.GetResourceString("Argument_InvalidHighSurrogate", index), "s"); 
                         }
-                    } else {
-                        // Found a high surrogate at the end of the string.
-                        throw new ArgumentException(Environment.GetResourceString("Argument_InvalidHighSurrogate", index), "s"); 
                     }
+                    // Found a standalone high surrogate.
+                    throw new ArgumentException(Environment.GetResourceString("Argument_InvalidHighSurrogate", index), "s");
                 } else {
                     // Find a low surrogate at the character pointed by index.
                     throw new ArgumentException(Environment.GetResourceString("Argument_InvalidLowSurrogate", index), "s"); 
                 }
             }
             // Not a high-surrogate or low-surrogate. Genereate the UTF32 value for the BMP characters.
-            return ((int)s[index]);
+            return (int)s[index];
         }
     }
 }

--- a/src/mscorlib/src/System/Globalization/CharUnicodeInfo.cs
+++ b/src/mscorlib/src/System/Globalization/CharUnicodeInfo.cs
@@ -147,9 +147,9 @@ namespace System.Globalization {
             Contract.Assert(index >= 0 && index < s.Length, "index < s.Length");
             if (index < s.Length - 1) {
                 int temp1 = (int)s[index] - HIGH_SURROGATE_START;
-                if (temp1 >= 0 && temp1 <= 0x3ff) {
+                if ((uint)temp1 <= 0x3ff) {
                     int temp2 = (int)s[index+1] - LOW_SURROGATE_START;
-                    if (temp2 >= 0 && temp2 <= 0x3ff) {
+                    if ((uint)temp2 <= 0x3ff) {
                         // Convert the surrogate to UTF32 and get the result.
                         return ((temp1 * 0x400) + temp2 + UNICODE_PLANE01_START);
                     }
@@ -187,9 +187,9 @@ namespace System.Globalization {
             charLength = 1;
             if (index < s.Length - 1) {
                 int temp1 = (int)s[index] - HIGH_SURROGATE_START;
-                if (temp1 >= 0 && temp1 <= 0x3ff) {
+                if ((uint)temp1 <= 0x3ff) {
                     int temp2 = (int)s[index+1] - LOW_SURROGATE_START;
-                    if (temp2 >= 0 && temp2 <= 0x3ff) {
+                    if ((uint)temp2 <= 0x3ff) {
                         // Convert the surrogate to UTF32 and get the result.
                         charLength++;
                         return ((temp1 * 0x400) + temp2 + UNICODE_PLANE01_START);
@@ -447,7 +447,7 @@ namespace System.Globalization {
             // Get the level 2 item from the highest 12 bit (8 - 19) of ch.
             ushort index = s_pCategoryLevel1Index[ch >> 8];
             // Get the level 2 WORD offset from the 4 - 7 bit of ch.  This provides the base offset of the level 3 table.
-            // Note that & has the lower precedence than addition, so don't forget the parathesis.
+            // Note that & has lower precedence than addition, so don't forget the parenthesis.
             index = s_pCategoryLevel1Index[index + ((ch >> 4) & 0x000f)];
             byte* pBytePtr = (byte*)&(s_pCategoryLevel1Index[index]);
             // Get the result from the 0 -3 bit of ch.


### PR DESCRIPTION
Right now many methods in `Char` are implemented like this (for example):

```cs
public static bool IsDigit(char c) => c >= '0' && c <= '9';
```

This isn't the most efficient way to implement it though; since these methods are often used in a loop, I've taken advantage of the fact that casting to `uint` causes the value to wrap, which avoids an additional branch. Here is the above method rewritten using this tactic:

```cs
// Similar to what @jkotas suggested in dotnet/corefx#7546
public static bool IsDigit(char c) => (uint)(c - '0') <= (uint)('9' - '0');
```

I've changed a bunch of static methods in `Char` to take advantage of this fact and avoid an additional branch, along with a couple of other changes:

- Used `stackalloc`, instead of creating a new char array on the heap, for `ConvertFromUtf32`.

- Many overloads that accept a string and an index can simply forward to the char-based overload.

- Added `HIGH_SURROGATE_END` and `LOW_SURROGATE_START` consts, and removed references to `CharUnicodeInfo` for getting those values.

Note: Some of the corefx tests [are failing](https://gist.github.com/jamesqo/cbcabb2f290a54da79d49f90d332f420) with my changes, but unfortunately I'm not sure why/for what chars as the error messages are not very helpful.

cc @JonHanna @jkotas @mikedn @hughbe 

**edit:** Looks like the string-and-index overloads actually *can't* just forward to the char-based ones, that's likely why the tests are failing. Will fix in a moment.