### PR TITLE
Change hosting API string encoding to UTF-8 on Windows

### DIFF
--- a/src/dlls/mscoree/unixinterface.cpp
+++ b/src/dlls/mscoree/unixinterface.cpp
@@ -56,13 +56,13 @@ public:
 // Convert 8 bit string to unicode
 static LPCWSTR StringToUnicode(LPCSTR str)
 {
-    int length = MultiByteToWideChar(CP_ACP, 0, str, -1, NULL, 0);
+    int length = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
     ASSERTE_ALL_BUILDS(length != 0);
 
     LPWSTR result = new (nothrow) WCHAR[length];
     ASSERTE_ALL_BUILDS(result != NULL);
     
-    length = MultiByteToWideChar(CP_ACP, 0, str, -1, result, length);
+    length = MultiByteToWideChar(CP_UTF8, 0, str, -1, result, length);
     ASSERTE_ALL_BUILDS(length != 0);
 
     return result;


### PR DESCRIPTION
This change fixes a problem with the string encoding in the hosting API
using CP_ACP, which causes problem when the input is a string in other
language than the current Windows one. In such case, it loses some
characters.
The fix is to use UTF-8 encoding (which is what CP_ACP means on Unix
PAL too).